### PR TITLE
feat: add LoggerConfig to all clients

### DIFF
--- a/clients/client-accessanalyzer/AccessAnalyzerClient.ts
+++ b/clients/client-accessanalyzer/AccessAnalyzerClient.ts
@@ -41,6 +41,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -208,7 +214,8 @@ export type AccessAnalyzerClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type AccessAnalyzerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -217,7 +224,8 @@ export type AccessAnalyzerClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS IAM Access Analyzer helps identify potential resource-access risks by enabling you to identify
@@ -247,13 +255,15 @@ export class AccessAnalyzerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-acm-pca/ACMPCAClient.ts
+++ b/clients/client-acm-pca/ACMPCAClient.ts
@@ -73,6 +73,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -244,7 +250,8 @@ export type ACMPCAClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ACMPCAClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -253,7 +260,8 @@ export type ACMPCAClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>This is the <i>ACM Private CA API Reference</i>. It provides descriptions,
@@ -289,13 +297,15 @@ export class ACMPCAClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-acm/ACMClient.ts
+++ b/clients/client-acm/ACMClient.ts
@@ -45,6 +45,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -202,7 +208,8 @@ export type ACMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ACMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -211,7 +218,8 @@ export type ACMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Certificate Manager</fullname>
@@ -240,13 +248,15 @@ export class ACMClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-alexa-for-business/AlexaForBusinessClient.ts
+++ b/clients/client-alexa-for-business/AlexaForBusinessClient.ts
@@ -224,6 +224,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -541,7 +547,8 @@ export type AlexaForBusinessClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type AlexaForBusinessClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -550,7 +557,8 @@ export type AlexaForBusinessClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Alexa for Business helps you use Alexa in your organization. Alexa for Business provides you with the tools
@@ -581,13 +589,15 @@ export class AlexaForBusinessClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-amplify/AmplifyClient.ts
+++ b/clients/client-amplify/AmplifyClient.ts
@@ -81,6 +81,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -286,7 +292,8 @@ export type AmplifyClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type AmplifyClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -295,7 +302,8 @@ export type AmplifyClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amplify enables developers to develop and deploy cloud-powered mobile and web apps.
@@ -324,13 +332,15 @@ export class AmplifyClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-api-gateway/APIGatewayClient.ts
+++ b/clients/client-api-gateway/APIGatewayClient.ts
@@ -242,6 +242,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import { getAcceptHeaderPlugin } from "@aws-sdk/middleware-sdk-api-gateway";
 import {
@@ -614,7 +620,8 @@ export type APIGatewayClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type APIGatewayClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -623,7 +630,8 @@ export type APIGatewayClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon API Gateway</fullname>
@@ -648,14 +656,16 @@ export class APIGatewayClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getAcceptHeaderPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-sdk-api-gateway": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",

--- a/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
+++ b/clients/client-apigatewaymanagementapi/ApiGatewayManagementApiClient.ts
@@ -17,6 +17,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -151,7 +157,8 @@ export type ApiGatewayManagementApiClientConfig = Partial<__SmithyConfiguration<
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ApiGatewayManagementApiClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -160,7 +167,8 @@ export type ApiGatewayManagementApiClientResolvedConfig = __SmithyResolvedConfig
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The Amazon API Gateway Management API allows you to directly manage runtime aspects of your deployed APIs. To use it, you must explicitly set the SDK's endpoint to point to the endpoint of your deployed API. The endpoint will be of the form https://{api-id}.execute-api.{region}.amazonaws.com/{stage}, or will be the endpoint corresponding to your API's custom domain and base path, if applicable.</p>
@@ -184,13 +192,15 @@ export class ApiGatewayManagementApiClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-apigatewayv2/ApiGatewayV2Client.ts
+++ b/clients/client-apigatewayv2/ApiGatewayV2Client.ts
@@ -121,6 +121,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -394,7 +400,8 @@ export type ApiGatewayV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ApiGatewayV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -403,7 +410,8 @@ export type ApiGatewayV2ClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon API Gateway V2</p>
@@ -427,13 +435,15 @@ export class ApiGatewayV2Client extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-app-mesh/AppMeshClient.ts
+++ b/clients/client-app-mesh/AppMeshClient.ts
@@ -78,6 +78,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -271,7 +277,8 @@ export type AppMeshClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type AppMeshClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -280,7 +287,8 @@ export type AppMeshClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS App Mesh is a service mesh based on the Envoy proxy that makes it easy to monitor and
@@ -316,13 +324,15 @@ export class AppMeshClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-app-mesh/models/index.ts
+++ b/clients/client-app-mesh/models/index.ts
@@ -10,7 +10,6 @@ export namespace AccessLog {
   interface $Base {
     __type?: "AccessLog";
   }
-
   /**
    * <p>The file object to send virtual node access logs to.</p>
    */
@@ -18,25 +17,17 @@ export namespace AccessLog {
     file: FileAccessLog;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     file?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     file: (value: FileAccessLog) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: AccessLog, visitor: Visitor<T>): T => {
     if (value.file !== undefined) return visitor.file(value.file);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: AccessLog): any => {
-    if (obj.file !== undefined) return { file: FileAccessLog.filterSensitiveLog(obj.file) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -107,7 +98,6 @@ export namespace Backend {
   interface $Base {
     __type?: "Backend";
   }
-
   /**
    * <p>Specifies a virtual service to use as a backend for a virtual node. </p>
    */
@@ -115,26 +105,17 @@ export namespace Backend {
     virtualService: VirtualServiceBackend;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     virtualService?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     virtualService: (value: VirtualServiceBackend) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: Backend, visitor: Visitor<T>): T => {
     if (value.virtualService !== undefined) return visitor.virtualService(value.virtualService);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: Backend): any => {
-    if (obj.virtualService !== undefined)
-      return { virtualService: VirtualServiceBackend.filterSensitiveLog(obj.virtualService) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -152,7 +133,6 @@ export interface BackendDefaults {
 export namespace BackendDefaults {
   export const filterSensitiveLog = (obj: BackendDefaults): any => ({
     ...obj,
-    ...(obj.clientPolicy && { clientPolicy: ClientPolicy.filterSensitiveLog(obj.clientPolicy) }),
   });
   export const isa = (o: any): o is BackendDefaults => __isa(o, "BackendDefaults");
 }
@@ -187,7 +167,6 @@ export interface ClientPolicy {
 export namespace ClientPolicy {
   export const filterSensitiveLog = (obj: ClientPolicy): any => ({
     ...obj,
-    ...(obj.tls && { tls: ClientPolicyTls.filterSensitiveLog(obj.tls) }),
   });
   export const isa = (o: any): o is ClientPolicy => __isa(o, "ClientPolicy");
 }
@@ -217,7 +196,6 @@ export interface ClientPolicyTls {
 export namespace ClientPolicyTls {
   export const filterSensitiveLog = (obj: ClientPolicyTls): any => ({
     ...obj,
-    ...(obj.validation && { validation: TlsValidationContext.filterSensitiveLog(obj.validation) }),
   });
   export const isa = (o: any): o is ClientPolicyTls => __isa(o, "ClientPolicyTls");
 }
@@ -412,7 +390,6 @@ export interface CreateVirtualNodeInput {
 export namespace CreateVirtualNodeInput {
   export const filterSensitiveLog = (obj: CreateVirtualNodeInput): any => ({
     ...obj,
-    ...(obj.spec && { spec: VirtualNodeSpec.filterSensitiveLog(obj.spec) }),
   });
   export const isa = (o: any): o is CreateVirtualNodeInput => __isa(o, "CreateVirtualNodeInput");
 }
@@ -431,7 +408,6 @@ export interface CreateVirtualNodeOutput {
 export namespace CreateVirtualNodeOutput {
   export const filterSensitiveLog = (obj: CreateVirtualNodeOutput): any => ({
     ...obj,
-    ...(obj.virtualNode && { virtualNode: VirtualNodeData.filterSensitiveLog(obj.virtualNode) }),
   });
   export const isa = (o: any): o is CreateVirtualNodeOutput => __isa(o, "CreateVirtualNodeOutput");
 }
@@ -548,7 +524,6 @@ export interface CreateVirtualServiceInput {
 export namespace CreateVirtualServiceInput {
   export const filterSensitiveLog = (obj: CreateVirtualServiceInput): any => ({
     ...obj,
-    ...(obj.spec && { spec: VirtualServiceSpec.filterSensitiveLog(obj.spec) }),
   });
   export const isa = (o: any): o is CreateVirtualServiceInput => __isa(o, "CreateVirtualServiceInput");
 }
@@ -567,7 +542,6 @@ export interface CreateVirtualServiceOutput {
 export namespace CreateVirtualServiceOutput {
   export const filterSensitiveLog = (obj: CreateVirtualServiceOutput): any => ({
     ...obj,
-    ...(obj.virtualService && { virtualService: VirtualServiceData.filterSensitiveLog(obj.virtualService) }),
   });
   export const isa = (o: any): o is CreateVirtualServiceOutput => __isa(o, "CreateVirtualServiceOutput");
 }
@@ -726,7 +700,6 @@ export interface DeleteVirtualNodeOutput {
 export namespace DeleteVirtualNodeOutput {
   export const filterSensitiveLog = (obj: DeleteVirtualNodeOutput): any => ({
     ...obj,
-    ...(obj.virtualNode && { virtualNode: VirtualNodeData.filterSensitiveLog(obj.virtualNode) }),
   });
   export const isa = (o: any): o is DeleteVirtualNodeOutput => __isa(o, "DeleteVirtualNodeOutput");
 }
@@ -821,7 +794,6 @@ export interface DeleteVirtualServiceOutput {
 export namespace DeleteVirtualServiceOutput {
   export const filterSensitiveLog = (obj: DeleteVirtualServiceOutput): any => ({
     ...obj,
-    ...(obj.virtualService && { virtualService: VirtualServiceData.filterSensitiveLog(obj.virtualService) }),
   });
   export const isa = (o: any): o is DeleteVirtualServiceOutput => __isa(o, "DeleteVirtualServiceOutput");
 }
@@ -963,7 +935,6 @@ export interface DescribeVirtualNodeOutput {
 export namespace DescribeVirtualNodeOutput {
   export const filterSensitiveLog = (obj: DescribeVirtualNodeOutput): any => ({
     ...obj,
-    ...(obj.virtualNode && { virtualNode: VirtualNodeData.filterSensitiveLog(obj.virtualNode) }),
   });
   export const isa = (o: any): o is DescribeVirtualNodeOutput => __isa(o, "DescribeVirtualNodeOutput");
 }
@@ -1058,7 +1029,6 @@ export interface DescribeVirtualServiceOutput {
 export namespace DescribeVirtualServiceOutput {
   export const filterSensitiveLog = (obj: DescribeVirtualServiceOutput): any => ({
     ...obj,
-    ...(obj.virtualService && { virtualService: VirtualServiceData.filterSensitiveLog(obj.virtualService) }),
   });
   export const isa = (o: any): o is DescribeVirtualServiceOutput => __isa(o, "DescribeVirtualServiceOutput");
 }
@@ -1343,7 +1313,6 @@ export interface GrpcRouteMatch {
 export namespace GrpcRouteMatch {
   export const filterSensitiveLog = (obj: GrpcRouteMatch): any => ({
     ...obj,
-    ...(obj.metadata && { metadata: obj.metadata.map((item) => GrpcRouteMetadata.filterSensitiveLog(item)) }),
   });
   export const isa = (o: any): o is GrpcRouteMatch => __isa(o, "GrpcRouteMatch");
 }
@@ -1372,7 +1341,6 @@ export interface GrpcRouteMetadata {
 export namespace GrpcRouteMetadata {
   export const filterSensitiveLog = (obj: GrpcRouteMetadata): any => ({
     ...obj,
-    ...(obj.match && { match: GrpcRouteMetadataMatchMethod.filterSensitiveLog(obj.match) }),
   });
   export const isa = (o: any): o is GrpcRouteMetadata => __isa(o, "GrpcRouteMetadata");
 }
@@ -1392,7 +1360,6 @@ export namespace GrpcRouteMetadataMatchMethod {
   interface $Base {
     __type?: "GrpcRouteMetadataMatchMethod";
   }
-
   /**
    * <p>The value sent by the client must match the specified value exactly.</p>
    */
@@ -1404,7 +1371,6 @@ export namespace GrpcRouteMetadataMatchMethod {
     suffix?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The value sent by the client must begin with the specified characters.</p>
    */
@@ -1416,7 +1382,6 @@ export namespace GrpcRouteMetadataMatchMethod {
     suffix?: never;
     $unknown?: never;
   }
-
   /**
    * <p>An object that represents the range of values to match on.</p>
    */
@@ -1428,7 +1393,6 @@ export namespace GrpcRouteMetadataMatchMethod {
     suffix?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The value sent by the client must include the specified characters.</p>
    */
@@ -1440,7 +1404,6 @@ export namespace GrpcRouteMetadataMatchMethod {
     suffix?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The value sent by the client must end with the specified characters.</p>
    */
@@ -1452,7 +1415,6 @@ export namespace GrpcRouteMetadataMatchMethod {
     suffix: string;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     exact?: never;
     prefix?: never;
@@ -1461,7 +1423,6 @@ export namespace GrpcRouteMetadataMatchMethod {
     suffix?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     exact: (value: string) => T;
     prefix: (value: string) => T;
@@ -1470,7 +1431,6 @@ export namespace GrpcRouteMetadataMatchMethod {
     suffix: (value: string) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: GrpcRouteMetadataMatchMethod, visitor: Visitor<T>): T => {
     if (value.exact !== undefined) return visitor.exact(value.exact);
     if (value.prefix !== undefined) return visitor.prefix(value.prefix);
@@ -1478,15 +1438,6 @@ export namespace GrpcRouteMetadataMatchMethod {
     if (value.regex !== undefined) return visitor.regex(value.regex);
     if (value.suffix !== undefined) return visitor.suffix(value.suffix);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: GrpcRouteMetadataMatchMethod): any => {
-    if (obj.exact !== undefined) return { exact: obj.exact };
-    if (obj.prefix !== undefined) return { prefix: obj.prefix };
-    if (obj.range !== undefined) return { range: MatchRange.filterSensitiveLog(obj.range) };
-    if (obj.regex !== undefined) return { regex: obj.regex };
-    if (obj.suffix !== undefined) return { suffix: obj.suffix };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -1526,7 +1477,6 @@ export namespace HeaderMatchMethod {
   interface $Base {
     __type?: "HeaderMatchMethod";
   }
-
   /**
    * <p>The value sent by the client must match the specified value exactly.</p>
    */
@@ -1538,7 +1488,6 @@ export namespace HeaderMatchMethod {
     suffix?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The value sent by the client must begin with the specified characters.</p>
    */
@@ -1550,7 +1499,6 @@ export namespace HeaderMatchMethod {
     suffix?: never;
     $unknown?: never;
   }
-
   /**
    * <p>An object that represents the range of values to match on.</p>
    */
@@ -1562,7 +1510,6 @@ export namespace HeaderMatchMethod {
     suffix?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The value sent by the client must include the specified characters.</p>
    */
@@ -1574,7 +1521,6 @@ export namespace HeaderMatchMethod {
     suffix?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The value sent by the client must end with the specified characters.</p>
    */
@@ -1586,7 +1532,6 @@ export namespace HeaderMatchMethod {
     suffix: string;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     exact?: never;
     prefix?: never;
@@ -1595,7 +1540,6 @@ export namespace HeaderMatchMethod {
     suffix?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     exact: (value: string) => T;
     prefix: (value: string) => T;
@@ -1604,7 +1548,6 @@ export namespace HeaderMatchMethod {
     suffix: (value: string) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: HeaderMatchMethod, visitor: Visitor<T>): T => {
     if (value.exact !== undefined) return visitor.exact(value.exact);
     if (value.prefix !== undefined) return visitor.prefix(value.prefix);
@@ -1612,15 +1555,6 @@ export namespace HeaderMatchMethod {
     if (value.regex !== undefined) return visitor.regex(value.regex);
     if (value.suffix !== undefined) return visitor.suffix(value.suffix);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: HeaderMatchMethod): any => {
-    if (obj.exact !== undefined) return { exact: obj.exact };
-    if (obj.prefix !== undefined) return { prefix: obj.prefix };
-    if (obj.range !== undefined) return { range: MatchRange.filterSensitiveLog(obj.range) };
-    if (obj.regex !== undefined) return { regex: obj.regex };
-    if (obj.suffix !== undefined) return { suffix: obj.suffix };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -1817,7 +1751,6 @@ export interface HttpRouteHeader {
 export namespace HttpRouteHeader {
   export const filterSensitiveLog = (obj: HttpRouteHeader): any => ({
     ...obj,
-    ...(obj.match && { match: HeaderMatchMethod.filterSensitiveLog(obj.match) }),
   });
   export const isa = (o: any): o is HttpRouteHeader => __isa(o, "HttpRouteHeader");
 }
@@ -1857,7 +1790,6 @@ export interface HttpRouteMatch {
 export namespace HttpRouteMatch {
   export const filterSensitiveLog = (obj: HttpRouteMatch): any => ({
     ...obj,
-    ...(obj.headers && { headers: obj.headers.map((item) => HttpRouteHeader.filterSensitiveLog(item)) }),
   });
   export const isa = (o: any): o is HttpRouteMatch => __isa(o, "HttpRouteMatch");
 }
@@ -2372,7 +2304,6 @@ export interface Logging {
 export namespace Logging {
   export const filterSensitiveLog = (obj: Logging): any => ({
     ...obj,
-    ...(obj.accessLog && { accessLog: AccessLog.filterSensitiveLog(obj.accessLog) }),
   });
   export const isa = (o: any): o is Logging => __isa(o, "Logging");
 }
@@ -2805,31 +2736,21 @@ export namespace SdsSource {
   interface $Base {
     __type?: "SdsSource";
   }
-
   export interface UnixDomainSocketMember extends $Base {
     unixDomainSocket: SdsUnixDomainSocketSource;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     unixDomainSocket?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     unixDomainSocket: (value: SdsUnixDomainSocketSource) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: SdsSource, visitor: Visitor<T>): T => {
     if (value.unixDomainSocket !== undefined) return visitor.unixDomainSocket(value.unixDomainSocket);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: SdsSource): any => {
-    if (obj.unixDomainSocket !== undefined)
-      return { unixDomainSocket: SdsUnixDomainSocketSource.filterSensitiveLog(obj.unixDomainSocket) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -2857,7 +2778,6 @@ export namespace ServiceDiscovery {
   interface $Base {
     __type?: "ServiceDiscovery";
   }
-
   /**
    * <p>Specifies any AWS Cloud Map information for the virtual node.</p>
    */
@@ -2866,7 +2786,6 @@ export namespace ServiceDiscovery {
     dns?: never;
     $unknown?: never;
   }
-
   /**
    * <p>Specifies the DNS information for the virtual node.</p>
    */
@@ -2875,30 +2794,20 @@ export namespace ServiceDiscovery {
     dns: DnsServiceDiscovery;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     awsCloudMap?: never;
     dns?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     awsCloudMap: (value: AwsCloudMapServiceDiscovery) => T;
     dns: (value: DnsServiceDiscovery) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: ServiceDiscovery, visitor: Visitor<T>): T => {
     if (value.awsCloudMap !== undefined) return visitor.awsCloudMap(value.awsCloudMap);
     if (value.dns !== undefined) return visitor.dns(value.dns);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: ServiceDiscovery): any => {
-    if (obj.awsCloudMap !== undefined)
-      return { awsCloudMap: AwsCloudMapServiceDiscovery.filterSensitiveLog(obj.awsCloudMap) };
-    if (obj.dns !== undefined) return { dns: DnsServiceDiscovery.filterSensitiveLog(obj.dns) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -3057,7 +2966,6 @@ export interface TlsValidationContext {
 export namespace TlsValidationContext {
   export const filterSensitiveLog = (obj: TlsValidationContext): any => ({
     ...obj,
-    ...(obj.trust && { trust: TlsValidationContextTrust.filterSensitiveLog(obj.trust) }),
   });
   export const isa = (o: any): o is TlsValidationContext => __isa(o, "TlsValidationContext");
 }
@@ -3109,7 +3017,6 @@ export interface TlsValidationContextSdsTrust {
 export namespace TlsValidationContextSdsTrust {
   export const filterSensitiveLog = (obj: TlsValidationContextSdsTrust): any => ({
     ...obj,
-    ...(obj.source && { source: SdsSource.filterSensitiveLog(obj.source) }),
   });
   export const isa = (o: any): o is TlsValidationContextSdsTrust => __isa(o, "TlsValidationContextSdsTrust");
 }
@@ -3127,7 +3034,6 @@ export namespace TlsValidationContextTrust {
   interface $Base {
     __type?: "TlsValidationContextTrust";
   }
-
   /**
    * <p>A reference to an object that represents a TLS validation context trust for an AWS Certicate Manager (ACM)
    *          certificate.</p>
@@ -3138,7 +3044,6 @@ export namespace TlsValidationContextTrust {
     sds?: never;
     $unknown?: never;
   }
-
   /**
    * <p>An object that represents a TLS validation context trust for a local file.</p>
    */
@@ -3148,40 +3053,29 @@ export namespace TlsValidationContextTrust {
     sds?: never;
     $unknown?: never;
   }
-
   export interface SdsMember extends $Base {
     acm?: never;
     file?: never;
     sds: TlsValidationContextSdsTrust;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     acm?: never;
     file?: never;
     sds?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     acm: (value: TlsValidationContextAcmTrust) => T;
     file: (value: TlsValidationContextFileTrust) => T;
     sds: (value: TlsValidationContextSdsTrust) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: TlsValidationContextTrust, visitor: Visitor<T>): T => {
     if (value.acm !== undefined) return visitor.acm(value.acm);
     if (value.file !== undefined) return visitor.file(value.file);
     if (value.sds !== undefined) return visitor.sds(value.sds);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: TlsValidationContextTrust): any => {
-    if (obj.acm !== undefined) return { acm: TlsValidationContextAcmTrust.filterSensitiveLog(obj.acm) };
-    if (obj.file !== undefined) return { file: TlsValidationContextFileTrust.filterSensitiveLog(obj.file) };
-    if (obj.sds !== undefined) return { sds: TlsValidationContextSdsTrust.filterSensitiveLog(obj.sds) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -3404,7 +3298,6 @@ export interface UpdateVirtualNodeInput {
 export namespace UpdateVirtualNodeInput {
   export const filterSensitiveLog = (obj: UpdateVirtualNodeInput): any => ({
     ...obj,
-    ...(obj.spec && { spec: VirtualNodeSpec.filterSensitiveLog(obj.spec) }),
   });
   export const isa = (o: any): o is UpdateVirtualNodeInput => __isa(o, "UpdateVirtualNodeInput");
 }
@@ -3423,7 +3316,6 @@ export interface UpdateVirtualNodeOutput {
 export namespace UpdateVirtualNodeOutput {
   export const filterSensitiveLog = (obj: UpdateVirtualNodeOutput): any => ({
     ...obj,
-    ...(obj.virtualNode && { virtualNode: VirtualNodeData.filterSensitiveLog(obj.virtualNode) }),
   });
   export const isa = (o: any): o is UpdateVirtualNodeOutput => __isa(o, "UpdateVirtualNodeOutput");
 }
@@ -3523,7 +3415,6 @@ export interface UpdateVirtualServiceInput {
 export namespace UpdateVirtualServiceInput {
   export const filterSensitiveLog = (obj: UpdateVirtualServiceInput): any => ({
     ...obj,
-    ...(obj.spec && { spec: VirtualServiceSpec.filterSensitiveLog(obj.spec) }),
   });
   export const isa = (o: any): o is UpdateVirtualServiceInput => __isa(o, "UpdateVirtualServiceInput");
 }
@@ -3542,7 +3433,6 @@ export interface UpdateVirtualServiceOutput {
 export namespace UpdateVirtualServiceOutput {
   export const filterSensitiveLog = (obj: UpdateVirtualServiceOutput): any => ({
     ...obj,
-    ...(obj.virtualService && { virtualService: VirtualServiceData.filterSensitiveLog(obj.virtualService) }),
   });
   export const isa = (o: any): o is UpdateVirtualServiceOutput => __isa(o, "UpdateVirtualServiceOutput");
 }
@@ -3581,7 +3471,6 @@ export interface VirtualNodeData {
 export namespace VirtualNodeData {
   export const filterSensitiveLog = (obj: VirtualNodeData): any => ({
     ...obj,
-    ...(obj.spec && { spec: VirtualNodeSpec.filterSensitiveLog(obj.spec) }),
   });
   export const isa = (o: any): o is VirtualNodeData => __isa(o, "VirtualNodeData");
 }
@@ -3681,10 +3570,6 @@ export interface VirtualNodeSpec {
 export namespace VirtualNodeSpec {
   export const filterSensitiveLog = (obj: VirtualNodeSpec): any => ({
     ...obj,
-    ...(obj.backendDefaults && { backendDefaults: BackendDefaults.filterSensitiveLog(obj.backendDefaults) }),
-    ...(obj.backends && { backends: obj.backends.map((item) => Backend.filterSensitiveLog(item)) }),
-    ...(obj.logging && { logging: Logging.filterSensitiveLog(obj.logging) }),
-    ...(obj.serviceDiscovery && { serviceDiscovery: ServiceDiscovery.filterSensitiveLog(obj.serviceDiscovery) }),
   });
   export const isa = (o: any): o is VirtualNodeSpec => __isa(o, "VirtualNodeSpec");
 }
@@ -3889,7 +3774,6 @@ export interface VirtualServiceBackend {
 export namespace VirtualServiceBackend {
   export const filterSensitiveLog = (obj: VirtualServiceBackend): any => ({
     ...obj,
-    ...(obj.clientPolicy && { clientPolicy: ClientPolicy.filterSensitiveLog(obj.clientPolicy) }),
   });
   export const isa = (o: any): o is VirtualServiceBackend => __isa(o, "VirtualServiceBackend");
 }
@@ -3928,7 +3812,6 @@ export interface VirtualServiceData {
 export namespace VirtualServiceData {
   export const filterSensitiveLog = (obj: VirtualServiceData): any => ({
     ...obj,
-    ...(obj.spec && { spec: VirtualServiceSpec.filterSensitiveLog(obj.spec) }),
   });
   export const isa = (o: any): o is VirtualServiceData => __isa(o, "VirtualServiceData");
 }
@@ -3945,7 +3828,6 @@ export namespace VirtualServiceProvider {
   interface $Base {
     __type?: "VirtualServiceProvider";
   }
-
   /**
    * <p>The virtual node associated with a virtual service.</p>
    */
@@ -3954,7 +3836,6 @@ export namespace VirtualServiceProvider {
     virtualRouter?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The virtual router associated with a virtual service.</p>
    */
@@ -3963,31 +3844,20 @@ export namespace VirtualServiceProvider {
     virtualRouter: VirtualRouterServiceProvider;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     virtualNode?: never;
     virtualRouter?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     virtualNode: (value: VirtualNodeServiceProvider) => T;
     virtualRouter: (value: VirtualRouterServiceProvider) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: VirtualServiceProvider, visitor: Visitor<T>): T => {
     if (value.virtualNode !== undefined) return visitor.virtualNode(value.virtualNode);
     if (value.virtualRouter !== undefined) return visitor.virtualRouter(value.virtualRouter);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: VirtualServiceProvider): any => {
-    if (obj.virtualNode !== undefined)
-      return { virtualNode: VirtualNodeServiceProvider.filterSensitiveLog(obj.virtualNode) };
-    if (obj.virtualRouter !== undefined)
-      return { virtualRouter: VirtualRouterServiceProvider.filterSensitiveLog(obj.virtualRouter) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -4046,7 +3916,6 @@ export interface VirtualServiceSpec {
 export namespace VirtualServiceSpec {
   export const filterSensitiveLog = (obj: VirtualServiceSpec): any => ({
     ...obj,
-    ...(obj.provider && { provider: VirtualServiceProvider.filterSensitiveLog(obj.provider) }),
   });
   export const isa = (o: any): o is VirtualServiceSpec => __isa(o, "VirtualServiceSpec");
 }

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-appconfig/AppConfigClient.ts
+++ b/clients/client-appconfig/AppConfigClient.ts
@@ -95,6 +95,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -292,7 +298,8 @@ export type AppConfigClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type AppConfigClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -301,7 +308,8 @@ export type AppConfigClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS AppConfig</fullname>
@@ -373,13 +381,15 @@ export class AppConfigClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
+++ b/clients/client-application-auto-scaling/ApplicationAutoScalingClient.ts
@@ -48,6 +48,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -199,7 +205,8 @@ export type ApplicationAutoScalingClientConfig = Partial<__SmithyConfiguration<_
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ApplicationAutoScalingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -208,7 +215,8 @@ export type ApplicationAutoScalingClientResolvedConfig = __SmithyResolvedConfigu
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>With Application Auto Scaling, you can configure automatic scaling for the following
@@ -296,13 +304,15 @@ export class ApplicationAutoScalingClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
+++ b/clients/client-application-discovery-service/ApplicationDiscoveryServiceClient.ts
@@ -84,6 +84,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -265,7 +271,8 @@ export type ApplicationDiscoveryServiceClientConfig = Partial<__SmithyConfigurat
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ApplicationDiscoveryServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -274,7 +281,8 @@ export type ApplicationDiscoveryServiceClientResolvedConfig = __SmithyResolvedCo
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Application Discovery Service</fullname>
@@ -424,13 +432,15 @@ export class ApplicationDiscoveryServiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-application-insights/ApplicationInsightsClient.ts
+++ b/clients/client-application-insights/ApplicationInsightsClient.ts
@@ -65,6 +65,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -250,7 +256,8 @@ export type ApplicationInsightsClientConfig = Partial<__SmithyConfiguration<__Ht
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ApplicationInsightsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -259,7 +266,8 @@ export type ApplicationInsightsClientResolvedConfig = __SmithyResolvedConfigurat
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon CloudWatch Application Insights for .NET and SQL Server</fullname>
@@ -295,13 +303,15 @@ export class ApplicationInsightsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-appstream/AppStreamClient.ts
+++ b/clients/client-appstream/AppStreamClient.ts
@@ -115,6 +115,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -340,7 +346,8 @@ export type AppStreamClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type AppStreamClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -349,7 +356,8 @@ export type AppStreamClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon AppStream 2.0</fullname>
@@ -393,13 +401,15 @@ export class AppStreamClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-appsync/AppSyncClient.ts
+++ b/clients/client-appsync/AppSyncClient.ts
@@ -70,6 +70,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -283,7 +289,8 @@ export type AppSyncClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type AppSyncClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -292,7 +299,8 @@ export type AppSyncClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS AppSync provides API actions for creating and interacting with data sources using
@@ -317,13 +325,15 @@ export class AppSyncClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-athena/AthenaClient.ts
+++ b/clients/client-athena/AthenaClient.ts
@@ -54,6 +54,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -241,7 +247,8 @@ export type AthenaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type AthenaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -250,7 +257,8 @@ export type AthenaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Athena is an interactive query service that lets you use standard SQL to
@@ -286,13 +294,15 @@ export class AthenaClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
+++ b/clients/client-auto-scaling-plans/AutoScalingPlansClient.ts
@@ -29,6 +29,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -172,7 +178,8 @@ export type AutoScalingPlansClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type AutoScalingPlansClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -181,7 +188,8 @@ export type AutoScalingPlansClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Auto Scaling</fullname>
@@ -212,13 +220,15 @@ export class AutoScalingPlansClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-auto-scaling/AutoScalingClient.ts
+++ b/clients/client-auto-scaling/AutoScalingClient.ts
@@ -194,6 +194,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -439,7 +445,8 @@ export type AutoScalingClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type AutoScalingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -448,7 +455,8 @@ export type AutoScalingClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon EC2 Auto Scaling</fullname>
@@ -478,13 +486,15 @@ export class AutoScalingClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-backup/BackupClient.ts
+++ b/clients/client-backup/BackupClient.ts
@@ -140,6 +140,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -367,7 +373,8 @@ export type BackupClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type BackupClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -376,7 +383,8 @@ export type BackupClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Backup</fullname>
@@ -403,13 +411,15 @@ export class BackupClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-batch/BatchClient.ts
+++ b/clients/client-batch/BatchClient.ts
@@ -51,6 +51,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -214,7 +220,8 @@ export type BatchClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type BatchClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -223,7 +230,8 @@ export type BatchClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Batch enables you to run batch computing workloads on the AWS Cloud. Batch computing is a common way for
@@ -257,13 +265,15 @@ export class BatchClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-budgets/BudgetsClient.ts
+++ b/clients/client-budgets/BudgetsClient.ts
@@ -37,6 +37,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -196,7 +202,8 @@ export type BudgetsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type BudgetsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -205,7 +212,8 @@ export type BudgetsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The AWS Budgets API enables you to use AWS Budgets to plan your service usage, service costs, and instance reservations. The API reference provides descriptions, syntax, and usage examples for each of the actions and data types for AWS Budgets. </p>
@@ -271,13 +279,15 @@ export class BudgetsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-chime/ChimeClient.ts
+++ b/clients/client-chime/ChimeClient.ts
@@ -322,6 +322,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -691,7 +697,8 @@ export type ChimeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ChimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -700,7 +707,8 @@ export type ChimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The Amazon Chime API (application programming interface) is designed for developers to
@@ -760,13 +768,15 @@ export class ChimeClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cloud9/Cloud9Client.ts
+++ b/clients/client-cloud9/Cloud9Client.ts
@@ -51,6 +51,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -208,7 +214,8 @@ export type Cloud9ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type Cloud9ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -217,7 +224,8 @@ export type Cloud9ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Cloud9</fullname>
@@ -298,13 +306,15 @@ export class Cloud9Client extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-clouddirectory/CloudDirectoryClient.ts
+++ b/clients/client-clouddirectory/CloudDirectoryClient.ts
@@ -158,6 +158,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -421,7 +427,8 @@ export type CloudDirectoryClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CloudDirectoryClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -430,7 +437,8 @@ export type CloudDirectoryClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Cloud Directory</fullname>
@@ -459,13 +467,15 @@ export class CloudDirectoryClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cloudformation/CloudFormationClient.ts
+++ b/clients/client-cloudformation/CloudFormationClient.ts
@@ -138,6 +138,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -379,7 +385,8 @@ export type CloudFormationClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CloudFormationClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -388,7 +395,8 @@ export type CloudFormationClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS CloudFormation</fullname>
@@ -426,13 +434,15 @@ export class CloudFormationClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cloudfront/CloudFrontClient.ts
+++ b/clients/client-cloudfront/CloudFrontClient.ts
@@ -187,6 +187,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -436,7 +442,8 @@ export type CloudFrontClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CloudFrontClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -445,7 +452,8 @@ export type CloudFrontClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon CloudFront</fullname>
@@ -471,13 +479,15 @@ export class CloudFrontClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
+++ b/clients/client-cloudhsm-v2/CloudHSMV2Client.ts
@@ -27,6 +27,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -184,7 +190,8 @@ export type CloudHSMV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CloudHSMV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -193,7 +200,8 @@ export type CloudHSMV2ClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>For more information about AWS CloudHSM, see <a href="http://aws.amazon.com/cloudhsm/">AWS CloudHSM</a> and the <a href="https://docs.aws.amazon.com/cloudhsm/latest/userguide/">AWS
@@ -218,13 +226,15 @@ export class CloudHSMV2Client extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cloudhsm/CloudHSMClient.ts
+++ b/clients/client-cloudhsm/CloudHSMClient.ts
@@ -40,6 +40,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -211,7 +217,8 @@ export type CloudHSMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CloudHSMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -220,7 +227,8 @@ export type CloudHSMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS CloudHSM Service</fullname>
@@ -254,13 +262,15 @@ export class CloudHSMClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
+++ b/clients/client-cloudsearch-domain/CloudSearchDomainClient.ts
@@ -17,6 +17,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -148,7 +154,8 @@ export type CloudSearchDomainClientConfig = Partial<__SmithyConfiguration<__Http
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CloudSearchDomainClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -157,7 +164,8 @@ export type CloudSearchDomainClientResolvedConfig = __SmithyResolvedConfiguratio
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>You use the AmazonCloudSearch2013 API to upload documents to a search domain and search those documents.</p>
@@ -184,13 +192,15 @@ export class CloudSearchDomainClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cloudsearch/CloudSearchClient.ts
+++ b/clients/client-cloudsearch/CloudSearchClient.ts
@@ -79,6 +79,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -262,7 +268,8 @@ export type CloudSearchClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CloudSearchClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -271,7 +278,8 @@ export type CloudSearchClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon CloudSearch Configuration Service</fullname>
@@ -301,13 +309,15 @@ export class CloudSearchClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cloudtrail/CloudTrailClient.ts
+++ b/clients/client-cloudtrail/CloudTrailClient.ts
@@ -38,6 +38,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -205,7 +211,8 @@ export type CloudTrailClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CloudTrailClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -214,7 +221,8 @@ export type CloudTrailClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS CloudTrail</fullname>
@@ -252,13 +260,15 @@ export class CloudTrailClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
+++ b/clients/client-cloudwatch-logs/CloudWatchLogsClient.ts
@@ -92,6 +92,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -307,7 +313,8 @@ export type CloudWatchLogsClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CloudWatchLogsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -316,7 +323,8 @@ export type CloudWatchLogsClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>You can use Amazon CloudWatch Logs to monitor, store, and access your log files from
@@ -373,13 +381,15 @@ export class CloudWatchLogsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cloudwatch/CloudWatchClient.ts
+++ b/clients/client-cloudwatch/CloudWatchClient.ts
@@ -77,6 +77,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -268,7 +274,8 @@ export type CloudWatchClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CloudWatchClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -277,7 +284,8 @@ export type CloudWatchClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon CloudWatch monitors your Amazon Web Services (AWS) resources and the
@@ -315,13 +323,15 @@ export class CloudWatchClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-codeartifact/CodeartifactClient.ts
+++ b/clients/client-codeartifact/CodeartifactClient.ts
@@ -108,6 +108,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -301,7 +307,8 @@ export type CodeartifactClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CodeartifactClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -310,7 +317,8 @@ export type CodeartifactClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p> AWS CodeArtifact is a fully managed artifact repository compatible with language-native
@@ -589,13 +597,15 @@ export class CodeartifactClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-codebuild/CodeBuildClient.ts
+++ b/clients/client-codebuild/CodeBuildClient.ts
@@ -96,6 +96,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -313,7 +319,8 @@ export type CodeBuildClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CodeBuildClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -322,7 +329,8 @@ export type CodeBuildClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS CodeBuild</fullname>
@@ -530,13 +538,15 @@ export class CodeBuildClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-codecommit/CodeCommitClient.ts
+++ b/clients/client-codecommit/CodeCommitClient.ts
@@ -235,6 +235,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -520,7 +526,8 @@ export type CodeCommitClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CodeCommitClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -529,7 +536,8 @@ export type CodeCommitClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS CodeCommit</fullname>
@@ -949,13 +957,15 @@ export class CodeCommitClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-codedeploy/CodeDeployClient.ts
+++ b/clients/client-codedeploy/CodeDeployClient.ts
@@ -163,6 +163,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -388,7 +394,8 @@ export type CodeDeployClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CodeDeployClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -397,7 +404,8 @@ export type CodeDeployClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS CodeDeploy</fullname>
@@ -520,13 +528,15 @@ export class CodeDeployClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
+++ b/clients/client-codeguru-reviewer/CodeGuruReviewerClient.ts
@@ -48,6 +48,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -199,7 +205,8 @@ export type CodeGuruReviewerClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CodeGuruReviewerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -208,7 +215,8 @@ export type CodeGuruReviewerClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>This section provides documentation for the Amazon CodeGuru Reviewer API operations. CodeGuru Reviewer is a service
@@ -240,13 +248,15 @@ export class CodeGuruReviewerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
+++ b/clients/client-codeguruprofiler/CodeGuruProfilerClient.ts
@@ -42,6 +42,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -199,7 +205,8 @@ export type CodeGuruProfilerClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CodeGuruProfilerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -208,7 +215,8 @@ export type CodeGuruProfilerClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>This section provides documentation for the Amazon CodeGuru Profiler API operations.</p>
@@ -232,13 +240,15 @@ export class CodeGuruProfilerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-codepipeline/CodePipelineClient.ts
+++ b/clients/client-codepipeline/CodePipelineClient.ts
@@ -111,6 +111,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -316,7 +322,8 @@ export type CodePipelineClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CodePipelineClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -325,7 +332,8 @@ export type CodePipelineClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS CodePipeline</fullname>
@@ -543,13 +551,15 @@ export class CodePipelineClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-codestar-connections/CodeStarConnectionsClient.ts
+++ b/clients/client-codestar-connections/CodeStarConnectionsClient.ts
@@ -28,6 +28,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -181,7 +187,8 @@ export type CodeStarConnectionsClientConfig = Partial<__SmithyConfiguration<__Ht
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CodeStarConnectionsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -190,7 +197,8 @@ export type CodeStarConnectionsClientResolvedConfig = __SmithyResolvedConfigurat
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS CodeStar Connections</fullname>
@@ -296,13 +304,15 @@ export class CodeStarConnectionsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-codestar-notifications/CodestarNotificationsClient.ts
+++ b/clients/client-codestar-notifications/CodestarNotificationsClient.ts
@@ -45,6 +45,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -202,7 +208,8 @@ export type CodestarNotificationsClientConfig = Partial<__SmithyConfiguration<__
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CodestarNotificationsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -211,7 +218,8 @@ export type CodestarNotificationsClientResolvedConfig = __SmithyResolvedConfigur
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>This AWS CodeStar Notifications API Reference provides descriptions and usage examples of the
@@ -318,13 +326,15 @@ export class CodestarNotificationsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-codestar/CodeStarClient.ts
+++ b/clients/client-codestar/CodeStarClient.ts
@@ -41,6 +41,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -208,7 +214,8 @@ export type CodeStarClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CodeStarClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -217,7 +224,8 @@ export type CodeStarClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS CodeStar</fullname>
@@ -330,13 +338,15 @@ export class CodeStarClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
@@ -282,6 +282,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -613,7 +619,8 @@ export type CognitoIdentityProviderClientConfig = Partial<__SmithyConfiguration<
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CognitoIdentityProviderClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -622,7 +629,8 @@ export type CognitoIdentityProviderClientResolvedConfig = __SmithyResolvedConfig
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Using the Amazon Cognito User Pools API, you can create a user pool to manage
@@ -651,13 +659,15 @@ export class CognitoIdentityProviderClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cognito-identity/CognitoIdentityClient.ts
+++ b/clients/client-cognito-identity/CognitoIdentityClient.ts
@@ -62,6 +62,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from "@aws-sdk/middleware-signing";
 import {
@@ -230,7 +236,8 @@ export type CognitoIdentityClientConfig = Partial<__SmithyConfiguration<__HttpHa
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CognitoIdentityClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -239,7 +246,8 @@ export type CognitoIdentityClientResolvedConfig = __SmithyResolvedConfiguration<
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Cognito Federated Identities</fullname>
@@ -276,12 +284,14 @@ export class CognitoIdentityClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -37,6 +37,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cognito-sync/CognitoSyncClient.ts
+++ b/clients/client-cognito-sync/CognitoSyncClient.ts
@@ -52,6 +52,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -217,7 +223,8 @@ export type CognitoSyncClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CognitoSyncClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -226,7 +233,8 @@ export type CognitoSyncClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Cognito Sync</fullname>
@@ -256,13 +264,15 @@ export class CognitoSyncClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-comprehend/ComprehendClient.ts
+++ b/clients/client-comprehend/ComprehendClient.ts
@@ -179,6 +179,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -412,7 +418,8 @@ export type ComprehendClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ComprehendClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -421,7 +428,8 @@ export type ComprehendClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Comprehend is an AWS service for gaining insight into the content of documents. Use these
@@ -447,13 +455,15 @@ export class ComprehendClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-comprehendmedical/ComprehendMedicalClient.ts
+++ b/clients/client-comprehendmedical/ComprehendMedicalClient.ts
@@ -83,6 +83,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -256,7 +262,8 @@ export type ComprehendMedicalClientConfig = Partial<__SmithyConfiguration<__Http
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ComprehendMedicalClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -265,7 +272,8 @@ export type ComprehendMedicalClientResolvedConfig = __SmithyResolvedConfiguratio
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p> Amazon Comprehend Medical extracts structured information from unstructured clinical text. Use these actions
@@ -290,13 +298,15 @@ export class ComprehendMedicalClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-compute-optimizer/ComputeOptimizerClient.ts
+++ b/clients/client-compute-optimizer/ComputeOptimizerClient.ts
@@ -50,6 +50,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -199,7 +205,8 @@ export type ComputeOptimizerClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ComputeOptimizerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -208,7 +215,8 @@ export type ComputeOptimizerClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Compute Optimizer is a service that analyzes the configuration and utilization metrics of your
@@ -242,13 +250,15 @@ export class ComputeOptimizerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-config-service/ConfigServiceClient.ts
+++ b/clients/client-config-service/ConfigServiceClient.ts
@@ -306,6 +306,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -595,7 +601,8 @@ export type ConfigServiceClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ConfigServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -604,7 +611,8 @@ export type ConfigServiceClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Config</fullname>
@@ -651,13 +659,15 @@ export class ConfigServiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-connect/ConnectClient.ts
+++ b/clients/client-connect/ConnectClient.ts
@@ -107,6 +107,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -304,7 +310,8 @@ export type ConnectClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ConnectClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -313,7 +320,8 @@ export type ConnectClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Connect is a cloud-based contact center solution that makes it easy to set up and manage a
@@ -344,13 +352,15 @@ export class ConnectClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-connectparticipant/ConnectParticipantClient.ts
+++ b/clients/client-connectparticipant/ConnectParticipantClient.ts
@@ -25,6 +25,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -166,7 +172,8 @@ export type ConnectParticipantClientConfig = Partial<__SmithyConfiguration<__Htt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ConnectParticipantClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -175,7 +182,8 @@ export type ConnectParticipantClientResolvedConfig = __SmithyResolvedConfigurati
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Connect is a cloud-based contact center solution that makes it easy to set up and manage
@@ -204,13 +212,15 @@ export class ConnectParticipantClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
+++ b/clients/client-cost-and-usage-report-service/CostAndUsageReportServiceClient.ts
@@ -30,6 +30,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -169,7 +175,8 @@ export type CostAndUsageReportServiceClientConfig = Partial<__SmithyConfiguratio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CostAndUsageReportServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -178,7 +185,8 @@ export type CostAndUsageReportServiceClientResolvedConfig = __SmithyResolvedConf
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The AWS Cost and Usage Report API enables you to programmatically create, query, and delete
@@ -220,13 +228,15 @@ export class CostAndUsageReportServiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-cost-explorer/CostExplorerClient.ts
+++ b/clients/client-cost-explorer/CostExplorerClient.ts
@@ -75,6 +75,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -244,7 +250,8 @@ export type CostExplorerClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type CostExplorerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -253,7 +260,8 @@ export type CostExplorerClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The Cost Explorer API enables you to programmatically query your cost and usage data. You can query for aggregated data
@@ -290,13 +298,15 @@ export class CostExplorerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-data-pipeline/DataPipelineClient.ts
+++ b/clients/client-data-pipeline/DataPipelineClient.ts
@@ -45,6 +45,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -214,7 +220,8 @@ export type DataPipelineClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DataPipelineClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -223,7 +230,8 @@ export type DataPipelineClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Data Pipeline configures and manages a data-driven workflow called a pipeline. AWS Data Pipeline handles the details of scheduling and ensuring that data dependencies are met so that your application can focus on processing the data.</p>
@@ -251,13 +259,15 @@ export class DataPipelineClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
+++ b/clients/client-database-migration-service/DatabaseMigrationServiceClient.ts
@@ -187,6 +187,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -424,7 +430,8 @@ export type DatabaseMigrationServiceClientConfig = Partial<__SmithyConfiguration
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DatabaseMigrationServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -433,7 +440,8 @@ export type DatabaseMigrationServiceClientResolvedConfig = __SmithyResolvedConfi
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Database Migration Service</fullname>
@@ -466,13 +474,15 @@ export class DatabaseMigrationServiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-dataexchange/DataExchangeClient.ts
+++ b/clients/client-dataexchange/DataExchangeClient.ts
@@ -42,6 +42,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -217,7 +223,8 @@ export type DataExchangeClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DataExchangeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -226,7 +233,8 @@ export type DataExchangeClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Data Exchange is a service that makes it easy for AWS customers to exchange data in the cloud. You can use the AWS Data Exchange APIs to create, update, manage, and access file-based data set in the AWS Cloud.</p><p>As a subscriber, you can view and access the data sets that you have an entitlement to through a subscription. You can use the APIS to download or copy your entitled data sets to Amazon S3 for use across a variety of AWS analytics and machine learning services.</p><p>As a provider, you can create and manage your data sets that you would like to publish to a product. Being able to package and provide your data sets into products requires a few steps to determine eligibility. For more information, visit the AWS Data Exchange User Guide.</p><p>A data set is a collection of data that can be changed or updated over time. Data sets can be updated using revisions, which represent a new version or incremental change to a data set.  A revision contains one or more assets. An asset in AWS Data Exchange is a piece of data that can be stored as an Amazon S3 object. The asset can be a structured data file, an image file, or some other data file. Jobs are asynchronous import or export operations used to create or copy assets.</p>
@@ -250,13 +258,15 @@ export class DataExchangeClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-datasync/DataSyncClient.ts
+++ b/clients/client-datasync/DataSyncClient.ts
@@ -75,6 +75,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -268,7 +274,8 @@ export type DataSyncClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DataSyncClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -277,7 +284,8 @@ export type DataSyncClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS DataSync</fullname>
@@ -307,13 +315,15 @@ export class DataSyncClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-dax/DAXClient.ts
+++ b/clients/client-dax/DAXClient.ts
@@ -59,6 +59,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -232,7 +238,8 @@ export type DAXClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DAXClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -241,7 +248,8 @@ export type DAXClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>DAX is a managed caching service engineered for Amazon DynamoDB. DAX
@@ -270,13 +278,15 @@ export class DAXClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-detective/DetectiveClient.ts
+++ b/clients/client-detective/DetectiveClient.ts
@@ -32,6 +32,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -187,7 +193,8 @@ export type DetectiveClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DetectiveClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -196,7 +203,8 @@ export type DetectiveClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Detective uses machine learning and purpose-built visualizations to help you analyze and
@@ -260,13 +268,15 @@ export class DetectiveClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-device-farm/DeviceFarmClient.ts
+++ b/clients/client-device-farm/DeviceFarmClient.ts
@@ -187,6 +187,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -472,7 +478,8 @@ export type DeviceFarmClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DeviceFarmClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -481,7 +488,8 @@ export type DeviceFarmClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Welcome to the AWS Device Farm API documentation, which contains APIs for:</p>
@@ -519,13 +527,15 @@ export class DeviceFarmClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-direct-connect/DirectConnectClient.ts
+++ b/clients/client-direct-connect/DirectConnectClient.ts
@@ -190,6 +190,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -433,7 +439,8 @@ export type DirectConnectClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DirectConnectClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -442,7 +449,8 @@ export type DirectConnectClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Direct Connect links your internal network to an AWS Direct Connect location over a standard Ethernet fiber-optic cable.
@@ -471,13 +479,15 @@ export class DirectConnectClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-directory-service/DirectoryServiceClient.ts
+++ b/clients/client-directory-service/DirectoryServiceClient.ts
@@ -146,6 +146,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -391,7 +397,8 @@ export type DirectoryServiceClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DirectoryServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -400,7 +407,8 @@ export type DirectoryServiceClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Directory Service</fullname>
@@ -429,13 +437,15 @@ export class DirectoryServiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-dlm/DLMClient.ts
+++ b/clients/client-dlm/DLMClient.ts
@@ -37,6 +37,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -184,7 +190,8 @@ export type DLMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DLMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -193,7 +200,8 @@ export type DLMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Data Lifecycle Manager</fullname> <p>With Amazon Data Lifecycle Manager, you can manage the lifecycle of your AWS resources. You create lifecycle policies, which are used to automate operations on the specified resources.</p> <p>Amazon DLM supports Amazon EBS volumes and snapshots. For information about using Amazon DLM with Amazon EBS, see <a href="https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html">Automating the Amazon EBS Snapshot Lifecycle</a> in the <i>Amazon EC2 User Guide</i>.</p>
@@ -217,13 +225,15 @@ export class DLMClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-docdb/DocDBClient.ts
+++ b/clients/client-docdb/DocDBClient.ts
@@ -143,6 +143,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -358,7 +364,8 @@ export type DocDBClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DocDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -367,7 +374,8 @@ export type DocDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon DocumentDB API documentation</p>
@@ -391,13 +399,15 @@ export class DocDBClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
+++ b/clients/client-dynamodb-streams/DynamoDBStreamsClient.ts
@@ -18,6 +18,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -157,7 +163,8 @@ export type DynamoDBStreamsClientConfig = Partial<__SmithyConfiguration<__HttpHa
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DynamoDBStreamsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -166,7 +173,8 @@ export type DynamoDBStreamsClientResolvedConfig = __SmithyResolvedConfiguration<
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon DynamoDB</fullname>
@@ -195,13 +203,15 @@ export class DynamoDBStreamsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-dynamodb/DynamoDBClient.ts
+++ b/clients/client-dynamodb/DynamoDBClient.ts
@@ -91,6 +91,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -304,7 +310,8 @@ export type DynamoDBClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type DynamoDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -313,7 +320,8 @@ export type DynamoDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon DynamoDB</fullname>
@@ -355,13 +363,15 @@ export class DynamoDBClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-ebs/EBSClient.ts
+++ b/clients/client-ebs/EBSClient.ts
@@ -20,6 +20,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -163,7 +169,8 @@ export type EBSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type EBSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -172,7 +179,8 @@ export type EBSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>You can use the Amazon Elastic Block Store (EBS) direct APIs to directly read the data on your EBS
@@ -210,13 +218,15 @@ export class EBSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
+++ b/clients/client-ec2-instance-connect/EC2InstanceConnectClient.ts
@@ -15,6 +15,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -146,7 +152,8 @@ export type EC2InstanceConnectClientConfig = Partial<__SmithyConfiguration<__Htt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type EC2InstanceConnectClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -155,7 +162,8 @@ export type EC2InstanceConnectClientResolvedConfig = __SmithyResolvedConfigurati
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS EC2 Connect Service is a service that enables system administrators to publish
@@ -181,13 +189,15 @@ export class EC2InstanceConnectClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-ec2/EC2Client.ts
+++ b/clients/client-ec2/EC2Client.ts
@@ -1355,6 +1355,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -2308,7 +2314,8 @@ export type EC2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type EC2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -2317,7 +2324,8 @@ export type EC2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Elastic Compute Cloud</fullname>
@@ -2363,13 +2371,15 @@ export class EC2Client extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-sdk-ec2": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",

--- a/clients/client-ecr/ECRClient.ts
+++ b/clients/client-ecr/ECRClient.ts
@@ -91,6 +91,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -280,7 +286,8 @@ export type ECRClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ECRClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -289,7 +296,8 @@ export type ECRClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Elastic Container Registry</fullname>
@@ -319,13 +327,15 @@ export class ECRClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-ecs/ECSClient.ts
+++ b/clients/client-ecs/ECSClient.ts
@@ -138,6 +138,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -367,7 +373,8 @@ export type ECSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ECSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -376,7 +383,8 @@ export type ECSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Elastic Container Service</fullname>
@@ -414,13 +422,15 @@ export class ECSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-efs/EFSClient.ts
+++ b/clients/client-efs/EFSClient.ts
@@ -75,6 +75,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -256,7 +262,8 @@ export type EFSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type EFSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -265,7 +272,8 @@ export type EFSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Elastic File System</fullname>
@@ -293,13 +301,15 @@ export class EFSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-eks/EKSClient.ts
+++ b/clients/client-eks/EKSClient.ts
@@ -62,6 +62,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -235,7 +241,8 @@ export type EKSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type EKSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -244,7 +251,8 @@ export type EKSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Elastic Kubernetes Service (Amazon EKS) is a managed service that makes it easy for you to run Kubernetes on
@@ -277,13 +285,15 @@ export class EKSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
+++ b/clients/client-elastic-beanstalk/ElasticBeanstalkClient.ts
@@ -178,6 +178,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -403,7 +409,8 @@ export type ElasticBeanstalkClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ElasticBeanstalkClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -412,7 +419,8 @@ export type ElasticBeanstalkClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Elastic Beanstalk</fullname>
@@ -450,13 +458,15 @@ export class ElasticBeanstalkClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-elastic-inference/ElasticInferenceClient.ts
+++ b/clients/client-elastic-inference/ElasticInferenceClient.ts
@@ -32,6 +32,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -175,7 +181,8 @@ export type ElasticInferenceClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ElasticInferenceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -184,7 +191,8 @@ export type ElasticInferenceClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>
@@ -210,13 +218,15 @@ export class ElasticInferenceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
+++ b/clients/client-elastic-load-balancing-v2/ElasticLoadBalancingV2Client.ts
@@ -84,6 +84,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -283,7 +289,8 @@ export type ElasticLoadBalancingV2ClientConfig = Partial<__SmithyConfiguration<_
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ElasticLoadBalancingV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -292,7 +299,8 @@ export type ElasticLoadBalancingV2ClientResolvedConfig = __SmithyResolvedConfigu
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Elastic Load Balancing</fullname>
@@ -344,13 +352,15 @@ export class ElasticLoadBalancingV2Client extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
+++ b/clients/client-elastic-load-balancing/ElasticLoadBalancingClient.ts
@@ -115,6 +115,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -304,7 +310,8 @@ export type ElasticLoadBalancingClientConfig = Partial<__SmithyConfiguration<__H
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ElasticLoadBalancingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -313,7 +320,8 @@ export type ElasticLoadBalancingClientResolvedConfig = __SmithyResolvedConfigura
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Elastic Load Balancing</fullname>
@@ -357,13 +365,15 @@ export class ElasticLoadBalancingClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
+++ b/clients/client-elastic-transcoder/ElasticTranscoderClient.ts
@@ -37,6 +37,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -202,7 +208,8 @@ export type ElasticTranscoderClientConfig = Partial<__SmithyConfiguration<__Http
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ElasticTranscoderClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -211,7 +218,8 @@ export type ElasticTranscoderClientResolvedConfig = __SmithyResolvedConfiguratio
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Elastic Transcoder Service</fullname>
@@ -236,13 +244,15 @@ export class ElasticTranscoderClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-elasticache/ElastiCacheClient.ts
+++ b/clients/client-elasticache/ElastiCacheClient.ts
@@ -203,6 +203,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -448,7 +454,8 @@ export type ElastiCacheClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ElastiCacheClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -457,7 +464,8 @@ export type ElastiCacheClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon ElastiCache</fullname>
@@ -490,13 +498,15 @@ export class ElastiCacheClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
+++ b/clients/client-elasticsearch-service/ElasticsearchServiceClient.ts
@@ -129,6 +129,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -334,7 +340,8 @@ export type ElasticsearchServiceClientConfig = Partial<__SmithyConfiguration<__H
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ElasticsearchServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -343,7 +350,8 @@ export type ElasticsearchServiceClientResolvedConfig = __SmithyResolvedConfigura
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Elasticsearch Configuration Service</fullname>
@@ -373,13 +381,15 @@ export class ElasticsearchServiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-emr/EMRClient.ts
+++ b/clients/client-emr/EMRClient.ts
@@ -95,6 +95,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -292,7 +298,8 @@ export type EMRClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type EMRClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -301,7 +308,8 @@ export type EMRClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon EMR is a web service that makes it easy to process large amounts of data efficiently. Amazon EMR uses Hadoop processing combined with several AWS products to do tasks such as web indexing, data mining, log file analysis, machine learning, scientific simulation, and data warehousing.</p>
@@ -325,13 +333,15 @@ export class EMRClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-eventbridge/EventBridgeClient.ts
+++ b/clients/client-eventbridge/EventBridgeClient.ts
@@ -75,6 +75,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -268,7 +274,8 @@ export type EventBridgeClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type EventBridgeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -277,7 +284,8 @@ export type EventBridgeClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon EventBridge helps you to respond to state changes in your AWS resources.
@@ -322,13 +330,15 @@ export class EventBridgeClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-firehose/FirehoseClient.ts
+++ b/clients/client-firehose/FirehoseClient.ts
@@ -50,6 +50,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -205,7 +211,8 @@ export type FirehoseClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type FirehoseClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -214,7 +221,8 @@ export type FirehoseClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Kinesis Data Firehose API Reference</fullname>
@@ -241,13 +249,15 @@ export class FirehoseClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-fms/FMSClient.ts
+++ b/clients/client-fms/FMSClient.ts
@@ -73,6 +73,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -256,7 +262,8 @@ export type FMSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type FMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -265,7 +272,8 @@ export type FMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Firewall Manager</fullname>
@@ -293,13 +301,15 @@ export class FMSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-forecast/ForecastClient.ts
+++ b/clients/client-forecast/ForecastClient.ts
@@ -73,6 +73,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -262,7 +268,8 @@ export type ForecastClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ForecastClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -271,7 +278,8 @@ export type ForecastClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Provides APIs for creating and managing Amazon Forecast resources.</p>
@@ -295,13 +303,15 @@ export class ForecastClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-forecastquery/ForecastqueryClient.ts
+++ b/clients/client-forecastquery/ForecastqueryClient.ts
@@ -15,6 +15,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -146,7 +152,8 @@ export type ForecastqueryClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ForecastqueryClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -155,7 +162,8 @@ export type ForecastqueryClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Provides APIs for creating and managing Amazon Forecast resources.</p>
@@ -179,13 +187,15 @@ export class ForecastqueryClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-frauddetector/FraudDetectorClient.ts
+++ b/clients/client-frauddetector/FraudDetectorClient.ts
@@ -92,6 +92,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -313,7 +319,8 @@ export type FraudDetectorClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type FraudDetectorClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -322,7 +329,8 @@ export type FraudDetectorClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>This is the Amazon Fraud Detector API Reference. This guide is for developers who need
@@ -348,13 +356,15 @@ export class FraudDetectorClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-fsx/FSxClient.ts
+++ b/clients/client-fsx/FSxClient.ts
@@ -46,6 +46,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -205,7 +211,8 @@ export type FSxClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type FSxClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -214,7 +221,8 @@ export type FSxClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon FSx is a fully managed service that makes it easy for storage and
@@ -239,13 +247,15 @@ export class FSxClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-gamelift/GameLiftClient.ts
+++ b/clients/client-gamelift/GameLiftClient.ts
@@ -256,6 +256,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -565,7 +571,8 @@ export type GameLiftClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type GameLiftClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -574,7 +581,8 @@ export type GameLiftClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon GameLift Service</fullname>
@@ -660,13 +668,15 @@ export class GameLiftClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-glacier/GlacierClient.ts
+++ b/clients/client-glacier/GlacierClient.ts
@@ -95,6 +95,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import { getGlacierPlugin } from "@aws-sdk/middleware-sdk-glacier";
 import {
@@ -302,7 +308,8 @@ export type GlacierClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type GlacierClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -311,7 +318,8 @@ export type GlacierClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p> Amazon S3 Glacier (Glacier) is a storage solution for "cold data."</p>
@@ -372,14 +380,16 @@ export class GlacierClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getGlacierPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -37,6 +37,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-sdk-glacier": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",

--- a/clients/client-global-accelerator/GlobalAcceleratorClient.ts
+++ b/clients/client-global-accelerator/GlobalAcceleratorClient.ts
@@ -66,6 +66,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -247,7 +253,8 @@ export type GlobalAcceleratorClientConfig = Partial<__SmithyConfiguration<__Http
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type GlobalAcceleratorClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -256,7 +263,8 @@ export type GlobalAcceleratorClientResolvedConfig = __SmithyResolvedConfiguratio
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Global Accelerator</fullname>
@@ -372,13 +380,15 @@ export class GlobalAcceleratorClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-glue/GlueClient.ts
+++ b/clients/client-glue/GlueClient.ts
@@ -252,6 +252,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -649,7 +655,8 @@ export type GlueClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOption
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type GlueClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -658,7 +665,8 @@ export type GlueClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandl
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Glue</fullname>
@@ -683,13 +691,15 @@ export class GlueClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-greengrass/GreengrassClient.ts
+++ b/clients/client-greengrass/GreengrassClient.ts
@@ -326,6 +326,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -637,7 +643,8 @@ export type GreengrassClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type GreengrassClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -646,7 +653,8 @@ export type GreengrassClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * AWS IoT Greengrass seamlessly extends AWS onto physical devices so they can act locally on the data they generate, while still using the cloud for management, analytics, and durable storage. AWS IoT Greengrass ensures your devices can respond quickly to local events and operate with intermittent connectivity. AWS IoT Greengrass minimizes the cost of transmitting data to the cloud by allowing you to author AWS Lambda functions that execute locally.
@@ -670,13 +678,15 @@ export class GreengrassClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-groundstation/GroundStationClient.ts
+++ b/clients/client-groundstation/GroundStationClient.ts
@@ -66,6 +66,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -247,7 +253,8 @@ export type GroundStationClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type GroundStationClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -256,7 +263,8 @@ export type GroundStationClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Welcome to the AWS Ground Station API Reference. AWS Ground Station is a fully managed service that
@@ -283,13 +291,15 @@ export class GroundStationClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-groundstation/models/index.ts
+++ b/clients/client-groundstation/models/index.ts
@@ -189,7 +189,6 @@ export namespace ConfigTypeData {
   interface $Base {
     __type?: "ConfigTypeData";
   }
-
   /**
    * <p>Information about how AWS Ground Station should configure an antenna for downlink during a contact.</p>
    */
@@ -202,7 +201,6 @@ export namespace ConfigTypeData {
     uplinkEchoConfig?: never;
     $unknown?: never;
   }
-
   /**
    * <p>Information about how AWS Ground Station should conﬁgure an antenna for downlink demod decode during a contact.</p>
    */
@@ -215,7 +213,6 @@ export namespace ConfigTypeData {
     uplinkEchoConfig?: never;
     $unknown?: never;
   }
-
   /**
    * <p>Information about how AWS Ground Station should conﬁgure an antenna for uplink during a contact.</p>
    */
@@ -228,7 +225,6 @@ export namespace ConfigTypeData {
     uplinkEchoConfig?: never;
     $unknown?: never;
   }
-
   /**
    * <p>Information about the dataflow endpoint <code>Config</code>.</p>
    */
@@ -241,7 +237,6 @@ export namespace ConfigTypeData {
     uplinkEchoConfig?: never;
     $unknown?: never;
   }
-
   /**
    * <p>Object that determines whether tracking should be used during a contact executed with this <code>Config</code> in the mission profile. </p>
    */
@@ -254,7 +249,6 @@ export namespace ConfigTypeData {
     uplinkEchoConfig?: never;
     $unknown?: never;
   }
-
   /**
    * <p>Information about an uplink echo <code>Config</code>.</p>
    *          <p>Parameters from the <code>AntennaUplinkConfig</code>, corresponding to the specified <code>AntennaUplinkConfigArn</code>, are used when this <code>UplinkEchoConfig</code> is used in a contact.</p>
@@ -268,7 +262,6 @@ export namespace ConfigTypeData {
     uplinkEchoConfig: UplinkEchoConfig;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     antennaDownlinkConfig?: never;
     antennaDownlinkDemodDecodeConfig?: never;
@@ -278,7 +271,6 @@ export namespace ConfigTypeData {
     uplinkEchoConfig?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     antennaDownlinkConfig: (value: AntennaDownlinkConfig) => T;
     antennaDownlinkDemodDecodeConfig: (value: AntennaDownlinkDemodDecodeConfig) => T;
@@ -288,7 +280,6 @@ export namespace ConfigTypeData {
     uplinkEchoConfig: (value: UplinkEchoConfig) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: ConfigTypeData, visitor: Visitor<T>): T => {
     if (value.antennaDownlinkConfig !== undefined) return visitor.antennaDownlinkConfig(value.antennaDownlinkConfig);
     if (value.antennaDownlinkDemodDecodeConfig !== undefined)
@@ -298,26 +289,6 @@ export namespace ConfigTypeData {
     if (value.trackingConfig !== undefined) return visitor.trackingConfig(value.trackingConfig);
     if (value.uplinkEchoConfig !== undefined) return visitor.uplinkEchoConfig(value.uplinkEchoConfig);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: ConfigTypeData): any => {
-    if (obj.antennaDownlinkConfig !== undefined)
-      return { antennaDownlinkConfig: AntennaDownlinkConfig.filterSensitiveLog(obj.antennaDownlinkConfig) };
-    if (obj.antennaDownlinkDemodDecodeConfig !== undefined)
-      return {
-        antennaDownlinkDemodDecodeConfig: AntennaDownlinkDemodDecodeConfig.filterSensitiveLog(
-          obj.antennaDownlinkDemodDecodeConfig
-        ),
-      };
-    if (obj.antennaUplinkConfig !== undefined)
-      return { antennaUplinkConfig: AntennaUplinkConfig.filterSensitiveLog(obj.antennaUplinkConfig) };
-    if (obj.dataflowEndpointConfig !== undefined)
-      return { dataflowEndpointConfig: DataflowEndpointConfig.filterSensitiveLog(obj.dataflowEndpointConfig) };
-    if (obj.trackingConfig !== undefined)
-      return { trackingConfig: TrackingConfig.filterSensitiveLog(obj.trackingConfig) };
-    if (obj.uplinkEchoConfig !== undefined)
-      return { uplinkEchoConfig: UplinkEchoConfig.filterSensitiveLog(obj.uplinkEchoConfig) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -456,7 +427,6 @@ export interface CreateConfigRequest {
 export namespace CreateConfigRequest {
   export const filterSensitiveLog = (obj: CreateConfigRequest): any => ({
     ...obj,
-    ...(obj.configData && { configData: ConfigTypeData.filterSensitiveLog(obj.configData) }),
   });
   export const isa = (o: any): o is CreateConfigRequest => __isa(o, "CreateConfigRequest");
 }
@@ -1042,7 +1012,6 @@ export interface GetConfigResponse {
 export namespace GetConfigResponse {
   export const filterSensitiveLog = (obj: GetConfigResponse): any => ({
     ...obj,
-    ...(obj.configData && { configData: ConfigTypeData.filterSensitiveLog(obj.configData) }),
   });
   export const isa = (o: any): o is GetConfigResponse => __isa(o, "GetConfigResponse");
 }
@@ -2059,7 +2028,6 @@ export interface UpdateConfigRequest {
 export namespace UpdateConfigRequest {
   export const filterSensitiveLog = (obj: UpdateConfigRequest): any => ({
     ...obj,
-    ...(obj.configData && { configData: ConfigTypeData.filterSensitiveLog(obj.configData) }),
   });
   export const isa = (o: any): o is UpdateConfigRequest => __isa(o, "UpdateConfigRequest");
 }

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-guardduty/GuardDutyClient.ts
+++ b/clients/client-guardduty/GuardDutyClient.ts
@@ -144,6 +144,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -391,7 +397,8 @@ export type GuardDutyClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type GuardDutyClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -400,7 +407,8 @@ export type GuardDutyClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon GuardDuty is a continuous security monitoring service that analyzes and processes
@@ -440,13 +448,15 @@ export class GuardDutyClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-health/HealthClient.ts
+++ b/clients/client-health/HealthClient.ts
@@ -60,6 +60,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -217,7 +223,8 @@ export type HealthClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type HealthClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -226,7 +233,8 @@ export type HealthClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Health</fullname>
@@ -352,13 +360,15 @@ export class HealthClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-honeycode/HoneycodeClient.ts
+++ b/clients/client-honeycode/HoneycodeClient.ts
@@ -19,6 +19,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -150,7 +156,8 @@ export type HoneycodeClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type HoneycodeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -159,7 +166,8 @@ export type HoneycodeClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>
@@ -187,13 +195,15 @@ export class HoneycodeClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iam/IAMClient.ts
+++ b/clients/client-iam/IAMClient.ts
@@ -352,6 +352,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -763,7 +769,8 @@ export type IAMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IAMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -772,7 +779,8 @@ export type IAMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Identity and Access Management</fullname>
@@ -800,13 +808,15 @@ export class IAMClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-imagebuilder/ImagebuilderClient.ts
+++ b/clients/client-imagebuilder/ImagebuilderClient.ts
@@ -119,6 +119,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -334,7 +340,8 @@ export type ImagebuilderClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ImagebuilderClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -343,7 +350,8 @@ export type ImagebuilderClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>EC2 Image Builder is a fully managed AWS service that makes it easier to automate the creation, management, and deployment of customized, secure, and up-to-date “golden” server images that are pre-installed and pre-configured with software and settings to meet specific IT standards.</p>
@@ -367,13 +375,15 @@ export class ImagebuilderClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-inspector/InspectorClient.ts
+++ b/clients/client-inspector/InspectorClient.ts
@@ -129,6 +129,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -334,7 +340,8 @@ export type InspectorClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type InspectorClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -343,7 +350,8 @@ export type InspectorClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Inspector</fullname>
@@ -370,13 +378,15 @@ export class InspectorClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
+++ b/clients/client-iot-1click-devices-service/IoT1ClickDevicesServiceClient.ts
@@ -39,6 +39,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -196,7 +202,8 @@ export type IoT1ClickDevicesServiceClientConfig = Partial<__SmithyConfiguration<
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoT1ClickDevicesServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -205,7 +212,8 @@ export type IoT1ClickDevicesServiceClientResolvedConfig = __SmithyResolvedConfig
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Describes all of the AWS IoT 1-Click device-related API operations for the service.
@@ -231,13 +239,15 @@ export class IoT1ClickDevicesServiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
+++ b/clients/client-iot-1click-projects/IoT1ClickProjectsClient.ts
@@ -42,6 +42,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -205,7 +211,8 @@ export type IoT1ClickProjectsClientConfig = Partial<__SmithyConfiguration<__Http
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoT1ClickProjectsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -214,7 +221,8 @@ export type IoT1ClickProjectsClientResolvedConfig = __SmithyResolvedConfiguratio
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The AWS IoT 1-Click Projects API Reference</p>
@@ -238,13 +246,15 @@ export class IoT1ClickProjectsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iot-data-plane/IoTDataPlaneClient.ts
+++ b/clients/client-iot-data-plane/IoTDataPlaneClient.ts
@@ -22,6 +22,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -163,7 +169,8 @@ export type IoTDataPlaneClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoTDataPlaneClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -172,7 +179,8 @@ export type IoTDataPlaneClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS IoT</fullname>
@@ -206,13 +214,15 @@ export class IoTDataPlaneClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iot-events-data/IoTEventsDataClient.ts
+++ b/clients/client-iot-events-data/IoTEventsDataClient.ts
@@ -21,6 +21,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -160,7 +166,8 @@ export type IoTEventsDataClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoTEventsDataClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -169,7 +176,8 @@ export type IoTEventsDataClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS IoT Events monitors your equipment or device fleets for failures or changes in operation,
@@ -195,13 +203,15 @@ export class IoTEventsDataClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iot-events/IoTEventsClient.ts
+++ b/clients/client-iot-events/IoTEventsClient.ts
@@ -51,6 +51,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -214,7 +220,8 @@ export type IoTEventsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoTEventsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -223,7 +230,8 @@ export type IoTEventsClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS IoT Events monitors your equipment or device fleets for failures or changes in operation, and
@@ -249,13 +257,15 @@ export class IoTEventsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
+++ b/clients/client-iot-jobs-data-plane/IoTJobsDataPlaneClient.ts
@@ -27,6 +27,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -166,7 +172,8 @@ export type IoTJobsDataPlaneClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoTJobsDataPlaneClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -175,7 +182,8 @@ export type IoTJobsDataPlaneClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS IoT Jobs is a service that allows you to define a set of jobs — remote operations that are sent to
@@ -209,13 +217,15 @@ export class IoTJobsDataPlaneClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iot/IoTClient.ts
+++ b/clients/client-iot/IoTClient.ts
@@ -575,6 +575,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -1120,7 +1126,8 @@ export type IoTClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoTClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -1129,7 +1136,8 @@ export type IoTClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS IoT</fullname>
@@ -1168,13 +1176,15 @@ export class IoTClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iotanalytics/IoTAnalyticsClient.ts
+++ b/clients/client-iotanalytics/IoTAnalyticsClient.ts
@@ -72,6 +72,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -271,7 +277,8 @@ export type IoTAnalyticsClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoTAnalyticsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -280,7 +287,8 @@ export type IoTAnalyticsClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS IoT Analytics allows you to collect large amounts of device data, process messages, and store them.
@@ -322,13 +330,15 @@ export class IoTAnalyticsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
+++ b/clients/client-iotsecuretunneling/IoTSecureTunnelingClient.ts
@@ -24,6 +24,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -169,7 +175,8 @@ export type IoTSecureTunnelingClientConfig = Partial<__SmithyConfiguration<__Htt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoTSecureTunnelingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -178,7 +185,8 @@ export type IoTSecureTunnelingClientResolvedConfig = __SmithyResolvedConfigurati
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS IoT Secure Tunneling</fullname>
@@ -206,13 +214,15 @@ export class IoTSecureTunnelingClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iotsitewise/IoTSiteWiseClient.ts
+++ b/clients/client-iotsitewise/IoTSiteWiseClient.ts
@@ -110,6 +110,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -349,7 +355,8 @@ export type IoTSiteWiseClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoTSiteWiseClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -358,7 +365,8 @@ export type IoTSiteWiseClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Welcome to the AWS IoT SiteWise API Reference. AWS IoT SiteWise is an AWS service that connects <a href="https://en.wikipedia.org/wiki/Internet_of_things#Industrial_applications">Industrial Internet of Things (IIoT)</a> devices to the power of the AWS Cloud. For more information, see the
@@ -383,13 +391,15 @@ export class IoTSiteWiseClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
+++ b/clients/client-iotthingsgraph/IoTThingsGraphClient.ts
@@ -112,6 +112,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -313,7 +319,8 @@ export type IoTThingsGraphClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IoTThingsGraphClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -322,7 +329,8 @@ export type IoTThingsGraphClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS IoT Things Graph</fullname>
@@ -350,13 +358,15 @@ export class IoTThingsGraphClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-ivs/IvsClient.ts
+++ b/clients/client-ivs/IvsClient.ts
@@ -35,6 +35,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -202,7 +208,8 @@ export type IvsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type IvsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -211,7 +218,8 @@ export type IvsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>
@@ -475,13 +483,15 @@ export class IvsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-kafka/KafkaClient.ts
+++ b/clients/client-kafka/KafkaClient.ts
@@ -74,6 +74,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -253,7 +259,8 @@ export type KafkaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type KafkaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -262,7 +269,8 @@ export type KafkaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The operations for managing an Amazon MSK cluster.</p>
@@ -286,13 +294,15 @@ export class KafkaClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-kendra/KendraClient.ts
+++ b/clients/client-kendra/KendraClient.ts
@@ -53,6 +53,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -232,7 +238,8 @@ export type KendraClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type KendraClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -241,7 +248,8 @@ export type KendraClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Kendra is a service for indexing large document sets.</p>
@@ -265,13 +273,15 @@ export class KendraClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
+++ b/clients/client-kinesis-analytics-v2/KinesisAnalyticsV2Client.ts
@@ -94,6 +94,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -277,7 +283,8 @@ export type KinesisAnalyticsV2ClientConfig = Partial<__SmithyConfiguration<__Htt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type KinesisAnalyticsV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -286,7 +293,8 @@ export type KinesisAnalyticsV2ClientResolvedConfig = __SmithyResolvedConfigurati
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Kinesis Data Analytics is a fully managed service that you can use to process and analyze streaming data using SQL or Java. The service
@@ -312,13 +320,15 @@ export class KinesisAnalyticsV2Client extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
+++ b/clients/client-kinesis-analytics/KinesisAnalyticsClient.ts
@@ -70,6 +70,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -241,7 +247,8 @@ export type KinesisAnalyticsClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type KinesisAnalyticsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -250,7 +257,8 @@ export type KinesisAnalyticsClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Kinesis Analytics</fullname>
@@ -283,13 +291,15 @@ export class KinesisAnalyticsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
+++ b/clients/client-kinesis-video-archived-media/KinesisVideoArchivedMediaClient.ts
@@ -28,6 +28,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -169,7 +175,8 @@ export type KinesisVideoArchivedMediaClientConfig = Partial<__SmithyConfiguratio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type KinesisVideoArchivedMediaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -178,7 +185,8 @@ export type KinesisVideoArchivedMediaClientResolvedConfig = __SmithyResolvedConf
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p></p>
@@ -202,13 +210,15 @@ export class KinesisVideoArchivedMediaClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
+++ b/clients/client-kinesis-video-media/KinesisVideoMediaClient.ts
@@ -15,6 +15,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -146,7 +152,8 @@ export type KinesisVideoMediaClientConfig = Partial<__SmithyConfiguration<__Http
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type KinesisVideoMediaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -155,7 +162,8 @@ export type KinesisVideoMediaClientResolvedConfig = __SmithyResolvedConfiguratio
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p></p>
@@ -179,13 +187,15 @@ export class KinesisVideoMediaClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
+++ b/clients/client-kinesis-video-signaling/KinesisVideoSignalingClient.ts
@@ -19,6 +19,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -150,7 +156,8 @@ export type KinesisVideoSignalingClientConfig = Partial<__SmithyConfiguration<__
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type KinesisVideoSignalingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -159,7 +166,8 @@ export type KinesisVideoSignalingClientResolvedConfig = __SmithyResolvedConfigur
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Kinesis Video Streams Signaling Service is a intermediate service that establishes a
@@ -185,13 +193,15 @@ export class KinesisVideoSignalingClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-kinesis-video/KinesisVideoClient.ts
+++ b/clients/client-kinesis-video/KinesisVideoClient.ts
@@ -57,6 +57,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -226,7 +232,8 @@ export type KinesisVideoClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type KinesisVideoClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -235,7 +242,8 @@ export type KinesisVideoClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p></p>
@@ -259,13 +267,15 @@ export class KinesisVideoClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-kinesis/KinesisClient.ts
+++ b/clients/client-kinesis/KinesisClient.ts
@@ -83,6 +83,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -277,6 +283,7 @@ export type KinesisClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   RetryInputConfig &
   UserAgentInputConfig &
   HostHeaderInputConfig &
+  LoggerInputConfig &
   EventStreamSerdeInputConfig;
 
 export type KinesisClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
@@ -287,6 +294,7 @@ export type KinesisClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   RetryResolvedConfig &
   UserAgentResolvedConfig &
   HostHeaderResolvedConfig &
+  LoggerResolvedConfig &
   EventStreamSerdeResolvedConfig;
 
 /**
@@ -313,14 +321,16 @@ export class KinesisClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    let _config_7 = resolveEventStreamSerdeConfig(_config_6);
-    super(_config_7);
-    this.config = _config_7;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    let _config_8 = resolveEventStreamSerdeConfig(_config_7);
+    super(_config_8);
+    this.config = _config_8;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kinesis/models/index.ts
+++ b/clients/client-kinesis/models/index.ts
@@ -2280,7 +2280,6 @@ export namespace SubscribeToShardEventStream {
   interface $Base {
     __type?: "SubscribeToShardEventStream";
   }
-
   /**
    * <p>The request was denied due to request throttling. For more information about throttling, see <a href="https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#requests-per-second">Limits</a> in the
    *             <i>AWS Key Management Service Developer Guide</i>.</p>
@@ -2298,7 +2297,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The request was rejected because the specified customer master key (CMK) isn't
    *             enabled.</p>
@@ -2316,7 +2314,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The ciphertext references a key that doesn't exist or that you don't have access to.</p>
    */
@@ -2333,7 +2330,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The request was rejected because the state of the specified resource isn't valid for this request. For more information, see
    *             <a href="https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html">How Key State Affects Use of a Customer Master Key</a> in the
@@ -2352,7 +2348,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The request was rejected because the specified entity or resource can't be
    *             found.</p>
@@ -2370,7 +2365,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The requested resource could not be found. The stream might not be specified correctly.</p>
    */
@@ -2387,7 +2381,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired?: never;
     $unknown?: never;
   }
-
   /**
    * <p>After you call <a>SubscribeToShard</a>, Kinesis Data Streams sends events of this type to your consumer. </p>
    */
@@ -2404,7 +2397,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The resource is not available for this operation. For successful operation, the
    *             resource must be in the <code>ACTIVE</code> state.</p>
@@ -2422,7 +2414,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired?: never;
     $unknown?: never;
   }
-
   export interface InternalFailureExceptionMember extends $Base {
     KMSThrottlingException?: never;
     KMSDisabledException?: never;
@@ -2436,7 +2427,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The AWS access key ID needs a subscription for the service.</p>
    */
@@ -2453,7 +2443,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired: KMSOptInRequired;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     KMSThrottlingException?: never;
     KMSDisabledException?: never;
@@ -2467,7 +2456,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     KMSThrottlingException: (value: KMSThrottlingException) => T;
     KMSDisabledException: (value: KMSDisabledException) => T;
@@ -2481,7 +2469,6 @@ export namespace SubscribeToShardEventStream {
     KMSOptInRequired: (value: KMSOptInRequired) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: SubscribeToShardEventStream, visitor: Visitor<T>): T => {
     if (value.KMSThrottlingException !== undefined) return visitor.KMSThrottlingException(value.KMSThrottlingException);
     if (value.KMSDisabledException !== undefined) return visitor.KMSDisabledException(value.KMSDisabledException);
@@ -2498,30 +2485,6 @@ export namespace SubscribeToShardEventStream {
       return visitor.InternalFailureException(value.InternalFailureException);
     if (value.KMSOptInRequired !== undefined) return visitor.KMSOptInRequired(value.KMSOptInRequired);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: SubscribeToShardEventStream): any => {
-    if (obj.KMSThrottlingException !== undefined)
-      return { KMSThrottlingException: KMSThrottlingException.filterSensitiveLog(obj.KMSThrottlingException) };
-    if (obj.KMSDisabledException !== undefined)
-      return { KMSDisabledException: KMSDisabledException.filterSensitiveLog(obj.KMSDisabledException) };
-    if (obj.KMSAccessDeniedException !== undefined)
-      return { KMSAccessDeniedException: KMSAccessDeniedException.filterSensitiveLog(obj.KMSAccessDeniedException) };
-    if (obj.KMSInvalidStateException !== undefined)
-      return { KMSInvalidStateException: KMSInvalidStateException.filterSensitiveLog(obj.KMSInvalidStateException) };
-    if (obj.KMSNotFoundException !== undefined)
-      return { KMSNotFoundException: KMSNotFoundException.filterSensitiveLog(obj.KMSNotFoundException) };
-    if (obj.ResourceNotFoundException !== undefined)
-      return { ResourceNotFoundException: ResourceNotFoundException.filterSensitiveLog(obj.ResourceNotFoundException) };
-    if (obj.SubscribeToShardEvent !== undefined)
-      return { SubscribeToShardEvent: SubscribeToShardEvent.filterSensitiveLog(obj.SubscribeToShardEvent) };
-    if (obj.ResourceInUseException !== undefined)
-      return { ResourceInUseException: ResourceInUseException.filterSensitiveLog(obj.ResourceInUseException) };
-    if (obj.InternalFailureException !== undefined)
-      return { InternalFailureException: InternalFailureException.filterSensitiveLog(obj.InternalFailureException) };
-    if (obj.KMSOptInRequired !== undefined)
-      return { KMSOptInRequired: KMSOptInRequired.filterSensitiveLog(obj.KMSOptInRequired) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -2559,7 +2522,6 @@ export interface SubscribeToShardOutput {
 export namespace SubscribeToShardOutput {
   export const filterSensitiveLog = (obj: SubscribeToShardOutput): any => ({
     ...obj,
-    ...(obj.EventStream && { EventStream: "STREAMING_CONTENT" }),
   });
   export const isa = (o: any): o is SubscribeToShardOutput => __isa(o, "SubscribeToShardOutput");
 }

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -38,6 +38,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-kms/KMSClient.ts
+++ b/clients/client-kms/KMSClient.ts
@@ -105,6 +105,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -328,7 +334,8 @@ export type KMSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type KMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -337,7 +344,8 @@ export type KMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Key Management Service</fullname>
@@ -449,13 +457,15 @@ export class KMSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-lakeformation/LakeFormationClient.ts
+++ b/clients/client-lakeformation/LakeFormationClient.ts
@@ -42,6 +42,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -199,7 +205,8 @@ export type LakeFormationClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type LakeFormationClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -208,7 +215,8 @@ export type LakeFormationClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Lake Formation</fullname>
@@ -233,13 +241,15 @@ export class LakeFormationClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-lambda/LambdaClient.ts
+++ b/clients/client-lambda/LambdaClient.ts
@@ -138,6 +138,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -367,7 +373,8 @@ export type LambdaClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type LambdaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -376,7 +383,8 @@ export type LambdaClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Lambda</fullname>
@@ -406,13 +414,15 @@ export class LambdaClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
+++ b/clients/client-lex-model-building-service/LexModelBuildingServiceClient.ts
@@ -83,6 +83,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -292,7 +298,8 @@ export type LexModelBuildingServiceClientConfig = Partial<__SmithyConfiguration<
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type LexModelBuildingServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -301,7 +308,8 @@ export type LexModelBuildingServiceClientResolvedConfig = __SmithyResolvedConfig
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Lex Build-Time Actions</fullname>
@@ -328,13 +336,15 @@ export class LexModelBuildingServiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
+++ b/clients/client-lex-runtime-service/LexRuntimeServiceClient.ts
@@ -19,6 +19,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -160,7 +166,8 @@ export type LexRuntimeServiceClientConfig = Partial<__SmithyConfiguration<__Http
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type LexRuntimeServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -169,7 +176,8 @@ export type LexRuntimeServiceClientResolvedConfig = __SmithyResolvedConfiguratio
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Lex provides both build and runtime endpoints. Each endpoint provides a set of
@@ -201,13 +209,15 @@ export class LexRuntimeServiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -36,6 +36,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-license-manager/LicenseManagerClient.ts
+++ b/clients/client-license-manager/LicenseManagerClient.ts
@@ -69,6 +69,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -232,7 +238,8 @@ export type LicenseManagerClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type LicenseManagerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -241,7 +248,8 @@ export type LicenseManagerClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname> AWS License Manager </fullname>
@@ -267,13 +275,15 @@ export class LicenseManagerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-lightsail/LightsailClient.ts
+++ b/clients/client-lightsail/LightsailClient.ts
@@ -315,6 +315,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -700,7 +706,8 @@ export type LightsailClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type LightsailClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -709,7 +716,8 @@ export type LightsailClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Lightsail is the easiest way to get started with Amazon Web Services (AWS) for developers
@@ -747,13 +755,15 @@ export class LightsailClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-machine-learning/MachineLearningClient.ts
+++ b/clients/client-machine-learning/MachineLearningClient.ts
@@ -75,6 +75,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -262,7 +268,8 @@ export type MachineLearningClientConfig = Partial<__SmithyConfiguration<__HttpHa
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MachineLearningClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -271,7 +278,8 @@ export type MachineLearningClientResolvedConfig = __SmithyResolvedConfiguration<
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Definition of the public APIs
@@ -296,13 +304,15 @@ export class MachineLearningClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-sdk-machinelearning": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",

--- a/clients/client-macie/MacieClient.ts
+++ b/clients/client-macie/MacieClient.ts
@@ -33,6 +33,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -178,7 +184,8 @@ export type MacieClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MacieClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -187,7 +194,8 @@ export type MacieClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Macie Classic</fullname>
@@ -221,13 +229,15 @@ export class MacieClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-macie2/Macie2Client.ts
+++ b/clients/client-macie2/Macie2Client.ts
@@ -149,6 +149,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -382,7 +388,8 @@ export type Macie2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type Macie2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -391,7 +398,8 @@ export type Macie2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Macie is a fully managed data security and data privacy service that uses machine learning and pattern matching to discover and protect your sensitive data in AWS. Macie automates the discovery of sensitive data, such as PII and intellectual property, to provide you with insight into the data that your organization stores in AWS. Macie also provides an inventory of your Amazon S3 buckets, which it continually monitors for you. If Macie detects sensitive data or potential data access issues, it generates detailed findings for you to review and act upon as necessary.</p>
@@ -415,13 +423,15 @@ export class Macie2Client extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-managedblockchain/ManagedBlockchainClient.ts
+++ b/clients/client-managedblockchain/ManagedBlockchainClient.ts
@@ -34,6 +34,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -205,7 +211,8 @@ export type ManagedBlockchainClientConfig = Partial<__SmithyConfiguration<__Http
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ManagedBlockchainClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -214,7 +221,8 @@ export type ManagedBlockchainClientResolvedConfig = __SmithyResolvedConfiguratio
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p></p>
@@ -239,13 +247,15 @@ export class ManagedBlockchainClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
+++ b/clients/client-marketplace-catalog/MarketplaceCatalogClient.ts
@@ -20,6 +20,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -163,7 +169,8 @@ export type MarketplaceCatalogClientConfig = Partial<__SmithyConfiguration<__Htt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MarketplaceCatalogClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -172,7 +179,8 @@ export type MarketplaceCatalogClientResolvedConfig = __SmithyResolvedConfigurati
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Catalog API actions allow you to manage your entities through list, describe, and update
@@ -202,13 +210,15 @@ export class MarketplaceCatalogClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
+++ b/clients/client-marketplace-commerce-analytics/MarketplaceCommerceAnalyticsClient.ts
@@ -19,6 +19,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -150,7 +156,8 @@ export type MarketplaceCommerceAnalyticsClientConfig = Partial<__SmithyConfigura
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MarketplaceCommerceAnalyticsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -159,7 +166,8 @@ export type MarketplaceCommerceAnalyticsClientResolvedConfig = __SmithyResolvedC
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * Provides AWS Marketplace business intelligence data on-demand.
@@ -183,13 +191,15 @@ export class MarketplaceCommerceAnalyticsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
+++ b/clients/client-marketplace-entitlement-service/MarketplaceEntitlementServiceClient.ts
@@ -15,6 +15,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -146,7 +152,8 @@ export type MarketplaceEntitlementServiceClientConfig = Partial<__SmithyConfigur
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MarketplaceEntitlementServiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -155,7 +162,8 @@ export type MarketplaceEntitlementServiceClientResolvedConfig = __SmithyResolved
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Marketplace Entitlement Service</fullname>
@@ -195,13 +203,15 @@ export class MarketplaceEntitlementServiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
+++ b/clients/client-marketplace-metering/MarketplaceMeteringClient.ts
@@ -18,6 +18,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -157,7 +163,8 @@ export type MarketplaceMeteringClientConfig = Partial<__SmithyConfiguration<__Ht
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MarketplaceMeteringClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -166,7 +173,8 @@ export type MarketplaceMeteringClientResolvedConfig = __SmithyResolvedConfigurat
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Marketplace Metering Service</fullname>
@@ -246,13 +254,15 @@ export class MarketplaceMeteringClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-mediaconnect/MediaConnectClient.ts
+++ b/clients/client-mediaconnect/MediaConnectClient.ts
@@ -54,6 +54,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -229,7 +235,8 @@ export type MediaConnectClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MediaConnectClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -238,7 +245,8 @@ export type MediaConnectClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * API for AWS Elemental MediaConnect
@@ -262,13 +270,15 @@ export class MediaConnectClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-mediaconvert/MediaConvertClient.ts
+++ b/clients/client-mediaconvert/MediaConvertClient.ts
@@ -48,6 +48,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -229,7 +235,8 @@ export type MediaConvertClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MediaConvertClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -238,7 +245,8 @@ export type MediaConvertClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * AWS Elemental MediaConvert
@@ -262,13 +270,15 @@ export class MediaConvertClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-medialive/MediaLiveClient.ts
+++ b/clients/client-medialive/MediaLiveClient.ts
@@ -106,6 +106,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -331,7 +337,8 @@ export type MediaLiveClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MediaLiveClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -340,7 +347,8 @@ export type MediaLiveClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * API for AWS Elemental MediaLive
@@ -364,13 +372,15 @@ export class MediaLiveClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-mediapackage-vod/MediaPackageVodClient.ts
+++ b/clients/client-mediapackage-vod/MediaPackageVodClient.ts
@@ -60,6 +60,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -223,7 +229,8 @@ export type MediaPackageVodClientConfig = Partial<__SmithyConfiguration<__HttpHa
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MediaPackageVodClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -232,7 +239,8 @@ export type MediaPackageVodClientResolvedConfig = __SmithyResolvedConfiguration<
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * AWS Elemental MediaPackage VOD
@@ -256,13 +264,15 @@ export class MediaPackageVodClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-mediapackage/MediaPackageClient.ts
+++ b/clients/client-mediapackage/MediaPackageClient.ts
@@ -56,6 +56,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -223,7 +229,8 @@ export type MediaPackageClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MediaPackageClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -232,7 +239,8 @@ export type MediaPackageClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * AWS Elemental MediaPackage
@@ -256,13 +264,15 @@ export class MediaPackageClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-mediastore-data/MediaStoreDataClient.ts
+++ b/clients/client-mediastore-data/MediaStoreDataClient.ts
@@ -19,6 +19,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -160,7 +166,8 @@ export type MediaStoreDataClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MediaStoreDataClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -169,7 +176,8 @@ export type MediaStoreDataClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>An AWS Elemental MediaStore asset is an object, similar to an object in the Amazon S3
@@ -195,13 +203,15 @@ export class MediaStoreDataClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -36,6 +36,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-mediastore/MediaStoreClient.ts
+++ b/clients/client-mediastore/MediaStoreClient.ts
@@ -44,6 +44,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -217,7 +223,8 @@ export type MediaStoreClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MediaStoreClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -226,7 +233,8 @@ export type MediaStoreClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>An AWS Elemental MediaStore container is a namespace that holds folders and objects.
@@ -251,13 +259,15 @@ export class MediaStoreClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-mediatailor/MediaTailorClient.ts
+++ b/clients/client-mediatailor/MediaTailorClient.ts
@@ -36,6 +36,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -181,7 +187,8 @@ export type MediaTailorClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MediaTailorClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -190,7 +197,8 @@ export type MediaTailorClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Use the AWS Elemental MediaTailor SDK to configure scalable ad insertion for your live and VOD content. With AWS Elemental MediaTailor, you can serve targeted ads to viewers while maintaining broadcast quality in over-the-top (OTT) video applications. For information about using the service, including detailed information about the settings covered in this guide, see the AWS Elemental MediaTailor User Guide.<p>Through the SDK, you manage AWS Elemental MediaTailor configurations the same as you do through the console. For example, you specify ad insertion behavior and mapping information for the origin server and the ad decision server (ADS).</p>
@@ -214,13 +222,15 @@ export class MediaTailorClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-migration-hub/MigrationHubClient.ts
+++ b/clients/client-migration-hub/MigrationHubClient.ts
@@ -79,6 +79,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -244,7 +250,8 @@ export type MigrationHubClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MigrationHubClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -253,7 +260,8 @@ export type MigrationHubClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The AWS Migration Hub API methods help to obtain server and application migration status
@@ -282,13 +290,15 @@ export class MigrationHubClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-migrationhub-config/MigrationHubConfigClient.ts
+++ b/clients/client-migrationhub-config/MigrationHubConfigClient.ts
@@ -23,6 +23,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -160,7 +166,8 @@ export type MigrationHubConfigClientConfig = Partial<__SmithyConfiguration<__Htt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MigrationHubConfigClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -169,7 +176,8 @@ export type MigrationHubConfigClientResolvedConfig = __SmithyResolvedConfigurati
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The AWS Migration Hub home region APIs are available specifically for working with your
@@ -218,13 +226,15 @@ export class MigrationHubConfigClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-mobile/MobileClient.ts
+++ b/clients/client-mobile/MobileClient.ts
@@ -23,6 +23,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -172,7 +178,8 @@ export type MobileClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MobileClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -181,7 +188,8 @@ export type MobileClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>
@@ -209,13 +217,15 @@ export class MobileClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-mq/MqClient.ts
+++ b/clients/client-mq/MqClient.ts
@@ -57,6 +57,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -232,7 +238,8 @@ export type MqClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MqClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -241,7 +248,8 @@ export type MqClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandler
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * Amazon MQ is a managed message broker service for Apache ActiveMQ that makes it easy to set up and operate message brokers in the cloud. A message broker allows software applications and components to communicate using various programming languages, operating systems, and formal messaging protocols.
@@ -265,13 +273,15 @@ export class MqClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-mturk/MTurkClient.ts
+++ b/clients/client-mturk/MTurkClient.ts
@@ -116,6 +116,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -325,7 +331,8 @@ export type MTurkClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type MTurkClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -334,7 +341,8 @@ export type MTurkClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Mechanical Turk API Reference</fullname>
@@ -358,13 +366,15 @@ export class MTurkClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-neptune/NeptuneClient.ts
+++ b/clients/client-neptune/NeptuneClient.ts
@@ -208,6 +208,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -457,7 +463,8 @@ export type NeptuneClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type NeptuneClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -466,7 +473,8 @@ export type NeptuneClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Neptune</fullname>
@@ -507,13 +515,15 @@ export class NeptuneClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-networkmanager/NetworkManagerClient.ts
+++ b/clients/client-networkmanager/NetworkManagerClient.ts
@@ -78,6 +78,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -265,7 +271,8 @@ export type NetworkManagerClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type NetworkManagerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -274,7 +281,8 @@ export type NetworkManagerClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Transit Gateway Network Manager (Network Manager) enables you to create a global network, in which you can monitor your
@@ -299,13 +307,15 @@ export class NetworkManagerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-opsworks/OpsWorksClient.ts
+++ b/clients/client-opsworks/OpsWorksClient.ts
@@ -166,6 +166,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -445,7 +451,8 @@ export type OpsWorksClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type OpsWorksClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -454,7 +461,8 @@ export type OpsWorksClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS OpsWorks</fullname>
@@ -592,13 +600,15 @@ export class OpsWorksClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-opsworkscm/OpsWorksCMClient.ts
+++ b/clients/client-opsworkscm/OpsWorksCMClient.ts
@@ -48,6 +48,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -217,7 +223,8 @@ export type OpsWorksCMClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type OpsWorksCMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -226,7 +233,8 @@ export type OpsWorksCMClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS OpsWorks CM</fullname>
@@ -337,13 +345,15 @@ export class OpsWorksCMClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-organizations/OrganizationsClient.ts
+++ b/clients/client-organizations/OrganizationsClient.ts
@@ -140,6 +140,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -373,7 +379,8 @@ export type OrganizationsClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type OrganizationsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -382,7 +389,8 @@ export type OrganizationsClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Organizations</fullname>
@@ -406,13 +414,15 @@ export class OrganizationsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-outposts/OutpostsClient.ts
+++ b/clients/client-outposts/OutpostsClient.ts
@@ -24,6 +24,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -169,7 +175,8 @@ export type OutpostsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type OutpostsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -178,7 +185,8 @@ export type OutpostsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Outposts is a fully-managed service that extends AWS infrastructure,
@@ -207,13 +215,15 @@ export class OutpostsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-personalize-events/PersonalizeEventsClient.ts
+++ b/clients/client-personalize-events/PersonalizeEventsClient.ts
@@ -15,6 +15,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -146,7 +152,8 @@ export type PersonalizeEventsClientConfig = Partial<__SmithyConfiguration<__Http
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type PersonalizeEventsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -155,7 +162,8 @@ export type PersonalizeEventsClientResolvedConfig = __SmithyResolvedConfiguratio
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p></p>
@@ -179,13 +187,15 @@ export class PersonalizeEventsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
+++ b/clients/client-personalize-runtime/PersonalizeRuntimeClient.ts
@@ -19,6 +19,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -150,7 +156,8 @@ export type PersonalizeRuntimeClientConfig = Partial<__SmithyConfiguration<__Htt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type PersonalizeRuntimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -159,7 +166,8 @@ export type PersonalizeRuntimeClientResolvedConfig = __SmithyResolvedConfigurati
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p></p>
@@ -183,13 +191,15 @@ export class PersonalizeRuntimeClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-personalize/PersonalizeClient.ts
+++ b/clients/client-personalize/PersonalizeClient.ts
@@ -93,6 +93,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -310,7 +316,8 @@ export type PersonalizeClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type PersonalizeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -319,7 +326,8 @@ export type PersonalizeClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Personalize is a machine learning service that makes it easy to add individualized
@@ -344,13 +352,15 @@ export class PersonalizeClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-pi/PIClient.ts
+++ b/clients/client-pi/PIClient.ts
@@ -19,6 +19,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -150,7 +156,8 @@ export type PIClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type PIClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -159,7 +166,8 @@ export type PIClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandler
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Performance Insights enables you to monitor and explore different dimensions of
@@ -196,13 +204,15 @@ export class PIClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-pinpoint-email/PinpointEmailClient.ts
+++ b/clients/client-pinpoint-email/PinpointEmailClient.ts
@@ -161,6 +161,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -376,7 +382,8 @@ export type PinpointEmailClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type PinpointEmailClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -385,7 +392,8 @@ export type PinpointEmailClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Pinpoint Email Service</fullname>
@@ -437,13 +445,15 @@ export class PinpointEmailClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
@@ -43,6 +43,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -190,7 +196,8 @@ export type PinpointSMSVoiceClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type PinpointSMSVoiceClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -199,7 +206,8 @@ export type PinpointSMSVoiceClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * Pinpoint SMS and Voice Messaging public facing APIs
@@ -223,13 +231,15 @@ export class PinpointSMSVoiceClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-pinpoint/PinpointClient.ts
+++ b/clients/client-pinpoint/PinpointClient.ts
@@ -234,6 +234,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -589,7 +595,8 @@ export type PinpointClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type PinpointClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -598,7 +605,8 @@ export type PinpointClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Doc Engage API - Amazon Pinpoint API</p>
@@ -622,13 +630,15 @@ export class PinpointClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-polly/PollyClient.ts
+++ b/clients/client-polly/PollyClient.ts
@@ -32,6 +32,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -181,7 +187,8 @@ export type PollyClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type PollyClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -190,7 +197,8 @@ export type PollyClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Polly is a web service that makes it easy to synthesize speech from text.</p>
@@ -216,13 +224,15 @@ export class PollyClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-pricing/PricingClient.ts
+++ b/clients/client-pricing/PricingClient.ts
@@ -17,6 +17,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -151,7 +157,8 @@ export type PricingClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type PricingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -160,7 +167,8 @@ export type PricingClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Price List Service API (AWS Price List Service) is a centralized and convenient way to
@@ -207,13 +215,15 @@ export class PricingClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-qldb-session/QLDBSessionClient.ts
+++ b/clients/client-qldb-session/QLDBSessionClient.ts
@@ -15,6 +15,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -146,7 +152,8 @@ export type QLDBSessionClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type QLDBSessionClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -155,7 +162,8 @@ export type QLDBSessionClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The transactional data APIs for Amazon QLDB</p>
@@ -199,13 +207,15 @@ export class QLDBSessionClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-qldb/QLDBClient.ts
+++ b/clients/client-qldb/QLDBClient.ts
@@ -57,6 +57,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -226,7 +232,8 @@ export type QLDBClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOption
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type QLDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -235,7 +242,8 @@ export type QLDBClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandl
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The control plane for Amazon QLDB</p>
@@ -259,13 +267,15 @@ export class QLDBClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-quicksight/QuickSightClient.ts
+++ b/clients/client-quicksight/QuickSightClient.ts
@@ -212,6 +212,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -523,7 +529,8 @@ export type QuickSightClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type QuickSightClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -532,7 +539,8 @@ export type QuickSightClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon QuickSight API Reference</fullname>
@@ -560,13 +568,15 @@ export class QuickSightClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-ram/RAMClient.ts
+++ b/clients/client-ram/RAMClient.ts
@@ -86,6 +86,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -265,7 +271,8 @@ export type RAMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type RAMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -274,7 +281,8 @@ export type RAMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Use AWS Resource Access Manager to share AWS resources between AWS accounts. To share a resource, you
@@ -303,13 +311,15 @@ export class RAMClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-rds-data/RDSDataClient.ts
+++ b/clients/client-rds-data/RDSDataClient.ts
@@ -26,6 +26,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -169,7 +175,8 @@ export type RDSDataClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type RDSDataClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -178,7 +185,8 @@ export type RDSDataClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon RDS Data Service</fullname>
@@ -211,13 +219,15 @@ export class RDSDataClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-rds-data/models/index.ts
+++ b/clients/client-rds-data/models/index.ts
@@ -16,7 +16,6 @@ export namespace ArrayValue {
   interface $Base {
     __type?: "ArrayValue";
   }
-
   /**
    * <p>An array of arrays.</p>
    */
@@ -28,7 +27,6 @@ export namespace ArrayValue {
     stringValues?: never;
     $unknown?: never;
   }
-
   /**
    * <p>An array of Boolean values.</p>
    */
@@ -40,7 +38,6 @@ export namespace ArrayValue {
     stringValues?: never;
     $unknown?: never;
   }
-
   /**
    * <p>An array of integers.</p>
    */
@@ -52,7 +49,6 @@ export namespace ArrayValue {
     stringValues?: never;
     $unknown?: never;
   }
-
   /**
    * <p>An array of floating point numbers.</p>
    */
@@ -64,7 +60,6 @@ export namespace ArrayValue {
     stringValues?: never;
     $unknown?: never;
   }
-
   /**
    * <p>An array of strings.</p>
    */
@@ -76,7 +71,6 @@ export namespace ArrayValue {
     stringValues: string[];
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     arrayValues?: never;
     booleanValues?: never;
@@ -85,7 +79,6 @@ export namespace ArrayValue {
     stringValues?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     arrayValues: (value: ArrayValue[]) => T;
     booleanValues: (value: boolean[]) => T;
@@ -94,7 +87,6 @@ export namespace ArrayValue {
     stringValues: (value: string[]) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: ArrayValue, visitor: Visitor<T>): T => {
     if (value.arrayValues !== undefined) return visitor.arrayValues(value.arrayValues);
     if (value.booleanValues !== undefined) return visitor.booleanValues(value.booleanValues);
@@ -102,16 +94,6 @@ export namespace ArrayValue {
     if (value.longValues !== undefined) return visitor.longValues(value.longValues);
     if (value.stringValues !== undefined) return visitor.stringValues(value.stringValues);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: ArrayValue): any => {
-    if (obj.arrayValues !== undefined)
-      return { arrayValues: obj.arrayValues.map((item) => ArrayValue.filterSensitiveLog(item)) };
-    if (obj.booleanValues !== undefined) return { booleanValues: obj.booleanValues };
-    if (obj.doubleValues !== undefined) return { doubleValues: obj.doubleValues };
-    if (obj.longValues !== undefined) return { longValues: obj.longValues };
-    if (obj.stringValues !== undefined) return { stringValues: obj.stringValues };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -543,7 +525,6 @@ export interface ExecuteStatementRequest {
 export namespace ExecuteStatementRequest {
   export const filterSensitiveLog = (obj: ExecuteStatementRequest): any => ({
     ...obj,
-    ...(obj.parameters && { parameters: obj.parameters.map((item) => SqlParameter.filterSensitiveLog(item)) }),
   });
   export const isa = (o: any): o is ExecuteStatementRequest => __isa(o, "ExecuteStatementRequest");
 }
@@ -585,7 +566,6 @@ export interface ExecuteStatementResponse {
 export namespace ExecuteStatementResponse {
   export const filterSensitiveLog = (obj: ExecuteStatementResponse): any => ({
     ...obj,
-    ...(obj.generatedFields && { generatedFields: obj.generatedFields.map((item) => Field.filterSensitiveLog(item)) }),
   });
   export const isa = (o: any): o is ExecuteStatementResponse => __isa(o, "ExecuteStatementResponse");
 }
@@ -607,7 +587,6 @@ export namespace Field {
   interface $Base {
     __type?: "Field";
   }
-
   /**
    * <p>An array of values.</p>
    */
@@ -621,7 +600,6 @@ export namespace Field {
     stringValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value of BLOB data type.</p>
    */
@@ -635,7 +613,6 @@ export namespace Field {
     stringValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value of Boolean data type.</p>
    */
@@ -649,7 +626,6 @@ export namespace Field {
     stringValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value of double data type.</p>
    */
@@ -663,7 +639,6 @@ export namespace Field {
     stringValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A NULL value.</p>
    */
@@ -677,7 +652,6 @@ export namespace Field {
     stringValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value of long data type.</p>
    */
@@ -691,7 +665,6 @@ export namespace Field {
     stringValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value of string data type.</p>
    */
@@ -705,7 +678,6 @@ export namespace Field {
     stringValue: string;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     arrayValue?: never;
     blobValue?: never;
@@ -716,7 +688,6 @@ export namespace Field {
     stringValue?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     arrayValue: (value: ArrayValue) => T;
     blobValue: (value: Uint8Array) => T;
@@ -727,7 +698,6 @@ export namespace Field {
     stringValue: (value: string) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: Field, visitor: Visitor<T>): T => {
     if (value.arrayValue !== undefined) return visitor.arrayValue(value.arrayValue);
     if (value.blobValue !== undefined) return visitor.blobValue(value.blobValue);
@@ -737,17 +707,6 @@ export namespace Field {
     if (value.longValue !== undefined) return visitor.longValue(value.longValue);
     if (value.stringValue !== undefined) return visitor.stringValue(value.stringValue);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: Field): any => {
-    if (obj.arrayValue !== undefined) return { arrayValue: ArrayValue.filterSensitiveLog(obj.arrayValue) };
-    if (obj.blobValue !== undefined) return { blobValue: obj.blobValue };
-    if (obj.booleanValue !== undefined) return { booleanValue: obj.booleanValue };
-    if (obj.doubleValue !== undefined) return { doubleValue: obj.doubleValue };
-    if (obj.isNull !== undefined) return { isNull: obj.isNull };
-    if (obj.longValue !== undefined) return { longValue: obj.longValue };
-    if (obj.stringValue !== undefined) return { stringValue: obj.stringValue };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -818,7 +777,6 @@ export interface _Record {
 export namespace _Record {
   export const filterSensitiveLog = (obj: _Record): any => ({
     ...obj,
-    ...(obj.values && { values: obj.values.map((item) => Value.filterSensitiveLog(item)) }),
   });
   export const isa = (o: any): o is _Record => __isa(o, "Record");
 }
@@ -1008,7 +966,6 @@ export interface SqlParameter {
 export namespace SqlParameter {
   export const filterSensitiveLog = (obj: SqlParameter): any => ({
     ...obj,
-    ...(obj.value && { value: Field.filterSensitiveLog(obj.value) }),
   });
   export const isa = (o: any): o is SqlParameter => __isa(o, "SqlParameter");
 }
@@ -1078,7 +1035,6 @@ export interface StructValue {
 export namespace StructValue {
   export const filterSensitiveLog = (obj: StructValue): any => ({
     ...obj,
-    ...(obj.attributes && { attributes: obj.attributes.map((item) => Value.filterSensitiveLog(item)) }),
   });
   export const isa = (o: any): o is StructValue => __isa(o, "StructValue");
 }
@@ -1104,7 +1060,6 @@ export interface UpdateResult {
 export namespace UpdateResult {
   export const filterSensitiveLog = (obj: UpdateResult): any => ({
     ...obj,
-    ...(obj.generatedFields && { generatedFields: obj.generatedFields.map((item) => Field.filterSensitiveLog(item)) }),
   });
   export const isa = (o: any): o is UpdateResult => __isa(o, "UpdateResult");
 }
@@ -1133,7 +1088,6 @@ export namespace Value {
   interface $Base {
     __type?: "Value";
   }
-
   /**
    * <p>An array of column values.</p>
    */
@@ -1150,7 +1104,6 @@ export namespace Value {
     structValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value for a column of big integer data type.</p>
    */
@@ -1167,7 +1120,6 @@ export namespace Value {
     structValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value for a column of BIT data type.</p>
    */
@@ -1184,7 +1136,6 @@ export namespace Value {
     structValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value for a column of BLOB data type.</p>
    */
@@ -1201,7 +1152,6 @@ export namespace Value {
     structValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value for a column of double data type.</p>
    */
@@ -1218,7 +1168,6 @@ export namespace Value {
     structValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value for a column of integer data type.</p>
    */
@@ -1235,7 +1184,6 @@ export namespace Value {
     structValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A NULL value.</p>
    */
@@ -1252,7 +1200,6 @@ export namespace Value {
     structValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value for a column of real data type.</p>
    */
@@ -1269,7 +1216,6 @@ export namespace Value {
     structValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value for a column of string data type.</p>
    */
@@ -1286,7 +1232,6 @@ export namespace Value {
     structValue?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A value for a column of STRUCT data type.</p>
    */
@@ -1303,7 +1248,6 @@ export namespace Value {
     structValue: StructValue;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     arrayValues?: never;
     bigIntValue?: never;
@@ -1317,7 +1261,6 @@ export namespace Value {
     structValue?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     arrayValues: (value: Value[]) => T;
     bigIntValue: (value: number) => T;
@@ -1331,7 +1274,6 @@ export namespace Value {
     structValue: (value: StructValue) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: Value, visitor: Visitor<T>): T => {
     if (value.arrayValues !== undefined) return visitor.arrayValues(value.arrayValues);
     if (value.bigIntValue !== undefined) return visitor.bigIntValue(value.bigIntValue);
@@ -1344,20 +1286,5 @@ export namespace Value {
     if (value.stringValue !== undefined) return visitor.stringValue(value.stringValue);
     if (value.structValue !== undefined) return visitor.structValue(value.structValue);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: Value): any => {
-    if (obj.arrayValues !== undefined)
-      return { arrayValues: obj.arrayValues.map((item) => Value.filterSensitiveLog(item)) };
-    if (obj.bigIntValue !== undefined) return { bigIntValue: obj.bigIntValue };
-    if (obj.bitValue !== undefined) return { bitValue: obj.bitValue };
-    if (obj.blobValue !== undefined) return { blobValue: obj.blobValue };
-    if (obj.doubleValue !== undefined) return { doubleValue: obj.doubleValue };
-    if (obj.intValue !== undefined) return { intValue: obj.intValue };
-    if (obj.isNull !== undefined) return { isNull: obj.isNull };
-    if (obj.realValue !== undefined) return { realValue: obj.realValue };
-    if (obj.stringValue !== undefined) return { stringValue: obj.stringValue };
-    if (obj.structValue !== undefined) return { structValue: StructValue.filterSensitiveLog(obj.structValue) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-rds/RDSClient.ts
+++ b/clients/client-rds/RDSClient.ts
@@ -429,6 +429,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -820,7 +826,8 @@ export type RDSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type RDSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -829,7 +836,8 @@ export type RDSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Relational Database Service</fullname>
@@ -909,13 +917,15 @@ export class RDSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-sdk-rds": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",

--- a/clients/client-redshift/RedshiftClient.ts
+++ b/clients/client-redshift/RedshiftClient.ts
@@ -319,6 +319,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -634,7 +640,8 @@ export type RedshiftClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type RedshiftClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -643,7 +650,8 @@ export type RedshiftClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Redshift</fullname>
@@ -688,13 +696,15 @@ export class RedshiftClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-rekognition/RekognitionClient.ts
+++ b/clients/client-rekognition/RekognitionClient.ts
@@ -121,6 +121,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -346,7 +352,8 @@ export type RekognitionClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type RekognitionClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -355,7 +362,8 @@ export type RekognitionClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>This is the Amazon Rekognition API reference.</p>
@@ -379,13 +387,15 @@ export class RekognitionClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
+++ b/clients/client-resource-groups-tagging-api/ResourceGroupsTaggingAPIClient.ts
@@ -31,6 +31,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -178,7 +184,8 @@ export type ResourceGroupsTaggingAPIClientConfig = Partial<__SmithyConfiguration
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ResourceGroupsTaggingAPIClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -187,7 +194,8 @@ export type ResourceGroupsTaggingAPIClientResolvedConfig = __SmithyResolvedConfi
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Resource Groups Tagging API</fullname>
@@ -572,13 +580,15 @@ export class ResourceGroupsTaggingAPIClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-resource-groups/ResourceGroupsClient.ts
+++ b/clients/client-resource-groups/ResourceGroupsClient.ts
@@ -32,6 +32,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -193,7 +199,8 @@ export type ResourceGroupsClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ResourceGroupsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -202,7 +209,8 @@ export type ResourceGroupsClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Resource Groups</fullname>
@@ -263,13 +271,15 @@ export class ResourceGroupsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-robomaker/RoboMakerClient.ts
+++ b/clients/client-robomaker/RoboMakerClient.ts
@@ -129,6 +129,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -340,7 +346,8 @@ export type RoboMakerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type RoboMakerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -349,7 +356,8 @@ export type RoboMakerClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>This section provides documentation for the AWS RoboMaker API operations.</p>
@@ -373,13 +381,15 @@ export class RoboMakerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-route-53-domains/Route53DomainsClient.ts
+++ b/clients/client-route-53-domains/Route53DomainsClient.ts
@@ -99,6 +99,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -286,7 +292,8 @@ export type Route53DomainsClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type Route53DomainsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -295,7 +302,8 @@ export type Route53DomainsClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Route 53 API actions let you register domain names and perform related operations.</p>
@@ -319,13 +327,15 @@ export class Route53DomainsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-route-53/Route53Client.ts
+++ b/clients/client-route-53/Route53Client.ts
@@ -188,6 +188,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -433,7 +439,8 @@ export type Route53ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type Route53ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -442,7 +449,8 @@ export type Route53ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Route 53 is a highly available and scalable Domain Name System (DNS) web service.</p>
@@ -466,13 +474,15 @@ export class Route53Client extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-sdk-route53": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",

--- a/clients/client-route53resolver/Route53ResolverClient.ts
+++ b/clients/client-route53resolver/Route53ResolverClient.ts
@@ -81,6 +81,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -256,7 +262,8 @@ export type Route53ResolverClientConfig = Partial<__SmithyConfiguration<__HttpHa
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type Route53ResolverClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -265,7 +272,8 @@ export type Route53ResolverClientResolvedConfig = __SmithyResolvedConfiguration<
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Here's how you set up to query an Amazon Route 53 private hosted zone from your network:</p>
@@ -331,13 +339,15 @@ export class Route53ResolverClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-s3-control/S3ControlClient.ts
+++ b/clients/client-s3-control/S3ControlClient.ts
@@ -54,6 +54,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import { getPrependAccountIdPlugin } from "@aws-sdk/middleware-sdk-s3-control";
 import {
@@ -224,7 +230,8 @@ export type S3ControlClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type S3ControlClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -233,7 +240,8 @@ export type S3ControlClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>
@@ -259,14 +267,16 @@ export class S3ControlClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getPrependAccountIdPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-sdk-s3-control": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",

--- a/clients/client-s3/S3Client.ts
+++ b/clients/client-s3/S3Client.ts
@@ -238,6 +238,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import { getValidateBucketNamePlugin } from "@aws-sdk/middleware-sdk-s3";
 import {
@@ -570,6 +576,7 @@ export type S3ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions>
   UserAgentInputConfig &
   BucketEndpointInputConfig &
   HostHeaderInputConfig &
+  LoggerInputConfig &
   EventStreamSerdeInputConfig;
 
 export type S3ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
@@ -581,6 +588,7 @@ export type S3ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandler
   UserAgentResolvedConfig &
   BucketEndpointResolvedConfig &
   HostHeaderResolvedConfig &
+  LoggerResolvedConfig &
   EventStreamSerdeResolvedConfig;
 
 /**
@@ -606,9 +614,10 @@ export class S3Client extends __Client<
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveBucketEndpointConfig(_config_5);
     let _config_7 = resolveHostHeaderConfig(_config_6);
-    let _config_8 = resolveEventStreamSerdeConfig(_config_7);
-    super(_config_8);
-    this.config = _config_8;
+    let _config_8 = resolveLoggerConfig(_config_7);
+    let _config_9 = resolveEventStreamSerdeConfig(_config_8);
+    super(_config_9);
+    this.config = _config_9;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
@@ -616,6 +625,7 @@ export class S3Client extends __Client<
     this.middlewareStack.use(getValidateBucketNamePlugin(this.config));
     this.middlewareStack.use(getAddExpectContinuePlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-s3/models/index.ts
+++ b/clients/client-s3/models/index.ts
@@ -9644,7 +9644,6 @@ export namespace SelectObjectContentEventStream {
   interface $Base {
     __type?: "SelectObjectContentEventStream";
   }
-
   /**
    * <p>The Stats Event.</p>
    */
@@ -9656,7 +9655,6 @@ export namespace SelectObjectContentEventStream {
     Cont?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The End Event.</p>
    */
@@ -9668,7 +9666,6 @@ export namespace SelectObjectContentEventStream {
     Cont?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The Progress Event.</p>
    */
@@ -9680,7 +9677,6 @@ export namespace SelectObjectContentEventStream {
     Cont?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The Records Event.</p>
    */
@@ -9692,7 +9688,6 @@ export namespace SelectObjectContentEventStream {
     Cont?: never;
     $unknown?: never;
   }
-
   /**
    * <p>The Continuation Event.</p>
    */
@@ -9704,7 +9699,6 @@ export namespace SelectObjectContentEventStream {
     Cont: ContinuationEvent;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     Stats?: never;
     End?: never;
@@ -9713,7 +9707,6 @@ export namespace SelectObjectContentEventStream {
     Cont?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     Stats: (value: StatsEvent) => T;
     End: (value: EndEvent) => T;
@@ -9722,7 +9715,6 @@ export namespace SelectObjectContentEventStream {
     Cont: (value: ContinuationEvent) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: SelectObjectContentEventStream, visitor: Visitor<T>): T => {
     if (value.Stats !== undefined) return visitor.Stats(value.Stats);
     if (value.End !== undefined) return visitor.End(value.End);
@@ -9730,15 +9722,6 @@ export namespace SelectObjectContentEventStream {
     if (value.Records !== undefined) return visitor.Records(value.Records);
     if (value.Cont !== undefined) return visitor.Cont(value.Cont);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: SelectObjectContentEventStream): any => {
-    if (obj.Cont !== undefined) return { Cont: ContinuationEvent.filterSensitiveLog(obj.Cont) };
-    if (obj.End !== undefined) return { End: EndEvent.filterSensitiveLog(obj.End) };
-    if (obj.Progress !== undefined) return { Progress: ProgressEvent.filterSensitiveLog(obj.Progress) };
-    if (obj.Records !== undefined) return { Records: RecordsEvent.filterSensitiveLog(obj.Records) };
-    if (obj.Stats !== undefined) return { Stats: StatsEvent.filterSensitiveLog(obj.Stats) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -9753,7 +9736,6 @@ export interface SelectObjectContentOutput {
 export namespace SelectObjectContentOutput {
   export const filterSensitiveLog = (obj: SelectObjectContentOutput): any => ({
     ...obj,
-    ...(obj.Payload && { Payload: "STREAMING_CONTENT" }),
   });
   export const isa = (o: any): o is SelectObjectContentOutput => __isa(o, "SelectObjectContentOutput");
 }

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/middleware-expect-continue": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
     "@aws-sdk/middleware-location-constraint": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-sdk-s3": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",

--- a/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
+++ b/clients/client-sagemaker-a2i-runtime/SageMakerA2IRuntimeClient.ts
@@ -19,6 +19,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -160,7 +166,8 @@ export type SageMakerA2IRuntimeClientConfig = Partial<__SmithyConfiguration<__Ht
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SageMakerA2IRuntimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -169,7 +176,8 @@ export type SageMakerA2IRuntimeClientResolvedConfig = __SmithyResolvedConfigurat
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <important>
@@ -222,13 +230,15 @@ export class SageMakerA2IRuntimeClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
+++ b/clients/client-sagemaker-runtime/SageMakerRuntimeClient.ts
@@ -15,6 +15,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -146,7 +152,8 @@ export type SageMakerRuntimeClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SageMakerRuntimeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -155,7 +162,8 @@ export type SageMakerRuntimeClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>
@@ -181,13 +189,15 @@ export class SageMakerRuntimeClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-sagemaker/SageMakerClient.ts
+++ b/clients/client-sagemaker/SageMakerClient.ts
@@ -343,6 +343,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -748,7 +754,8 @@ export type SageMakerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SageMakerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -757,7 +764,8 @@ export type SageMakerClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Provides APIs for creating and managing Amazon SageMaker resources. </p>
@@ -796,13 +804,15 @@ export class SageMakerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-savingsplans/SavingsplansClient.ts
+++ b/clients/client-savingsplans/SavingsplansClient.ts
@@ -37,6 +37,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -184,7 +190,8 @@ export type SavingsplansClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SavingsplansClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -193,7 +200,8 @@ export type SavingsplansClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Savings Plans are a pricing model that offer significant savings on AWS usage (for
@@ -220,13 +228,15 @@ export class SavingsplansClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-schemas/SchemasClient.ts
+++ b/clients/client-schemas/SchemasClient.ts
@@ -62,6 +62,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -253,7 +259,8 @@ export type SchemasClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SchemasClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -262,7 +269,8 @@ export type SchemasClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon EventBridge Schema Registry</p>
@@ -286,13 +294,15 @@ export class SchemasClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-secrets-manager/SecretsManagerClient.ts
+++ b/clients/client-secrets-manager/SecretsManagerClient.ts
@@ -45,6 +45,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -214,7 +220,8 @@ export type SecretsManagerClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SecretsManagerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -223,7 +230,8 @@ export type SecretsManagerClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Secrets Manager API Reference</fullname>
@@ -309,13 +317,15 @@ export class SecretsManagerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-securityhub/SecurityHubClient.ts
+++ b/clients/client-securityhub/SecurityHubClient.ts
@@ -105,6 +105,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -322,7 +328,8 @@ export type SecurityHubClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SecurityHubClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -331,7 +338,8 @@ export type SecurityHubClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Security Hub provides you with a comprehensive view of the security state of your AWS
@@ -395,13 +403,15 @@ export class SecurityHubClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
+++ b/clients/client-serverlessapplicationrepository/ServerlessApplicationRepositoryClient.ts
@@ -52,6 +52,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -211,7 +217,8 @@ export type ServerlessApplicationRepositoryClientConfig = Partial<__SmithyConfig
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ServerlessApplicationRepositoryClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -220,7 +227,8 @@ export type ServerlessApplicationRepositoryClientResolvedConfig = __SmithyResolv
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The AWS Serverless Application Repository makes it easy for developers and enterprises to quickly find
@@ -263,13 +271,15 @@ export class ServerlessApplicationRepositoryClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-service-catalog/ServiceCatalogClient.ts
+++ b/clients/client-service-catalog/ServiceCatalogClient.ts
@@ -271,6 +271,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -568,7 +574,8 @@ export type ServiceCatalogClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ServiceCatalogClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -577,7 +584,8 @@ export type ServiceCatalogClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Service Catalog</fullname>
@@ -606,13 +614,15 @@ export class ServiceCatalogClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-service-quotas/ServiceQuotasClient.ts
+++ b/clients/client-service-quotas/ServiceQuotasClient.ts
@@ -69,6 +69,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -232,7 +238,8 @@ export type ServiceQuotasClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ServiceQuotasClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -241,7 +248,8 @@ export type ServiceQuotasClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p> Service Quotas is a web service that you can use to manage many of your AWS service
@@ -276,13 +284,15 @@ export class ServiceQuotasClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-servicediscovery/ServiceDiscoveryClient.ts
+++ b/clients/client-servicediscovery/ServiceDiscoveryClient.ts
@@ -55,6 +55,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -232,7 +238,8 @@ export type ServiceDiscoveryClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ServiceDiscoveryClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -241,7 +248,8 @@ export type ServiceDiscoveryClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Cloud Map lets you configure public DNS, private DNS, or HTTP namespaces that your microservice applications
@@ -269,13 +277,15 @@ export class ServiceDiscoveryClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-ses/SESClient.ts
+++ b/clients/client-ses/SESClient.ts
@@ -235,6 +235,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -508,7 +514,8 @@ export type SESClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SESClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -517,7 +524,8 @@ export type SESClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Simple Email Service</fullname>
@@ -549,13 +557,15 @@ export class SESClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-sesv2/SESv2Client.ts
+++ b/clients/client-sesv2/SESv2Client.ts
@@ -249,6 +249,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -514,7 +520,8 @@ export type SESv2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SESv2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -523,7 +530,8 @@ export type SESv2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon SES API v2</fullname>
@@ -566,13 +574,15 @@ export class SESv2Client extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-sfn/SFNClient.ts
+++ b/clients/client-sfn/SFNClient.ts
@@ -48,6 +48,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -223,7 +229,8 @@ export type SFNClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SFNClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -232,7 +239,8 @@ export type SFNClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Step Functions</fullname>
@@ -271,13 +279,15 @@ export class SFNClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-shield/ShieldClient.ts
+++ b/clients/client-shield/ShieldClient.ts
@@ -73,6 +73,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -250,7 +256,8 @@ export type ShieldClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type ShieldClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -259,7 +266,8 @@ export type ShieldClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Shield Advanced</fullname>
@@ -286,13 +294,15 @@ export class ShieldClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-signer/SignerClient.ts
+++ b/clients/client-signer/SignerClient.ts
@@ -38,6 +38,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -193,7 +199,8 @@ export type SignerClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpti
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SignerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -202,7 +209,8 @@ export type SignerClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHan
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>With code signing for IoT, you can sign code that you create for any IoT device that is
@@ -230,13 +238,15 @@ export class SignerClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-sms/SMSClient.ts
+++ b/clients/client-sms/SMSClient.ts
@@ -84,6 +84,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -271,7 +277,8 @@ export type SMSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -280,7 +287,8 @@ export type SMSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AAWS Sever Migration Service</fullname>
@@ -324,13 +332,15 @@ export class SMSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-snowball/SnowballClient.ts
+++ b/clients/client-snowball/SnowballClient.ts
@@ -36,6 +36,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -205,7 +211,8 @@ export type SnowballClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SnowballClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -214,7 +221,8 @@ export type SnowballClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Snowball is a petabyte-scale data transport solution that uses secure devices to
@@ -244,13 +252,15 @@ export class SnowballClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-sns/SNSClient.ts
+++ b/clients/client-sns/SNSClient.ts
@@ -95,6 +95,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -292,7 +298,8 @@ export type SNSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SNSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -301,7 +308,8 @@ export type SNSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Simple Notification Service</fullname>
@@ -334,13 +342,15 @@ export class SNSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-sqs/SQSClient.ts
+++ b/clients/client-sqs/SQSClient.ts
@@ -43,6 +43,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -220,7 +226,8 @@ export type SQSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SQSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -229,7 +236,8 @@ export type SQSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Welcome to the <i>Amazon Simple Queue Service API Reference</i>.</p>
@@ -317,13 +325,15 @@ export class SQSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -36,6 +36,7 @@
     "@aws-sdk/md5-js": "1.0.0-gamma.6",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-sdk-sqs": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",

--- a/clients/client-ssm/SSMClient.ts
+++ b/clients/client-ssm/SSMClient.ts
@@ -385,6 +385,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -760,7 +766,8 @@ export type SSMClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SSMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -769,7 +776,8 @@ export type SSMClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Systems Manager</fullname>
@@ -806,13 +814,15 @@ export class SSMClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-sso-oidc/SSOOIDCClient.ts
+++ b/clients/client-sso-oidc/SSOOIDCClient.ts
@@ -20,6 +20,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -157,7 +163,8 @@ export type SSOOIDCClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SSOOIDCClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -166,7 +173,8 @@ export type SSOOIDCClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Single Sign-On (SSO) OpenID Connect (OIDC) is a web service that enables a client
@@ -207,13 +215,15 @@ export class SSOOIDCClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-sso/SSOClient.ts
+++ b/clients/client-sso/SSOClient.ts
@@ -18,6 +18,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -157,7 +163,8 @@ export type SSOClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SSOClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -166,7 +173,8 @@ export type SSOClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Single Sign-On Portal is a web service that makes it easy for you to assign user
@@ -205,13 +213,15 @@ export class SSOClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-storage-gateway/StorageGatewayClient.ts
+++ b/clients/client-storage-gateway/StorageGatewayClient.ts
@@ -218,6 +218,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -505,7 +511,8 @@ export type StorageGatewayClientConfig = Partial<__SmithyConfiguration<__HttpHan
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type StorageGatewayClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -514,7 +521,8 @@ export type StorageGatewayClientResolvedConfig = __SmithyResolvedConfiguration<_
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Storage Gateway Service</fullname>
@@ -609,13 +617,15 @@ export class StorageGatewayClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -28,6 +28,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -175,7 +181,8 @@ export type STSClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type STSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -184,7 +191,8 @@ export type STSClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Security Token Service</fullname>
@@ -276,13 +284,15 @@ export class STSClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-support/SupportClient.ts
+++ b/clients/client-support/SupportClient.ts
@@ -55,6 +55,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -214,7 +220,8 @@ export type SupportClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOpt
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SupportClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -223,7 +230,8 @@ export type SupportClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHa
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>AWS Support</fullname>
@@ -323,13 +331,15 @@ export class SupportClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-swf/SWFClient.ts
+++ b/clients/client-swf/SWFClient.ts
@@ -135,6 +135,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -340,7 +346,8 @@ export type SWFClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SWFClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -349,7 +356,8 @@ export type SWFClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon Simple Workflow Service</fullname>
@@ -388,13 +396,15 @@ export class SWFClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-synthetics/SyntheticsClient.ts
+++ b/clients/client-synthetics/SyntheticsClient.ts
@@ -36,6 +36,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -193,7 +199,8 @@ export type SyntheticsClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type SyntheticsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -202,7 +209,8 @@ export type SyntheticsClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon CloudWatch Synthetics</fullname>
@@ -241,13 +249,15 @@ export class SyntheticsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-textract/TextractClient.ts
+++ b/clients/client-textract/TextractClient.ts
@@ -32,6 +32,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -175,7 +181,8 @@ export type TextractClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type TextractClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -184,7 +191,8 @@ export type TextractClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon Textract detects and analyzes text in documents and converts it
@@ -210,13 +218,15 @@ export class TextractClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
+++ b/clients/client-transcribe-streaming/TranscribeStreamingClient.ts
@@ -28,6 +28,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   WebSocketInputConfig,
@@ -178,6 +184,7 @@ export type TranscribeStreamingClientConfig = Partial<__SmithyConfiguration<__Ht
   RetryInputConfig &
   UserAgentInputConfig &
   HostHeaderInputConfig &
+  LoggerInputConfig &
   EventStreamInputConfig &
   WebSocketInputConfig &
   EventStreamSerdeInputConfig;
@@ -190,6 +197,7 @@ export type TranscribeStreamingClientResolvedConfig = __SmithyResolvedConfigurat
   RetryResolvedConfig &
   UserAgentResolvedConfig &
   HostHeaderResolvedConfig &
+  LoggerResolvedConfig &
   EventStreamResolvedConfig &
   WebSocketResolvedConfig &
   EventStreamSerdeResolvedConfig;
@@ -216,16 +224,18 @@ export class TranscribeStreamingClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    let _config_7 = resolveEventStreamConfig(_config_6);
-    let _config_8 = resolveWebSocketConfig(_config_7);
-    let _config_9 = resolveEventStreamSerdeConfig(_config_8);
-    super(_config_9);
-    this.config = _config_9;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    let _config_8 = resolveEventStreamConfig(_config_7);
+    let _config_9 = resolveWebSocketConfig(_config_8);
+    let _config_10 = resolveEventStreamSerdeConfig(_config_9);
+    super(_config_10);
+    this.config = _config_10;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getWebSocketPlugin(this.config));
   }
 

--- a/clients/client-transcribe-streaming/models/index.ts
+++ b/clients/client-transcribe-streaming/models/index.ts
@@ -51,7 +51,6 @@ export namespace AudioStream {
   interface $Base {
     __type?: "AudioStream";
   }
-
   /**
    * <p>A blob of audio from your application. You audio stream consists of one or more audio
    *       events.</p>
@@ -60,25 +59,17 @@ export namespace AudioStream {
     AudioEvent: AudioEvent;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     AudioEvent?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     AudioEvent: (value: AudioEvent) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: AudioStream, visitor: Visitor<T>): T => {
     if (value.AudioEvent !== undefined) return visitor.AudioEvent(value.AudioEvent);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: AudioStream): any => {
-    if (obj.AudioEvent !== undefined) return { AudioEvent: AudioEvent.filterSensitiveLog(obj.AudioEvent) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 
@@ -333,7 +324,6 @@ export interface StartStreamTranscriptionRequest {
 export namespace StartStreamTranscriptionRequest {
   export const filterSensitiveLog = (obj: StartStreamTranscriptionRequest): any => ({
     ...obj,
-    ...(obj.AudioStream && { AudioStream: "STREAMING_CONTENT" }),
   });
   export const isa = (o: any): o is StartStreamTranscriptionRequest => __isa(o, "StartStreamTranscriptionRequest");
 }
@@ -390,7 +380,6 @@ export interface StartStreamTranscriptionResponse {
 export namespace StartStreamTranscriptionResponse {
   export const filterSensitiveLog = (obj: StartStreamTranscriptionResponse): any => ({
     ...obj,
-    ...(obj.TranscriptResultStream && { TranscriptResultStream: "STREAMING_CONTENT" }),
   });
   export const isa = (o: any): o is StartStreamTranscriptionResponse => __isa(o, "StartStreamTranscriptionResponse");
 }
@@ -451,7 +440,6 @@ export namespace TranscriptResultStream {
   interface $Base {
     __type?: "TranscriptResultStream";
   }
-
   /**
    * <p>A portion of the transcription of the audio stream. Events are sent periodically from
    *       Amazon Transcribe to your application. The event can be a partial transcription of a section of the audio
@@ -467,7 +455,6 @@ export namespace TranscriptResultStream {
     LimitExceededException?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A client error occurred when the stream was created. Check the parameters of the request
    *       and try your request again.</p>
@@ -481,7 +468,6 @@ export namespace TranscriptResultStream {
     LimitExceededException?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A problem occurred while processing the audio. Amazon Transcribe terminated processing.</p>
    */
@@ -494,7 +480,6 @@ export namespace TranscriptResultStream {
     LimitExceededException?: never;
     $unknown?: never;
   }
-
   /**
    * <p>A new stream started with the same session ID. The current stream has been
    *       terminated.</p>
@@ -508,7 +493,6 @@ export namespace TranscriptResultStream {
     LimitExceededException?: never;
     $unknown?: never;
   }
-
   /**
    * <p>Service is currently unavailable. Try your request later.</p>
    */
@@ -521,7 +505,6 @@ export namespace TranscriptResultStream {
     LimitExceededException?: never;
     $unknown?: never;
   }
-
   /**
    * <p>Your client has exceeded one of the Amazon Transcribe limits, typically the limit on audio length.
    *       Break your audio stream into smaller chunks and try your request again.</p>
@@ -535,7 +518,6 @@ export namespace TranscriptResultStream {
     LimitExceededException: LimitExceededException;
     $unknown?: never;
   }
-
   export interface $UnknownMember extends $Base {
     TranscriptEvent?: never;
     BadRequestException?: never;
@@ -545,7 +527,6 @@ export namespace TranscriptResultStream {
     LimitExceededException?: never;
     $unknown: [string, any];
   }
-
   export interface Visitor<T> {
     TranscriptEvent: (value: TranscriptEvent) => T;
     BadRequestException: (value: BadRequestException) => T;
@@ -555,7 +536,6 @@ export namespace TranscriptResultStream {
     LimitExceededException: (value: LimitExceededException) => T;
     _: (name: string, value: any) => T;
   }
-
   export const visit = <T>(value: TranscriptResultStream, visitor: Visitor<T>): T => {
     if (value.TranscriptEvent !== undefined) return visitor.TranscriptEvent(value.TranscriptEvent);
     if (value.BadRequestException !== undefined) return visitor.BadRequestException(value.BadRequestException);
@@ -566,24 +546,6 @@ export namespace TranscriptResultStream {
       return visitor.ServiceUnavailableException(value.ServiceUnavailableException);
     if (value.LimitExceededException !== undefined) return visitor.LimitExceededException(value.LimitExceededException);
     return visitor._(value.$unknown[0], value.$unknown[1]);
-  };
-
-  export const filterSensitiveLog = (obj: TranscriptResultStream): any => {
-    if (obj.TranscriptEvent !== undefined)
-      return { TranscriptEvent: TranscriptEvent.filterSensitiveLog(obj.TranscriptEvent) };
-    if (obj.BadRequestException !== undefined)
-      return { BadRequestException: BadRequestException.filterSensitiveLog(obj.BadRequestException) };
-    if (obj.InternalFailureException !== undefined)
-      return { InternalFailureException: InternalFailureException.filterSensitiveLog(obj.InternalFailureException) };
-    if (obj.ConflictException !== undefined)
-      return { ConflictException: ConflictException.filterSensitiveLog(obj.ConflictException) };
-    if (obj.ServiceUnavailableException !== undefined)
-      return {
-        ServiceUnavailableException: ServiceUnavailableException.filterSensitiveLog(obj.ServiceUnavailableException),
-      };
-    if (obj.LimitExceededException !== undefined)
-      return { LimitExceededException: LimitExceededException.filterSensitiveLog(obj.LimitExceededException) };
-    if (obj.$unknown !== undefined) return { [obj.$unknown[0]]: "UNKNOWN" };
   };
 }
 

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -42,6 +42,7 @@
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-eventstream": "1.0.0-gamma.5",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-sdk-transcribe-streaming": "1.0.0-gamma.5",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",

--- a/clients/client-transcribe/TranscribeClient.ts
+++ b/clients/client-transcribe/TranscribeClient.ts
@@ -91,6 +91,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -268,7 +274,8 @@ export type TranscribeClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type TranscribeClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -277,7 +284,8 @@ export type TranscribeClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Operations and objects for transcribing speech to text.</p>
@@ -301,13 +309,15 @@ export class TranscribeClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-transfer/TransferClient.ts
+++ b/clients/client-transfer/TransferClient.ts
@@ -38,6 +38,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -205,7 +211,8 @@ export type TransferClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type TransferClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -214,7 +221,8 @@ export type TransferClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS Transfer Family is a fully managed service that enables the transfer of files over the
@@ -246,13 +254,15 @@ export class TransferClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-translate/TranslateClient.ts
+++ b/clients/client-translate/TranslateClient.ts
@@ -35,6 +35,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -184,7 +190,8 @@ export type TranslateClientConfig = Partial<__SmithyConfiguration<__HttpHandlerO
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type TranslateClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -193,7 +200,8 @@ export type TranslateClientResolvedConfig = __SmithyResolvedConfiguration<__Http
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Provides translation between one source language and another of the same set of
@@ -218,13 +226,15 @@ export class TranslateClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-waf-regional/WAFRegionalClient.ts
+++ b/clients/client-waf-regional/WAFRegionalClient.ts
@@ -200,6 +200,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -493,7 +499,8 @@ export type WAFRegionalClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type WAFRegionalClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -502,7 +509,8 @@ export type WAFRegionalClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <note>
@@ -536,13 +544,15 @@ export class WAFRegionalClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-waf/WAFClient.ts
+++ b/clients/client-waf/WAFClient.ts
@@ -190,6 +190,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -475,7 +481,8 @@ export type WAFClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptions
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type WAFClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -484,7 +491,8 @@ export type WAFClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandle
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <note>
@@ -518,13 +526,15 @@ export class WAFClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-wafv2/WAFV2Client.ts
+++ b/clients/client-wafv2/WAFV2Client.ts
@@ -108,6 +108,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -319,7 +325,8 @@ export type WAFV2ClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOptio
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type WAFV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -328,7 +335,8 @@ export type WAFV2ClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHand
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <note>
@@ -407,13 +415,15 @@ export class WAFV2Client extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-workdocs/WorkDocsClient.ts
+++ b/clients/client-workdocs/WorkDocsClient.ts
@@ -103,6 +103,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -316,7 +322,8 @@ export type WorkDocsClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type WorkDocsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -325,7 +332,8 @@ export type WorkDocsClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The WorkDocs API is designed for the following use cases:</p>
@@ -381,13 +389,15 @@ export class WorkDocsClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-worklink/WorkLinkClient.ts
+++ b/clients/client-worklink/WorkLinkClient.ts
@@ -107,6 +107,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -304,7 +310,8 @@ export type WorkLinkClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type WorkLinkClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -313,7 +320,8 @@ export type WorkLinkClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon WorkLink is a cloud-based service that provides secure access
@@ -343,13 +351,15 @@ export class WorkLinkClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-workmail/WorkMailClient.ts
+++ b/clients/client-workmail/WorkMailClient.ts
@@ -80,6 +80,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -277,7 +283,8 @@ export type WorkMailClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOp
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type WorkMailClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -286,7 +293,8 @@ export type WorkMailClientResolvedConfig = __SmithyResolvedConfiguration<__HttpH
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>Amazon WorkMail is a secure, managed business email and calendaring service with support for
@@ -344,13 +352,15 @@ export class WorkMailClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
+++ b/clients/client-workmailmessageflow/WorkMailMessageFlowClient.ts
@@ -18,6 +18,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -149,7 +155,8 @@ export type WorkMailMessageFlowClientConfig = Partial<__SmithyConfiguration<__Ht
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type WorkMailMessageFlowClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -158,7 +165,8 @@ export type WorkMailMessageFlowClientResolvedConfig = __SmithyResolvedConfigurat
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>The WorkMail Message Flow API provides access to email messages as they are
@@ -186,13 +194,15 @@ export class WorkMailMessageFlowClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-workspaces/WorkSpacesClient.ts
+++ b/clients/client-workspaces/WorkSpacesClient.ts
@@ -126,6 +126,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -343,7 +349,8 @@ export type WorkSpacesClientConfig = Partial<__SmithyConfiguration<__HttpHandler
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type WorkSpacesClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -352,7 +359,8 @@ export type WorkSpacesClientResolvedConfig = __SmithyResolvedConfiguration<__Htt
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <fullname>Amazon WorkSpaces Service</fullname>
@@ -378,13 +386,15 @@ export class WorkSpacesClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/clients/client-xray/XRayClient.ts
+++ b/clients/client-xray/XRayClient.ts
@@ -49,6 +49,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -220,7 +226,8 @@ export type XRayClientConfig = Partial<__SmithyConfiguration<__HttpHandlerOption
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type XRayClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -229,7 +236,8 @@ export type XRayClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandl
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * <p>AWS X-Ray provides APIs for managing debug traces and retrieving service maps
@@ -254,13 +262,15 @@ export class XRayClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -205,6 +205,9 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                 RuntimeClientPlugin.builder()
                         .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_MIDDLEWARE)
                         .operationPredicate(AddBuiltinPlugins::operationUsesAwsAuth)
+                        .build(),
+                RuntimeClientPlugin.builder()
+                        .withConventions(AwsDependency.MIDDLEWARE_LOGGER.dependency, "Logger")
                         .build()
         );
     }

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AwsDependency.java
@@ -60,7 +60,8 @@ public enum AwsDependency implements SymbolDependencyContainer {
     TRANSCRIBE_STREAMING_MIDDLEWARE(NORMAL_DEPENDENCY, "@aws-sdk/middleware-sdk-transcribe-streaming",
             "^1.0.0-gamma.0"),
     RETRY_CONFIG_PROVIDER(NORMAL_DEPENDENCY, "@aws-sdk/retry-config-provider", "^1.0.0-gamma.0"),
-    NODE_CONFIG_PROVIDER(NORMAL_DEPENDENCY, "@aws-sdk/node-config-provider", "^1.0.0-gamma.0");
+    NODE_CONFIG_PROVIDER(NORMAL_DEPENDENCY, "@aws-sdk/node-config-provider", "^1.0.0-gamma.0"),
+    MIDDLEWARE_LOGGER(NORMAL_DEPENDENCY, "@aws-sdk/middleware-logger", "^1.0.0-gamma.0");
 
     public final String packageName;
     public final String version;

--- a/packages/middleware-logger/LICENSE
+++ b/packages/middleware-logger/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/middleware-logger/README.md
+++ b/packages/middleware-logger/README.md
@@ -1,0 +1,4 @@
+# @aws-sdk/middleware-logger
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-logger/beta.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-logger)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-logger.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-logger)

--- a/packages/middleware-logger/jest.config.js
+++ b/packages/middleware-logger/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@aws-sdk/middleware-logger",
+  "version": "1.0.0-gamma.0",
+  "scripts": {
+    "prepublishOnly": "yarn build:cjs && yarn build:es",
+    "pretest": "yarn build:cjs",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build": "yarn build:es && yarn build:cjs",
+    "test": "jest --passWithNoTests"
+  },
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "email": "",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "dependencies": {
+    "@aws-sdk/types": "1.0.0-gamma.5",
+    "tslib": "^1.8.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.4",
+    "@types/node": "^10.0.0",
+    "jest": "^26.1.0",
+    "typescript": "~4.0.2"
+  }
+}

--- a/packages/middleware-logger/src/configurations.ts
+++ b/packages/middleware-logger/src/configurations.ts
@@ -4,6 +4,11 @@ export interface LoggerInputConfig {
   logger?: Logger;
 }
 
+interface PreviouslyResolved {}
+
 export interface LoggerResolvedConfig {
   logger?: Logger;
 }
+
+export const resolveLoggerConfig = <T>(input: T & PreviouslyResolved & LoggerInputConfig): T & LoggerResolvedConfig =>
+  input;

--- a/packages/middleware-logger/src/configurations.ts
+++ b/packages/middleware-logger/src/configurations.ts
@@ -1,0 +1,9 @@
+import { Logger } from "@aws-sdk/types";
+
+export interface LoggerInputConfig {
+  logger?: Logger;
+}
+
+export interface LoggerResolvedConfig {
+  logger?: Logger;
+}

--- a/packages/middleware-logger/src/index.ts
+++ b/packages/middleware-logger/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./configurations";

--- a/packages/middleware-logger/src/index.ts
+++ b/packages/middleware-logger/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./configurations";
+export * from "./loggerMiddleware";

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -1,0 +1,33 @@
+import {
+  AbsoluteLocation,
+  FinalizeHandler,
+  FinalizeHandlerArguments,
+  FinalizeHandlerOutput,
+  FinalizeRequestHandlerOptions,
+  MetadataBearer,
+  Pluggable,
+} from "@aws-sdk/types";
+
+import { LoggerResolvedConfig } from "./configurations";
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+export const loggerMiddleware = (options: LoggerResolvedConfig) => <Output extends MetadataBearer = MetadataBearer>(
+  next: FinalizeHandler<any, Output>
+): FinalizeHandler<any, Output> => async (
+  args: FinalizeHandlerArguments<any>
+): Promise<FinalizeHandlerOutput<Output>> => {
+  // TODO: use and call options.logger once it's available in context
+  return next(args);
+};
+
+export const loggerMiddlewareOptions: FinalizeRequestHandlerOptions & AbsoluteLocation = {
+  name: "loggerMiddleware",
+  tags: ["LOGGER"],
+  step: "finalizeRequest",
+};
+
+export const getLoggerPlugin = (options: LoggerResolvedConfig): Pluggable<any, any> => ({
+  applyToStack: (clientStack) => {
+    clientStack.add(loggerMiddleware(options), loggerMiddlewareOptions);
+  },
+});

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "strict": true,
+    "sourceMap": false,
+    "downlevelIteration": true,
+    "noEmitHelpers": true,
+    "importHelpers": true,
+    "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "rootDir": "./src",
+    "outDir": "./dist/cjs",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/middleware-logger/tsconfig.es.json
+++ b/packages/middleware-logger/tsconfig.es.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "strict": true,
+    "sourceMap": false,
+    "downlevelIteration": true,
+    "noEmitHelpers": true,
+    "importHelpers": true,
+    "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/protocol_tests/aws-ec2/EC2ProtocolClient.ts
+++ b/protocol_tests/aws-ec2/EC2ProtocolClient.ts
@@ -42,6 +42,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -205,7 +211,8 @@ export type EC2ProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandle
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type EC2ProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -214,7 +221,8 @@ export type EC2ProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__Ht
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * An EC2 query service that sends query requests and XML responses.
@@ -238,13 +246,15 @@ export class EC2ProtocolClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/protocol_tests/aws-json/JsonProtocolClient.ts
+++ b/protocol_tests/aws-json/JsonProtocolClient.ts
@@ -23,6 +23,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -160,7 +166,8 @@ export type JsonProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHandl
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type JsonProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -169,7 +176,8 @@ export type JsonProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__H
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 export class JsonProtocolClient extends __Client<
   __HttpHandlerOptions,
@@ -190,13 +198,15 @@ export class JsonProtocolClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/protocol_tests/aws-query/QueryProtocolClient.ts
+++ b/protocol_tests/aws-query/QueryProtocolClient.ts
@@ -51,6 +51,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -226,7 +232,8 @@ export type QueryProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHand
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type QueryProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -235,7 +242,8 @@ export type QueryProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * A query service that sends query requests and XML responses.
@@ -259,13 +267,15 @@ export class QueryProtocolClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
+++ b/protocol_tests/aws-restjson/RestJsonProtocolClient.ts
@@ -93,6 +93,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -280,7 +286,8 @@ export type RestJsonProtocolClientConfig = Partial<__SmithyConfiguration<__HttpH
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type RestJsonProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -289,7 +296,8 @@ export type RestJsonProtocolClientResolvedConfig = __SmithyResolvedConfiguration
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * A REST JSON service that sends JSON requests and responses.
@@ -313,13 +321,15 @@ export class RestJsonProtocolClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",

--- a/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
+++ b/protocol_tests/aws-restxml/RestXmlProtocolClient.ts
@@ -117,6 +117,12 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import {
+  LoggerInputConfig,
+  LoggerResolvedConfig,
+  getLoggerPlugin,
+  resolveLoggerConfig,
+} from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -322,7 +328,8 @@ export type RestXmlProtocolClientConfig = Partial<__SmithyConfiguration<__HttpHa
   AwsAuthInputConfig &
   RetryInputConfig &
   UserAgentInputConfig &
-  HostHeaderInputConfig;
+  HostHeaderInputConfig &
+  LoggerInputConfig;
 
 export type RestXmlProtocolClientResolvedConfig = __SmithyResolvedConfiguration<__HttpHandlerOptions> &
   Required<ClientDefaults> &
@@ -331,7 +338,8 @@ export type RestXmlProtocolClientResolvedConfig = __SmithyResolvedConfiguration<
   AwsAuthResolvedConfig &
   RetryResolvedConfig &
   UserAgentResolvedConfig &
-  HostHeaderResolvedConfig;
+  HostHeaderResolvedConfig &
+  LoggerResolvedConfig;
 
 /**
  * A REST XML service that sends XML requests and responses.
@@ -355,13 +363,15 @@ export class RestXmlProtocolClient extends __Client<
     let _config_4 = resolveRetryConfig(_config_3);
     let _config_5 = resolveUserAgentConfig(_config_4);
     let _config_6 = resolveHostHeaderConfig(_config_5);
-    super(_config_6);
-    this.config = _config_6;
+    let _config_7 = resolveLoggerConfig(_config_6);
+    super(_config_7);
+    this.config = _config_7;
     this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.6",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.6",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.0",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.6",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.5",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.6",


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-2036
In place of https://github.com/aws/aws-sdk-js-v3/pull/1470

*Description of changes:*
LoggerConfig allows logger to be passed during client creation.
In future commits, this logger will be populated in handlerExecutionContext, and the middleware will be updated to log request/response and metadata/input/output

This PR:
* Commit 450e3fb adds basic configurations in middleware-logger
* Commit 393d504 adds initial setup for middleware-logger
* Commit 1fd11eb adds logger dependency in codegen, and e503b52 generates all clients

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
