### PR TITLE
fix(codegen): add tests folder in overwritablePathnames

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -9,6 +9,7 @@ const getOverwritablePredicate = (packageName) => (pathName) => {
     "models",
     "protocols",
     "pagination",
+    "tests",
     "LICENCE",
     "runtimeConfig.ts",
     "runtimeConfig.browser.ts",


### PR DESCRIPTION
*Issue #, if available:*
Similar to fix in https://github.com/aws/aws-sdk-js-v3/issues/1483, but in this case, the tests folder is protocol_tests is not getting updated:
* https://github.com/aws/aws-sdk-js-v3/tree/master/protocol_tests/aws-ec2/tests/functional
* https://github.com/aws/aws-sdk-js-v3/tree/master/protocol_tests/aws-json/tests/functional

*Description of changes:*
* Verified that folders no tests folders in clients were overwritten after running `yarn generate-clients`
* Verified that when [HttpProtocolTestGenerator.java](https://github.com/awslabs/smithy-typescript/blob/0dd8c148e3b6d9fab6227a3f2a022bc3d4367c97/smithy-typescript-codegen/src/main/java/software/amazon/smithy/typescript/codegen/HttpProtocolTestGenerator.java#L75) is edited, the tests folders in protocol_tests are updated

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
