### PR TITLE
fix: exit generate-clients if child process errors or fails

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -87,7 +87,7 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
         writer.addImport("Credentials", "__Credentials", TypeScriptDependency.AWS_SDK_TYPES.packageName);
 
         writer.writeDocs("The service name with which to sign requests.")
-                .write("signingName?:< string;\n");
+                .write("signingName?: string;\n");
         writer.writeDocs("Default credentials provider; Not available in browser runtime")
                 .write("credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;\n");
         writer.writeDocs("The AWS region to which this client will send requests")

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -87,7 +87,7 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
         writer.addImport("Credentials", "__Credentials", TypeScriptDependency.AWS_SDK_TYPES.packageName);
 
         writer.writeDocs("The service name with which to sign requests.")
-                .write("signingName?: string;\n");
+                .write("signingName?:< string;\n");
         writer.writeDocs("Default credentials provider; Not available in browser runtime")
                 .write("credentialDefaultProvider?: (input: any) => __Provider<__Credentials>;\n");
         writer.writeDocs("The AWS region to which this client will send requests")

--- a/scripts/generate-clients/spawn-process.js
+++ b/scripts/generate-clients/spawn-process.js
@@ -1,24 +1,18 @@
 // @ts-check
 const { spawn } = require("child_process");
 
-const spawnProcess = (command, args = [], options = {}) =>
-  new Promise((resolve, reject) => {
-    try {
-      const ls = spawn(command, args, options);
-      ls.stdout.on("data", (data) => {
-        console.log(data.toString());
-      });
-      ls.stderr.on("data", (data) => {
-        console.error(`stderr: ${data.toString()}`);
-      });
+const spawnProcess = async (command, args = [], options = {}) => {
+  const childProcess = spawn(command, args, options);
 
-      ls.on("close", (code) => {
-        console.log(`child process exited with code ${code}`);
-        resolve();
-      });
-    } catch (e) {
-      reject(e);
-    }
+  childProcess.stdout.pipe(process.stdout);
+  childProcess.stderr.pipe(process.stderr);
+
+  return new Promise((resolve, reject) => {
+    childProcess.on("error", reject);
+    childProcess.on("exit", (code, signal) =>
+      code === 0 ? resolve() : reject(`${command} failed with { code: ${code}, signal: ${signal} }`)
+    );
   });
+};
 
 module.exports = { spawnProcess };


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1497

*Description of changes:*
exit generate-clients if child process errors or fails
* child_process documentation https://nodejs.org/api/child_process.html
* Success is traditionally represented with exit 0 in shell scripts https://www.shellscript.sh/exitcodes.html

Verified that generate-client fails with error code emitted by prettier in #1497 

<details>
<summary>error Command failed with exit code 1</summary>

```console
5 actionable tasks: 2 executed, 3 up-to-date
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/build-info/smithy-build-info.json 43ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/model/model.json 156ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/sources/model.json 7ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/Braket.ts 237ms

[error] codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/BraketClient.ts: SyntaxError: ',' expected. (166:24)
[error]   164 |    * The service name with which to sign requests.
[error]   165 |    */
[error] > 166 |   signingName?:< string;
[error]       |                        ^
[error]   167 | 
[error]   168 |   /**
[error]   169 |    * Default credentials provider; Not available in browser runtime
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/commands/CancelQuantumTaskCommand.ts 23ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/commands/CreateQuantumTaskCommand.ts 18ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/commands/GetDeviceCommand.ts 17ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/commands/GetQuantumTaskCommand.ts 16ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/commands/SearchDevicesCommand.ts 16ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/commands/SearchQuantumTasksCommand.ts 10ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/endpoints.ts 14ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/index.ts 4ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/jest.config.js 7ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/models/index.ts 89ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/package.json 16ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/pagination/Interfaces.ts 2ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/pagination/SearchDevicesPaginator.ts 11ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/pagination/SearchQuantumTasksPaginator.ts 9ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/protocols/Aws_restJson1.ts 193ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/README.md 27ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/runtimeConfig.browser.ts 7ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/runtimeConfig.native.ts 4ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/runtimeConfig.shared.ts 3ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/runtimeConfig.ts 9ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/tsconfig.es.json 3ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/braket.2019/typescript-codegen/tsconfig.json 4ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/source/build-info/smithy-build-info.json 7ms
codegen/sdk-codegen/build/smithyprojections/sdk-codegen/source/model/model.json 51ms
./node_modules/.bin/prettier failed with { code: 2, signal: null }
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
