### PR TITLE
fix: do not overwrite body while logging req/res

### DIFF
--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -31,10 +31,10 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
 
   if (typeof logger.debug === "function") {
     logger.debug({
-      httpRequest: { ...(args.request as any), body: "examine input under info" },
+      httpRequest: args.request,
     });
     logger.debug({
-      httpResponse: { ...(response.response as any), body: "examine output under info" },
+      httpResponse: response.response,
     });
   }
 


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-1790

*Description of changes:*
Do not overwrite body while logging req/res

In the initial PoC of logger-middleware, the body was overwritten for request/response but the decision was reverted. The code in https://github.com/aws/aws-sdk-js-v3/pull/1478 didn't remove the code to overwrite body from original PoC

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
