### PR TITLE
fix: re-add cloudwatch-events models file

### DIFF
--- a/clients/client-cloudwatch-events/CloudWatchEvents.ts
+++ b/clients/client-cloudwatch-events/CloudWatchEvents.ts
@@ -125,35 +125,33 @@ import {
 import { HttpHandlerOptions as __HttpHandlerOptions } from "@aws-sdk/types";
 
 /**
- * <p>Amazon EventBridge helps you to respond to state changes in your AWS
- *             resources. When your resources change state, they automatically send events into an
- *             event stream. You can create rules that match selected events in the stream and route
- *             them to targets to take action. You can also use rules to take action on a predetermined
- *             schedule. For example, you can configure rules to:</p>
+ * <p>Amazon EventBridge helps you to respond to state changes in your AWS resources.
+ *             When your resources change state, they automatically send events into an event stream.
+ *             You can create rules that match selected events in the stream and route them to targets
+ *             to take action. You can also use rules to take action on a predetermined schedule. For
+ *             example, you can configure rules to:</p>
  *         <ul>
  *             <li>
- *                <p>Automatically invoke an AWS Lambda function to update DNS entries when an event notifies
- *                     you that Amazon EC2 instance enters the running state</p>
+ *                 <p>Automatically invoke an AWS Lambda function to update DNS entries when an
+ *                     event notifies you that Amazon EC2 instance enters the running state.</p>
  *             </li>
  *             <li>
- *                <p>Direct specific API records from AWS CloudTrail to an Amazon Kinesis data stream for
- *                     detailed analysis of potential security or availability risks</p>
+ *                 <p>Direct specific API records from AWS CloudTrail to an Amazon Kinesis data
+ *                     stream for detailed analysis of potential security or availability
+ *                     risks.</p>
  *             </li>
  *             <li>
- *                <p>Periodically invoke a built-in target to create a snapshot of an Amazon EBS
- *                     volume</p>
+ *                 <p>Periodically invoke a built-in target to create a snapshot of an Amazon EBS
+ *                     volume.</p>
  *             </li>
  *          </ul>
- *         <p>For more information about the features of Amazon EventBridge, see the
- *             <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/">Amazon EventBridge User Guide</a>.</p>
+ *         <p>For more information about the features of Amazon EventBridge, see the <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide">Amazon EventBridge User
+ *                 Guide</a>.</p>
  */
 export class CloudWatchEvents extends CloudWatchEventsClient {
   /**
-   * <p>Activates a partner event source that has been deactivated. Once activated, your matching event bus will start receiving events
-   *         from the event source.</p>
-   *         <note>
-   *             <p>This operation is performed by AWS customers, not by SaaS partners.</p>
-   *          </note>
+   * <p>Activates a partner event source that has been deactivated. Once activated, your
+   *             matching event bus will start receiving events from the event source.</p>
    */
   public activateEventSource(
     args: ActivateEventSourceCommandInput,
@@ -185,11 +183,9 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Creates a new event bus within your account. This can be a custom event bus which you can use to receive events from your
-   *         own custom applications and services, or it can be a partner event bus which can be matched to a partner event source.</p>
-   *         <note>
-   *             <p>This operation is used by AWS customers, not by SaaS partners.</p>
-   *          </note>
+   * <p>Creates a new event bus within your account. This can be a custom event bus which you
+   *             can use to receive events from your custom applications and services, or it can be a
+   *             partner event bus which can be matched to a partner event source.</p>
    */
   public createEventBus(
     args: CreateEventBusCommandInput,
@@ -221,41 +217,30 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Called by an SaaS partner to create a partner event source.</p>
-   *         <note>
-   *             <p>This operation is not used by AWS customers.</p>
-   *          </note>
-   *
-   *         <p>Each partner event source can be used by one AWS account to create a matching
-   *             partner event bus in that AWS account. A SaaS partner must create one partner event source for each AWS account that wants to receive those event types. </p>
-   *         <p>A partner event source creates events based on resources in the SaaS partner's service
-   *             or application.</p>
+   * <p>Called by an SaaS partner to create a partner event source. This operation is not used
+   *             by AWS customers.</p>
+   *         <p>Each partner event source can be used by one AWS account to create a matching partner
+   *             event bus in that AWS account. A SaaS partner must create one partner event source for
+   *             each AWS account that wants to receive those event types. </p>
+   *         <p>A partner event source creates events based on resources within the SaaS partner's
+   *             service or application.</p>
    *         <p>An AWS account that creates a partner event bus that matches the partner event source
    *             can use that event bus to receive events from the partner, and then process them using
-   *             AWS
-   *             Events rules and targets.</p>
+   *             AWS Events rules and targets.</p>
    *         <p>Partner event source names follow this format:</p>
-   *
    *         <p>
-   *             <code>aws.partner/<i>partner_name</i>/<i>event_namespace</i>/<i>event_name</i>
+   *             <code>
+   *                <i>partner_name</i>/<i>event_namespace</i>/<i>event_name</i>
    *             </code>
    *          </p>
-   *         <ul>
-   *             <li>
-   *                <p>
-   *                   <i>partner_name</i> is determined during partner registration and identifies the partner to AWS customers.</p>
-   *             </li>
-   *             <li>
-   *                <p>For <i>event_namespace</i>, we recommend that partners use a string that identifies the AWS customer within the partner's system. This should not
-   *                 be the customer's AWS account ID.</p>
-   *             </li>
-   *             <li>
-   *                <p>
-   *                   <i>event_name</i> is determined by the partner, and should uniquely identify an event-generating resource within the partner
-   *                 system. This should help AWS customers
-   *                 decide whether to create an event bus to receive these events.</p>
-   *             </li>
-   *          </ul>
+   *         <p>
+   *             <i>partner_name</i> is determined during partner registration and
+   *             identifies the partner to AWS customers. <i>event_namespace</i> is
+   *             determined by the partner and is a way for the partner to categorize their events.
+   *                 <i>event_name</i> is determined by the partner, and should uniquely
+   *             identify an event-generating resource within the partner system. The combination of
+   *                 <i>event_namespace</i> and <i>event_name</i> should help
+   *             AWS customers decide whether to create an event bus to receive these events.</p>
    */
   public createPartnerEventSource(
     args: CreatePartnerEventSourceCommandInput,
@@ -287,11 +272,10 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>An AWS customer uses this operation to temporarily stop receiving events from the
-   *             specified partner event source. The matching event bus isn't deleted. </p>
-   *         <p>When you deactivate a partner event source, the source goes into <code>PENDING</code>
-   *             state. If it remains in <code>PENDING</code> state for more than two weeks, it's
-   *             deleted.</p>
+   * <p>You can use this operation to temporarily stop receiving events from the specified
+   *             partner event source. The matching event bus is not deleted. </p>
+   *         <p>When you deactivate a partner event source, the source goes into PENDING state. If it
+   *             remains in PENDING state for more than two weeks, it is deleted.</p>
    *         <p>To activate a deactivated partner event source, use <a>ActivateEventSource</a>.</p>
    */
   public deactivateEventSource(
@@ -324,11 +308,9 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Deletes the specified custom event bus or partner event bus. All rules associated with this event bus are also deleted. You can't delete your
-   *         account's default event bus.</p>
-   *         <note>
-   *             <p>This operation is performed by AWS customers, not by SaaS partners.</p>
-   *          </note>
+   * <p>Deletes the specified custom event bus or partner event bus. All rules associated with
+   *             this event bus need to be deleted. You can't delete your account's default event
+   *             bus.</p>
    */
   public deleteEventBus(
     args: DeleteEventBusCommandInput,
@@ -360,10 +342,11 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>This operation is used by SaaS partners to delete a partner event source. AWS
-   *             customers don't use this operation.</p>
+   * <p>This operation is used by SaaS partners to delete a partner event source. This
+   *             operation is not used by AWS customers.</p>
    *         <p>When you delete an event source, the status of the corresponding partner event bus in
-   *             the AWS customer account becomes <code>DELETED</code>.</p>
+   *             the AWS customer account becomes DELETED.</p>
+   *         <p></p>
    */
   public deletePartnerEventSource(
     args: DeletePartnerEventSourceCommandInput,
@@ -404,7 +387,7 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
    *         <p>Managed rules are rules created and managed by another AWS service on your behalf.
    *             These rules are created by those other AWS services to support functionality in those
    *             services. You can delete these rules using the <code>Force</code> option, but you should
-   *             do so only if you're sure that the other service isn't still using that rule.</p>
+   *             do so only if you are sure the other service is not still using that rule.</p>
    */
   public deleteRule(args: DeleteRuleCommandInput, options?: __HttpHandlerOptions): Promise<DeleteRuleCommandOutput>;
   public deleteRule(args: DeleteRuleCommandInput, cb: (err: any, data?: DeleteRuleCommandOutput) => void): void;
@@ -430,11 +413,12 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Displays details about an event bus in your account. This can include the external AWS accounts that are permitted to write events to your
-   *             default event bus, and the associated policy. For custom event buses and partner event buses, it displays the name, ARN, policy, state, and creation time.</p>
-   *         <p>
-   *             To enable your account to
-   *             receive events from other accounts on its default event bus, use <a>PutPermission</a>.</p>
+   * <p>Displays details about an event bus in your account. This can include the external
+   *             AWS accounts that are permitted to write events to your default event bus, and the
+   *             associated policy. For custom event buses and partner event buses, it displays the name,
+   *             ARN, policy, state, and creation time.</p>
+   *         <p> To enable your account to receive events from other accounts on its default event
+   *             bus, use <a>PutPermission</a>.</p>
    *         <p>For more information about partner event buses, see <a>CreateEventBus</a>.</p>
    */
   public describeEventBus(
@@ -467,11 +451,8 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>This operation lists details about a partner event source that is shared
-   *             with your account.</p>
-   *         <note>
-   *             <p>This operation is run by AWS customers, not by SaaS partners.</p>
-   *          </note>
+   * <p>This operation lists details about a partner event source that is shared with your
+   *             account.</p>
    */
   public describeEventSource(
     args: DescribeEventSourceCommandInput,
@@ -503,11 +484,10 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>An SaaS partner can use this operation to list details about a partner event source that they have created.</p>
-   *         <note>
-   *             <p>AWS customers do not use this operation.
-   *             Instead, AWS customers can use <a>DescribeEventSource</a> to see details about a partner event source that is shared with them.</p>
-   *          </note>
+   * <p>An SaaS partner can use this operation to list details about a partner event source
+   *             that they have created. AWS customers do not use this operation. Instead, AWS customers
+   *             can use <a>DescribeEventSource</a> to see details about a partner event
+   *             source that is shared with them.</p>
    */
   public describePartnerEventSource(
     args: DescribePartnerEventSourceCommandInput,
@@ -540,9 +520,8 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
 
   /**
    * <p>Describes the specified rule.</p>
-   *         <p>
-   *             <code>DescribeRule</code> doesn't list the targets of a rule. To see the targets
-   *             associated with a rule, use <a>ListTargetsByRule</a>.</p>
+   *         <p>DescribeRule does not list the targets of a rule. To see the targets associated
+   *             with a rule, use <a>ListTargetsByRule</a>.</p>
    */
   public describeRule(
     args: DescribeRuleCommandInput,
@@ -571,7 +550,7 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Disables the specified rule. A disabled rule won't match any events and won't
+   * <p>Disables the specified rule. A disabled rule won't match any events, and won't
    *             self-trigger if it has a schedule expression.</p>
    *
    *         <p>When you disable a rule, incoming events might continue to match to the disabled
@@ -601,7 +580,7 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Enables the specified rule. If the rule doesn't exist, the operation
+   * <p>Enables the specified rule. If the rule does not exist, the operation
    *             fails.</p>
    *
    *         <p>When you enable a rule, incoming events might not immediately start matching to a
@@ -631,10 +610,8 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Lists all the event buses in your account, including the default event bus, custom event buses, and partner event buses.</p>
-   *             <note>
-   *             <p>This operation is run by AWS customers, not by SaaS partners.</p>
-   *          </note>
+   * <p>Lists all the event buses in your account, including the default event bus, custom
+   *             event buses, and partner event buses.</p>
    */
   public listEventBuses(
     args: ListEventBusesCommandInput,
@@ -666,11 +643,8 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>You can use this to see all the partner event sources that have been shared with your AWS account.
-   *                 For more information about partner event sources, see <a>CreateEventBus</a>.</p>
-   *             <note>
-   *             <p>This operation is run by AWS customers, not by SaaS partners.</p>
-   *          </note>
+   * <p>You can use this to see all the partner event sources that have been shared with your
+   *             AWS account. For more information about partner event sources, see <a>CreateEventBus</a>.</p>
    */
   public listEventSources(
     args: ListEventSourcesCommandInput,
@@ -702,11 +676,9 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>An SaaS partner can use this operation to display the AWS account ID that a particular partner event source name
-   *                 is associated with.</p>
-   *             <note>
-   *             <p>This operation is used by SaaS partners, not by AWS customers.</p>
-   *          </note>
+   * <p>An SaaS partner can use this operation to display the AWS account ID that a particular
+   *             partner event source name is associated with. This operation is not used by AWS
+   *             customers.</p>
    */
   public listPartnerEventSourceAccounts(
     args: ListPartnerEventSourceAccountsCommandInput,
@@ -738,11 +710,8 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>An SaaS partner can use this operation to list all the partner event source names that they have created.</p>
-   *                 <note>
-   *             <p>This operation is
-   *                 not used by AWS customers.</p>
-   *          </note>
+   * <p>An SaaS partner can use this operation to list all the partner event source names that
+   *             they have created. This operation is not used by AWS customers.</p>
    */
   public listPartnerEventSources(
     args: ListPartnerEventSourcesCommandInput,
@@ -774,8 +743,8 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Lists the rules for the specified target.
-   *             You can see which rules can invoke a specific target in your account.</p>
+   * <p>Lists the rules for the specified target. You can see which of the rules in Amazon
+   *             EventBridge can invoke a specific target in your account.</p>
    */
   public listRuleNamesByTarget(
     args: ListRuleNamesByTargetCommandInput,
@@ -807,12 +776,11 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Lists your EventBridge rules. You can either list all the rules or
+   * <p>Lists your Amazon EventBridge rules. You can either list all the rules or you can
    *             provide a prefix to match to the rule names.</p>
    *
-   *         <p>
-   *             <code>ListRules</code> doesn't list the targets of a rule. To see the targets
-   *             associated with a rule, use <a>ListTargetsByRule</a>.</p>
+   *         <p>ListRules does not list the targets of a rule. To see the targets associated with a
+   *             rule, use <a>ListTargetsByRule</a>.</p>
    */
   public listRules(args: ListRulesCommandInput, options?: __HttpHandlerOptions): Promise<ListRulesCommandOutput>;
   public listRules(args: ListRulesCommandInput, cb: (err: any, data?: ListRulesCommandOutput) => void): void;
@@ -838,7 +806,8 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Displays the tags associated with an EventBridge resource. In EventBridge, rules can be tagged.</p>
+   * <p>Displays the tags associated with an EventBridge resource. In EventBridge,
+   *             rules and event buses can be tagged.</p>
    */
   public listTagsForResource(
     args: ListTagsForResourceCommandInput,
@@ -902,8 +871,8 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Sends custom events to EventBridge so that they can be matched to rules. These events can be from your custom applications
-   *         and services.</p>
+   * <p>Sends custom events to Amazon EventBridge so that they can be matched to
+   *             rules.</p>
    */
   public putEvents(args: PutEventsCommandInput, options?: __HttpHandlerOptions): Promise<PutEventsCommandOutput>;
   public putEvents(args: PutEventsCommandInput, cb: (err: any, data?: PutEventsCommandOutput) => void): void;
@@ -929,11 +898,8 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>This is used by SaaS partners to write events to a customer's partner event bus.</p>
-   *             <note>
-   *             <p>AWS customers do not use this operation. Instead, AWS customers can use
-   *                 <a>PutEvents</a> to write custom events from their own applications to an event bus.</p>
-   *          </note>
+   * <p>This is used by SaaS partners to write events to a customer's partner event bus. AWS
+   *             customers do not use this operation.</p>
    */
   public putPartnerEvents(
     args: PutPartnerEventsCommandInput,
@@ -965,22 +931,28 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Running <code>PutPermission</code> permits the specified AWS account or AWS organization to put events to the specified <i>event bus</i>.
-   *             Rules in your account are triggered by these events arriving to an event bus in your account.  </p>
-   *         <p>For another account to send events to your account, that external account must have a rule with your account's
-   *         event bus as a target.</p>
+   * <p>Running <code>PutPermission</code> permits the specified AWS account or AWS
+   *             organization to put events to the specified <i>event bus</i>. Amazon EventBridge (CloudWatch Events)
+   *             rules in your account are triggered by these events arriving to an event bus in
+   *             your account. </p>
+   *         <p>For another account to send events to your account, that external account must have
+   *             an EventBridge rule with your account's event bus as a target.</p>
    *
-   *         <p>To enable multiple AWS accounts to put events to an event bus, run <code>PutPermission</code> once for each of these accounts. Or,
-   *         if all the accounts are members of the same AWS organization, you can run <code>PutPermission</code> once specifying <code>Principal</code>
-   *         as "*" and specifying the AWS organization ID in <code>Condition</code>, to grant permissions to all accounts
-   *         in that organization.</p>
+   *         <p>To enable multiple AWS accounts to put events to your event bus, run
+   *                 <code>PutPermission</code> once for each of these accounts. Or, if all the accounts
+   *             are members of the same AWS organization, you can run <code>PutPermission</code> once
+   *             specifying <code>Principal</code> as "*" and specifying the AWS organization ID in
+   *                 <code>Condition</code>, to grant permissions to all accounts in that
+   *             organization.</p>
    *
-   *         <p>If you grant permissions using an organization, then accounts in that
-   *             organization must specify a <code>RoleArn</code> with proper permissions
-   *             when they use <code>PutTarget</code> to add your account's event bus as a
-   *             target. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html">Sending and Receiving Events Between AWS Accounts</a> in the <i>Amazon EventBridge User Guide</i>.</p>
+   *         <p>If you grant permissions using an organization, then accounts in that organization
+   *             must specify a <code>RoleArn</code> with proper permissions when they use
+   *                 <code>PutTarget</code> to add your account's event bus as a target. For more
+   *             information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html">Sending and Receiving Events Between AWS Accounts</a> in the <i>Amazon
+   *                 EventBridge User Guide</i>.</p>
    *
-   *         <p>The permission policy on an event bus can't exceed 10 KB in size.</p>
+   *         <p>The permission policy on the default event bus cannot exceed 10 KB in
+   *             size.</p>
    */
   public putPermission(
     args: PutPermissionCommandInput,
@@ -1012,54 +984,56 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Creates or updates the specified rule. Rules are enabled by default or based on
+   * <p>Creates or updates the specified rule. Rules are enabled by default, or based on
    *             value of the state. You can disable a rule using <a>DisableRule</a>.</p>
    *
-   *         <p>A single rule watches for events from a single event bus. Events generated by AWS services go to your
-   *         account's default event bus. Events generated by SaaS partner services or applications go to the matching partner event bus. If you have
-   *         custom applications or services, you can specify whether their events go to your default event bus or a custom event bus that you
-   *         have created.  For more information, see <a>CreateEventBus</a>.</p>
+   *         <p>A single rule watches for events from a single event bus. Events generated by AWS
+   *             services go to your account's default event bus. Events generated by SaaS partner
+   *             services or applications go to the matching partner event bus. If you have custom
+   *             applications or services, you can specify whether their events go to your default event
+   *             bus or a custom event bus that you have created. For more information, see <a>CreateEventBus</a>.</p>
    *
-   *         <p>If you're updating an existing rule, the rule is replaced with what you specify in
+   *         <p>If you are updating an existing rule, the rule is replaced with what you specify in
    *             this <code>PutRule</code> command. If you omit arguments in <code>PutRule</code>, the
-   *             old values for those arguments aren't kept. Instead, they're replaced with null
+   *             old values for those arguments are not kept. Instead, they are replaced with null
    *             values.</p>
    *
    *         <p>When you create or update a rule, incoming events might not immediately start
    *             matching to new or updated rules. Allow a short period of time for changes to take
    *             effect.</p>
    *
-   *         <p>A rule must contain at least an <code>EventPattern</code> or
-   *                 <code>ScheduleExpression</code>. Rules with <code>EventPatterns</code> are triggered
-   *             when a matching event is observed. Rules with <code>ScheduleExpressions</code>
-   *             self-trigger based on the given schedule. A rule can have both an
-   *                 <code>EventPattern</code> and a <code>ScheduleExpression</code>, in which case the
-   *             rule triggers on matching events as well as on a schedule.</p>
+   *         <p>A rule must contain at least an EventPattern or ScheduleExpression. Rules with
+   *             EventPatterns are triggered when a matching event is observed. Rules with
+   *             ScheduleExpressions self-trigger based on the given schedule. A rule can have both an
+   *             EventPattern and a ScheduleExpression, in which case the rule triggers on matching
+   *             events as well as on a schedule.</p>
    *
-   *         <p>When you initially create a rule, you can optionally assign one or more tags to the rule. Tags can help you organize and categorize your
-   *             resources. You can also use them to scope user permissions, by granting a user permission to access or change only rules with
-   *             certain tag values. To use the <code>PutRule</code> operation and assign tags, you must have both the <code>events:PutRule</code>
-   *         and <code>events:TagResource</code> permissions.</p>
-   *         <p>If you are updating an existing rule, any tags you specify in the <code>PutRule</code> operation are ignored. To update
-   *             the tags of an existing rule, use <a>TagResource</a> and <a>UntagResource</a>.</p>
+   *         <p>When you initially create a rule, you can optionally assign one or more tags to the
+   *             rule. Tags can help you organize and categorize your resources. You can also use them to
+   *             scope user permissions, by granting a user permission to access or change only rules
+   *             with certain tag values. To use the <code>PutRule</code> operation and assign tags, you
+   *             must have both the <code>events:PutRule</code> and <code>events:TagResource</code>
+   *             permissions.</p>
+   *         <p>If you are updating an existing rule, any tags you specify in the <code>PutRule</code>
+   *             operation are ignored. To update the tags of an existing rule, use <a>TagResource</a> and <a>UntagResource</a>.</p>
    *
-   *         <p>Most services in AWS treat <code>:</code> or <code>/</code> as the same character
-   *             in Amazon Resource Names (ARNs). However, EventBridge uses an exact match in event
-   *             patterns and rules. Be sure to use the correct ARN characters when creating event
-   *             patterns so that they match the ARN syntax in the event that you want to
-   *             match.</p>
+   *         <p>Most services in AWS treat : or / as the same character in Amazon Resource Names
+   *             (ARNs). However, EventBridge uses an exact match in event patterns and rules. Be sure to
+   *             use the correct ARN characters when creating event patterns so that they match the ARN
+   *             syntax in the event you want to match.</p>
    *
-   *         <p>In EventBridge, you could create rules that lead to infinite loops, where a rule
-   *             is fired repeatedly. For example, a rule might detect that ACLs have changed on an S3
-   *             bucket, and trigger software to change them to the desired state. If you don't write the
-   *             rule carefully, the subsequent change to the ACLs fires the rule again, creating an
+   *         <p>In EventBridge, it is possible to create rules that lead to infinite loops, where a
+   *             rule is fired repeatedly. For example, a rule might detect that ACLs have changed on an
+   *             S3 bucket, and trigger software to change them to the desired state. If the rule is not
+   *             written carefully, the subsequent change to the ACLs fires the rule again, creating an
    *             infinite loop.</p>
-   *         <p>To prevent this, write the rules so that the triggered actions don't refire the same
+   *         <p>To prevent this, write the rules so that the triggered actions do not re-fire the same
    *             rule. For example, your rule could fire only if ACLs are found to be in a bad state,
    *             instead of after any change. </p>
-   *         <p>An infinite loop can quickly cause higher than expected charges. We recommend that you use budgeting,
-   *             which alerts you when charges exceed your specified limit. For more information, see
-   *             <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-managing-costs.html">Managing Your Costs with Budgets</a>.</p>
+   *         <p>An infinite loop can quickly cause higher than expected charges. We recommend that you
+   *             use budgeting, which alerts you when charges exceed your specified limit. For more
+   *             information, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-managing-costs.html">Managing Your
+   *                 Costs with Budgets</a>.</p>
    */
   public putRule(args: PutRuleCommandInput, options?: __HttpHandlerOptions): Promise<PutRuleCommandOutput>;
   public putRule(args: PutRuleCommandInput, cb: (err: any, data?: PutRuleCommandOutput) => void): void;
@@ -1085,62 +1059,65 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Adds the specified targets to the specified rule, or updates the targets if they're
-   *             already associated with the rule.</p>
+   * <p>Adds the specified targets to the specified rule, or updates the targets if they
+   *             are already associated with the rule.</p>
    *         <p>Targets are the resources that are invoked when a rule is triggered.</p>
-   *         <p>You can configure the following as targets in EventBridge:</p>
+   *         <p>You can configure the following as targets for Events:</p>
    *
-   *            <ul>
+   *         <ul>
    *             <li>
-   *                <p>EC2 instances</p>
+   *                 <p>EC2 instances</p>
    *             </li>
    *             <li>
-   *                <p>SSM Run Command</p>
+   *                 <p>SSM Run Command</p>
    *             </li>
    *             <li>
-   *                <p>SSM Automation</p>
+   *                 <p>SSM Automation</p>
    *             </li>
    *             <li>
-   *                <p>AWS Lambda functions</p>
+   *                 <p>AWS Lambda functions</p>
    *             </li>
    *             <li>
-   *                <p>Data streams in Amazon Kinesis Data Streams</p>
+   *                 <p>Data streams in Amazon Kinesis Data Streams</p>
    *             </li>
    *             <li>
-   *                <p>Data delivery streams in Amazon Kinesis Data Firehose</p>
+   *                 <p>Data delivery streams in Amazon Kinesis Data Firehose</p>
    *             </li>
    *             <li>
-   *                <p>Amazon ECS tasks</p>
+   *                 <p>Amazon ECS tasks</p>
    *             </li>
    *             <li>
-   *                <p>AWS Step Functions state machines</p>
+   *                 <p>AWS Step Functions state machines</p>
    *             </li>
    *             <li>
-   *                <p>AWS Batch jobs</p>
+   *                 <p>AWS Batch jobs</p>
    *             </li>
    *             <li>
-   *                <p>AWS CodeBuild projects</p>
+   *                 <p>AWS CodeBuild projects</p>
    *             </li>
    *             <li>
-   *                <p>Pipelines in AWS CodePipeline</p>
+   *                 <p>Pipelines in AWS CodePipeline</p>
    *             </li>
    *             <li>
-   *                <p>Amazon Inspector assessment templates</p>
+   *                 <p>Amazon Inspector assessment templates</p>
    *             </li>
    *             <li>
-   *                <p>Amazon SNS topics</p>
+   *                 <p>Amazon SNS topics</p>
    *             </li>
    *             <li>
-   *                <p>Amazon SQS queues, including FIFO queues</p>
+   *                 <p>Amazon SQS queues, including FIFO queues</p>
    *             </li>
    *             <li>
-   *                <p>The default event bus of another AWS account</p>
+   *                 <p>The default event bus of another AWS account</p>
+   *             </li>
+   *             <li>
+   *                 <p>Amazon API Gateway REST APIs</p>
    *             </li>
    *          </ul>
    *
    *
    *
-   *         <p>Creating rules with built-in targets is supported only on the AWS Management
+   *         <p>Creating rules with built-in targets is supported only in the AWS Management
    *             Console. The built-in targets are <code>EC2 CreateSnapshot API call</code>, <code>EC2
    *                 RebootInstances API call</code>, <code>EC2 StopInstances API call</code>, and
    *                 <code>EC2 TerminateInstances API call</code>. </p>
@@ -1151,70 +1128,77 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
    *             multiple EC2 instances with one rule, you can use the <code>RunCommandParameters</code>
    *             field.</p>
    *         <p>To be able to make API calls against the resources that you own, Amazon EventBridge
-   *             needs the appropriate permissions. For AWS Lambda and Amazon SNS resources,
+   *             (CloudWatch Events) needs the appropriate permissions. For AWS Lambda and Amazon SNS resources,
    *             EventBridge relies on resource-based policies. For EC2 instances, Kinesis data
-   *             streams, and AWS Step Functions state machines, EventBridge relies on IAM roles
-   *             that you specify in the <code>RoleARN</code> argument in <code>PutTargets</code>. For
-   *             more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html">Authentication
-   *                 and Access Control</a> in the <i>Amazon EventBridge User
+   *             streams, AWS Step Functions state machines and API Gateway REST APIs, EventBridge relies on IAM roles
+   *             that you specify in the <code>RoleARN</code> argument in <code>PutTargets</code>. For more information,
+   *             see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html">Authentication and Access Control</a> in the <i>Amazon EventBridge User
    *                 Guide</i>.</p>
-   *         <p>If another AWS account is in the same Region and has granted you permission (using
+   *
+   *         <p>If another AWS account is in the same region and has granted you permission (using
    *                 <code>PutPermission</code>), you can send events to that account. Set that account's
    *             event bus as a target of the rules in your account. To send the matched events to the
    *             other account, specify that account's event bus as the <code>Arn</code> value when you
    *             run <code>PutTargets</code>. If your account sends events to another account, your
    *             account is charged for each sent event. Each event sent to another account is charged as
-   *             a custom event. The account receiving the event isn't charged. For more information, see
-   *                 <a href="https://aws.amazon.com/eventbridge/pricing/">Amazon EventBridge
+   *             a custom event. The account receiving the event is not charged. For more information,
+   *             see <a href="https://aws.amazon.com/eventbridge/pricing/">Amazon EventBridge (CloudWatch Events)
    *                 Pricing</a>.</p>
    *
-   *         <p>If you're setting an event bus in another account as the target and that account
+   *         <note>
+   *             <p>
+   *                <code>Input</code>, <code>InputPath</code>, and <code>InputTransformer</code> are
+   *                 not available with <code>PutTarget</code> if the target is an event bus of a
+   *                 different AWS account.</p>
+   *         </note>
+   *
+   *         <p>If you are setting the event bus of another account as the target, and that account
    *             granted permission to your account through an organization instead of directly by the
-   *             account ID, you must specify a <code>RoleArn</code> with proper permissions in the
-   *                 <code>Target</code> structure. For more information, see
-   *             <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html">Sending and Receiving Events Between AWS Accounts</a> in the <i>Amazon
+   *             account ID, then you must specify a <code>RoleArn</code> with proper permissions in the
+   *                 <code>Target</code> structure. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html">Sending and Receiving Events Between AWS Accounts</a> in the <i>Amazon
    *                 EventBridge User Guide</i>.</p>
    *
-   *         <p>For more information about enabling cross-account
-   *             events, see <a>PutPermission</a>.</p>
+   *         <p>For more information about enabling cross-account events, see <a>PutPermission</a>.</p>
    *
    *         <p>
-   *             <code>Input</code>, <code>InputPath</code>, and <code>InputTransformer</code> are
-   *             mutually exclusive and optional parameters of a target. When a rule is triggered due to
-   *             a matched event:</p>
+   *             <b>Input</b>, <b>InputPath</b>, and
+   *                 <b>InputTransformer</b> are mutually exclusive and
+   *             optional parameters of a target. When a rule is triggered due to a matched
+   *             event:</p>
    *
    *         <ul>
    *             <li>
-   *                <p>If none of the following arguments are specified for a target, the entire event is passed
-   *                     to the target in JSON format (unless the target is Amazon EC2 Run Command or
-   *                     Amazon ECS task, in which case nothing from the event is passed to the
-   *                     target).</p>
+   *                 <p>If none of the following arguments are specified for a target, then the
+   *                     entire event is passed to the target in JSON format (unless the target is Amazon
+   *                     EC2 Run Command or Amazon ECS task, in which case nothing from the event is
+   *                     passed to the target).</p>
    *             </li>
    *             <li>
-   *                 <p>If <code>Input</code> is specified in the form of valid JSON, then the
-   *                     matched event is overridden with this constant.</p>
+   *                 <p>If <b>Input</b> is specified in the form of valid
+   *                     JSON, then the matched event is overridden with this constant.</p>
    *             </li>
    *             <li>
-   *                <p>If <code>InputPath</code> is specified in the form of JSONPath (for example,
-   *                         <code>$.detail</code>), only the part of the event specified in the path is
-   *                     passed to the target (for example, only the detail part of the event is
-   *                     passed).</p>
+   *                 <p>If <b>InputPath</b> is specified in the form of
+   *                     JSONPath (for example, <code>$.detail</code>), then only the part of the event
+   *                     specified in the path is passed to the target (for example, only the detail part
+   *                     of the event is passed).</p>
    *             </li>
    *             <li>
-   *                <p>If <code>InputTransformer</code> is specified, one or more specified JSONPaths are
-   *                     extracted from the event and used as values in a template that you specify as
-   *                     the input to the target.</p>
+   *                 <p>If <b>InputTransformer</b> is specified, then one
+   *                     or more specified JSONPaths are extracted from the event and used as values in a
+   *                     template that you specify as the input to the target.</p>
    *             </li>
    *          </ul>
    *
-   *         <p>When you specify <code>InputPath</code> or <code>InputTransformer</code>, you must use JSON dot notation, not bracket notation.</p>
+   *         <p>When you specify <code>InputPath</code> or <code>InputTransformer</code>, you must
+   *             use JSON dot notation, not bracket notation.</p>
    *
    *         <p>When you add targets to a rule and the associated rule triggers soon after, new or
    *             updated targets might not be immediately invoked. Allow a short period of time for
    *             changes to take effect.</p>
    *
    *         <p>This action can partially fail if too many requests are made at the same time. If
-   *             that happens, <code>FailedEntryCount</code> is nonzero in the response, and each entry
+   *             that happens, <code>FailedEntryCount</code> is non-zero in the response and each entry
    *             in <code>FailedEntries</code> provides the ID of the failed target and the error
    *             code.</p>
    */
@@ -1242,9 +1226,10 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Revokes the permission of another AWS account to be able to put events to the specified event bus. Specify the account to
-   *             revoke by the <code>StatementId</code> value that you associated with the account when you granted it permission with <code>PutPermission</code>.
-   *             You can find the <code>StatementId</code> by using <a>DescribeEventBus</a>.</p>
+   * <p>Revokes the permission of another AWS account to be able to put events to the
+   *             specified event bus. Specify the account to revoke by the <code>StatementId</code> value
+   *             that you associated with the account when you granted it permission with
+   *                 <code>PutPermission</code>. You can find the <code>StatementId</code> by using <a>DescribeEventBus</a>.</p>
    */
   public removePermission(
     args: RemovePermissionCommandInput,
@@ -1276,14 +1261,17 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Removes the specified targets from the specified rule. When the rule is triggered, those targets are no longer be invoked.</p>
+   * <p>Removes the specified targets from the specified rule. When the rule is triggered,
+   *             those targets are no longer be invoked.</p>
    *
    *         <p>When you remove a target, when the associated rule triggers, removed targets might
    *             continue to be invoked. Allow a short period of time for changes to take
    *             effect.</p>
    *
-   *         <p>This action can partially fail if too many requests are made at the same time. If that happens, <code>FailedEntryCount</code> is non-zero in the response and
-   *             each entry in <code>FailedEntries</code> provides the ID of the failed target and the error code.</p>
+   *         <p>This action can partially fail if too many requests are made at the same time. If
+   *             that happens, <code>FailedEntryCount</code> is non-zero in the response and each entry
+   *             in <code>FailedEntries</code> provides the ID of the failed target and the error
+   *             code.</p>
    */
   public removeTargets(
     args: RemoveTargetsCommandInput,
@@ -1318,15 +1306,15 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
    * <p>Assigns one or more tags (key-value pairs) to the specified EventBridge
    *             resource. Tags can help you organize and categorize your resources. You can also use
    *             them to scope user permissions by granting a user permission to access or change only
-   *             resources with certain tag values. In EventBridge, rules can be tagged.</p>
-   *             <p>Tags don't have any semantic meaning to AWS and are interpreted strictly as
-   *             strings of characters.</p>
-   *             <p>You can use the <code>TagResource</code> action with a rule that already has tags.
-   *             If you specify a new tag key for the rule, this tag is appended to the list of tags
-   *             associated with the rule. If you specify a tag key that is already associated with the
-   *             rule, the new tag value that you specify replaces the previous value for that
+   *             resources with certain tag values. In EventBridge, rules and event buses can be tagged.</p>
+   *         <p>Tags don't have any semantic meaning to AWS and are interpreted strictly as strings of
+   *             characters.</p>
+   *         <p>You can use the <code>TagResource</code> action with a resource that already has tags. If
+   *             you specify a new tag key, this tag is appended to the list of tags
+   *             associated with the resource. If you specify a tag key that is already associated with the
+   *             resource, the new tag value that you specify replaces the previous value for that
    *             tag.</p>
-   *             <p>You can associate as many as 50 tags with a resource.</p>
+   *         <p>You can associate as many as 50 tags with a resource.</p>
    */
   public tagResource(args: TagResourceCommandInput, options?: __HttpHandlerOptions): Promise<TagResourceCommandOutput>;
   public tagResource(args: TagResourceCommandInput, cb: (err: any, data?: TagResourceCommandOutput) => void): void;
@@ -1353,11 +1341,10 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
 
   /**
    * <p>Tests whether the specified event pattern matches the provided event.</p>
-   *         <p>Most services in AWS treat <code>:</code> or <code>/</code> as the same character
-   *             in Amazon Resource Names (ARNs). However, EventBridge uses an exact match in event
-   *             patterns and rules. Be sure to use the correct ARN characters when creating event
-   *             patterns so that they match the ARN syntax in the event that you want to
-   *             match.</p>
+   *         <p>Most services in AWS treat : or / as the same character in Amazon Resource Names
+   *             (ARNs). However, EventBridge uses an exact match in event patterns and rules. Be sure to
+   *             use the correct ARN characters when creating event patterns so that they match the ARN
+   *             syntax in the event you want to match.</p>
    */
   public testEventPattern(
     args: TestEventPatternCommandInput,
@@ -1389,7 +1376,8 @@ export class CloudWatchEvents extends CloudWatchEventsClient {
   }
 
   /**
-   * <p>Removes one or more tags from the specified EventBridge resource. In EventBridge, rules can be tagged.</p>
+   * <p>Removes one or more tags from the specified EventBridge resource. In Amazon EventBridge (CloudWatch
+   *             Events, rules and event buses can be tagged.</p>
    */
   public untagResource(
     args: UntagResourceCommandInput,

--- a/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
+++ b/clients/client-cloudwatch-events/CloudWatchEventsClient.ts
@@ -75,6 +75,7 @@ import {
   getHostHeaderPlugin,
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
+import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
@@ -101,6 +102,7 @@ import {
   Encoder as __Encoder,
   HashConstructor as __HashConstructor,
   HttpHandlerOptions as __HttpHandlerOptions,
+  Logger as __Logger,
   Provider as __Provider,
   StreamCollector as __StreamCollector,
   UrlParser as __UrlParser,
@@ -256,6 +258,11 @@ export interface ClientDefaults extends Partial<__SmithyResolvedConfiguration<__
   maxAttempts?: number | __Provider<number>;
 
   /**
+   * Optional logger for logging debug/info/warn/error.
+   */
+  logger?: __Logger;
+
+  /**
    * Fetch related hostname, signing name or signing region with given region.
    */
   regionInfoProvider?: RegionInfoProvider;
@@ -280,27 +287,28 @@ export type CloudWatchEventsClientResolvedConfig = __SmithyResolvedConfiguration
   HostHeaderResolvedConfig;
 
 /**
- * <p>Amazon EventBridge helps you to respond to state changes in your AWS
- *             resources. When your resources change state, they automatically send events into an
- *             event stream. You can create rules that match selected events in the stream and route
- *             them to targets to take action. You can also use rules to take action on a predetermined
- *             schedule. For example, you can configure rules to:</p>
+ * <p>Amazon EventBridge helps you to respond to state changes in your AWS resources.
+ *             When your resources change state, they automatically send events into an event stream.
+ *             You can create rules that match selected events in the stream and route them to targets
+ *             to take action. You can also use rules to take action on a predetermined schedule. For
+ *             example, you can configure rules to:</p>
  *         <ul>
  *             <li>
- *                <p>Automatically invoke an AWS Lambda function to update DNS entries when an event notifies
- *                     you that Amazon EC2 instance enters the running state</p>
+ *                 <p>Automatically invoke an AWS Lambda function to update DNS entries when an
+ *                     event notifies you that Amazon EC2 instance enters the running state.</p>
  *             </li>
  *             <li>
- *                <p>Direct specific API records from AWS CloudTrail to an Amazon Kinesis data stream for
- *                     detailed analysis of potential security or availability risks</p>
+ *                 <p>Direct specific API records from AWS CloudTrail to an Amazon Kinesis data
+ *                     stream for detailed analysis of potential security or availability
+ *                     risks.</p>
  *             </li>
  *             <li>
- *                <p>Periodically invoke a built-in target to create a snapshot of an Amazon EBS
- *                     volume</p>
+ *                 <p>Periodically invoke a built-in target to create a snapshot of an Amazon EBS
+ *                     volume.</p>
  *             </li>
  *          </ul>
- *         <p>For more information about the features of Amazon EventBridge, see the
- *             <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/">Amazon EventBridge User Guide</a>.</p>
+ *         <p>For more information about the features of Amazon EventBridge, see the <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide">Amazon EventBridge User
+ *                 Guide</a>.</p>
  */
 export class CloudWatchEventsClient extends __Client<
   __HttpHandlerOptions,
@@ -328,6 +336,7 @@ export class CloudWatchEventsClient extends __Client<
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
+    this.middlewareStack.use(getLoggerPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-cloudwatch-events/commands/ActivateEventSourceCommand.ts
+++ b/clients/client-cloudwatch-events/commands/ActivateEventSourceCommand.ts
@@ -43,8 +43,11 @@ export class ActivateEventSourceCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: ActivateEventSourceRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: (output: any) => output,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/CreateEventBusCommand.ts
+++ b/clients/client-cloudwatch-events/commands/CreateEventBusCommand.ts
@@ -43,8 +43,11 @@ export class CreateEventBusCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: CreateEventBusRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: CreateEventBusResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/CreatePartnerEventSourceCommand.ts
+++ b/clients/client-cloudwatch-events/commands/CreatePartnerEventSourceCommand.ts
@@ -43,8 +43,11 @@ export class CreatePartnerEventSourceCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: CreatePartnerEventSourceRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: CreatePartnerEventSourceResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/DeactivateEventSourceCommand.ts
+++ b/clients/client-cloudwatch-events/commands/DeactivateEventSourceCommand.ts
@@ -43,8 +43,11 @@ export class DeactivateEventSourceCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: DeactivateEventSourceRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: (output: any) => output,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/DeleteEventBusCommand.ts
+++ b/clients/client-cloudwatch-events/commands/DeleteEventBusCommand.ts
@@ -43,8 +43,11 @@ export class DeleteEventBusCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: DeleteEventBusRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: (output: any) => output,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/DeletePartnerEventSourceCommand.ts
+++ b/clients/client-cloudwatch-events/commands/DeletePartnerEventSourceCommand.ts
@@ -43,8 +43,11 @@ export class DeletePartnerEventSourceCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: DeletePartnerEventSourceRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: (output: any) => output,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/DeleteRuleCommand.ts
+++ b/clients/client-cloudwatch-events/commands/DeleteRuleCommand.ts
@@ -43,8 +43,11 @@ export class DeleteRuleCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: DeleteRuleRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: (output: any) => output,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/DescribeEventBusCommand.ts
+++ b/clients/client-cloudwatch-events/commands/DescribeEventBusCommand.ts
@@ -43,8 +43,11 @@ export class DescribeEventBusCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: DescribeEventBusRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: DescribeEventBusResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/DescribeEventSourceCommand.ts
+++ b/clients/client-cloudwatch-events/commands/DescribeEventSourceCommand.ts
@@ -43,8 +43,11 @@ export class DescribeEventSourceCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: DescribeEventSourceRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: DescribeEventSourceResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/DescribePartnerEventSourceCommand.ts
+++ b/clients/client-cloudwatch-events/commands/DescribePartnerEventSourceCommand.ts
@@ -43,8 +43,11 @@ export class DescribePartnerEventSourceCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: DescribePartnerEventSourceRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: DescribePartnerEventSourceResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/DescribeRuleCommand.ts
+++ b/clients/client-cloudwatch-events/commands/DescribeRuleCommand.ts
@@ -43,8 +43,11 @@ export class DescribeRuleCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: DescribeRuleRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: DescribeRuleResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/DisableRuleCommand.ts
+++ b/clients/client-cloudwatch-events/commands/DisableRuleCommand.ts
@@ -43,8 +43,11 @@ export class DisableRuleCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: DisableRuleRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: (output: any) => output,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/EnableRuleCommand.ts
+++ b/clients/client-cloudwatch-events/commands/EnableRuleCommand.ts
@@ -43,8 +43,11 @@ export class EnableRuleCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: EnableRuleRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: (output: any) => output,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/ListEventBusesCommand.ts
+++ b/clients/client-cloudwatch-events/commands/ListEventBusesCommand.ts
@@ -43,8 +43,11 @@ export class ListEventBusesCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: ListEventBusesRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: ListEventBusesResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/ListEventSourcesCommand.ts
+++ b/clients/client-cloudwatch-events/commands/ListEventSourcesCommand.ts
@@ -43,8 +43,11 @@ export class ListEventSourcesCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: ListEventSourcesRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: ListEventSourcesResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/ListPartnerEventSourceAccountsCommand.ts
+++ b/clients/client-cloudwatch-events/commands/ListPartnerEventSourceAccountsCommand.ts
@@ -43,8 +43,11 @@ export class ListPartnerEventSourceAccountsCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: ListPartnerEventSourceAccountsRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: ListPartnerEventSourceAccountsResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/ListPartnerEventSourcesCommand.ts
+++ b/clients/client-cloudwatch-events/commands/ListPartnerEventSourcesCommand.ts
@@ -43,8 +43,11 @@ export class ListPartnerEventSourcesCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: ListPartnerEventSourcesRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: ListPartnerEventSourcesResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/ListRuleNamesByTargetCommand.ts
+++ b/clients/client-cloudwatch-events/commands/ListRuleNamesByTargetCommand.ts
@@ -43,8 +43,11 @@ export class ListRuleNamesByTargetCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: ListRuleNamesByTargetRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: ListRuleNamesByTargetResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/ListRulesCommand.ts
+++ b/clients/client-cloudwatch-events/commands/ListRulesCommand.ts
@@ -40,8 +40,11 @@ export class ListRulesCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: ListRulesRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: ListRulesResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/ListTagsForResourceCommand.ts
+++ b/clients/client-cloudwatch-events/commands/ListTagsForResourceCommand.ts
@@ -43,8 +43,11 @@ export class ListTagsForResourceCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: ListTagsForResourceRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: ListTagsForResourceResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/ListTargetsByRuleCommand.ts
+++ b/clients/client-cloudwatch-events/commands/ListTargetsByRuleCommand.ts
@@ -43,8 +43,11 @@ export class ListTargetsByRuleCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: ListTargetsByRuleRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: ListTargetsByRuleResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/PutEventsCommand.ts
+++ b/clients/client-cloudwatch-events/commands/PutEventsCommand.ts
@@ -40,8 +40,11 @@ export class PutEventsCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: PutEventsRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: PutEventsResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/PutPartnerEventsCommand.ts
+++ b/clients/client-cloudwatch-events/commands/PutPartnerEventsCommand.ts
@@ -43,8 +43,11 @@ export class PutPartnerEventsCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: PutPartnerEventsRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: PutPartnerEventsResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/PutPermissionCommand.ts
+++ b/clients/client-cloudwatch-events/commands/PutPermissionCommand.ts
@@ -43,8 +43,11 @@ export class PutPermissionCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: PutPermissionRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: (output: any) => output,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/PutRuleCommand.ts
+++ b/clients/client-cloudwatch-events/commands/PutRuleCommand.ts
@@ -40,8 +40,11 @@ export class PutRuleCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: PutRuleRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: PutRuleResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/PutTargetsCommand.ts
+++ b/clients/client-cloudwatch-events/commands/PutTargetsCommand.ts
@@ -43,8 +43,11 @@ export class PutTargetsCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: PutTargetsRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: PutTargetsResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/RemovePermissionCommand.ts
+++ b/clients/client-cloudwatch-events/commands/RemovePermissionCommand.ts
@@ -43,8 +43,11 @@ export class RemovePermissionCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: RemovePermissionRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: (output: any) => output,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/RemoveTargetsCommand.ts
+++ b/clients/client-cloudwatch-events/commands/RemoveTargetsCommand.ts
@@ -43,8 +43,11 @@ export class RemoveTargetsCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: RemoveTargetsRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: RemoveTargetsResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/TagResourceCommand.ts
+++ b/clients/client-cloudwatch-events/commands/TagResourceCommand.ts
@@ -43,8 +43,11 @@ export class TagResourceCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: TagResourceRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: TagResourceResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/TestEventPatternCommand.ts
+++ b/clients/client-cloudwatch-events/commands/TestEventPatternCommand.ts
@@ -43,8 +43,11 @@ export class TestEventPatternCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: TestEventPatternRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: TestEventPatternResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/commands/UntagResourceCommand.ts
+++ b/clients/client-cloudwatch-events/commands/UntagResourceCommand.ts
@@ -43,8 +43,11 @@ export class UntagResourceCommand extends $Command<
 
     const stack = clientStack.concat(this.middlewareStack);
 
+    const { logger } = configuration;
     const handlerExecutionContext: HandlerExecutionContext = {
-      logger: {} as any,
+      logger,
+      inputFilterSensitiveLog: UntagResourceRequest.filterSensitiveLog,
+      outputFilterSensitiveLog: UntagResourceResponse.filterSensitiveLog,
     };
     const { requestHandler } = configuration;
     return stack.resolve(

--- a/clients/client-cloudwatch-events/models/index.ts
+++ b/clients/client-cloudwatch-events/models/index.ts
@@ -22,21 +22,22 @@ export enum AssignPublicIp {
 }
 
 /**
- * <p>This structure specifies the VPC subnets and security groups for the task and whether
+ * <p>This structure specifies the VPC subnets and security groups for the task, and whether
  *             a public IP address is to be used. This structure is relevant only for ECS tasks that
  *             use the <code>awsvpc</code> network mode.</p>
  */
 export interface AwsVpcConfiguration {
   __type?: "AwsVpcConfiguration";
   /**
-   * <p>Specifies whether the task's elastic network interface receives a public IP address. You can specify <code>ENABLED</code> only when
-   *         <code>LaunchType</code> in <code>EcsParameters</code> is set to <code>FARGATE</code>.</p>
+   * <p>Specifies whether the task's elastic network interface receives a public IP address.
+   *             You can specify <code>ENABLED</code> only when <code>LaunchType</code> in
+   *                 <code>EcsParameters</code> is set to <code>FARGATE</code>.</p>
    */
   AssignPublicIp?: AssignPublicIp | string;
 
   /**
    * <p>Specifies the security groups associated with the task. These security groups must all
-   *             be in the same VPC. You can specify as many as five security groups. If you don't
+   *             be in the same VPC. You can specify as many as five security groups. If you do not
    *             specify a security group, the default security group for the VPC is used.</p>
    */
   SecurityGroups?: string[];
@@ -56,15 +57,16 @@ export namespace AwsVpcConfiguration {
 }
 
 /**
- * <p>The array properties for the submitted job, such as the size of the
- *             array. The array size can be between 2 and 10,000. If you specify array properties for a job, it becomes an array job. This
- *             parameter is used only if the target is an AWS Batch job.</p>
+ * <p>The array properties for the submitted job, such as the size of the array. The
+ *             array size can be between 2 and 10,000. If you specify array properties for a job, it
+ *             becomes an array job. This parameter is used only if the target is an AWS Batch
+ *             job.</p>
  */
 export interface BatchArrayProperties {
   __type?: "BatchArrayProperties";
   /**
-   * <p>The size of the array, if this is an array batch job. Valid values are
-   *             integers between 2 and 10,000.</p>
+   * <p>The size of the array, if this is an array batch job. Valid values are integers
+   *             between 2 and 10,000.</p>
    */
   Size?: number;
 }
@@ -82,24 +84,27 @@ export namespace BatchArrayProperties {
 export interface BatchParameters {
   __type?: "BatchParameters";
   /**
-   * <p>The array properties for the submitted job, such as the size of the
-   *             array. The array size can be between 2 and 10,000. If you specify array properties for a job, it becomes an array job. This
-   *         parameter is used only if the target is an AWS Batch job.</p>
+   * <p>The array properties for the submitted job, such as the size of the array. The
+   *             array size can be between 2 and 10,000. If you specify array properties for a job, it
+   *             becomes an array job. This parameter is used only if the target is an AWS Batch
+   *             job.</p>
    */
   ArrayProperties?: BatchArrayProperties;
 
   /**
-   * <p>The ARN or name of the job definition to use if the event target is an AWS Batch job. This job definition must already exist.</p>
+   * <p>The ARN or name of the job definition to use if the event target is an AWS Batch
+   *             job. This job definition must already exist.</p>
    */
   JobDefinition: string | undefined;
 
   /**
-   * <p>The name to use for this execution of the job, if the target is an AWS Batch job.</p>
+   * <p>The name to use for this execution of the job, if the target is an AWS Batch
+   *             job.</p>
    */
   JobName: string | undefined;
 
   /**
-   * <p>The retry strategy to use for failed jobs if the target is an AWS Batch job. The
+   * <p>The retry strategy to use for failed jobs, if the target is an AWS Batch job. The
    *             retry strategy is the number of times to retry the failed job execution. Valid values
    *             are 1–10. When you specify a retry strategy here, it overrides the retry strategy
    *             defined in the job definition.</p>
@@ -115,8 +120,8 @@ export namespace BatchParameters {
 }
 
 /**
- * <p>The retry strategy to use for failed jobs if the target is an AWS Batch job. If you
- *             specify a retry strategy here, it overrides the retry strategy defined in the job
+ * <p>The retry strategy to use for failed jobs, if the target is an AWS Batch job. If
+ *             you specify a retry strategy here, it overrides the retry strategy defined in the job
  *             definition.</p>
  */
 export interface BatchRetryStrategy {
@@ -136,7 +141,7 @@ export namespace BatchRetryStrategy {
 }
 
 /**
- * <p>There is concurrent modification on a resource.</p>
+ * <p>There is concurrent modification on a rule or target.</p>
  */
 export interface ConcurrentModificationException extends __SmithyException, $MetadataBearer {
   name: "ConcurrentModificationException";
@@ -152,34 +157,36 @@ export namespace ConcurrentModificationException {
 }
 
 /**
- * <p>A JSON string that you can use to limit the event bus permissions that you're granting
- *             to only accounts that fulfill the condition. Currently, the only supported condition is
+ * <p>A JSON string which you can use to limit the event bus permissions you are granting to
+ *             only accounts that fulfill the condition. Currently, the only supported condition is
  *             membership in a certain AWS organization. The string must contain <code>Type</code>,
  *                 <code>Key</code>, and <code>Value</code> fields. The <code>Value</code> field
- *             specifies the ID of the AWS organization. The following is an example value for
+ *             specifies the ID of the AWS organization. Following is an example value for
  *                 <code>Condition</code>:</p>
  *         <p>
- *             <code>'{"Type" : "StringEquals", "Key": "aws:PrincipalOrgID", "Value": "o-1234567890"}'</code>
+ *             <code>'{"Type" : "StringEquals", "Key": "aws:PrincipalOrgID", "Value":
+ *                 "o-1234567890"}'</code>
  *          </p>
  */
 export interface Condition {
   __type?: "Condition";
   /**
-   * <p>The key for the condition. Currently, the only supported key is
-   *                 <code>aws:PrincipalOrgID</code>.</p>
-   */
-  Key: string | undefined;
-
-  /**
-   * <p>The type of condition. Currently, the only supported value is
+   * <p>Specifies the type of condition. Currently the only supported value is
    *                 <code>StringEquals</code>.</p>
    */
   Type: string | undefined;
 
   /**
-   * <p>The value for the key. Currently, this must be the ID of the organization.</p>
+   * <p>Specifies the value for the key. Currently, this must be the ID of the
+   *             organization.</p>
    */
   Value: string | undefined;
+
+  /**
+   * <p>Specifies the key for the condition. Currently the only supported key is
+   *                 <code>aws:PrincipalOrgID</code>.</p>
+   */
+  Key: string | undefined;
 }
 
 export namespace Condition {
@@ -192,20 +199,25 @@ export namespace Condition {
 export interface CreateEventBusRequest {
   __type?: "CreateEventBusRequest";
   /**
-   * <p>If you're creating a partner event bus, this specifies the partner event source that
+   * <p>If you are creating a partner event bus, this specifies the partner event source that
    *             the new event bus will be matched with.</p>
    */
   EventSourceName?: string;
 
   /**
    * <p>The name of the new event bus. </p>
-   *         <p>The names of custom event buses can't contain the <code>/</code> character. You can't use the name
-   *                 <code>default</code> for a custom event bus because this name is already used for
-   *             your account's default event bus.</p>
-   *         <p>If this is a partner event bus, the name must exactly match the name of the partner event source that this event bus
-   *             is matched to. This name will include the <code>/</code> character.</p>
+   *         <p>Event bus names cannot contain the / character. You can't use the name
+   *                 <code>default</code> for a custom event bus, as this name is already used for your
+   *             account's default event bus.</p>
+   *         <p>If this is a partner event bus, the name must exactly match the name of the partner
+   *             event source that this event bus is matched to.</p>
    */
   Name: string | undefined;
+
+  /**
+   * <p>Tags to associate with the event bus.</p>
+   */
+  Tags?: Tag[];
 }
 
 export namespace CreateEventBusRequest {
@@ -233,19 +245,21 @@ export namespace CreateEventBusResponse {
 export interface CreatePartnerEventSourceRequest {
   __type?: "CreatePartnerEventSourceRequest";
   /**
-   * <p>The AWS account ID of the customer who is permitted to create a matching partner event bus for this partner event source.</p>
-   */
-  Account: string | undefined;
-
-  /**
-   * <p>The name of the partner event source. This name must be unique and must be in the format
-   *             <code>
+   * <p>The name of the partner event source. This name must be unique and must be in the
+   *             format
+   *                     <code>
    *                <i>partner_name</i>/<i>event_namespace</i>/<i>event_name</i>
    *             </code>.
-   *             The AWS account that wants to use this partner event source
-   *         must create a partner event bus with a name that matches the name of the partner event source.</p>
+   *             The AWS account that wants to use this partner event source must create a partner event
+   *             bus with a name that matches the name of the partner event source.</p>
    */
   Name: string | undefined;
+
+  /**
+   * <p>The AWS account ID that is permitted to create a matching partner event bus for this
+   *             partner event source.</p>
+   */
+  Account: string | undefined;
 }
 
 export namespace CreatePartnerEventSourceRequest {
@@ -323,22 +337,24 @@ export namespace DeletePartnerEventSourceRequest {
 export interface DeleteRuleRequest {
   __type?: "DeleteRuleRequest";
   /**
-   * <p>The event bus associated with the rule. If you omit this, the default event bus is used.</p>
+   * <p>The event bus associated with the rule. If you omit this, the default event bus is
+   *             used.</p>
    */
   EventBusName?: string;
-
-  /**
-   * <p>If this is a managed rule, created by an AWS service on your behalf, you must specify <code>Force</code>
-   *         as <code>True</code> to delete the rule. This parameter is ignored for rules that are not managed rules. You can check
-   *         whether a rule is a managed rule by using <code>DescribeRule</code> or <code>ListRules</code> and checking the
-   *         <code>ManagedBy</code> field of the response.</p>
-   */
-  Force?: boolean;
 
   /**
    * <p>The name of the rule.</p>
    */
   Name: string | undefined;
+
+  /**
+   * <p>If this is a managed rule, created by an AWS service on your behalf, you must specify
+   *                 <code>Force</code> as <code>True</code> to delete the rule. This parameter is
+   *             ignored for rules that are not managed rules. You can check whether a rule is a managed
+   *             rule by using <code>DescribeRule</code> or <code>ListRules</code> and checking the
+   *                 <code>ManagedBy</code> field of the response.</p>
+   */
+  Force?: boolean;
 }
 
 export namespace DeleteRuleRequest {
@@ -351,7 +367,8 @@ export namespace DeleteRuleRequest {
 export interface DescribeEventBusRequest {
   __type?: "DescribeEventBusRequest";
   /**
-   * <p>The name of the event bus to show details for. If you omit this, the default event bus is displayed.</p>
+   * <p>The name of the event bus to show details for. If you omit this, the default event bus
+   *             is displayed.</p>
    */
   Name?: string;
 }
@@ -366,17 +383,20 @@ export namespace DescribeEventBusRequest {
 export interface DescribeEventBusResponse {
   __type?: "DescribeEventBusResponse";
   /**
-   * <p>The Amazon Resource Name (ARN) of the account permitted to write events to the current account.</p>
-   */
-  Arn?: string;
-
-  /**
-   * <p>The name of the event bus. Currently, this is always <code>default</code>.</p>
+   * <p>The name of the event bus. Currently, this is always
+   *             <code>default</code>.</p>
    */
   Name?: string;
 
   /**
-   * <p>The policy that enables the external account to send events to your account.</p>
+   * <p>The Amazon Resource Name (ARN) of the account permitted to write events to the
+   *             current account.</p>
+   */
+  Arn?: string;
+
+  /**
+   * <p>The policy that enables the external account to send events to your
+   *             account.</p>
    */
   Policy?: string;
 }
@@ -406,25 +426,9 @@ export namespace DescribeEventSourceRequest {
 export interface DescribeEventSourceResponse {
   __type?: "DescribeEventSourceResponse";
   /**
-   * <p>The ARN of the partner event source.</p>
-   */
-  Arn?: string;
-
-  /**
    * <p>The name of the SaaS partner that created the event source.</p>
    */
   CreatedBy?: string;
-
-  /**
-   * <p>The date and time that the event source was created.</p>
-   */
-  CreationTime?: Date;
-
-  /**
-   * <p>The date and time that the event source will expire if you don't create a matching
-   *             event bus.</p>
-   */
-  ExpirationTime?: Date;
 
   /**
    * <p>The name of the partner event source.</p>
@@ -432,13 +436,29 @@ export interface DescribeEventSourceResponse {
   Name?: string;
 
   /**
-   * <p>The state of the event source. If it's <code>ACTIVE</code>, you have already created a
-   *             matching event bus for this event source, and that event bus is active. If it's
-   *                 <code>PENDING</code>, either you haven't yet created a matching event bus, or that
-   *             event bus is deactivated. If it's <code>DELETED</code>, you have created a matching
-   *             event bus, but the event source has since been deleted.</p>
+   * <p>The date and time that the event source will expire if you do not create a matching
+   *             event bus.</p>
+   */
+  ExpirationTime?: Date;
+
+  /**
+   * <p>The ARN of the partner event source.</p>
+   */
+  Arn?: string;
+
+  /**
+   * <p>The state of the event source. If it is ACTIVE, you have already created a matching
+   *             event bus for this event source, and that event bus is active. If it is PENDING, either
+   *             you haven't yet created a matching event bus, or that event bus is deactivated. If it is
+   *             DELETED, you have created a matching event bus, but the event source has since been
+   *             deleted.</p>
    */
   State?: EventSourceState | string;
+
+  /**
+   * <p>The date and time that the event source was created.</p>
+   */
+  CreationTime?: Date;
 }
 
 export namespace DescribeEventSourceResponse {
@@ -487,7 +507,8 @@ export namespace DescribePartnerEventSourceResponse {
 export interface DescribeRuleRequest {
   __type?: "DescribeRuleRequest";
   /**
-   * <p>The event bus associated with the rule. If you omit this, the default event bus is used.</p>
+   * <p>The event bus associated with the rule. If you omit this, the default event bus is
+   *             used.</p>
    */
   EventBusName?: string;
 
@@ -507,30 +528,10 @@ export namespace DescribeRuleRequest {
 export interface DescribeRuleResponse {
   __type?: "DescribeRuleResponse";
   /**
-   * <p>The Amazon Resource Name (ARN) of the rule.</p>
+   * <p>The scheduling expression. For example, "cron(0 20 * * ? *)", "rate(5
+   *             minutes)".</p>
    */
-  Arn?: string;
-
-  /**
-   * <p>The description of the rule.</p>
-   */
-  Description?: string;
-
-  /**
-   * <p>The event bus associated with the rule.</p>
-   */
-  EventBusName?: string;
-
-  /**
-   * <p>The event pattern. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html">Event Patterns</a> in the <i>Amazon EventBridge User Guide</i>.</p>
-   */
-  EventPattern?: string;
-
-  /**
-   * <p>If this is a managed rule, created by an AWS service on your behalf, this field
-   *             displays the principal name of the AWS service that created the rule.</p>
-   */
-  ManagedBy?: string;
+  ScheduleExpression?: string;
 
   /**
    * <p>The name of the rule.</p>
@@ -543,15 +544,37 @@ export interface DescribeRuleResponse {
   RoleArn?: string;
 
   /**
-   * <p>The scheduling expression: for example, <code>"cron(0 20 * * ? *)"</code> or
-   *                 <code>"rate(5 minutes)"</code>.</p>
+   * <p>The event bus associated with the rule.</p>
    */
-  ScheduleExpression?: string;
+  EventBusName?: string;
 
   /**
    * <p>Specifies whether the rule is enabled or disabled.</p>
    */
   State?: RuleState | string;
+
+  /**
+   * <p>The Amazon Resource Name (ARN) of the rule.</p>
+   */
+  Arn?: string;
+
+  /**
+   * <p>The event pattern. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html">Events and
+   *                 Event Patterns</a> in the <i>Amazon EventBridge User
+   *             Guide</i>.</p>
+   */
+  EventPattern?: string;
+
+  /**
+   * <p>If this is a managed rule, created by an AWS service on your behalf, this field
+   *             displays the principal name of the AWS service that created the rule.</p>
+   */
+  ManagedBy?: string;
+
+  /**
+   * <p>The description of the rule.</p>
+   */
+  Description?: string;
 }
 
 export namespace DescribeRuleResponse {
@@ -564,7 +587,8 @@ export namespace DescribeRuleResponse {
 export interface DisableRuleRequest {
   __type?: "DisableRuleRequest";
   /**
-   * <p>The event bus associated with the rule. If you omit this, the default event bus is used.</p>
+   * <p>The event bus associated with the rule. If you omit this, the default event bus is
+   *             used.</p>
    */
   EventBusName?: string;
 
@@ -592,46 +616,47 @@ export interface EcsParameters {
   Group?: string;
 
   /**
-   * <p>Specifies the launch type on which your task is running. The launch type that you
-   *             specify here must match one of the launch type (compatibilities) of the target task. The <code>FARGATE</code>
-   *             value is supported only in the Regions where AWS Fargate with Amazon ECS is supported.
-   *             For more information, see <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS-Fargate.html">AWS Fargate on Amazon
-   *                 ECS</a> in the <i>Amazon Elastic Container Service Developer
-   *                 Guide</i>.</p>
-   */
-  LaunchType?: LaunchType | string;
-
-  /**
-   * <p>Use this structure if the ECS task uses the <code>awsvpc</code> network mode. This
-   *             structure specifies the VPC subnets and security groups associated with the task and
-   *             whether a public IP address is to be used. This structure is required if
-   *                 <code>LaunchType</code> is <code>FARGATE</code> because the <code>awsvpc</code> mode
-   *             is required for Fargate tasks.</p>
-   *         <p>If you specify <code>NetworkConfiguration</code> when the target ECS task doesn't use
-   *             the <code>awsvpc</code> network mode, the task fails.</p>
-   */
-  NetworkConfiguration?: NetworkConfiguration;
-
-  /**
-   * <p>Specifies the platform version for the task. Specify only the numeric portion of the
-   *             platform version, such as <code>1.1.0</code>.</p>
-   *             <p>This structure is used only if <code>LaunchType</code> is <code>FARGATE</code>.
-   *             For more information about valid platform versions, see <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html">AWS Fargate Platform
-   *                 Versions</a> in the <i>Amazon Elastic Container Service Developer
-   *                 Guide</i>.</p>
-   */
-  PlatformVersion?: string;
-
-  /**
    * <p>The number of tasks to create based on <code>TaskDefinition</code>. The default is
    *             1.</p>
    */
   TaskCount?: number;
 
   /**
-   * <p>The ARN of the task definition to use if the event target is an Amazon ECS task. </p>
+   * <p>Specifies the platform version for the task. Specify only the numeric portion of the
+   *             platform version, such as <code>1.1.0</code>.</p>
+   *         <p>This structure is used only if <code>LaunchType</code> is <code>FARGATE</code>. For
+   *             more information about valid platform versions, see <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html">AWS Fargate Platform
+   *                 Versions</a> in the <i>Amazon Elastic Container Service Developer
+   *                 Guide</i>.</p>
+   */
+  PlatformVersion?: string;
+
+  /**
+   * <p>Use this structure if the ECS task uses the <code>awsvpc</code> network mode. This
+   *             structure specifies the VPC subnets and security groups associated with the task, and
+   *             whether a public IP address is to be used. This structure is required if
+   *                 <code>LaunchType</code> is <code>FARGATE</code> because the <code>awsvpc</code> mode
+   *             is required for Fargate tasks.</p>
+   *         <p>If you specify <code>NetworkConfiguration</code> when the target ECS task does not use
+   *             the <code>awsvpc</code> network mode, the task fails.</p>
+   */
+  NetworkConfiguration?: NetworkConfiguration;
+
+  /**
+   * <p>The ARN of the task definition to use if the event target is an Amazon ECS task.
+   *         </p>
    */
   TaskDefinitionArn: string | undefined;
+
+  /**
+   * <p>Specifies the launch type on which your task is running. The launch type that you
+   *             specify here must match one of the launch type (compatibilities) of the target task. The
+   *                 <code>FARGATE</code> value is supported only in the Regions where AWS Fargate with
+   *             Amazon ECS is supported. For more information, see <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS-Fargate.html">AWS Fargate on Amazon
+   *                 ECS</a> in the <i>Amazon Elastic Container Service Developer
+   *                 Guide</i>.</p>
+   */
+  LaunchType?: LaunchType | string;
 }
 
 export namespace EcsParameters {
@@ -644,7 +669,8 @@ export namespace EcsParameters {
 export interface EnableRuleRequest {
   __type?: "EnableRuleRequest";
   /**
-   * <p>The event bus associated with the rule. If you omit this, the default event bus is used.</p>
+   * <p>The event bus associated with the rule. If you omit this, the default event bus is
+   *             used.</p>
    */
   EventBusName?: string;
 
@@ -662,10 +688,11 @@ export namespace EnableRuleRequest {
 }
 
 /**
- * <p>An event bus receives events from a source and routes them to rules associated with that event bus. Your
- *             account's default event bus receives rules from AWS services. A custom event bus can receive rules from AWS services
- *             as well as your custom applications and services. A partner event bus receives events from an event source created
- *             by an SaaS partner. These events come from the partners services or applications.</p>
+ * <p>An event bus receives events from a source and routes them to rules associated with
+ *             that event bus. Your account's default event bus receives rules from AWS services. A
+ *             custom event bus can receive rules from AWS services as well as your custom applications
+ *             and services. A partner event bus receives events from an event source created by an
+ *             SaaS partner. These events come from the partners services or applications.</p>
  */
 export interface EventBus {
   __type?: "EventBus";
@@ -680,7 +707,8 @@ export interface EventBus {
   Name?: string;
 
   /**
-   * <p>The permissions policy of the event bus, describing which other AWS accounts can write events to this event bus.</p>
+   * <p>The permissions policy of the event bus, describing which other AWS accounts can write
+   *             events to this event bus.</p>
    */
   Policy?: string;
 }
@@ -693,15 +721,25 @@ export namespace EventBus {
 }
 
 /**
- * <p>A partner event source is created by an SaaS partner. If a customer creates a partner event bus that matches this event source,
- *                 that AWS account can receive events from the partner's applications or services.</p>
+ * <p>A partner event source is created by an SaaS partner. If a customer creates a partner
+ *             event bus that matches this event source, that AWS account can receive events from the
+ *             partner's applications or services.</p>
  */
 export interface EventSource {
   __type?: "EventSource";
   /**
-   * <p>The ARN of the event source.</p>
+   * <p>The name of the event source.</p>
    */
-  Arn?: string;
+  Name?: string;
+
+  /**
+   * <p>The state of the event source. If it is ACTIVE, you have already created a matching
+   *             event bus for this event source, and that event bus is active. If it is PENDING, either
+   *             you haven't yet created a matching event bus, or that event bus is deactivated. If it is
+   *             DELETED, you have created a matching event bus, but the event source has since been
+   *             deleted.</p>
+   */
+  State?: EventSourceState | string;
 
   /**
    * <p>The name of the partner that created the event source.</p>
@@ -709,29 +747,20 @@ export interface EventSource {
   CreatedBy?: string;
 
   /**
-   * <p>The date and time when the event source was created.</p>
+   * <p>The date and time the event source was created.</p>
    */
   CreationTime?: Date;
 
   /**
-   * <p>The date and time when the event source will expire if the AWS account doesn't
-   *             create a matching event bus for it.</p>
+   * <p>The date and time that the event source will expire, if the AWS account doesn't create
+   *             a matching event bus for it.</p>
    */
   ExpirationTime?: Date;
 
   /**
-   * <p>The name of the event source.</p>
+   * <p>The ARN of the event source.</p>
    */
-  Name?: string;
-
-  /**
-   * <p>The state of the event source. If it's <code>ACTIVE</code>, you have already
-   *             created a matching event bus for this event source, and that event bus is active. If
-   *             it's <code>PENDING</code>, either you haven't yet created a matching event bus, or that
-   *             event bus is deactivated. If it's <code>DELETED</code>, you have created a matching
-   *             event bus, but the event source has since been deleted.</p>
-   */
-  State?: EventSourceState | string;
+  Arn?: string;
 }
 
 export namespace EventSource {
@@ -748,54 +777,80 @@ export enum EventSourceState {
 }
 
 /**
- * <p>Contains the parameters needed for you to provide custom input to a target based on one or more pieces of data extracted from the event.</p>
+ * <p>These are custom parameter to be used when the target is an API Gateway REST
+ *             APIs.</p>
+ */
+export interface HttpParameters {
+  __type?: "HttpParameters";
+  /**
+   * <p>The headers that need to be sent as part of request invoking the API Gateway REST
+   *             API.</p>
+   */
+  HeaderParameters?: { [key: string]: string };
+
+  /**
+   * <p>The path parameter values to be used to populate API Gateway REST API
+   *          path wildcards ("*").</p>
+   */
+  PathParameterValues?: string[];
+
+  /**
+   * <p>The query string keys/values that need to be sent as part of request invoking the
+   *             API Gateway REST API.</p>
+   */
+  QueryStringParameters?: { [key: string]: string };
+}
+
+export namespace HttpParameters {
+  export const filterSensitiveLog = (obj: HttpParameters): any => ({
+    ...obj,
+  });
+  export const isa = (o: any): o is HttpParameters => __isa(o, "HttpParameters");
+}
+
+/**
+ * <p>Contains the parameters needed for you to provide custom input to a target based on
+ *             one or more pieces of data extracted from the event.</p>
  */
 export interface InputTransformer {
   __type?: "InputTransformer";
   /**
-   * <p>Map of JSON paths to be extracted from the event. You can then insert these in the
-   *             template in <code>InputTemplate</code> to produce the output to be sent to the
-   *             target.</p>
-   *         <p>
-   *             <code>InputPathsMap</code> is an array key-value pairs, where each value is a valid JSON path. You can have
-   *             as many as 10 key-value pairs.
-   *             You must use JSON dot notation, not bracket notation.</p>
-   *         <p>The keys can't start with <code>"AWS"</code>.</p>
-   */
-  InputPathsMap?: { [key: string]: string };
-
-  /**
    * <p>Input template where you specify placeholders that will be filled with the values
    *             of the keys from <code>InputPathsMap</code> to customize the data sent to the target.
    *             Enclose each <code>InputPathsMaps</code> value in brackets:
-   *                 <<i>value</i>>. The InputTemplate must be valid JSON.</p>
+   *                 <<i>value</i>> The InputTemplate must be valid JSON.</p>
    *
-   *         <p>If <code>InputTemplate</code> is a JSON object (surrounded by curly braces), the following restrictions apply:</p>
+   *         <p>If <code>InputTemplate</code> is a JSON object (surrounded by curly braces), the
+   *             following restrictions apply:</p>
    *         <ul>
    *             <li>
-   *                 <p>The placeholder can't be used as an object key</p>
+   *                 <p>The placeholder cannot be used as an object key.</p>
    *             </li>
    *             <li>
-   *                 <p>Object values can't include quote marks</p>
+   *                 <p>Object values cannot include quote marks.</p>
    *             </li>
    *          </ul>
-   *         <p>The following example shows the syntax for using <code>InputPathsMap</code> and <code>InputTemplate</code>.</p>
+   *         <p>The following example shows the syntax for using <code>InputPathsMap</code> and
+   *                 <code>InputTemplate</code>.</p>
    *         <p>
    *             <code> "InputTransformer":</code>
    *          </p>
-   *          <p>
+   *         <p>
    *             <code>{</code>
    *          </p>
-   *          <p>
-   *             <code>"InputPathsMap": {"instance": "$.detail.instance","status": "$.detail.status"},</code>
+   *         <p>
+   *             <code>"InputPathsMap": {"instance": "$.detail.instance","status":
+   *                 "$.detail.status"},</code>
    *          </p>
-   *          <p>
-   *             <code>"InputTemplate": "<instance> is in state <status>"</code>
+   *         <p>
+   *             <code>"InputTemplate": "<instance> is in state
+   *             <status>"</code>
    *          </p>
-   *          <p>
+   *         <p>
    *             <code>}</code>
    *          </p>
-   *         <p>To have the <code>InputTemplate</code> include quote marks within a JSON string, escape each quote marks with a slash, as in the following example:</p>
+   *         <p>To have the <code>InputTemplate</code> include quote marks within a JSON string,
+   *             escape each quote marks with a slash, as in the following example:</p>
    *         <p>
    *             <code> "InputTransformer":</code>
    *          </p>
@@ -803,16 +858,30 @@ export interface InputTransformer {
    *             <code>{</code>
    *          </p>
    *         <p>
-   *             <code>"InputPathsMap": {"instance": "$.detail.instance","status": "$.detail.status"},</code>
+   *             <code>"InputPathsMap": {"instance": "$.detail.instance","status":
+   *                 "$.detail.status"},</code>
    *          </p>
    *         <p>
-   *             <code>"InputTemplate": "<instance> is in state \"<status>\""</code>
+   *             <code>"InputTemplate": "<instance> is in state
+   *             \"<status>\""</code>
    *          </p>
    *         <p>
    *             <code>}</code>
    *          </p>
    */
   InputTemplate: string | undefined;
+
+  /**
+   * <p>Map of JSON paths to be extracted from the event. You can then insert these in the
+   *             template in <code>InputTemplate</code> to produce the output you want to be sent to the
+   *             target.</p>
+   *         <p>
+   *             <code>InputPathsMap</code> is an array key-value pairs, where each value is a valid
+   *             JSON path. You can have as many as 10 key-value pairs. You must use JSON dot notation,
+   *             not bracket notation.</p>
+   *         <p>The keys cannot start with "AWS." </p>
+   */
+  InputPathsMap?: { [key: string]: string };
 }
 
 export namespace InputTransformer {
@@ -839,7 +908,7 @@ export namespace InternalException {
 }
 
 /**
- * <p>The event pattern isn't valid.</p>
+ * <p>The event pattern is not valid.</p>
  */
 export interface InvalidEventPatternException extends __SmithyException, $MetadataBearer {
   name: "InvalidEventPatternException";
@@ -855,7 +924,7 @@ export namespace InvalidEventPatternException {
 }
 
 /**
- * <p>The specified state isn't a valid state for an event source.</p>
+ * <p>The specified state is not a valid state for an event source.</p>
  */
 export interface InvalidStateException extends __SmithyException, $MetadataBearer {
   name: "InvalidStateException";
@@ -872,14 +941,17 @@ export namespace InvalidStateException {
 
 /**
  * <p>This object enables you to specify a JSON path to extract from the event and use as
- *             the partition key for the Amazon Kinesis data stream so that you can control the shard
- *             that the event goes to. If you don't include this parameter, the default is to use the
+ *             the partition key for the Amazon Kinesis data stream, so that you can control the shard
+ *             to which the event goes. If you do not include this parameter, the default is to use the
  *                 <code>eventId</code> as the partition key.</p>
  */
 export interface KinesisParameters {
   __type?: "KinesisParameters";
   /**
-   * <p>The JSON path to be extracted from the event and used as the partition key. For more information, see <a href="https://docs.aws.amazon.com/streams/latest/dev/key-concepts.html#partition-key">Amazon Kinesis Streams Key Concepts</a> in the <i>Amazon Kinesis Streams Developer Guide</i>.</p>
+   * <p>The JSON path to be extracted from the event and used as the partition key. For
+   *             more information, see <a href="https://docs.aws.amazon.com/streams/latest/dev/key-concepts.html#partition-key">Amazon Kinesis Streams Key
+   *                 Concepts</a> in the <i>Amazon Kinesis Streams Developer
+   *             Guide</i>.</p>
    */
   PartitionKeyPath: string | undefined;
 }
@@ -897,7 +969,8 @@ export enum LaunchType {
 }
 
 /**
- * <p>You tried to create more resources than is allowed.</p>
+ * <p>You tried to create more rules or add more targets to a rule than is
+ *             allowed.</p>
  */
 export interface LimitExceededException extends __SmithyException, $MetadataBearer {
   name: "LimitExceededException";
@@ -915,15 +988,8 @@ export namespace LimitExceededException {
 export interface ListEventBusesRequest {
   __type?: "ListEventBusesRequest";
   /**
-   * <p>Specifying this limits the number of results returned by this operation. The
-   *             operation also returns a <code>NextToken</code> that you can use in a subsequent
-   *             operation to retrieve the next set of results.</p>
-   */
-  Limit?: number;
-
-  /**
    * <p>Specifying this limits the results to only those event buses with names that start
-   *                 with the specified prefix.</p>
+   *             with the specified prefix.</p>
    */
   NamePrefix?: string;
 
@@ -931,6 +997,13 @@ export interface ListEventBusesRequest {
    * <p>The token returned by a previous call to retrieve the next set of results.</p>
    */
   NextToken?: string;
+
+  /**
+   * <p>Specifying this limits the number of results returned by this operation. The operation
+   *             also returns a NextToken which you can use in a subsequent operation to retrieve the
+   *             next set of results.</p>
+   */
+  Limit?: number;
 }
 
 export namespace ListEventBusesRequest {
@@ -948,7 +1021,8 @@ export interface ListEventBusesResponse {
   EventBuses?: EventBus[];
 
   /**
-   * <p>A token you can use in a subsequent operation to retrieve the next set of results.</p>
+   * <p>A token you can use in a subsequent operation to retrieve the next set of
+   *             results.</p>
    */
   NextToken?: string;
 }
@@ -963,17 +1037,17 @@ export namespace ListEventBusesResponse {
 export interface ListEventSourcesRequest {
   __type?: "ListEventSourcesRequest";
   /**
-   * <p>Specifying this limits the number of results returned by this operation. The
-   *             operation also returns a <code>NextToken</code> that you can use in a subsequent
-   *             operation to retrieve the next set of results.</p>
-   */
-  Limit?: number;
-
-  /**
-   * <p>Specifying this limits the results to only those partner event sources with names that start
-   *             with the specified prefix.</p>
+   * <p>Specifying this limits the results to only those partner event sources with names that
+   *             start with the specified prefix.</p>
    */
   NamePrefix?: string;
+
+  /**
+   * <p>Specifying this limits the number of results returned by this operation. The operation
+   *             also returns a NextToken which you can use in a subsequent operation to retrieve the
+   *             next set of results.</p>
+   */
+  Limit?: number;
 
   /**
    * <p>The token returned by a previous call to retrieve the next set of results.</p>
@@ -991,14 +1065,15 @@ export namespace ListEventSourcesRequest {
 export interface ListEventSourcesResponse {
   __type?: "ListEventSourcesResponse";
   /**
+   * <p>A token you can use in a subsequent operation to retrieve the next set of
+   *             results.</p>
+   */
+  NextToken?: string;
+
+  /**
    * <p>The list of event sources.</p>
    */
   EventSources?: EventSource[];
-
-  /**
-   * <p>A token you can use in a subsequent operation to retrieve the next set of results.</p>
-   */
-  NextToken?: string;
 }
 
 export namespace ListEventSourcesResponse {
@@ -1011,21 +1086,22 @@ export namespace ListEventSourcesResponse {
 export interface ListPartnerEventSourceAccountsRequest {
   __type?: "ListPartnerEventSourceAccountsRequest";
   /**
+   * <p>The token returned by a previous call to this operation. Specifying this retrieves the
+   *             next set of results.</p>
+   */
+  NextToken?: string;
+
+  /**
    * <p>The name of the partner event source to display account information about.</p>
    */
   EventSourceName: string | undefined;
 
   /**
-   * <p>Specifying this limits the number of results returned by this operation. The
-   *             operation also returns a <code>NextToken</code> that you can use in a subsequent
-   *             operation to retrieve the next set of results.</p>
+   * <p>Specifying this limits the number of results returned by this operation. The operation
+   *             also returns a NextToken which you can use in a subsequent operation to retrieve the
+   *             next set of results.</p>
    */
   Limit?: number;
-
-  /**
-   * <p>The token returned by a previous call to this operation. Specifying this retrieves the next set of results.</p>
-   */
-  NextToken?: string;
 }
 
 export namespace ListPartnerEventSourceAccountsRequest {
@@ -1039,14 +1115,15 @@ export namespace ListPartnerEventSourceAccountsRequest {
 export interface ListPartnerEventSourceAccountsResponse {
   __type?: "ListPartnerEventSourceAccountsResponse";
   /**
-   * <p>A token you can use in a subsequent operation to retrieve the next set of results.</p>
-   */
-  NextToken?: string;
-
-  /**
    * <p>The list of partner event sources returned by the operation.</p>
    */
   PartnerEventSourceAccounts?: PartnerEventSourceAccount[];
+
+  /**
+   * <p>A token you can use in a subsequent operation to retrieve the next set of
+   *             results.</p>
+   */
+  NextToken?: string;
 }
 
 export namespace ListPartnerEventSourceAccountsResponse {
@@ -1060,20 +1137,21 @@ export namespace ListPartnerEventSourceAccountsResponse {
 export interface ListPartnerEventSourcesRequest {
   __type?: "ListPartnerEventSourcesRequest";
   /**
-   * <p>pecifying this limits the number of results returned by this operation. The
-   *             operation also returns a <code>NextToken</code> that you can use in a subsequent
-   *             operation to retrieve the next set of results.</p>
-   */
-  Limit?: number;
-
-  /**
-   * <p>If you specify this, the results are limited to only those partner event sources that start with the
-   *                 string you specify.</p>
+   * <p>If you specify this, the results are limited to only those partner event sources that
+   *             start with the string you specify.</p>
    */
   NamePrefix: string | undefined;
 
   /**
-   * <p>The token returned by a previous call to this operation. Specifying this retrieves the next set of results.</p>
+   * <p>pecifying this limits the number of results returned by this operation. The operation
+   *             also returns a NextToken which you can use in a subsequent operation to retrieve the
+   *             next set of results.</p>
+   */
+  Limit?: number;
+
+  /**
+   * <p>The token returned by a previous call to this operation. Specifying this retrieves the
+   *             next set of results.</p>
    */
   NextToken?: string;
 }
@@ -1088,14 +1166,15 @@ export namespace ListPartnerEventSourcesRequest {
 export interface ListPartnerEventSourcesResponse {
   __type?: "ListPartnerEventSourcesResponse";
   /**
-   * <p>A token you can use in a subsequent operation to retrieve the next set of results.</p>
-   */
-  NextToken?: string;
-
-  /**
    * <p>The list of partner event sources returned by the operation.</p>
    */
   PartnerEventSources?: PartnerEventSource[];
+
+  /**
+   * <p>A token you can use in a subsequent operation to retrieve the next set of
+   *             results.</p>
+   */
+  NextToken?: string;
 }
 
 export namespace ListPartnerEventSourcesResponse {
@@ -1108,19 +1187,21 @@ export namespace ListPartnerEventSourcesResponse {
 export interface ListRuleNamesByTargetRequest {
   __type?: "ListRuleNamesByTargetRequest";
   /**
-   * <p>Limits the results to show only the rules associated with the specified event bus.</p>
-   */
-  EventBusName?: string;
-
-  /**
    * <p>The maximum number of results to return.</p>
    */
   Limit?: number;
 
   /**
-   * <p>The token returned by a previous call to retrieve the next set of results.</p>
+   * <p>The token returned by a previous call to retrieve the next set of
+   *             results.</p>
    */
   NextToken?: string;
+
+  /**
+   * <p>Limits the results to show only the rules associated with the specified event
+   *             bus.</p>
+   */
+  EventBusName?: string;
 
   /**
    * <p>The Amazon Resource Name (ARN) of the target resource.</p>
@@ -1138,14 +1219,15 @@ export namespace ListRuleNamesByTargetRequest {
 export interface ListRuleNamesByTargetResponse {
   __type?: "ListRuleNamesByTargetResponse";
   /**
-   * <p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>
-   */
-  NextToken?: string;
-
-  /**
    * <p>The names of the rules that can invoke the given target.</p>
    */
   RuleNames?: string[];
+
+  /**
+   * <p>Indicates whether there are additional results to retrieve. If there are no more
+   *             results, the value is null.</p>
+   */
+  NextToken?: string;
 }
 
 export namespace ListRuleNamesByTargetResponse {
@@ -1158,14 +1240,16 @@ export namespace ListRuleNamesByTargetResponse {
 export interface ListRulesRequest {
   __type?: "ListRulesRequest";
   /**
-   * <p>Limits the results to show only the rules associated with the specified event bus.</p>
+   * <p>The token returned by a previous call to retrieve the next set of
+   *             results.</p>
    */
-  EventBusName?: string;
+  NextToken?: string;
 
   /**
-   * <p>The maximum number of results to return.</p>
+   * <p>Limits the results to show only the rules associated with the specified event
+   *             bus.</p>
    */
-  Limit?: number;
+  EventBusName?: string;
 
   /**
    * <p>The prefix matching the rule name.</p>
@@ -1173,9 +1257,9 @@ export interface ListRulesRequest {
   NamePrefix?: string;
 
   /**
-   * <p>The token returned by a previous call to retrieve the next set of results.</p>
+   * <p>The maximum number of results to return.</p>
    */
-  NextToken?: string;
+  Limit?: number;
 }
 
 export namespace ListRulesRequest {
@@ -1188,14 +1272,15 @@ export namespace ListRulesRequest {
 export interface ListRulesResponse {
   __type?: "ListRulesResponse";
   /**
-   * <p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>
-   */
-  NextToken?: string;
-
-  /**
    * <p>The rules that match the specified criteria.</p>
    */
   Rules?: Rule[];
+
+  /**
+   * <p>Indicates whether there are additional results to retrieve. If there are no more
+   *             results, the value is null.</p>
+   */
+  NextToken?: string;
 }
 
 export namespace ListRulesResponse {
@@ -1208,7 +1293,7 @@ export namespace ListRulesResponse {
 export interface ListTagsForResourceRequest {
   __type?: "ListTagsForResourceRequest";
   /**
-   * <p>The ARN of the rule for which you want to view tags.</p>
+   * <p>The ARN of the EventBridge resource for which you want to view tags.</p>
    */
   ResourceARN: string | undefined;
 }
@@ -1223,7 +1308,7 @@ export namespace ListTagsForResourceRequest {
 export interface ListTagsForResourceResponse {
   __type?: "ListTagsForResourceResponse";
   /**
-   * <p>The list of tag keys and values associated with the rule that you specified.</p>
+   * <p>The list of tag keys and values associated with the resource you specified</p>
    */
   Tags?: Tag[];
 }
@@ -1238,17 +1323,14 @@ export namespace ListTagsForResourceResponse {
 export interface ListTargetsByRuleRequest {
   __type?: "ListTargetsByRuleRequest";
   /**
-   * <p>The event bus associated with the rule. If you omit this, the default event bus is used.</p>
+   * <p>The event bus associated with the rule. If you omit this, the default event bus is
+   *             used.</p>
    */
   EventBusName?: string;
 
   /**
-   * <p>The maximum number of results to return.</p>
-   */
-  Limit?: number;
-
-  /**
-   * <p>The token returned by a previous call to retrieve the next set of results.</p>
+   * <p>The token returned by a previous call to retrieve the next set of
+   *             results.</p>
    */
   NextToken?: string;
 
@@ -1256,6 +1338,11 @@ export interface ListTargetsByRuleRequest {
    * <p>The name of the rule.</p>
    */
   Rule: string | undefined;
+
+  /**
+   * <p>The maximum number of results to return.</p>
+   */
+  Limit?: number;
 }
 
 export namespace ListTargetsByRuleRequest {
@@ -1268,7 +1355,8 @@ export namespace ListTargetsByRuleRequest {
 export interface ListTargetsByRuleResponse {
   __type?: "ListTargetsByRuleResponse";
   /**
-   * <p>Indicates whether there are additional results to retrieve. If there are no more results, the value is null.</p>
+   * <p>Indicates whether there are additional results to retrieve. If there are no more
+   *             results, the value is null.</p>
    */
   NextToken?: string;
 
@@ -1286,11 +1374,11 @@ export namespace ListTargetsByRuleResponse {
 }
 
 /**
- * <p>An AWS service created this rule on behalf of your account. That service manages it.
- *             If you see this error in response to <code>DeleteRule</code> or
+ * <p>This rule was created by an AWS service on behalf of your account. It is managed by
+ *             that service. If you see this error in response to <code>DeleteRule</code> or
  *                 <code>RemoveTargets</code>, you can use the <code>Force</code> parameter in those
- *             calls to delete the rule or remove targets from the rule. You can't modify these managed
- *             rules by using <code>DisableRule</code>, <code>EnableRule</code>,
+ *             calls to delete the rule or remove targets from the rule. You cannot modify these
+ *             managed rules by using <code>DisableRule</code>, <code>EnableRule</code>,
  *                 <code>PutTargets</code>, <code>PutRule</code>, <code>TagResource</code>, or
  *                 <code>UntagResource</code>. </p>
  */
@@ -1313,7 +1401,7 @@ export namespace ManagedRuleException {
 export interface NetworkConfiguration {
   __type?: "NetworkConfiguration";
   /**
-   * <p>Use this structure to specify the VPC subnets and security groups for the task and
+   * <p>Use this structure to specify the VPC subnets and security groups for the task, and
    *             whether a public IP address is to be used. This structure is relevant only for ECS tasks
    *             that use the <code>awsvpc</code> network mode.</p>
    */
@@ -1328,20 +1416,37 @@ export namespace NetworkConfiguration {
 }
 
 /**
- * <p>A partner event source is created by an SaaS partner. If a customer creates a partner event bus that matches this event source,
- *                 that AWS account can receive events from the partner's applications or services.</p>
+ * <p>The operation you are attempting is not available in this region.</p>
+ */
+export interface OperationDisabledException extends __SmithyException, $MetadataBearer {
+  name: "OperationDisabledException";
+  $fault: "client";
+  message?: string;
+}
+
+export namespace OperationDisabledException {
+  export const filterSensitiveLog = (obj: OperationDisabledException): any => ({
+    ...obj,
+  });
+  export const isa = (o: any): o is OperationDisabledException => __isa(o, "OperationDisabledException");
+}
+
+/**
+ * <p>A partner event source is created by an SaaS partner. If a customer creates a partner
+ *             event bus that matches this event source, that AWS account can receive events from the
+ *             partner's applications or services.</p>
  */
 export interface PartnerEventSource {
   __type?: "PartnerEventSource";
   /**
-   * <p>The ARN of the partner event source.</p>
-   */
-  Arn?: string;
-
-  /**
    * <p>The name of the partner event source.</p>
    */
   Name?: string;
+
+  /**
+   * <p>The ARN of the partner event source.</p>
+   */
+  Arn?: string;
 }
 
 export namespace PartnerEventSource {
@@ -1357,27 +1462,27 @@ export namespace PartnerEventSource {
 export interface PartnerEventSourceAccount {
   __type?: "PartnerEventSourceAccount";
   /**
+   * <p>The date and time the event source was created.</p>
+   */
+  CreationTime?: Date;
+
+  /**
+   * <p>The date and time that the event source will expire, if the AWS account doesn't create
+   *             a matching event bus for it.</p>
+   */
+  ExpirationTime?: Date;
+
+  /**
    * <p>The AWS account ID that the partner event source was offered to.</p>
    */
   Account?: string;
 
   /**
-   * <p>The date and time when the event source was created.</p>
-   */
-  CreationTime?: Date;
-
-  /**
-   * <p>The date and time when the event source will expire if the AWS account doesn't
-   *             create a matching event bus for it.</p>
-   */
-  ExpirationTime?: Date;
-
-  /**
-   * <p>The state of the event source. If it's <code>ACTIVE</code>, you have already
-   *             created a matching event bus for this event source, and that event bus is active. If
-   *             it's <code>PENDING</code>, either you haven't yet created a matching event bus, or that
-   *             event bus is deactivated. If it's <code>DELETED</code>, you have created a matching
-   *             event bus, but the event source has since been deleted.</p>
+   * <p>The state of the event source. If it is ACTIVE, you have already created a matching
+   *             event bus for this event source, and that event bus is active. If it is PENDING, either
+   *             you haven't yet created a matching event bus, or that event bus is deactivated. If it is
+   *             DELETED, you have created a matching event bus, but the event source has since been
+   *             deleted.</p>
    */
   State?: EventSourceState | string;
 }
@@ -1408,7 +1513,9 @@ export namespace PolicyLengthExceededException {
 export interface PutEventsRequest {
   __type?: "PutEventsRequest";
   /**
-   * <p>The entry that defines an event in your system. You can specify several parameters for the entry such as the source and type of the event, resources associated with the event, and so on.</p>
+   * <p>The entry that defines an event in your system. You can specify several parameters
+   *             for the entry such as the source and type of the event, resources associated with the
+   *             event, and so on.</p>
    */
   Entries: PutEventsRequestEntry[] | undefined;
 }
@@ -1426,39 +1533,39 @@ export namespace PutEventsRequest {
 export interface PutEventsRequestEntry {
   __type?: "PutEventsRequestEntry";
   /**
-   * <p>A valid JSON string. There is no other schema imposed. The JSON string can contain
-   *             fields and nested subobjects.</p>
+   * <p>The source of the event.</p>
    */
-  Detail?: string;
+  Source?: string;
 
   /**
-   * <p>Free-form string used to decide which fields to expect in the event
+   * <p>The time stamp of the event, per <a href="https://www.rfc-editor.org/rfc/rfc3339.txt">RFC3339</a>. If no time stamp
+   *             is provided, the time stamp of the <a>PutEvents</a> call is used.</p>
+   */
+  Time?: Date;
+
+  /**
+   * <p>AWS resources, identified by Amazon Resource Name (ARN), which the event primarily
+   *             concerns. Any number, including zero, may be present.</p>
+   */
+  Resources?: string[];
+
+  /**
+   * <p>Free-form string used to decide what fields to expect in the event
    *             detail.</p>
    */
   DetailType?: string;
 
   /**
+   * <p>A valid JSON string. There is no other schema imposed. The JSON string may contain
+   *             fields and nested subobjects.</p>
+   */
+  Detail?: string;
+
+  /**
    * <p>The event bus that will receive the event. Only the rules that are associated with
-   *             this event bus can match the event.</p>
+   *             this event bus will be able to match the event.</p>
    */
   EventBusName?: string;
-
-  /**
-   * <p>AWS resources, identified by Amazon Resource Name (ARN), that the event primarily
-   *             concerns. Any number, including zero, can be present.</p>
-   */
-  Resources?: string[];
-
-  /**
-   * <p>The source of the event. This field is required.</p>
-   */
-  Source?: string;
-
-  /**
-   * <p>The timestamp of the event, per <a href="https://www.rfc-editor.org/rfc/rfc3339.txt">RFC3339</a>. If no timestamp is
-   *             provided, the timestamp of the <a>PutEvents</a> call is used.</p>
-   */
-  Time?: Date;
 }
 
 export namespace PutEventsRequestEntry {
@@ -1471,16 +1578,16 @@ export namespace PutEventsRequestEntry {
 export interface PutEventsResponse {
   __type?: "PutEventsResponse";
   /**
-   * <p>The successfully and unsuccessfully ingested events results. If the ingestion was successful,
-   *             the entry has the event ID in it. Otherwise, you can use the error code and error message
-   *             to identify the problem with the entry.</p>
-   */
-  Entries?: PutEventsResultEntry[];
-
-  /**
    * <p>The number of failed entries.</p>
    */
   FailedEntryCount?: number;
+
+  /**
+   * <p>The successfully and unsuccessfully ingested events results. If the ingestion was
+   *             successful, the entry has the event ID in it. Otherwise, you can use the error code and
+   *             error message to identify the problem with the entry.</p>
+   */
+  Entries?: PutEventsResultEntry[];
 }
 
 export namespace PutEventsResponse {
@@ -1501,14 +1608,14 @@ export interface PutEventsResultEntry {
   ErrorCode?: string;
 
   /**
-   * <p>The error message that explains why the event submission failed.</p>
-   */
-  ErrorMessage?: string;
-
-  /**
    * <p>The ID of the event.</p>
    */
   EventId?: string;
+
+  /**
+   * <p>The error message that explains why the event submission failed.</p>
+   */
+  ErrorMessage?: string;
 }
 
 export namespace PutEventsResultEntry {
@@ -1539,22 +1646,15 @@ export namespace PutPartnerEventsRequest {
 export interface PutPartnerEventsRequestEntry {
   __type?: "PutPartnerEventsRequestEntry";
   /**
-   * <p>A valid JSON string. There is no other schema imposed. The JSON string can contain
+   * <p>A valid JSON string. There is no other schema imposed. The JSON string may contain
    *             fields and nested subobjects.</p>
    */
   Detail?: string;
 
   /**
-   * <p>A free-form string used to decide which fields to expect in the event
-   *             detail.</p>
+   * <p>A free-form string used to decide what fields to expect in the event detail.</p>
    */
   DetailType?: string;
-
-  /**
-   * <p>AWS resources, identified by Amazon Resource Name (ARN), that the event primarily
-   *             concerns. Any number, including zero, can be present.</p>
-   */
-  Resources?: string[];
 
   /**
    * <p>The event source that is generating the evntry.</p>
@@ -1565,6 +1665,12 @@ export interface PutPartnerEventsRequestEntry {
    * <p>The date and time of the event.</p>
    */
   Time?: Date;
+
+  /**
+   * <p>AWS resources, identified by Amazon Resource Name (ARN), which the event primarily
+   *             concerns. Any number, including zero, may be present.</p>
+   */
+  Resources?: string[];
 }
 
 export namespace PutPartnerEventsRequestEntry {
@@ -1577,15 +1683,16 @@ export namespace PutPartnerEventsRequestEntry {
 export interface PutPartnerEventsResponse {
   __type?: "PutPartnerEventsResponse";
   /**
-   * <p>The list of events from this operation that were successfully written to the partner event bus.</p>
-   */
-  Entries?: PutPartnerEventsResultEntry[];
-
-  /**
-   * <p>The number of events from this operation that couldn't be written to the partner
+   * <p>The number of events from this operation that could not be written to the partner
    *             event bus.</p>
    */
   FailedEntryCount?: number;
+
+  /**
+   * <p>The list of events from this operation that were successfully written to the partner
+   *             event bus.</p>
+   */
+  Entries?: PutPartnerEventsResultEntry[];
 }
 
 export namespace PutPartnerEventsResponse {
@@ -1596,15 +1703,10 @@ export namespace PutPartnerEventsResponse {
 }
 
 /**
- * <p>Represents an event that a partner tried to generate but failed.</p>
+ * <p>Represents an event that a partner tried to generate, but failed.</p>
  */
 export interface PutPartnerEventsResultEntry {
   __type?: "PutPartnerEventsResultEntry";
-  /**
-   * <p>The error code that indicates why the event submission failed.</p>
-   */
-  ErrorCode?: string;
-
   /**
    * <p>The error message that explains why the event submission failed.</p>
    */
@@ -1614,6 +1716,11 @@ export interface PutPartnerEventsResultEntry {
    * <p>The ID of the event.</p>
    */
   EventId?: string;
+
+  /**
+   * <p>The error code that indicates why the event submission failed.</p>
+   */
+  ErrorCode?: string;
 }
 
 export namespace PutPartnerEventsResultEntry {
@@ -1626,45 +1733,47 @@ export namespace PutPartnerEventsResultEntry {
 export interface PutPermissionRequest {
   __type?: "PutPermissionRequest";
   /**
-   * <p>The action that you're enabling the other account to perform. Currently, this must
+   * <p>The action that you are enabling the other account to perform. Currently, this must
    *             be <code>events:PutEvents</code>.</p>
    */
   Action: string | undefined;
 
   /**
-   * <p>This parameter enables you to limit the permission to accounts that fulfill a certain
-   *             condition, such as being a member of a certain AWS organization. For more information
-   *             about AWS Organizations, see <a href="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html">What Is AWS
-   *                 Organizations?</a> in the <i>AWS Organizations User
-   *             Guide</i>.</p>
-   *         <p>If you specify <code>Condition</code> with an AWS organization ID and specify "*" as
-   *             the value for <code>Principal</code>, you grant permission to all the accounts in the
-   *             named organization.</p>
-   *
-   *         <p>The <code>Condition</code> is a JSON string that must contain <code>Type</code>,
-   *                 <code>Key</code>, and <code>Value</code> fields.</p>
-   */
-  Condition?: Condition;
-
-  /**
-   * <p>The event bus associated with the rule. If you omit this, the default event bus is used.</p>
+   * <p>The event bus associated with the rule. If you omit this, the default event bus is
+   *             used.</p>
    */
   EventBusName?: string;
 
   /**
    * <p>The 12-digit AWS account ID that you are permitting to put events to your default
-   *             event bus. Specify "*" to permit any account to put events to your default event bus.</p>
+   *             event bus. Specify "*" to permit any account to put events to your default event
+   *             bus.</p>
    *
    *         <p>If you specify "*" without specifying <code>Condition</code>, avoid creating rules
-   *             that might match undesirable events. To create more secure rules, make sure that the
-   *             event pattern for each rule contains an <code>account</code> field with a specific
-   *             account ID to receive events from. Rules with an account field don't match any events
-   *             sent from other accounts.</p>
+   *             that may match undesirable events. To create more secure rules, make sure that the event
+   *             pattern for each rule contains an <code>account</code> field with a specific account ID
+   *             from which to receive events. Rules with an account field do not match any events sent
+   *             from other accounts.</p>
    */
   Principal: string | undefined;
 
   /**
-   * <p>An identifier string for the external account that you're granting permissions to.
+   * <p>This parameter enables you to limit the permission to accounts that fulfill a certain
+   *             condition, such as being a member of a certain AWS organization. For more information
+   *             about AWS Organizations, see <a href="https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html">What Is AWS
+   *                 Organizations</a> in the <i>AWS Organizations User
+   *             Guide</i>.</p>
+   *         <p>If you specify <code>Condition</code> with an AWS organization ID, and specify "*" as
+   *             the value for <code>Principal</code>, you grant permission to all the accounts in the
+   *             named organization.</p>
+   *
+   *         <p>The <code>Condition</code> is a JSON string which must contain <code>Type</code>,
+   *                 <code>Key</code>, and <code>Value</code> fields.</p>
+   */
+  Condition?: Condition;
+
+  /**
+   * <p>An identifier string for the external account that you are granting permissions to.
    *             If you later want to revoke the permission for this external account, specify this
    *                 <code>StatementId</code> when you run <a>RemovePermission</a>.</p>
    */
@@ -1681,34 +1790,8 @@ export namespace PutPermissionRequest {
 export interface PutRuleRequest {
   __type?: "PutRuleRequest";
   /**
-   * <p>A description of the rule.</p>
-   */
-  Description?: string;
-
-  /**
-   * <p>The event bus to associate with this rule. If you omit this, the default event bus is used.</p>
-   */
-  EventBusName?: string;
-
-  /**
-   * <p>The event pattern. For more information, see
-   *             <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html">Event Patterns</a> in the <i>Amazon EventBridge User Guide</i>.</p>
-   */
-  EventPattern?: string;
-
-  /**
-   * <p>The name of the rule that you're creating or updating.</p>
-   */
-  Name: string | undefined;
-
-  /**
-   * <p>The Amazon Resource Name (ARN) of the IAM role associated with the rule.</p>
-   */
-  RoleArn?: string;
-
-  /**
-   * <p>The scheduling expression: for example, <code>"cron(0 20 * * ? *)"</code> or
-   *                 <code>"rate(5 minutes)"</code>.</p>
+   * <p>The scheduling expression. For example, "cron(0 20 * * ? *)" or "rate(5
+   *             minutes)".</p>
    */
   ScheduleExpression?: string;
 
@@ -1718,9 +1801,37 @@ export interface PutRuleRequest {
   State?: RuleState | string;
 
   /**
+   * <p>A description of the rule.</p>
+   */
+  Description?: string;
+
+  /**
+   * <p>The event pattern. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html">Events and
+   *                 Event Patterns</a> in the <i>Amazon EventBridge User
+   *             Guide</i>.</p>
+   */
+  EventPattern?: string;
+
+  /**
+   * <p>The event bus to associate with this rule. If you omit this, the default event bus is
+   *             used.</p>
+   */
+  EventBusName?: string;
+
+  /**
    * <p>The list of key-value pairs to associate with the rule.</p>
    */
   Tags?: Tag[];
+
+  /**
+   * <p>The Amazon Resource Name (ARN) of the IAM role associated with the rule.</p>
+   */
+  RoleArn?: string;
+
+  /**
+   * <p>The name of the rule that you are creating or updating.</p>
+   */
+  Name: string | undefined;
 }
 
 export namespace PutRuleRequest {
@@ -1748,7 +1859,8 @@ export namespace PutRuleResponse {
 export interface PutTargetsRequest {
   __type?: "PutTargetsRequest";
   /**
-   * <p>The name of the event bus associated with the rule. If you omit this, the default event bus is used.</p>
+   * <p>The name of the event bus associated with the rule. If you omit this, the default
+   *             event bus is used.</p>
    */
   EventBusName?: string;
 
@@ -1796,15 +1908,16 @@ export namespace PutTargetsResponse {
 export interface PutTargetsResultEntry {
   __type?: "PutTargetsResultEntry";
   /**
-   * <p>The error code that indicates why the target addition failed. If the value is <code>ConcurrentModificationException</code>, too many
-   *         requests were made at the same time.</p>
-   */
-  ErrorCode?: string;
-
-  /**
    * <p>The error message that explains why the target addition failed.</p>
    */
   ErrorMessage?: string;
+
+  /**
+   * <p>The error code that indicates why the target addition failed. If the value is
+   *                 <code>ConcurrentModificationException</code>, too many requests were made at the
+   *             same time.</p>
+   */
+  ErrorCode?: string;
 
   /**
    * <p>The ID of the target.</p>
@@ -1822,14 +1935,16 @@ export namespace PutTargetsResultEntry {
 export interface RemovePermissionRequest {
   __type?: "RemovePermissionRequest";
   /**
-   * <p>The name of the event bus to revoke permissions for. If you omit this, the default event bus is used.</p>
-   */
-  EventBusName?: string;
-
-  /**
-   * <p>The statement ID corresponding to the account that is no longer allowed to put events to the default event bus.</p>
+   * <p>The statement ID corresponding to the account that is no longer allowed to put
+   *             events to the default event bus.</p>
    */
   StatementId: string | undefined;
+
+  /**
+   * <p>The name of the event bus to revoke permissions for. If you omit this, the default
+   *             event bus is used.</p>
+   */
+  EventBusName?: string;
 }
 
 export namespace RemovePermissionRequest {
@@ -1842,14 +1957,9 @@ export namespace RemovePermissionRequest {
 export interface RemoveTargetsRequest {
   __type?: "RemoveTargetsRequest";
   /**
-   * <p>The name of the event bus associated with the rule.</p>
-   */
-  EventBusName?: string;
-
-  /**
-   * <p>If this is a managed rule created by an AWS service on your behalf, you must specify
+   * <p>If this is a managed rule, created by an AWS service on your behalf, you must specify
    *                 <code>Force</code> as <code>True</code> to remove targets. This parameter is ignored
-   *             for rules that aren't managed rules. You can check whether a rule is a managed rule by
+   *             for rules that are not managed rules. You can check whether a rule is a managed rule by
    *             using <code>DescribeRule</code> or <code>ListRules</code> and checking the
    *                 <code>ManagedBy</code> field of the response.</p>
    */
@@ -1864,6 +1974,11 @@ export interface RemoveTargetsRequest {
    * <p>The name of the rule.</p>
    */
   Rule: string | undefined;
+
+  /**
+   * <p>The name of the event bus associated with the rule.</p>
+   */
+  EventBusName?: string;
 }
 
 export namespace RemoveTargetsRequest {
@@ -1876,14 +1991,14 @@ export namespace RemoveTargetsRequest {
 export interface RemoveTargetsResponse {
   __type?: "RemoveTargetsResponse";
   /**
-   * <p>The failed target entries.</p>
-   */
-  FailedEntries?: RemoveTargetsResultEntry[];
-
-  /**
    * <p>The number of failed entries.</p>
    */
   FailedEntryCount?: number;
+
+  /**
+   * <p>The failed target entries.</p>
+   */
+  FailedEntries?: RemoveTargetsResultEntry[];
 }
 
 export namespace RemoveTargetsResponse {
@@ -1899,20 +2014,21 @@ export namespace RemoveTargetsResponse {
 export interface RemoveTargetsResultEntry {
   __type?: "RemoveTargetsResultEntry";
   /**
-   * <p>The error code that indicates why the target removal failed. If the value is <code>ConcurrentModificationException</code>, too many
-   *             requests were made at the same time.</p>
+   * <p>The error code that indicates why the target removal failed. If the value is
+   *                 <code>ConcurrentModificationException</code>, too many requests were made at the
+   *             same time.</p>
    */
   ErrorCode?: string;
-
-  /**
-   * <p>The error message that explains why the target removal failed.</p>
-   */
-  ErrorMessage?: string;
 
   /**
    * <p>The ID of the target.</p>
    */
   TargetId?: string;
+
+  /**
+   * <p>The error message that explains why the target removal failed.</p>
+   */
+  ErrorMessage?: string;
 }
 
 export namespace RemoveTargetsResultEntry {
@@ -1923,7 +2039,7 @@ export namespace RemoveTargetsResultEntry {
 }
 
 /**
- * <p>The resource that you're trying to create already exists.</p>
+ * <p>The resource you are trying to create already exists.</p>
  */
 export interface ResourceAlreadyExistsException extends __SmithyException, $MetadataBearer {
   name: "ResourceAlreadyExistsException";
@@ -1939,7 +2055,7 @@ export namespace ResourceAlreadyExistsException {
 }
 
 /**
- * <p>An entity that you specified doesn't exist.</p>
+ * <p>An entity that you specified does not exist.</p>
  */
 export interface ResourceNotFoundException extends __SmithyException, $MetadataBearer {
   name: "ResourceNotFoundException";
@@ -1960,14 +2076,27 @@ export namespace ResourceNotFoundException {
 export interface Rule {
   __type?: "Rule";
   /**
+   * <p>The state of the rule.</p>
+   */
+  State?: RuleState | string;
+
+  /**
+   * <p>The Amazon Resource Name (ARN) of the role that is used for target
+   *             invocation.</p>
+   */
+  RoleArn?: string;
+
+  /**
    * <p>The Amazon Resource Name (ARN) of the rule.</p>
    */
   Arn?: string;
 
   /**
-   * <p>The description of the rule.</p>
+   * <p>The event pattern of the rule. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html">Events and
+   *                 Event Patterns</a> in the <i>Amazon EventBridge User
+   *             Guide</i>.</p>
    */
-  Description?: string;
+  EventPattern?: string;
 
   /**
    * <p>The event bus associated with the rule.</p>
@@ -1975,36 +2104,26 @@ export interface Rule {
   EventBusName?: string;
 
   /**
-   * <p>The event pattern of the rule. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html">Event Patterns</a> in the <i>Amazon EventBridge User Guide</i>.</p>
-   */
-  EventPattern?: string;
-
-  /**
-   * <p>If an AWS service created the rule on behalf of your account, this field displays the
-   *             principal name of the service that created the rule.</p>
+   * <p>If the rule was created on behalf of your account by an AWS service, this field
+   *             displays the principal name of the service that created the rule.</p>
    */
   ManagedBy?: string;
+
+  /**
+   * <p>The description of the rule.</p>
+   */
+  Description?: string;
+
+  /**
+   * <p>The scheduling expression. For example, "cron(0 20 * * ? *)", "rate(5
+   *             minutes)".</p>
+   */
+  ScheduleExpression?: string;
 
   /**
    * <p>The name of the rule.</p>
    */
   Name?: string;
-
-  /**
-   * <p>The Amazon Resource Name (ARN) of the role that is used for target invocation.</p>
-   */
-  RoleArn?: string;
-
-  /**
-   * <p>The scheduling expression: for example, <code>"cron(0 20 * * ? *)"</code> or
-   *                 <code>"rate(5 minutes)"</code>.</p>
-   */
-  ScheduleExpression?: string;
-
-  /**
-   * <p>The state of the rule.</p>
-   */
-  State?: RuleState | string;
 }
 
 export namespace Rule {
@@ -2020,14 +2139,14 @@ export enum RuleState {
 }
 
 /**
- * <p>This parameter contains the criteria (either <code>InstanceIds</code> or a tag)
- *             used to specify which EC2 instances are to be sent the command. </p>
+ * <p>This parameter contains the criteria (either InstanceIds or a tag) used to specify
+ *             which EC2 instances are to be sent the command. </p>
  */
 export interface RunCommandParameters {
   __type?: "RunCommandParameters";
   /**
-   * <p>Currently, we support including only one <code>RunCommandTarget</code> block, which
-   *             specifies either an array of <code>InstanceIds</code> or a tag.</p>
+   * <p>Currently, we support including only one RunCommandTarget block, which specifies
+   *             either an array of InstanceIds or a tag.</p>
    */
   RunCommandTargets: RunCommandTarget[] | undefined;
 }
@@ -2042,22 +2161,25 @@ export namespace RunCommandParameters {
 /**
  * <p>Information about the EC2 instances that are to be sent the command, specified as
  *             key-value pairs. Each <code>RunCommandTarget</code> block can include only one key, but
- *             this key can specify multiple values.</p>
+ *             this key may specify multiple values.</p>
  */
 export interface RunCommandTarget {
   __type?: "RunCommandTarget";
   /**
-   * <p>Can be either <code>tag:</code>
-   *             <i>tag-key</i> or <code>InstanceIds</code>.</p>
-   */
-  Key: string | undefined;
-
-  /**
    * <p>If <code>Key</code> is <code>tag:</code>
-   *             <i>tag-key</i>, <code>Values</code> is a list of tag values.
-   *             If <code>Key</code> is <code>InstanceIds</code>, <code>Values</code> is a list of Amazon EC2 instance IDs.</p>
+   *             <i>tag-key</i>,
+   *                 <code>Values</code> is a list of tag values. If <code>Key</code> is
+   *                 <code>InstanceIds</code>, <code>Values</code> is a list of Amazon EC2 instance
+   *             IDs.</p>
    */
   Values: string[] | undefined;
+
+  /**
+   * <p>Can be either <code>tag:</code>
+   *             <i>tag-key</i> or
+   *                 <code>InstanceIds</code>.</p>
+   */
+  Key: string | undefined;
 }
 
 export namespace RunCommandTarget {
@@ -2068,7 +2190,8 @@ export namespace RunCommandTarget {
 }
 
 /**
- * <p>This structure includes the custom parameter to be used when the target is an SQS FIFO queue.</p>
+ * <p>This structure includes the custom parameter to be used when the target is an SQS FIFO
+ *             queue.</p>
  */
 export interface SqsParameters {
   __type?: "SqsParameters";
@@ -2086,20 +2209,21 @@ export namespace SqsParameters {
 }
 
 /**
- * <p>A key-value pair associated with an AWS resource. In EventBridge, rules support tagging.</p>
+ * <p>A key-value pair associated with an AWS resource. In EventBridge, rules and event buses support
+ *             tagging.</p>
  */
 export interface Tag {
   __type?: "Tag";
   /**
-   * <p>A string that you can use to assign a value. The combination of tag keys and values
-   *             can help you organize and categorize your resources.</p>
-   */
-  Key: string | undefined;
-
-  /**
    * <p>The value for the specified tag key.</p>
    */
   Value: string | undefined;
+
+  /**
+   * <p>A string you can use to assign a value. The combination of tag keys and values can
+   *             help you organize and categorize your resources.</p>
+   */
+  Key: string | undefined;
 }
 
 export namespace Tag {
@@ -2112,12 +2236,12 @@ export namespace Tag {
 export interface TagResourceRequest {
   __type?: "TagResourceRequest";
   /**
-   * <p>The ARN of the rule that you're adding tags to.</p>
+   * <p>The ARN of the EventBridge resource that you're adding tags to.</p>
    */
   ResourceARN: string | undefined;
 
   /**
-   * <p>The list of key-value pairs to associate with the rule.</p>
+   * <p>The list of key-value pairs to associate with the resource.</p>
    */
   Tags: Tag[] | undefined;
 }
@@ -2141,22 +2265,30 @@ export namespace TagResourceResponse {
 }
 
 /**
- * <p>Targets are the resources to be invoked when a rule is triggered. For a complete list of services and resources that can be
- *             set as a target, see <a>PutTargets</a>.</p>
+ * <p>Targets are the resources to be invoked when a rule is triggered. For a complete
+ *             list of services and resources that can be set as a target, see <a>PutTargets</a>.</p>
  *
- *         <p>If you're setting the event bus of another account as the target and that account
+ *         <p>If you are setting the event bus of another account as the target, and that account
  *             granted permission to your account through an organization instead of directly by the
- *             account ID, you must specify a <code>RoleArn</code> with proper permissions in the
- *                 <code>Target</code> structure. For more information, see
- *             <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html">Sending and Receiving Events Between AWS Accounts</a> in the <i>Amazon
+ *             account ID, then you must specify a <code>RoleArn</code> with proper permissions in the
+ *                 <code>Target</code> structure. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html">Sending and Receiving Events Between AWS Accounts</a> in the <i>Amazon
  *                 EventBridge User Guide</i>.</p>
  */
 export interface Target {
   __type?: "Target";
   /**
-   * <p>The Amazon Resource Name (ARN) of the target.</p>
+   * <p>Valid JSON text passed to the target. In this case, nothing from the event itself
+   *             is passed to the target. For more information, see <a href="http://www.rfc-editor.org/rfc/rfc7159.txt">The JavaScript Object Notation
+   *                 (JSON) Data Interchange Format</a>.</p>
    */
-  Arn: string | undefined;
+  Input?: string;
+
+  /**
+   * <p>The value of the JSONPath that is used for extracting part of the matched event
+   *             when passing it to the target. You must use JSON dot notation, not bracket notation. For
+   *             more information about JSON paths, see <a href="http://goessner.net/articles/JsonPath/">JSONPath</a>.</p>
+   */
+  InputPath?: string;
 
   /**
    * <p>If the event target is an AWS Batch job, this contains the job definition, job
@@ -2166,12 +2298,18 @@ export interface Target {
   BatchParameters?: BatchParameters;
 
   /**
-   * <p>Contains the Amazon ECS task definition and task count to be used if the event
-   *             target is an Amazon ECS task. For more information about Amazon ECS tasks, see <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html">Task
-   *                 Definitions </a> in the <i>Amazon EC2 Container Service Developer
-   *                 Guide</i>.</p>
+   * <p>The custom parameter you can use to control the shard assignment, when the target
+   *             is a Kinesis data stream. If you do not include this parameter, the default is to use
+   *             the <code>eventId</code> as the partition key.</p>
    */
-  EcsParameters?: EcsParameters;
+  KinesisParameters?: KinesisParameters;
+
+  /**
+   * <p>The Amazon Resource Name (ARN) of the IAM role to be used for this target when the
+   *             rule is triggered. If one rule triggers multiple targets, you can use a different IAM
+   *             role for each target.</p>
+   */
+  RoleArn?: string;
 
   /**
    * <p>The ID of the target.</p>
@@ -2179,47 +2317,46 @@ export interface Target {
   Id: string | undefined;
 
   /**
-   * <p>Valid JSON text passed to the target. In this case, nothing from the event itself is passed
-   *             to the target. For more information, see <a href="http://www.rfc-editor.org/rfc/rfc7159.txt">The JavaScript Object Notation (JSON) Data Interchange Format</a>.</p>
-   */
-  Input?: string;
-
-  /**
-   * <p>The value of the JSONPath that is used for extracting part of the matched event when
-   *             passing it to the target. You must use JSON dot notation, not bracket notation. For more information about JSON
-   *             paths, see <a href="http://goessner.net/articles/JsonPath/">JSONPath</a>.</p>
-   */
-  InputPath?: string;
-
-  /**
-   * <p>Settings to enable you to provide custom input to a target based on certain event data. You can extract one or more key-value pairs
-   *         from the event and then use that data to send customized input to the target.</p>
+   * <p>Settings to enable you to provide custom input to a target based on certain event
+   *             data. You can extract one or more key-value pairs from the event and then use that data
+   *             to send customized input to the target.</p>
    */
   InputTransformer?: InputTransformer;
 
   /**
-   * <p>The custom parameter that you can use to control the shard assignment when the
-   *             target is a Kinesis data stream. If you don't include this parameter, the default is to
-   *             use the <code>eventId</code> as the partition key.</p>
+   * <p>The Amazon Resource Name (ARN) of the target.</p>
    */
-  KinesisParameters?: KinesisParameters;
+  Arn: string | undefined;
 
   /**
-   * <p>The Amazon Resource Name (ARN) of the IAM role to be used for this target when the rule is triggered. If one rule triggers
-   *         multiple targets, you can use a different IAM role for each target.</p>
-   */
-  RoleArn?: string;
-
-  /**
-   * <p>Parameters used when you are using the rule to invoke Amazon EC2 Run Command.</p>
+   * <p>Parameters used when you are using the rule to invoke Amazon EC2 Run
+   *             Command.</p>
    */
   RunCommandParameters?: RunCommandParameters;
 
   /**
+   * <p>Contains the HTTP parameters to use when the target is a API Gateway REST
+   *             endpoint.</p>
+   *         <p>If you specify an API Gateway REST API as a target, you can use this
+   *         parameter to specify headers, path parameter, query string keys/values as part of your target
+   *         invoking request.</p>
+   */
+  HttpParameters?: HttpParameters;
+
+  /**
    * <p>Contains the message group ID to use when the target is a FIFO queue.</p>
-   *         <p>If you specify an SQS FIFO queue as a target, the queue must have content-based deduplication enabled.</p>
+   *         <p>If you specify an SQS FIFO queue as a target, the queue must have content-based
+   *             deduplication enabled.</p>
    */
   SqsParameters?: SqsParameters;
+
+  /**
+   * <p>Contains the Amazon ECS task definition and task count to be used, if the event
+   *             target is an Amazon ECS task. For more information about Amazon ECS tasks, see <a href="https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html">Task
+   *                 Definitions </a> in the <i>Amazon EC2 Container Service Developer
+   *                 Guide</i>.</p>
+   */
+  EcsParameters?: EcsParameters;
 }
 
 export namespace Target {
@@ -2237,8 +2374,9 @@ export interface TestEventPatternRequest {
   Event: string | undefined;
 
   /**
-   * <p>The event pattern. For more information, see
-   *             <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html">Event Patterns</a> in the <i>Amazon EventBridge User Guide</i>.</p>
+   * <p>The event pattern. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html">Events and
+   *                 Event Patterns</a> in the <i>Amazon EventBridge User
+   *             Guide</i>.</p>
    */
   EventPattern: string | undefined;
 }
@@ -2268,7 +2406,7 @@ export namespace TestEventPatternResponse {
 export interface UntagResourceRequest {
   __type?: "UntagResourceRequest";
   /**
-   * <p>The ARN of the rule that you're removing tags from.</p>
+   * <p>The ARN of the EventBridge resource from which you are removing tags.</p>
    */
   ResourceARN: string | undefined;
 

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/invalid-dependency": "1.0.0-gamma.5",
     "@aws-sdk/middleware-content-length": "1.0.0-gamma.7",
     "@aws-sdk/middleware-host-header": "1.0.0-gamma.7",
+    "@aws-sdk/middleware-logger": "1.0.0-gamma.1",
     "@aws-sdk/middleware-retry": "1.0.0-gamma.7",
     "@aws-sdk/middleware-serde": "1.0.0-gamma.6",
     "@aws-sdk/middleware-signing": "1.0.0-gamma.7",

--- a/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
@@ -88,6 +88,7 @@ import {
   EnableRuleRequest,
   EventBus,
   EventSource,
+  HttpParameters,
   InputTransformer,
   InternalException,
   InvalidEventPatternException,
@@ -112,6 +113,7 @@ import {
   ListTargetsByRuleResponse,
   ManagedRuleException,
   NetworkConfiguration,
+  OperationDisabledException,
   PartnerEventSource,
   PartnerEventSourceAccount,
   PolicyLengthExceededException,
@@ -588,6 +590,14 @@ const deserializeAws_json1_1ActivateEventSourceCommandError = async (
   const errorTypeParts: String = parsedOutput.body["__type"].split("#");
   errorCode = errorTypeParts[1] === undefined ? errorTypeParts[0] : errorTypeParts[1];
   switch (errorCode) {
+    case "ConcurrentModificationException":
+    case "com.amazonaws.cloudwatchevents#ConcurrentModificationException":
+      response = {
+        ...(await deserializeAws_json1_1ConcurrentModificationExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "InternalException":
     case "com.amazonaws.cloudwatchevents#InternalException":
       response = {
@@ -600,6 +610,14 @@ const deserializeAws_json1_1ActivateEventSourceCommandError = async (
     case "com.amazonaws.cloudwatchevents#InvalidStateException":
       response = {
         ...(await deserializeAws_json1_1InvalidStateExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -692,6 +710,14 @@ const deserializeAws_json1_1CreateEventBusCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "ResourceAlreadyExistsException":
     case "com.amazonaws.cloudwatchevents#ResourceAlreadyExistsException":
       response = {
@@ -780,6 +806,14 @@ const deserializeAws_json1_1CreatePartnerEventSourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "ResourceAlreadyExistsException":
     case "com.amazonaws.cloudwatchevents#ResourceAlreadyExistsException":
       response = {
@@ -832,6 +866,14 @@ const deserializeAws_json1_1DeactivateEventSourceCommandError = async (
   const errorTypeParts: String = parsedOutput.body["__type"].split("#");
   errorCode = errorTypeParts[1] === undefined ? errorTypeParts[0] : errorTypeParts[1];
   switch (errorCode) {
+    case "ConcurrentModificationException":
+    case "com.amazonaws.cloudwatchevents#ConcurrentModificationException":
+      response = {
+        ...(await deserializeAws_json1_1ConcurrentModificationExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "InternalException":
     case "com.amazonaws.cloudwatchevents#InternalException":
       response = {
@@ -844,6 +886,14 @@ const deserializeAws_json1_1DeactivateEventSourceCommandError = async (
     case "com.amazonaws.cloudwatchevents#InvalidStateException":
       response = {
         ...(await deserializeAws_json1_1InvalidStateExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -900,6 +950,14 @@ const deserializeAws_json1_1DeleteEventBusCommandError = async (
   const errorTypeParts: String = parsedOutput.body["__type"].split("#");
   errorCode = errorTypeParts[1] === undefined ? errorTypeParts[0] : errorTypeParts[1];
   switch (errorCode) {
+    case "ConcurrentModificationException":
+    case "com.amazonaws.cloudwatchevents#ConcurrentModificationException":
+      response = {
+        ...(await deserializeAws_json1_1ConcurrentModificationExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "InternalException":
     case "com.amazonaws.cloudwatchevents#InternalException":
       response = {
@@ -952,10 +1010,26 @@ const deserializeAws_json1_1DeletePartnerEventSourceCommandError = async (
   const errorTypeParts: String = parsedOutput.body["__type"].split("#");
   errorCode = errorTypeParts[1] === undefined ? errorTypeParts[0] : errorTypeParts[1];
   switch (errorCode) {
+    case "ConcurrentModificationException":
+    case "com.amazonaws.cloudwatchevents#ConcurrentModificationException":
+      response = {
+        ...(await deserializeAws_json1_1ConcurrentModificationExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "InternalException":
     case "com.amazonaws.cloudwatchevents#InternalException":
       response = {
         ...(await deserializeAws_json1_1InternalExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1156,6 +1230,14 @@ const deserializeAws_json1_1DescribeEventSourceCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     case "ResourceNotFoundException":
     case "com.amazonaws.cloudwatchevents#ResourceNotFoundException":
       response = {
@@ -1216,6 +1298,14 @@ const deserializeAws_json1_1DescribePartnerEventSourceCommandError = async (
     case "com.amazonaws.cloudwatchevents#InternalException":
       response = {
         ...(await deserializeAws_json1_1InternalExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1556,6 +1646,14 @@ const deserializeAws_json1_1ListEventSourcesCommandError = async (
         $metadata: deserializeMetadata(output),
       };
       break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
     default:
       const parsedBody = parsedOutput.body;
       errorCode = parsedBody.code || parsedBody.Code || errorCode;
@@ -1608,6 +1706,14 @@ const deserializeAws_json1_1ListPartnerEventSourceAccountsCommandError = async (
     case "com.amazonaws.cloudwatchevents#InternalException":
       response = {
         ...(await deserializeAws_json1_1InternalExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -1672,6 +1778,14 @@ const deserializeAws_json1_1ListPartnerEventSourcesCommandError = async (
     case "com.amazonaws.cloudwatchevents#InternalException":
       response = {
         ...(await deserializeAws_json1_1InternalExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2040,6 +2154,14 @@ const deserializeAws_json1_1PutPartnerEventsCommandError = async (
     case "com.amazonaws.cloudwatchevents#InternalException":
       response = {
         ...(await deserializeAws_json1_1InternalExceptionResponse(parsedOutput, context)),
+        name: errorCode,
+        $metadata: deserializeMetadata(output),
+      };
+      break;
+    case "OperationDisabledException":
+    case "com.amazonaws.cloudwatchevents#OperationDisabledException":
+      response = {
+        ...(await deserializeAws_json1_1OperationDisabledExceptionResponse(parsedOutput, context)),
         name: errorCode,
         $metadata: deserializeMetadata(output),
       };
@@ -2783,6 +2905,21 @@ const deserializeAws_json1_1ManagedRuleExceptionResponse = async (
   return contents;
 };
 
+const deserializeAws_json1_1OperationDisabledExceptionResponse = async (
+  parsedOutput: any,
+  context: __SerdeContext
+): Promise<OperationDisabledException> => {
+  const body = parsedOutput.body;
+  const deserialized: any = deserializeAws_json1_1OperationDisabledException(body, context);
+  const contents: OperationDisabledException = {
+    name: "OperationDisabledException",
+    $fault: "client",
+    $metadata: deserializeMetadata(parsedOutput),
+    ...deserialized,
+  };
+  return contents;
+};
+
 const deserializeAws_json1_1PolicyLengthExceededExceptionResponse = async (
   parsedOutput: any,
   context: __SerdeContext
@@ -2884,6 +3021,7 @@ const serializeAws_json1_1CreateEventBusRequest = (input: CreateEventBusRequest,
   return {
     ...(input.EventSourceName !== undefined && { EventSourceName: input.EventSourceName }),
     ...(input.Name !== undefined && { Name: input.Name }),
+    ...(input.Tags !== undefined && { Tags: serializeAws_json1_1TagList(input.Tags, context) }),
   };
 };
 
@@ -2992,6 +3130,30 @@ const serializeAws_json1_1EventResourceList = (input: string[], context: __Serde
   return input.map((entry) => entry);
 };
 
+const serializeAws_json1_1HeaderParametersMap = (input: { [key: string]: string }, context: __SerdeContext): any => {
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value,
+    }),
+    {}
+  );
+};
+
+const serializeAws_json1_1HttpParameters = (input: HttpParameters, context: __SerdeContext): any => {
+  return {
+    ...(input.HeaderParameters !== undefined && {
+      HeaderParameters: serializeAws_json1_1HeaderParametersMap(input.HeaderParameters, context),
+    }),
+    ...(input.PathParameterValues !== undefined && {
+      PathParameterValues: serializeAws_json1_1PathParameterList(input.PathParameterValues, context),
+    }),
+    ...(input.QueryStringParameters !== undefined && {
+      QueryStringParameters: serializeAws_json1_1QueryStringParametersMap(input.QueryStringParameters, context),
+    }),
+  };
+};
+
 const serializeAws_json1_1InputTransformer = (input: InputTransformer, context: __SerdeContext): any => {
   return {
     ...(input.InputPathsMap !== undefined && {
@@ -3095,6 +3257,10 @@ const serializeAws_json1_1NetworkConfiguration = (input: NetworkConfiguration, c
   };
 };
 
+const serializeAws_json1_1PathParameterList = (input: string[], context: __SerdeContext): any => {
+  return input.map((entry) => entry);
+};
+
 const serializeAws_json1_1PutEventsRequest = (input: PutEventsRequest, context: __SerdeContext): any => {
   return {
     ...(input.Entries !== undefined && {
@@ -3184,6 +3350,19 @@ const serializeAws_json1_1PutTargetsRequest = (input: PutTargetsRequest, context
   };
 };
 
+const serializeAws_json1_1QueryStringParametersMap = (
+  input: { [key: string]: string },
+  context: __SerdeContext
+): any => {
+  return Object.entries(input).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value,
+    }),
+    {}
+  );
+};
+
 const serializeAws_json1_1RemovePermissionRequest = (input: RemovePermissionRequest, context: __SerdeContext): any => {
   return {
     ...(input.EventBusName !== undefined && { EventBusName: input.EventBusName }),
@@ -3263,6 +3442,9 @@ const serializeAws_json1_1Target = (input: Target, context: __SerdeContext): any
     }),
     ...(input.EcsParameters !== undefined && {
       EcsParameters: serializeAws_json1_1EcsParameters(input.EcsParameters, context),
+    }),
+    ...(input.HttpParameters !== undefined && {
+      HttpParameters: serializeAws_json1_1HttpParameters(input.HttpParameters, context),
     }),
     ...(input.Id !== undefined && { Id: input.Id }),
     ...(input.Input !== undefined && { Input: input.Input }),
@@ -3506,6 +3688,34 @@ const deserializeAws_json1_1EventSourceList = (output: any, context: __SerdeCont
   return (output || []).map((entry: any) => deserializeAws_json1_1EventSource(entry, context));
 };
 
+const deserializeAws_json1_1HeaderParametersMap = (output: any, context: __SerdeContext): { [key: string]: string } => {
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value,
+    }),
+    {}
+  );
+};
+
+const deserializeAws_json1_1HttpParameters = (output: any, context: __SerdeContext): HttpParameters => {
+  return {
+    __type: "HttpParameters",
+    HeaderParameters:
+      output.HeaderParameters !== undefined && output.HeaderParameters !== null
+        ? deserializeAws_json1_1HeaderParametersMap(output.HeaderParameters, context)
+        : undefined,
+    PathParameterValues:
+      output.PathParameterValues !== undefined && output.PathParameterValues !== null
+        ? deserializeAws_json1_1PathParameterList(output.PathParameterValues, context)
+        : undefined,
+    QueryStringParameters:
+      output.QueryStringParameters !== undefined && output.QueryStringParameters !== null
+        ? deserializeAws_json1_1QueryStringParametersMap(output.QueryStringParameters, context)
+        : undefined,
+  } as any;
+};
+
 const deserializeAws_json1_1InputTransformer = (output: any, context: __SerdeContext): InputTransformer => {
   return {
     __type: "InputTransformer",
@@ -3679,6 +3889,16 @@ const deserializeAws_json1_1NetworkConfiguration = (output: any, context: __Serd
   } as any;
 };
 
+const deserializeAws_json1_1OperationDisabledException = (
+  output: any,
+  context: __SerdeContext
+): OperationDisabledException => {
+  return {
+    __type: "OperationDisabledException",
+    message: output.message !== undefined && output.message !== null ? output.message : undefined,
+  } as any;
+};
+
 const deserializeAws_json1_1PartnerEventSource = (output: any, context: __SerdeContext): PartnerEventSource => {
   return {
     __type: "PartnerEventSource",
@@ -3715,6 +3935,10 @@ const deserializeAws_json1_1PartnerEventSourceAccountList = (
 
 const deserializeAws_json1_1PartnerEventSourceList = (output: any, context: __SerdeContext): PartnerEventSource[] => {
   return (output || []).map((entry: any) => deserializeAws_json1_1PartnerEventSource(entry, context));
+};
+
+const deserializeAws_json1_1PathParameterList = (output: any, context: __SerdeContext): string[] => {
+  return (output || []).map((entry: any) => entry);
 };
 
 const deserializeAws_json1_1PolicyLengthExceededException = (
@@ -3822,6 +4046,19 @@ const deserializeAws_json1_1PutTargetsResultEntryList = (
   context: __SerdeContext
 ): PutTargetsResultEntry[] => {
   return (output || []).map((entry: any) => deserializeAws_json1_1PutTargetsResultEntry(entry, context));
+};
+
+const deserializeAws_json1_1QueryStringParametersMap = (
+  output: any,
+  context: __SerdeContext
+): { [key: string]: string } => {
+  return Object.entries(output).reduce(
+    (acc: { [key: string]: string }, [key, value]: [string, any]) => ({
+      ...acc,
+      [key]: value,
+    }),
+    {}
+  );
 };
 
 const deserializeAws_json1_1RemoveTargetsResponse = (output: any, context: __SerdeContext): RemoveTargetsResponse => {
@@ -3971,6 +4208,10 @@ const deserializeAws_json1_1Target = (output: any, context: __SerdeContext): Tar
     EcsParameters:
       output.EcsParameters !== undefined && output.EcsParameters !== null
         ? deserializeAws_json1_1EcsParameters(output.EcsParameters, context)
+        : undefined,
+    HttpParameters:
+      output.HttpParameters !== undefined && output.HttpParameters !== null
+        ? deserializeAws_json1_1HttpParameters(output.HttpParameters, context)
         : undefined,
     Id: output.Id !== undefined && output.Id !== null ? output.Id : undefined,
     Input: output.Input !== undefined && output.Input !== null ? output.Input : undefined,

--- a/clients/client-cloudwatch-events/runtimeConfig.shared.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.shared.ts
@@ -1,8 +1,10 @@
 import { defaultRegionInfoProvider } from "./endpoints";
+import { Logger as __Logger } from "@aws-sdk/types";
 
 export const ClientSharedValues = {
   apiVersion: "2015-10-07",
   disableHostPrefix: false,
+  logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
   signingName: "events",
 };

--- a/codegen/sdk-codegen/aws-models/cloudwatch-events.2015-10-07.json
+++ b/codegen/sdk-codegen/aws-models/cloudwatch-events.2015-10-07.json
@@ -1,0 +1,3405 @@
+{
+  "smithy": "1.0",
+  "metadata": {
+    "suppressions": [
+      {
+        "id": "HttpMethodSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpResponseCodeSemantics",
+        "namespace": "*"
+      },
+      {
+        "id": "PaginatedTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpHeaderTrait",
+        "namespace": "*"
+      },
+      {
+        "id": "HttpUriConflict",
+        "namespace": "*"
+      },
+      {
+        "id": "Service",
+        "namespace": "*"
+      }
+    ]
+  },
+  "shapes": {
+    "com.amazonaws.cloudwatchevents#AWSEvents": {
+      "type": "service",
+      "version": "2015-10-07",
+      "operations": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ActivateEventSource"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#CreateEventBus"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#CreatePartnerEventSource"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#DeactivateEventSource"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#DeleteEventBus"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#DeletePartnerEventSource"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#DeleteRule"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#DescribeEventBus"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#DescribeEventSource"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#DescribePartnerEventSource"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#DescribeRule"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#DisableRule"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#EnableRule"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ListEventBuses"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ListEventSources"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ListPartnerEventSourceAccounts"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ListPartnerEventSources"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ListRuleNamesByTarget"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ListRules"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ListTagsForResource"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ListTargetsByRule"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#PutEvents"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#PutPartnerEvents"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#PutPermission"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#PutRule"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#PutTargets"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#RemovePermission"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#RemoveTargets"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#TagResource"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#TestEventPattern"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#UntagResource"
+        }
+      ],
+      "traits": {
+        "aws.api#service": {
+          "sdkId": "CloudWatch Events",
+          "arnNamespace": "events",
+          "cloudFormationName": "Events",
+          "cloudTrailEventSource": "v20151007.jetstream.amazon.com"
+        },
+        "aws.auth#sigv4": {
+          "name": "events"
+        },
+        "aws.protocols#awsJson1_1": {},
+        "smithy.api#documentation": "<p>Amazon EventBridge helps you to respond to state changes in your AWS resources.\n            When your resources change state, they automatically send events into an event stream.\n            You can create rules that match selected events in the stream and route them to targets\n            to take action. You can also use rules to take action on a predetermined schedule. For\n            example, you can configure rules to:</p>\n        <ul>\n            <li>\n                <p>Automatically invoke an AWS Lambda function to update DNS entries when an\n                    event notifies you that Amazon EC2 instance enters the running state.</p>\n            </li>\n            <li>\n                <p>Direct specific API records from AWS CloudTrail to an Amazon Kinesis data\n                    stream for detailed analysis of potential security or availability\n                    risks.</p>\n            </li>\n            <li>\n                <p>Periodically invoke a built-in target to create a snapshot of an Amazon EBS\n                    volume.</p>\n            </li>\n         </ul>\n        <p>For more information about the features of Amazon EventBridge, see the <a href=\"https://docs.aws.amazon.com/eventbridge/latest/userguide\">Amazon EventBridge User\n                Guide</a>.</p>",
+        "smithy.api#title": "Amazon CloudWatch Events",
+        "smithy.api#xmlNamespace": {
+          "uri": "http://events.amazonaws.com/doc/2015-10-07"
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#AccountId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 12,
+          "max": 12
+        },
+        "smithy.api#pattern": "\\d{12}"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#Action": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "events:[a-zA-Z]+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ActivateEventSource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#ActivateEventSourceRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InvalidStateException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Activates a partner event source that has been deactivated. Once activated, your\n            matching event bus will start receiving events from the event source.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ActivateEventSourceRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the partner event source to activate.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#Arn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1600
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#AssignPublicIp": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": [
+          {
+            "value": "ENABLED",
+            "name": "ENABLED"
+          },
+          {
+            "value": "DISABLED",
+            "name": "DISABLED"
+          }
+        ]
+      }
+    },
+    "com.amazonaws.cloudwatchevents#AwsVpcConfiguration": {
+      "type": "structure",
+      "members": {
+        "AssignPublicIp": {
+          "target": "com.amazonaws.cloudwatchevents#AssignPublicIp",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the task's elastic network interface receives a public IP address.\n            You can specify <code>ENABLED</code> only when <code>LaunchType</code> in\n                <code>EcsParameters</code> is set to <code>FARGATE</code>.</p>"
+          }
+        },
+        "SecurityGroups": {
+          "target": "com.amazonaws.cloudwatchevents#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the security groups associated with the task. These security groups must all\n            be in the same VPC. You can specify as many as five security groups. If you do not\n            specify a security group, the default security group for the VPC is used.</p>"
+          }
+        },
+        "Subnets": {
+          "target": "com.amazonaws.cloudwatchevents#StringList",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the subnets associated with the task. These subnets must all be in the same\n            VPC. You can specify as many as 16 subnets.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This structure specifies the VPC subnets and security groups for the task, and whether\n            a public IP address is to be used. This structure is relevant only for ECS tasks that\n            use the <code>awsvpc</code> network mode.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#BatchArrayProperties": {
+      "type": "structure",
+      "members": {
+        "Size": {
+          "target": "com.amazonaws.cloudwatchevents#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The size of the array, if this is an array batch job. Valid values are integers\n            between 2 and 10,000.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The array properties for the submitted job, such as the size of the array. The\n            array size can be between 2 and 10,000. If you specify array properties for a job, it\n            becomes an array job. This parameter is used only if the target is an AWS Batch\n            job.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#BatchParameters": {
+      "type": "structure",
+      "members": {
+        "ArrayProperties": {
+          "target": "com.amazonaws.cloudwatchevents#BatchArrayProperties",
+          "traits": {
+            "smithy.api#documentation": "<p>The array properties for the submitted job, such as the size of the array. The\n            array size can be between 2 and 10,000. If you specify array properties for a job, it\n            becomes an array job. This parameter is used only if the target is an AWS Batch\n            job.</p>"
+          }
+        },
+        "JobDefinition": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN or name of the job definition to use if the event target is an AWS Batch\n            job. This job definition must already exist.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "JobName": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name to use for this execution of the job, if the target is an AWS Batch\n            job.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RetryStrategy": {
+          "target": "com.amazonaws.cloudwatchevents#BatchRetryStrategy",
+          "traits": {
+            "smithy.api#documentation": "<p>The retry strategy to use for failed jobs, if the target is an AWS Batch job. The\n            retry strategy is the number of times to retry the failed job execution. Valid values\n            are 1–10. When you specify a retry strategy here, it overrides the retry strategy\n            defined in the job definition.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The custom parameters to be used when the target is an AWS Batch job.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#BatchRetryStrategy": {
+      "type": "structure",
+      "members": {
+        "Attempts": {
+          "target": "com.amazonaws.cloudwatchevents#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of times to attempt to retry, if the job fails. Valid values are\n            1–10.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The retry strategy to use for failed jobs, if the target is an AWS Batch job. If\n            you specify a retry strategy here, it overrides the retry strategy defined in the job\n            definition.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#Boolean": {
+      "type": "boolean"
+    },
+    "com.amazonaws.cloudwatchevents#ConcurrentModificationException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>There is concurrent modification on a rule or target.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#Condition": {
+      "type": "structure",
+      "members": {
+        "Type": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the type of condition. Currently the only supported value is\n                <code>StringEquals</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Value": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the value for the key. Currently, this must be the ID of the\n            organization.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Key": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the key for the condition. Currently the only supported key is\n                <code>aws:PrincipalOrgID</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A JSON string which you can use to limit the event bus permissions you are granting to\n            only accounts that fulfill the condition. Currently, the only supported condition is\n            membership in a certain AWS organization. The string must contain <code>Type</code>,\n                <code>Key</code>, and <code>Value</code> fields. The <code>Value</code> field\n            specifies the ID of the AWS organization. Following is an example value for\n                <code>Condition</code>:</p>\n        <p>\n            <code>'{\"Type\" : \"StringEquals\", \"Key\": \"aws:PrincipalOrgID\", \"Value\":\n                \"o-1234567890\"}'</code>\n         </p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#CreateEventBus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#CreateEventBusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#CreateEventBusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InvalidStateException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceAlreadyExistsException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates a new event bus within your account. This can be a custom event bus which you\n            can use to receive events from your custom applications and services, or it can be a\n            partner event bus which can be matched to a partner event source.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#CreateEventBusRequest": {
+      "type": "structure",
+      "members": {
+        "EventSourceName": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>If you are creating a partner event bus, this specifies the partner event source that\n            the new event bus will be matched with.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the new event bus. </p>\n        <p>Event bus names cannot contain the / character. You can't use the name\n                <code>default</code> for a custom event bus, as this name is already used for your\n            account's default event bus.</p>\n        <p>If this is a partner event bus, the name must exactly match the name of the partner\n            event source that this event bus is matched to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.cloudwatchevents#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>Tags to associate with the event bus.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#CreateEventBusResponse": {
+      "type": "structure",
+      "members": {
+        "EventBusArn": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the new event bus.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#CreatePartnerEventSource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#CreatePartnerEventSourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#CreatePartnerEventSourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceAlreadyExistsException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Called by an SaaS partner to create a partner event source. This operation is not used\n            by AWS customers.</p>\n        <p>Each partner event source can be used by one AWS account to create a matching partner\n            event bus in that AWS account. A SaaS partner must create one partner event source for\n            each AWS account that wants to receive those event types. </p>\n        <p>A partner event source creates events based on resources within the SaaS partner's\n            service or application.</p>\n        <p>An AWS account that creates a partner event bus that matches the partner event source\n            can use that event bus to receive events from the partner, and then process them using\n            AWS Events rules and targets.</p>\n        <p>Partner event source names follow this format:</p>\n        <p>\n            <code>\n               <i>partner_name</i>/<i>event_namespace</i>/<i>event_name</i>\n            </code>\n         </p>\n        <p>\n            <i>partner_name</i> is determined during partner registration and\n            identifies the partner to AWS customers. <i>event_namespace</i> is\n            determined by the partner and is a way for the partner to categorize their events.\n                <i>event_name</i> is determined by the partner, and should uniquely\n            identify an event-generating resource within the partner system. The combination of\n                <i>event_namespace</i> and <i>event_name</i> should help\n            AWS customers decide whether to create an event bus to receive these events.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#CreatePartnerEventSourceRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the partner event source. This name must be unique and must be in the\n            format\n                    <code>\n               <i>partner_name</i>/<i>event_namespace</i>/<i>event_name</i>\n            </code>.\n            The AWS account that wants to use this partner event source must create a partner event\n            bus with a name that matches the name of the partner event source.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Account": {
+          "target": "com.amazonaws.cloudwatchevents#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The AWS account ID that is permitted to create a matching partner event bus for this\n            partner event source.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#CreatePartnerEventSourceResponse": {
+      "type": "structure",
+      "members": {
+        "EventSourceArn": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the partner event source.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DeactivateEventSource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#DeactivateEventSourceRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InvalidStateException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>You can use this operation to temporarily stop receiving events from the specified\n            partner event source. The matching event bus is not deleted. </p>\n        <p>When you deactivate a partner event source, the source goes into PENDING state. If it\n            remains in PENDING state for more than two weeks, it is deleted.</p>\n        <p>To activate a deactivated partner event source, use <a>ActivateEventSource</a>.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DeactivateEventSourceRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the partner event source to deactivate.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DeleteEventBus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#DeleteEventBusRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified custom event bus or partner event bus. All rules associated with\n            this event bus need to be deleted. You can't delete your account's default event\n            bus.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DeleteEventBusRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event bus to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DeletePartnerEventSource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#DeletePartnerEventSourceRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>This operation is used by SaaS partners to delete a partner event source. This\n            operation is not used by AWS customers.</p>\n        <p>When you delete an event source, the status of the corresponding partner event bus in\n            the AWS customer account becomes DELETED.</p>\n        <p></p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DeletePartnerEventSourceRequest": {
+      "type": "structure",
+      "members": {
+        "Account": {
+          "target": "com.amazonaws.cloudwatchevents#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The AWS account ID of the AWS customer that the event source was created for.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event source to delete.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DeleteRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#DeleteRuleRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ManagedRuleException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Deletes the specified rule.</p>\n        <p>Before you can delete the rule, you must remove all targets, using <a>RemoveTargets</a>.</p>\n\n        <p>When you delete a rule, incoming events might continue to match to the deleted\n            rule. Allow a short period of time for changes to take effect.</p>\n\n        <p>Managed rules are rules created and managed by another AWS service on your behalf.\n            These rules are created by those other AWS services to support functionality in those\n            services. You can delete these rules using the <code>Force</code> option, but you should\n            do so only if you are sure the other service is not still using that rule.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DeleteRuleRequest": {
+      "type": "structure",
+      "members": {
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event bus associated with the rule. If you omit this, the default event bus is\n            used.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Force": {
+          "target": "com.amazonaws.cloudwatchevents#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>If this is a managed rule, created by an AWS service on your behalf, you must specify\n                <code>Force</code> as <code>True</code> to delete the rule. This parameter is\n            ignored for rules that are not managed rules. You can check whether a rule is a managed\n            rule by using <code>DescribeRule</code> or <code>ListRules</code> and checking the\n                <code>ManagedBy</code> field of the response.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribeEventBus": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#DescribeEventBusRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#DescribeEventBusResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Displays details about an event bus in your account. This can include the external\n            AWS accounts that are permitted to write events to your default event bus, and the\n            associated policy. For custom event buses and partner event buses, it displays the name,\n            ARN, policy, state, and creation time.</p>\n        <p> To enable your account to receive events from other accounts on its default event\n            bus, use <a>PutPermission</a>.</p>\n        <p>For more information about partner event buses, see <a>CreateEventBus</a>.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribeEventBusRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event bus to show details for. If you omit this, the default event bus\n            is displayed.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribeEventBusResponse": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event bus. Currently, this is always\n            <code>default</code>.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the account permitted to write events to the\n            current account.</p>"
+          }
+        },
+        "Policy": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The policy that enables the external account to send events to your\n            account.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribeEventSource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#DescribeEventSourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#DescribeEventSourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>This operation lists details about a partner event source that is shared with your\n            account.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribeEventSourceRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the partner event source to display the details of.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribeEventSourceResponse": {
+      "type": "structure",
+      "members": {
+        "CreatedBy": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the SaaS partner that created the event source.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the partner event source.</p>"
+          }
+        },
+        "ExpirationTime": {
+          "target": "com.amazonaws.cloudwatchevents#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the event source will expire if you do not create a matching\n            event bus.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the partner event source.</p>"
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the event source. If it is ACTIVE, you have already created a matching\n            event bus for this event source, and that event bus is active. If it is PENDING, either\n            you haven't yet created a matching event bus, or that event bus is deactivated. If it is\n            DELETED, you have created a matching event bus, but the event source has since been\n            deleted.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.cloudwatchevents#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the event source was created.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribePartnerEventSource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#DescribePartnerEventSourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#DescribePartnerEventSourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>An SaaS partner can use this operation to list details about a partner event source\n            that they have created. AWS customers do not use this operation. Instead, AWS customers\n            can use <a>DescribeEventSource</a> to see details about a partner event\n            source that is shared with them.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribePartnerEventSourceRequest": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event source to display.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribePartnerEventSourceResponse": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the event source.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event source.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribeRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#DescribeRuleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#DescribeRuleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Describes the specified rule.</p>\n        <p>DescribeRule does not list the targets of a rule. To see the targets associated\n            with a rule, use <a>ListTargetsByRule</a>.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribeRuleRequest": {
+      "type": "structure",
+      "members": {
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event bus associated with the rule. If you omit this, the default event bus is\n            used.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the rule.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DescribeRuleResponse": {
+      "type": "structure",
+      "members": {
+        "ScheduleExpression": {
+          "target": "com.amazonaws.cloudwatchevents#ScheduleExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The scheduling expression. For example, \"cron(0 20 * * ? *)\", \"rate(5\n            minutes)\".</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the rule.</p>"
+          }
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.cloudwatchevents#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role associated with the rule.</p>"
+          }
+        },
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event bus associated with the rule.</p>"
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.cloudwatchevents#RuleState",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies whether the rule is enabled or disabled.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.cloudwatchevents#RuleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the rule.</p>"
+          }
+        },
+        "EventPattern": {
+          "target": "com.amazonaws.cloudwatchevents#EventPattern",
+          "traits": {
+            "smithy.api#documentation": "<p>The event pattern. For more information, see <a href=\"https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html\">Events and\n                Event Patterns</a> in the <i>Amazon EventBridge User\n            Guide</i>.</p>"
+          }
+        },
+        "ManagedBy": {
+          "target": "com.amazonaws.cloudwatchevents#ManagedBy",
+          "traits": {
+            "smithy.api#documentation": "<p>If this is a managed rule, created by an AWS service on your behalf, this field\n            displays the principal name of the AWS service that created the rule.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.cloudwatchevents#RuleDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the rule.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DisableRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#DisableRuleRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ManagedRuleException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Disables the specified rule. A disabled rule won't match any events, and won't\n            self-trigger if it has a schedule expression.</p>\n\n        <p>When you disable a rule, incoming events might continue to match to the disabled\n            rule. Allow a short period of time for changes to take effect.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#DisableRuleRequest": {
+      "type": "structure",
+      "members": {
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event bus associated with the rule. If you omit this, the default event bus is\n            used.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the rule.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EcsParameters": {
+      "type": "structure",
+      "members": {
+        "Group": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies an ECS task group for the task. The maximum length is 255 characters.</p>"
+          }
+        },
+        "TaskCount": {
+          "target": "com.amazonaws.cloudwatchevents#LimitMin1",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of tasks to create based on <code>TaskDefinition</code>. The default is\n            1.</p>"
+          }
+        },
+        "PlatformVersion": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the platform version for the task. Specify only the numeric portion of the\n            platform version, such as <code>1.1.0</code>.</p>\n        <p>This structure is used only if <code>LaunchType</code> is <code>FARGATE</code>. For\n            more information about valid platform versions, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/platform_versions.html\">AWS Fargate Platform\n                Versions</a> in the <i>Amazon Elastic Container Service Developer\n                Guide</i>.</p>"
+          }
+        },
+        "NetworkConfiguration": {
+          "target": "com.amazonaws.cloudwatchevents#NetworkConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Use this structure if the ECS task uses the <code>awsvpc</code> network mode. This\n            structure specifies the VPC subnets and security groups associated with the task, and\n            whether a public IP address is to be used. This structure is required if\n                <code>LaunchType</code> is <code>FARGATE</code> because the <code>awsvpc</code> mode\n            is required for Fargate tasks.</p>\n        <p>If you specify <code>NetworkConfiguration</code> when the target ECS task does not use\n            the <code>awsvpc</code> network mode, the task fails.</p>"
+          }
+        },
+        "TaskDefinitionArn": {
+          "target": "com.amazonaws.cloudwatchevents#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the task definition to use if the event target is an Amazon ECS task.\n        </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "LaunchType": {
+          "target": "com.amazonaws.cloudwatchevents#LaunchType",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifies the launch type on which your task is running. The launch type that you\n            specify here must match one of the launch type (compatibilities) of the target task. The\n                <code>FARGATE</code> value is supported only in the Regions where AWS Fargate with\n            Amazon ECS is supported. For more information, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/AWS-Fargate.html\">AWS Fargate on Amazon\n                ECS</a> in the <i>Amazon Elastic Container Service Developer\n                Guide</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The custom parameters to be used when the target is an Amazon ECS task.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EnableRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#EnableRuleRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ManagedRuleException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Enables the specified rule. If the rule does not exist, the operation\n            fails.</p>\n\n        <p>When you enable a rule, incoming events might not immediately start matching to a\n            newly enabled rule. Allow a short period of time for changes to take effect.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EnableRuleRequest": {
+      "type": "structure",
+      "members": {
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event bus associated with the rule. If you omit this, the default event bus is\n            used.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the rule.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ErrorCode": {
+      "type": "string"
+    },
+    "com.amazonaws.cloudwatchevents#ErrorMessage": {
+      "type": "string"
+    },
+    "com.amazonaws.cloudwatchevents#EventBus": {
+      "type": "structure",
+      "members": {
+        "Arn": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the event bus.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event bus.</p>"
+          }
+        },
+        "Policy": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The permissions policy of the event bus, describing which other AWS accounts can write\n            events to this event bus.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An event bus receives events from a source and routes them to rules associated with\n            that event bus. Your account's default event bus receives rules from AWS services. A\n            custom event bus can receive rules from AWS services as well as your custom applications\n            and services. A partner event bus receives events from an event source created by an\n            SaaS partner. These events come from the partners services or applications.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EventBusList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#EventBus"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EventBusName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "[/\\.\\-_A-Za-z0-9]+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EventId": {
+      "type": "string"
+    },
+    "com.amazonaws.cloudwatchevents#EventPattern": {
+      "type": "string"
+    },
+    "com.amazonaws.cloudwatchevents#EventResource": {
+      "type": "string"
+    },
+    "com.amazonaws.cloudwatchevents#EventResourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#EventResource"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EventSource": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event source.</p>"
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the event source. If it is ACTIVE, you have already created a matching\n            event bus for this event source, and that event bus is active. If it is PENDING, either\n            you haven't yet created a matching event bus, or that event bus is deactivated. If it is\n            DELETED, you have created a matching event bus, but the event source has since been\n            deleted.</p>"
+          }
+        },
+        "CreatedBy": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the partner that created the event source.</p>"
+          }
+        },
+        "CreationTime": {
+          "target": "com.amazonaws.cloudwatchevents#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the event source was created.</p>"
+          }
+        },
+        "ExpirationTime": {
+          "target": "com.amazonaws.cloudwatchevents#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the event source will expire, if the AWS account doesn't create\n            a matching event bus for it.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the event source.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A partner event source is created by an SaaS partner. If a customer creates a partner\n            event bus that matches this event source, that AWS account can receive events from the\n            partner's applications or services.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EventSourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#EventSource"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EventSourceName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "aws\\.partner(/[\\.\\-_A-Za-z0-9]+){2,}"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EventSourceNamePrefix": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "[/\\.\\-_A-Za-z0-9]+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EventSourceState": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": [
+          {
+            "value": "PENDING",
+            "name": "PENDING"
+          },
+          {
+            "value": "ACTIVE",
+            "name": "ACTIVE"
+          },
+          {
+            "value": "DELETED",
+            "name": "DELETED"
+          }
+        ]
+      }
+    },
+    "com.amazonaws.cloudwatchevents#EventTime": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.cloudwatchevents#HeaderKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 512
+        },
+        "smithy.api#pattern": "^[!#$%&'*+-.^_`|~0-9a-zA-Z]+$"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#HeaderParametersMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.cloudwatchevents#HeaderKey"
+      },
+      "value": {
+        "target": "com.amazonaws.cloudwatchevents#HeaderValue"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#HeaderValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 512
+        },
+        "smithy.api#pattern": "^[ \\t]*[\\x20-\\x7E]+([ \\t]+[\\x20-\\x7E]+)*[ \\t]*$"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#HttpParameters": {
+      "type": "structure",
+      "members": {
+        "HeaderParameters": {
+          "target": "com.amazonaws.cloudwatchevents#HeaderParametersMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The headers that need to be sent as part of request invoking the API Gateway REST \n            API.</p>"
+          }
+        },
+        "PathParameterValues": {
+          "target": "com.amazonaws.cloudwatchevents#PathParameterList",
+          "traits": {
+            "smithy.api#documentation": "<p>The path parameter values to be used to populate API Gateway REST API\n         path wildcards (\"*\").</p>"
+          }
+        },
+        "QueryStringParameters": {
+          "target": "com.amazonaws.cloudwatchevents#QueryStringParametersMap",
+          "traits": {
+            "smithy.api#documentation": "<p>The query string keys/values that need to be sent as part of request invoking the \n            API Gateway REST API.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>These are custom parameter to be used when the target is an API Gateway REST \n            APIs.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#InputTransformer": {
+      "type": "structure",
+      "members": {
+        "InputTemplate": {
+          "target": "com.amazonaws.cloudwatchevents#TransformerInput",
+          "traits": {
+            "smithy.api#documentation": "<p>Input template where you specify placeholders that will be filled with the values\n            of the keys from <code>InputPathsMap</code> to customize the data sent to the target.\n            Enclose each <code>InputPathsMaps</code> value in brackets:\n                <<i>value</i>> The InputTemplate must be valid JSON.</p>\n\n        <p>If <code>InputTemplate</code> is a JSON object (surrounded by curly braces), the\n            following restrictions apply:</p>\n        <ul>\n            <li>\n                <p>The placeholder cannot be used as an object key.</p>\n            </li>\n            <li>\n                <p>Object values cannot include quote marks.</p>\n            </li>\n         </ul>\n        <p>The following example shows the syntax for using <code>InputPathsMap</code> and\n                <code>InputTemplate</code>.</p>\n        <p>\n            <code> \"InputTransformer\":</code>\n         </p>\n        <p>\n            <code>{</code>\n         </p>\n        <p>\n            <code>\"InputPathsMap\": {\"instance\": \"$.detail.instance\",\"status\":\n                \"$.detail.status\"},</code>\n         </p>\n        <p>\n            <code>\"InputTemplate\": \"<instance> is in state\n            <status>\"</code>\n         </p>\n        <p>\n            <code>}</code>\n         </p>\n        <p>To have the <code>InputTemplate</code> include quote marks within a JSON string,\n            escape each quote marks with a slash, as in the following example:</p>\n        <p>\n            <code> \"InputTransformer\":</code>\n         </p>\n        <p>\n            <code>{</code>\n         </p>\n        <p>\n            <code>\"InputPathsMap\": {\"instance\": \"$.detail.instance\",\"status\":\n                \"$.detail.status\"},</code>\n         </p>\n        <p>\n            <code>\"InputTemplate\": \"<instance> is in state\n            \\\"<status>\\\"\"</code>\n         </p>\n        <p>\n            <code>}</code>\n         </p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InputPathsMap": {
+          "target": "com.amazonaws.cloudwatchevents#TransformerPaths",
+          "traits": {
+            "smithy.api#documentation": "<p>Map of JSON paths to be extracted from the event. You can then insert these in the\n            template in <code>InputTemplate</code> to produce the output you want to be sent to the\n            target.</p>\n        <p>\n            <code>InputPathsMap</code> is an array key-value pairs, where each value is a valid\n            JSON path. You can have as many as 10 key-value pairs. You must use JSON dot notation,\n            not bracket notation.</p>\n        <p>The keys cannot start with \"AWS.\" </p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains the parameters needed for you to provide custom input to a target based on\n            one or more pieces of data extracted from the event.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#InputTransformerPathKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "[A-Za-z0-9\\_\\-]+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#Integer": {
+      "type": "integer"
+    },
+    "com.amazonaws.cloudwatchevents#InternalException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This exception occurs due to unexpected causes.</p>",
+        "smithy.api#error": "server"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#InvalidEventPatternException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The event pattern is not valid.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#InvalidStateException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The specified state is not a valid state for an event source.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#KinesisParameters": {
+      "type": "structure",
+      "members": {
+        "PartitionKeyPath": {
+          "target": "com.amazonaws.cloudwatchevents#TargetPartitionKeyPath",
+          "traits": {
+            "smithy.api#documentation": "<p>The JSON path to be extracted from the event and used as the partition key. For\n            more information, see <a href=\"https://docs.aws.amazon.com/streams/latest/dev/key-concepts.html#partition-key\">Amazon Kinesis Streams Key\n                Concepts</a> in the <i>Amazon Kinesis Streams Developer\n            Guide</i>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This object enables you to specify a JSON path to extract from the event and use as\n            the partition key for the Amazon Kinesis data stream, so that you can control the shard\n            to which the event goes. If you do not include this parameter, the default is to use the\n                <code>eventId</code> as the partition key.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#LaunchType": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": [
+          {
+            "value": "EC2",
+            "name": "EC2"
+          },
+          {
+            "value": "FARGATE",
+            "name": "FARGATE"
+          }
+        ]
+      }
+    },
+    "com.amazonaws.cloudwatchevents#LimitExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>You tried to create more rules or add more targets to a rule than is\n            allowed.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#LimitMax100": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#box": {},
+        "smithy.api#range": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#LimitMin1": {
+      "type": "integer",
+      "traits": {
+        "smithy.api#box": {},
+        "smithy.api#range": {
+          "min": 1
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListEventBuses": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#ListEventBusesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#ListEventBusesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists all the event buses in your account, including the default event bus, custom\n            event buses, and partner event buses.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListEventBusesRequest": {
+      "type": "structure",
+      "members": {
+        "NamePrefix": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifying this limits the results to only those event buses with names that start\n            with the specified prefix.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The token returned by a previous call to retrieve the next set of results.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.cloudwatchevents#LimitMax100",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifying this limits the number of results returned by this operation. The operation\n            also returns a NextToken which you can use in a subsequent operation to retrieve the\n            next set of results.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListEventBusesResponse": {
+      "type": "structure",
+      "members": {
+        "EventBuses": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusList",
+          "traits": {
+            "smithy.api#documentation": "<p>This list of event buses.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token you can use in a subsequent operation to retrieve the next set of\n            results.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListEventSources": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#ListEventSourcesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#ListEventSourcesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>You can use this to see all the partner event sources that have been shared with your\n            AWS account. For more information about partner event sources, see <a>CreateEventBus</a>.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListEventSourcesRequest": {
+      "type": "structure",
+      "members": {
+        "NamePrefix": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceNamePrefix",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifying this limits the results to only those partner event sources with names that\n            start with the specified prefix.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.cloudwatchevents#LimitMax100",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifying this limits the number of results returned by this operation. The operation\n            also returns a NextToken which you can use in a subsequent operation to retrieve the\n            next set of results.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The token returned by a previous call to retrieve the next set of results.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListEventSourcesResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token you can use in a subsequent operation to retrieve the next set of\n            results.</p>"
+          }
+        },
+        "EventSources": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of event sources.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListPartnerEventSourceAccounts": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#ListPartnerEventSourceAccountsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#ListPartnerEventSourceAccountsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>An SaaS partner can use this operation to display the AWS account ID that a particular\n            partner event source name is associated with. This operation is not used by AWS\n            customers.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListPartnerEventSourceAccountsRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The token returned by a previous call to this operation. Specifying this retrieves the\n            next set of results.</p>"
+          }
+        },
+        "EventSourceName": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the partner event source to display account information about.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.cloudwatchevents#LimitMax100",
+          "traits": {
+            "smithy.api#documentation": "<p>Specifying this limits the number of results returned by this operation. The operation\n            also returns a NextToken which you can use in a subsequent operation to retrieve the\n            next set of results.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListPartnerEventSourceAccountsResponse": {
+      "type": "structure",
+      "members": {
+        "PartnerEventSourceAccounts": {
+          "target": "com.amazonaws.cloudwatchevents#PartnerEventSourceAccountList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of partner event sources returned by the operation.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token you can use in a subsequent operation to retrieve the next set of\n            results.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListPartnerEventSources": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#ListPartnerEventSourcesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#ListPartnerEventSourcesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>An SaaS partner can use this operation to list all the partner event source names that\n            they have created. This operation is not used by AWS customers.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListPartnerEventSourcesRequest": {
+      "type": "structure",
+      "members": {
+        "NamePrefix": {
+          "target": "com.amazonaws.cloudwatchevents#PartnerEventSourceNamePrefix",
+          "traits": {
+            "smithy.api#documentation": "<p>If you specify this, the results are limited to only those partner event sources that\n            start with the string you specify.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.cloudwatchevents#LimitMax100",
+          "traits": {
+            "smithy.api#documentation": "<p>pecifying this limits the number of results returned by this operation. The operation\n            also returns a NextToken which you can use in a subsequent operation to retrieve the\n            next set of results.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The token returned by a previous call to this operation. Specifying this retrieves the\n            next set of results.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListPartnerEventSourcesResponse": {
+      "type": "structure",
+      "members": {
+        "PartnerEventSources": {
+          "target": "com.amazonaws.cloudwatchevents#PartnerEventSourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of partner event sources returned by the operation.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>A token you can use in a subsequent operation to retrieve the next set of\n            results.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListRuleNamesByTarget": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#ListRuleNamesByTargetRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#ListRuleNamesByTargetResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the rules for the specified target. You can see which of the rules in Amazon\n            EventBridge can invoke a specific target in your account.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListRuleNamesByTargetRequest": {
+      "type": "structure",
+      "members": {
+        "Limit": {
+          "target": "com.amazonaws.cloudwatchevents#LimitMax100",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The token returned by a previous call to retrieve the next set of\n            results.</p>"
+          }
+        },
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>Limits the results to show only the rules associated with the specified event\n            bus.</p>"
+          }
+        },
+        "TargetArn": {
+          "target": "com.amazonaws.cloudwatchevents#TargetArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the target resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListRuleNamesByTargetResponse": {
+      "type": "structure",
+      "members": {
+        "RuleNames": {
+          "target": "com.amazonaws.cloudwatchevents#RuleNameList",
+          "traits": {
+            "smithy.api#documentation": "<p>The names of the rules that can invoke the given target.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether there are additional results to retrieve. If there are no more\n            results, the value is null.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListRules": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#ListRulesRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#ListRulesResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists your Amazon EventBridge rules. You can either list all the rules or you can\n            provide a prefix to match to the rule names.</p>\n\n        <p>ListRules does not list the targets of a rule. To see the targets associated with a\n            rule, use <a>ListTargetsByRule</a>.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListRulesRequest": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The token returned by a previous call to retrieve the next set of\n            results.</p>"
+          }
+        },
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>Limits the results to show only the rules associated with the specified event\n            bus.</p>"
+          }
+        },
+        "NamePrefix": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The prefix matching the rule name.</p>"
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.cloudwatchevents#LimitMax100",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListRulesResponse": {
+      "type": "structure",
+      "members": {
+        "Rules": {
+          "target": "com.amazonaws.cloudwatchevents#RuleResponseList",
+          "traits": {
+            "smithy.api#documentation": "<p>The rules that match the specified criteria.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether there are additional results to retrieve. If there are no more\n            results, the value is null.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListTagsForResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#ListTagsForResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#ListTagsForResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Displays the tags associated with an EventBridge resource. In EventBridge,\n            rules and event buses can be tagged.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListTagsForResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.cloudwatchevents#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the EventBridge resource for which you want to view tags.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListTagsForResourceResponse": {
+      "type": "structure",
+      "members": {
+        "Tags": {
+          "target": "com.amazonaws.cloudwatchevents#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tag keys and values associated with the resource you specified</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListTargetsByRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#ListTargetsByRuleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#ListTargetsByRuleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Lists the targets assigned to the specified rule.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListTargetsByRuleRequest": {
+      "type": "structure",
+      "members": {
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event bus associated with the rule. If you omit this, the default event bus is\n            used.</p>"
+          }
+        },
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>The token returned by a previous call to retrieve the next set of\n            results.</p>"
+          }
+        },
+        "Rule": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Limit": {
+          "target": "com.amazonaws.cloudwatchevents#LimitMax100",
+          "traits": {
+            "smithy.api#documentation": "<p>The maximum number of results to return.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ListTargetsByRuleResponse": {
+      "type": "structure",
+      "members": {
+        "NextToken": {
+          "target": "com.amazonaws.cloudwatchevents#NextToken",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether there are additional results to retrieve. If there are no more\n            results, the value is null.</p>"
+          }
+        },
+        "Targets": {
+          "target": "com.amazonaws.cloudwatchevents#TargetList",
+          "traits": {
+            "smithy.api#documentation": "<p>The targets assigned to the rule.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ManagedBy": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ManagedRuleException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This rule was created by an AWS service on behalf of your account. It is managed by\n            that service. If you see this error in response to <code>DeleteRule</code> or\n                <code>RemoveTargets</code>, you can use the <code>Force</code> parameter in those\n            calls to delete the rule or remove targets from the rule. You cannot modify these\n            managed rules by using <code>DisableRule</code>, <code>EnableRule</code>,\n                <code>PutTargets</code>, <code>PutRule</code>, <code>TagResource</code>, or\n                <code>UntagResource</code>. </p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#MessageGroupId": {
+      "type": "string"
+    },
+    "com.amazonaws.cloudwatchevents#NetworkConfiguration": {
+      "type": "structure",
+      "members": {
+        "awsvpcConfiguration": {
+          "target": "com.amazonaws.cloudwatchevents#AwsVpcConfiguration",
+          "traits": {
+            "smithy.api#documentation": "<p>Use this structure to specify the VPC subnets and security groups for the task, and\n            whether a public IP address is to be used. This structure is relevant only for ECS tasks\n            that use the <code>awsvpc</code> network mode.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This structure specifies the network configuration for an ECS task.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#NextToken": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 2048
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#NonPartnerEventBusName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "[\\.\\-_A-Za-z0-9]+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#OperationDisabledException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The operation you are attempting is not available in this region.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PartnerEventSource": {
+      "type": "structure",
+      "members": {
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the partner event source.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the partner event source.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A partner event source is created by an SaaS partner. If a customer creates a partner\n            event bus that matches this event source, that AWS account can receive events from the\n            partner's applications or services.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PartnerEventSourceAccount": {
+      "type": "structure",
+      "members": {
+        "CreationTime": {
+          "target": "com.amazonaws.cloudwatchevents#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time the event source was created.</p>"
+          }
+        },
+        "ExpirationTime": {
+          "target": "com.amazonaws.cloudwatchevents#Timestamp",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time that the event source will expire, if the AWS account doesn't create\n            a matching event bus for it.</p>"
+          }
+        },
+        "Account": {
+          "target": "com.amazonaws.cloudwatchevents#AccountId",
+          "traits": {
+            "smithy.api#documentation": "<p>The AWS account ID that the partner event source was offered to.</p>"
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the event source. If it is ACTIVE, you have already created a matching\n            event bus for this event source, and that event bus is active. If it is PENDING, either\n            you haven't yet created a matching event bus, or that event bus is deactivated. If it is\n            DELETED, you have created a matching event bus, but the event source has since been\n            deleted.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The AWS account that a partner event source has been offered to.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PartnerEventSourceAccountList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#PartnerEventSourceAccount"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PartnerEventSourceList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#PartnerEventSource"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PartnerEventSourceNamePrefix": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        },
+        "smithy.api#pattern": "aws\\.partner/[\\.\\-_A-Za-z0-9]+/[/\\.\\-_A-Za-z0-9]*"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PathParameter": {
+      "type": "string",
+      "traits": {
+        "smithy.api#pattern": "^(?!\\s*$).+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PathParameterList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#PathParameter"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PolicyLengthExceededException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The event bus policy is too long. For more information, see the limits.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#Principal": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 12
+        },
+        "smithy.api#pattern": "(\\d{12}|\\*)"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutEvents": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#PutEventsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#PutEventsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Sends custom events to Amazon EventBridge so that they can be matched to\n            rules.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutEventsRequest": {
+      "type": "structure",
+      "members": {
+        "Entries": {
+          "target": "com.amazonaws.cloudwatchevents#PutEventsRequestEntryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The entry that defines an event in your system. You can specify several parameters\n            for the entry such as the source and type of the event, resources associated with the\n            event, and so on.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutEventsRequestEntry": {
+      "type": "structure",
+      "members": {
+        "Source": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The source of the event.</p>"
+          }
+        },
+        "Time": {
+          "target": "com.amazonaws.cloudwatchevents#EventTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The time stamp of the event, per <a href=\"https://www.rfc-editor.org/rfc/rfc3339.txt\">RFC3339</a>. If no time stamp\n            is provided, the time stamp of the <a>PutEvents</a> call is used.</p>"
+          }
+        },
+        "Resources": {
+          "target": "com.amazonaws.cloudwatchevents#EventResourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>AWS resources, identified by Amazon Resource Name (ARN), which the event primarily\n            concerns. Any number, including zero, may be present.</p>"
+          }
+        },
+        "DetailType": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>Free-form string used to decide what fields to expect in the event\n            detail.</p>"
+          }
+        },
+        "Detail": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A valid JSON string. There is no other schema imposed. The JSON string may contain\n            fields and nested subobjects.</p>"
+          }
+        },
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#NonPartnerEventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event bus that will receive the event. Only the rules that are associated with\n            this event bus will be able to match the event.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an event to be submitted.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutEventsRequestEntryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#PutEventsRequestEntry"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutEventsResponse": {
+      "type": "structure",
+      "members": {
+        "FailedEntryCount": {
+          "target": "com.amazonaws.cloudwatchevents#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of failed entries.</p>"
+          }
+        },
+        "Entries": {
+          "target": "com.amazonaws.cloudwatchevents#PutEventsResultEntryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The successfully and unsuccessfully ingested events results. If the ingestion was\n            successful, the entry has the event ID in it. Otherwise, you can use the error code and\n            error message to identify the problem with the entry.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutEventsResultEntry": {
+      "type": "structure",
+      "members": {
+        "ErrorCode": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code that indicates why the event submission failed.</p>"
+          }
+        },
+        "EventId": {
+          "target": "com.amazonaws.cloudwatchevents#EventId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the event.</p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The error message that explains why the event submission failed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an event that failed to be submitted.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutEventsResultEntryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#PutEventsResultEntry"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutPartnerEvents": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#PutPartnerEventsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#PutPartnerEventsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#OperationDisabledException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>This is used by SaaS partners to write events to a customer's partner event bus. AWS\n            customers do not use this operation.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutPartnerEventsRequest": {
+      "type": "structure",
+      "members": {
+        "Entries": {
+          "target": "com.amazonaws.cloudwatchevents#PutPartnerEventsRequestEntryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of events to write to the event bus.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutPartnerEventsRequestEntry": {
+      "type": "structure",
+      "members": {
+        "Detail": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A valid JSON string. There is no other schema imposed. The JSON string may contain\n            fields and nested subobjects.</p>"
+          }
+        },
+        "DetailType": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>A free-form string used to decide what fields to expect in the event detail.</p>"
+          }
+        },
+        "Source": {
+          "target": "com.amazonaws.cloudwatchevents#EventSourceName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event source that is generating the evntry.</p>"
+          }
+        },
+        "Time": {
+          "target": "com.amazonaws.cloudwatchevents#EventTime",
+          "traits": {
+            "smithy.api#documentation": "<p>The date and time of the event.</p>"
+          }
+        },
+        "Resources": {
+          "target": "com.amazonaws.cloudwatchevents#EventResourceList",
+          "traits": {
+            "smithy.api#documentation": "<p>AWS resources, identified by Amazon Resource Name (ARN), which the event primarily\n            concerns. Any number, including zero, may be present.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The details about an event generated by an SaaS partner.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutPartnerEventsRequestEntryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#PutPartnerEventsRequestEntry"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 20
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutPartnerEventsResponse": {
+      "type": "structure",
+      "members": {
+        "FailedEntryCount": {
+          "target": "com.amazonaws.cloudwatchevents#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of events from this operation that could not be written to the partner\n            event bus.</p>"
+          }
+        },
+        "Entries": {
+          "target": "com.amazonaws.cloudwatchevents#PutPartnerEventsResultEntryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of events from this operation that were successfully written to the partner\n            event bus.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutPartnerEventsResultEntry": {
+      "type": "structure",
+      "members": {
+        "ErrorMessage": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The error message that explains why the event submission failed.</p>"
+          }
+        },
+        "EventId": {
+          "target": "com.amazonaws.cloudwatchevents#EventId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the event.</p>"
+          }
+        },
+        "ErrorCode": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code that indicates why the event submission failed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents an event that a partner tried to generate, but failed.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutPartnerEventsResultEntryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#PutPartnerEventsResultEntry"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutPermission": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#PutPermissionRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#PolicyLengthExceededException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Running <code>PutPermission</code> permits the specified AWS account or AWS\n            organization to put events to the specified <i>event bus</i>. Amazon EventBridge (CloudWatch Events) \n            rules in your account are triggered by these events arriving to an event bus in\n            your account. </p>\n        <p>For another account to send events to your account, that external account must have\n            an EventBridge rule with your account's event bus as a target.</p>\n\n        <p>To enable multiple AWS accounts to put events to your event bus, run\n                <code>PutPermission</code> once for each of these accounts. Or, if all the accounts\n            are members of the same AWS organization, you can run <code>PutPermission</code> once\n            specifying <code>Principal</code> as \"*\" and specifying the AWS organization ID in\n                <code>Condition</code>, to grant permissions to all accounts in that\n            organization.</p>\n\n        <p>If you grant permissions using an organization, then accounts in that organization\n            must specify a <code>RoleArn</code> with proper permissions when they use\n                <code>PutTarget</code> to add your account's event bus as a target. For more\n            information, see <a href=\"https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html\">Sending and Receiving Events Between AWS Accounts</a> in the <i>Amazon\n                EventBridge User Guide</i>.</p>\n\n        <p>The permission policy on the default event bus cannot exceed 10 KB in\n            size.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutPermissionRequest": {
+      "type": "structure",
+      "members": {
+        "Action": {
+          "target": "com.amazonaws.cloudwatchevents#Action",
+          "traits": {
+            "smithy.api#documentation": "<p>The action that you are enabling the other account to perform. Currently, this must\n            be <code>events:PutEvents</code>.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#NonPartnerEventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event bus associated with the rule. If you omit this, the default event bus is\n            used.</p>"
+          }
+        },
+        "Principal": {
+          "target": "com.amazonaws.cloudwatchevents#Principal",
+          "traits": {
+            "smithy.api#documentation": "<p>The 12-digit AWS account ID that you are permitting to put events to your default\n            event bus. Specify \"*\" to permit any account to put events to your default event\n            bus.</p>\n\n        <p>If you specify \"*\" without specifying <code>Condition</code>, avoid creating rules\n            that may match undesirable events. To create more secure rules, make sure that the event\n            pattern for each rule contains an <code>account</code> field with a specific account ID\n            from which to receive events. Rules with an account field do not match any events sent\n            from other accounts.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Condition": {
+          "target": "com.amazonaws.cloudwatchevents#Condition",
+          "traits": {
+            "smithy.api#documentation": "<p>This parameter enables you to limit the permission to accounts that fulfill a certain\n            condition, such as being a member of a certain AWS organization. For more information\n            about AWS Organizations, see <a href=\"https://docs.aws.amazon.com/organizations/latest/userguide/orgs_introduction.html\">What Is AWS\n                Organizations</a> in the <i>AWS Organizations User\n            Guide</i>.</p>\n        <p>If you specify <code>Condition</code> with an AWS organization ID, and specify \"*\" as\n            the value for <code>Principal</code>, you grant permission to all the accounts in the\n            named organization.</p>\n\n        <p>The <code>Condition</code> is a JSON string which must contain <code>Type</code>,\n                <code>Key</code>, and <code>Value</code> fields.</p>"
+          }
+        },
+        "StatementId": {
+          "target": "com.amazonaws.cloudwatchevents#StatementId",
+          "traits": {
+            "smithy.api#documentation": "<p>An identifier string for the external account that you are granting permissions to.\n            If you later want to revoke the permission for this external account, specify this\n                <code>StatementId</code> when you run <a>RemovePermission</a>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutRule": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#PutRuleRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#PutRuleResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InvalidEventPatternException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ManagedRuleException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Creates or updates the specified rule. Rules are enabled by default, or based on\n            value of the state. You can disable a rule using <a>DisableRule</a>.</p>\n\n        <p>A single rule watches for events from a single event bus. Events generated by AWS\n            services go to your account's default event bus. Events generated by SaaS partner\n            services or applications go to the matching partner event bus. If you have custom\n            applications or services, you can specify whether their events go to your default event\n            bus or a custom event bus that you have created. For more information, see <a>CreateEventBus</a>.</p>\n\n        <p>If you are updating an existing rule, the rule is replaced with what you specify in\n            this <code>PutRule</code> command. If you omit arguments in <code>PutRule</code>, the\n            old values for those arguments are not kept. Instead, they are replaced with null\n            values.</p>\n\n        <p>When you create or update a rule, incoming events might not immediately start\n            matching to new or updated rules. Allow a short period of time for changes to take\n            effect.</p>\n\n        <p>A rule must contain at least an EventPattern or ScheduleExpression. Rules with\n            EventPatterns are triggered when a matching event is observed. Rules with\n            ScheduleExpressions self-trigger based on the given schedule. A rule can have both an\n            EventPattern and a ScheduleExpression, in which case the rule triggers on matching\n            events as well as on a schedule.</p>\n\n        <p>When you initially create a rule, you can optionally assign one or more tags to the\n            rule. Tags can help you organize and categorize your resources. You can also use them to\n            scope user permissions, by granting a user permission to access or change only rules\n            with certain tag values. To use the <code>PutRule</code> operation and assign tags, you\n            must have both the <code>events:PutRule</code> and <code>events:TagResource</code>\n            permissions.</p>\n        <p>If you are updating an existing rule, any tags you specify in the <code>PutRule</code>\n            operation are ignored. To update the tags of an existing rule, use <a>TagResource</a> and <a>UntagResource</a>.</p>\n\n        <p>Most services in AWS treat : or / as the same character in Amazon Resource Names\n            (ARNs). However, EventBridge uses an exact match in event patterns and rules. Be sure to\n            use the correct ARN characters when creating event patterns so that they match the ARN\n            syntax in the event you want to match.</p>\n\n        <p>In EventBridge, it is possible to create rules that lead to infinite loops, where a\n            rule is fired repeatedly. For example, a rule might detect that ACLs have changed on an\n            S3 bucket, and trigger software to change them to the desired state. If the rule is not\n            written carefully, the subsequent change to the ACLs fires the rule again, creating an\n            infinite loop.</p>\n        <p>To prevent this, write the rules so that the triggered actions do not re-fire the same\n            rule. For example, your rule could fire only if ACLs are found to be in a bad state,\n            instead of after any change. </p>\n        <p>An infinite loop can quickly cause higher than expected charges. We recommend that you\n            use budgeting, which alerts you when charges exceed your specified limit. For more\n            information, see <a href=\"https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-managing-costs.html\">Managing Your\n                Costs with Budgets</a>.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutRuleRequest": {
+      "type": "structure",
+      "members": {
+        "ScheduleExpression": {
+          "target": "com.amazonaws.cloudwatchevents#ScheduleExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The scheduling expression. For example, \"cron(0 20 * * ? *)\" or \"rate(5\n            minutes)\".</p>"
+          }
+        },
+        "State": {
+          "target": "com.amazonaws.cloudwatchevents#RuleState",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the rule is enabled or disabled.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.cloudwatchevents#RuleDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>A description of the rule.</p>"
+          }
+        },
+        "EventPattern": {
+          "target": "com.amazonaws.cloudwatchevents#EventPattern",
+          "traits": {
+            "smithy.api#documentation": "<p>The event pattern. For more information, see <a href=\"https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html\">Events and\n                Event Patterns</a> in the <i>Amazon EventBridge User\n            Guide</i>.</p>"
+          }
+        },
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event bus to associate with this rule. If you omit this, the default event bus is\n            used.</p>"
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.cloudwatchevents#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of key-value pairs to associate with the rule.</p>"
+          }
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.cloudwatchevents#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role associated with the rule.</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the rule that you are creating or updating.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutRuleResponse": {
+      "type": "structure",
+      "members": {
+        "RuleArn": {
+          "target": "com.amazonaws.cloudwatchevents#RuleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the rule.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutTargets": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#PutTargetsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#PutTargetsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#LimitExceededException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ManagedRuleException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Adds the specified targets to the specified rule, or updates the targets if they\n            are already associated with the rule.</p>\n        <p>Targets are the resources that are invoked when a rule is triggered.</p>\n        <p>You can configure the following as targets for Events:</p>\n\n        <ul>\n            <li>\n                <p>EC2 instances</p>\n            </li>\n            <li>\n                <p>SSM Run Command</p>\n            </li>\n            <li>\n                <p>SSM Automation</p>\n            </li>\n            <li>\n                <p>AWS Lambda functions</p>\n            </li>\n            <li>\n                <p>Data streams in Amazon Kinesis Data Streams</p>\n            </li>\n            <li>\n                <p>Data delivery streams in Amazon Kinesis Data Firehose</p>\n            </li>\n            <li>\n                <p>Amazon ECS tasks</p>\n            </li>\n            <li>\n                <p>AWS Step Functions state machines</p>\n            </li>\n            <li>\n                <p>AWS Batch jobs</p>\n            </li>\n            <li>\n                <p>AWS CodeBuild projects</p>\n            </li>\n            <li>\n                <p>Pipelines in AWS CodePipeline</p>\n            </li>\n            <li>\n                <p>Amazon Inspector assessment templates</p>\n            </li>\n            <li>\n                <p>Amazon SNS topics</p>\n            </li>\n            <li>\n                <p>Amazon SQS queues, including FIFO queues</p>\n            </li>\n            <li>\n                <p>The default event bus of another AWS account</p>\n            </li>\n            <li>\n                <p>Amazon API Gateway REST APIs</p>\n            </li>\n         </ul>\n\n\n\n        <p>Creating rules with built-in targets is supported only in the AWS Management\n            Console. The built-in targets are <code>EC2 CreateSnapshot API call</code>, <code>EC2\n                RebootInstances API call</code>, <code>EC2 StopInstances API call</code>, and\n                <code>EC2 TerminateInstances API call</code>. </p>\n\n        <p>For some target types, <code>PutTargets</code> provides target-specific parameters.\n            If the target is a Kinesis data stream, you can optionally specify which shard the event\n            goes to by using the <code>KinesisParameters</code> argument. To invoke a command on\n            multiple EC2 instances with one rule, you can use the <code>RunCommandParameters</code>\n            field.</p>\n        <p>To be able to make API calls against the resources that you own, Amazon EventBridge \n            (CloudWatch Events) needs the appropriate permissions. For AWS Lambda and Amazon SNS resources,\n            EventBridge relies on resource-based policies. For EC2 instances, Kinesis data\n            streams, AWS Step Functions state machines and API Gateway REST APIs, EventBridge relies on IAM roles\n            that you specify in the <code>RoleARN</code> argument in <code>PutTargets</code>. For more information, \n            see <a href=\"https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html\">Authentication and Access Control</a> in the <i>Amazon EventBridge User\n                Guide</i>.</p>\n\n        <p>If another AWS account is in the same region and has granted you permission (using\n                <code>PutPermission</code>), you can send events to that account. Set that account's\n            event bus as a target of the rules in your account. To send the matched events to the\n            other account, specify that account's event bus as the <code>Arn</code> value when you\n            run <code>PutTargets</code>. If your account sends events to another account, your\n            account is charged for each sent event. Each event sent to another account is charged as\n            a custom event. The account receiving the event is not charged. For more information,\n            see <a href=\"https://aws.amazon.com/eventbridge/pricing/\">Amazon EventBridge (CloudWatch Events)\n                Pricing</a>.</p>\n\n        <note>\n            <p>\n               <code>Input</code>, <code>InputPath</code>, and <code>InputTransformer</code> are\n                not available with <code>PutTarget</code> if the target is an event bus of a\n                different AWS account.</p>\n        </note>\n\n        <p>If you are setting the event bus of another account as the target, and that account\n            granted permission to your account through an organization instead of directly by the\n            account ID, then you must specify a <code>RoleArn</code> with proper permissions in the\n                <code>Target</code> structure. For more information, see <a href=\"https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html\">Sending and Receiving Events Between AWS Accounts</a> in the <i>Amazon\n                EventBridge User Guide</i>.</p>\n\n        <p>For more information about enabling cross-account events, see <a>PutPermission</a>.</p>\n\n        <p>\n            <b>Input</b>, <b>InputPath</b>, and\n                <b>InputTransformer</b> are mutually exclusive and\n            optional parameters of a target. When a rule is triggered due to a matched\n            event:</p>\n\n        <ul>\n            <li>\n                <p>If none of the following arguments are specified for a target, then the\n                    entire event is passed to the target in JSON format (unless the target is Amazon\n                    EC2 Run Command or Amazon ECS task, in which case nothing from the event is\n                    passed to the target).</p>\n            </li>\n            <li>\n                <p>If <b>Input</b> is specified in the form of valid\n                    JSON, then the matched event is overridden with this constant.</p>\n            </li>\n            <li>\n                <p>If <b>InputPath</b> is specified in the form of\n                    JSONPath (for example, <code>$.detail</code>), then only the part of the event\n                    specified in the path is passed to the target (for example, only the detail part\n                    of the event is passed).</p>\n            </li>\n            <li>\n                <p>If <b>InputTransformer</b> is specified, then one\n                    or more specified JSONPaths are extracted from the event and used as values in a\n                    template that you specify as the input to the target.</p>\n            </li>\n         </ul>\n\n        <p>When you specify <code>InputPath</code> or <code>InputTransformer</code>, you must\n            use JSON dot notation, not bracket notation.</p>\n\n        <p>When you add targets to a rule and the associated rule triggers soon after, new or\n            updated targets might not be immediately invoked. Allow a short period of time for\n            changes to take effect.</p>\n\n        <p>This action can partially fail if too many requests are made at the same time. If\n            that happens, <code>FailedEntryCount</code> is non-zero in the response and each entry\n            in <code>FailedEntries</code> provides the ID of the failed target and the error\n            code.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutTargetsRequest": {
+      "type": "structure",
+      "members": {
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event bus associated with the rule. If you omit this, the default\n            event bus is used.</p>"
+          }
+        },
+        "Rule": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Targets": {
+          "target": "com.amazonaws.cloudwatchevents#TargetList",
+          "traits": {
+            "smithy.api#documentation": "<p>The targets to update or add to the rule.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutTargetsResponse": {
+      "type": "structure",
+      "members": {
+        "FailedEntries": {
+          "target": "com.amazonaws.cloudwatchevents#PutTargetsResultEntryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The failed target entries.</p>"
+          }
+        },
+        "FailedEntryCount": {
+          "target": "com.amazonaws.cloudwatchevents#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of failed entries.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutTargetsResultEntry": {
+      "type": "structure",
+      "members": {
+        "ErrorMessage": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The error message that explains why the target addition failed.</p>"
+          }
+        },
+        "ErrorCode": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code that indicates why the target addition failed. If the value is\n                <code>ConcurrentModificationException</code>, too many requests were made at the\n            same time.</p>"
+          }
+        },
+        "TargetId": {
+          "target": "com.amazonaws.cloudwatchevents#TargetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the target.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a target that failed to be added to a rule.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#PutTargetsResultEntryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#PutTargetsResultEntry"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#QueryStringKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 512
+        },
+        "smithy.api#pattern": "[^\\x00-\\x1F\\x7F]+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#QueryStringParametersMap": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.cloudwatchevents#QueryStringKey"
+      },
+      "value": {
+        "target": "com.amazonaws.cloudwatchevents#QueryStringValue"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#QueryStringValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 512
+        },
+        "smithy.api#pattern": "[^\\x00-\\x09\\x0B\\x0C\\x0E-\\x1F\\x7F]+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RemovePermission": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#RemovePermissionRequest"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Revokes the permission of another AWS account to be able to put events to the\n            specified event bus. Specify the account to revoke by the <code>StatementId</code> value\n            that you associated with the account when you granted it permission with\n                <code>PutPermission</code>. You can find the <code>StatementId</code> by using <a>DescribeEventBus</a>.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RemovePermissionRequest": {
+      "type": "structure",
+      "members": {
+        "StatementId": {
+          "target": "com.amazonaws.cloudwatchevents#StatementId",
+          "traits": {
+            "smithy.api#documentation": "<p>The statement ID corresponding to the account that is no longer allowed to put\n            events to the default event bus.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#NonPartnerEventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event bus to revoke permissions for. If you omit this, the default\n            event bus is used.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RemoveTargets": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#RemoveTargetsRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#RemoveTargetsResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ManagedRuleException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes the specified targets from the specified rule. When the rule is triggered,\n            those targets are no longer be invoked.</p>\n\n        <p>When you remove a target, when the associated rule triggers, removed targets might\n            continue to be invoked. Allow a short period of time for changes to take\n            effect.</p>\n\n        <p>This action can partially fail if too many requests are made at the same time. If\n            that happens, <code>FailedEntryCount</code> is non-zero in the response and each entry\n            in <code>FailedEntries</code> provides the ID of the failed target and the error\n            code.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RemoveTargetsRequest": {
+      "type": "structure",
+      "members": {
+        "Force": {
+          "target": "com.amazonaws.cloudwatchevents#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>If this is a managed rule, created by an AWS service on your behalf, you must specify\n                <code>Force</code> as <code>True</code> to remove targets. This parameter is ignored\n            for rules that are not managed rules. You can check whether a rule is a managed rule by\n            using <code>DescribeRule</code> or <code>ListRules</code> and checking the\n                <code>ManagedBy</code> field of the response.</p>"
+          }
+        },
+        "Ids": {
+          "target": "com.amazonaws.cloudwatchevents#TargetIdList",
+          "traits": {
+            "smithy.api#documentation": "<p>The IDs of the targets to remove from the rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Rule": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the rule.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the event bus associated with the rule.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RemoveTargetsResponse": {
+      "type": "structure",
+      "members": {
+        "FailedEntryCount": {
+          "target": "com.amazonaws.cloudwatchevents#Integer",
+          "traits": {
+            "smithy.api#documentation": "<p>The number of failed entries.</p>"
+          }
+        },
+        "FailedEntries": {
+          "target": "com.amazonaws.cloudwatchevents#RemoveTargetsResultEntryList",
+          "traits": {
+            "smithy.api#documentation": "<p>The failed target entries.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RemoveTargetsResultEntry": {
+      "type": "structure",
+      "members": {
+        "ErrorCode": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorCode",
+          "traits": {
+            "smithy.api#documentation": "<p>The error code that indicates why the target removal failed. If the value is\n                <code>ConcurrentModificationException</code>, too many requests were made at the\n            same time.</p>"
+          }
+        },
+        "TargetId": {
+          "target": "com.amazonaws.cloudwatchevents#TargetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the target.</p>"
+          }
+        },
+        "ErrorMessage": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage",
+          "traits": {
+            "smithy.api#documentation": "<p>The error message that explains why the target removal failed.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Represents a target that failed to be removed from a rule.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RemoveTargetsResultEntryList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#RemoveTargetsResultEntry"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ResourceAlreadyExistsException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>The resource you are trying to create already exists.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ResourceNotFoundException": {
+      "type": "structure",
+      "members": {
+        "message": {
+          "target": "com.amazonaws.cloudwatchevents#ErrorMessage"
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>An entity that you specified does not exist.</p>",
+        "smithy.api#error": "client"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RoleArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1600
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#Rule": {
+      "type": "structure",
+      "members": {
+        "State": {
+          "target": "com.amazonaws.cloudwatchevents#RuleState",
+          "traits": {
+            "smithy.api#documentation": "<p>The state of the rule.</p>"
+          }
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.cloudwatchevents#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the role that is used for target\n            invocation.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.cloudwatchevents#RuleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the rule.</p>"
+          }
+        },
+        "EventPattern": {
+          "target": "com.amazonaws.cloudwatchevents#EventPattern",
+          "traits": {
+            "smithy.api#documentation": "<p>The event pattern of the rule. For more information, see <a href=\"https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html\">Events and\n                Event Patterns</a> in the <i>Amazon EventBridge User\n            Guide</i>.</p>"
+          }
+        },
+        "EventBusName": {
+          "target": "com.amazonaws.cloudwatchevents#EventBusName",
+          "traits": {
+            "smithy.api#documentation": "<p>The event bus associated with the rule.</p>"
+          }
+        },
+        "ManagedBy": {
+          "target": "com.amazonaws.cloudwatchevents#ManagedBy",
+          "traits": {
+            "smithy.api#documentation": "<p>If the rule was created on behalf of your account by an AWS service, this field\n            displays the principal name of the service that created the rule.</p>"
+          }
+        },
+        "Description": {
+          "target": "com.amazonaws.cloudwatchevents#RuleDescription",
+          "traits": {
+            "smithy.api#documentation": "<p>The description of the rule.</p>"
+          }
+        },
+        "ScheduleExpression": {
+          "target": "com.amazonaws.cloudwatchevents#ScheduleExpression",
+          "traits": {
+            "smithy.api#documentation": "<p>The scheduling expression. For example, \"cron(0 20 * * ? *)\", \"rate(5\n            minutes)\".</p>"
+          }
+        },
+        "Name": {
+          "target": "com.amazonaws.cloudwatchevents#RuleName",
+          "traits": {
+            "smithy.api#documentation": "<p>The name of the rule.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Contains information about a rule in Amazon EventBridge.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RuleArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1600
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RuleDescription": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 512
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RuleName": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "[\\.\\-_A-Za-z0-9]+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RuleNameList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#RuleName"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RuleResponseList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#Rule"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RuleState": {
+      "type": "string",
+      "traits": {
+        "smithy.api#enum": [
+          {
+            "value": "ENABLED",
+            "name": "ENABLED"
+          },
+          {
+            "value": "DISABLED",
+            "name": "DISABLED"
+          }
+        ]
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RunCommandParameters": {
+      "type": "structure",
+      "members": {
+        "RunCommandTargets": {
+          "target": "com.amazonaws.cloudwatchevents#RunCommandTargets",
+          "traits": {
+            "smithy.api#documentation": "<p>Currently, we support including only one RunCommandTarget block, which specifies\n            either an array of InstanceIds or a tag.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This parameter contains the criteria (either InstanceIds or a tag) used to specify\n            which EC2 instances are to be sent the command. </p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RunCommandTarget": {
+      "type": "structure",
+      "members": {
+        "Values": {
+          "target": "com.amazonaws.cloudwatchevents#RunCommandTargetValues",
+          "traits": {
+            "smithy.api#documentation": "<p>If <code>Key</code> is <code>tag:</code>\n            <i>tag-key</i>,\n                <code>Values</code> is a list of tag values. If <code>Key</code> is\n                <code>InstanceIds</code>, <code>Values</code> is a list of Amazon EC2 instance\n            IDs.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Key": {
+          "target": "com.amazonaws.cloudwatchevents#RunCommandTargetKey",
+          "traits": {
+            "smithy.api#documentation": "<p>Can be either <code>tag:</code>\n            <i>tag-key</i> or\n                <code>InstanceIds</code>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Information about the EC2 instances that are to be sent the command, specified as\n            key-value pairs. Each <code>RunCommandTarget</code> block can include only one key, but\n            this key may specify multiple values.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RunCommandTargetKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        },
+        "smithy.api#pattern": "^[\\p{L}\\p{Z}\\p{N}_.:/=+\\-@]*$"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RunCommandTargetValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RunCommandTargetValues": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#RunCommandTargetValue"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 50
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#RunCommandTargets": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#RunCommandTarget"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 5
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#ScheduleExpression": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#SqsParameters": {
+      "type": "structure",
+      "members": {
+        "MessageGroupId": {
+          "target": "com.amazonaws.cloudwatchevents#MessageGroupId",
+          "traits": {
+            "smithy.api#documentation": "<p>The FIFO message group ID to use as the target.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>This structure includes the custom parameter to be used when the target is an SQS FIFO\n            queue.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#StatementId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "[a-zA-Z0-9-_]+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#String": {
+      "type": "string"
+    },
+    "com.amazonaws.cloudwatchevents#StringList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#String"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#Tag": {
+      "type": "structure",
+      "members": {
+        "Value": {
+          "target": "com.amazonaws.cloudwatchevents#TagValue",
+          "traits": {
+            "smithy.api#documentation": "<p>The value for the specified tag key.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Key": {
+          "target": "com.amazonaws.cloudwatchevents#TagKey",
+          "traits": {
+            "smithy.api#documentation": "<p>A string you can use to assign a value. The combination of tag keys and values can\n            help you organize and categorize your resources.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>A key-value pair associated with an AWS resource. In EventBridge, rules and event buses support\n            tagging.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TagKey": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 128
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TagKeyList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#TagKey"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TagList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#Tag"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#TagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#TagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ManagedRuleException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Assigns one or more tags (key-value pairs) to the specified EventBridge\n            resource. Tags can help you organize and categorize your resources. You can also use\n            them to scope user permissions by granting a user permission to access or change only\n            resources with certain tag values. In EventBridge, rules and event buses can be tagged.</p>\n        <p>Tags don't have any semantic meaning to AWS and are interpreted strictly as strings of\n            characters.</p>\n        <p>You can use the <code>TagResource</code> action with a resource that already has tags. If\n            you specify a new tag key, this tag is appended to the list of tags\n            associated with the resource. If you specify a tag key that is already associated with the\n            resource, the new tag value that you specify replaces the previous value for that\n            tag.</p>\n        <p>You can associate as many as 50 tags with a resource.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.cloudwatchevents#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the EventBridge resource that you're adding tags to.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "Tags": {
+          "target": "com.amazonaws.cloudwatchevents#TagList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of key-value pairs to associate with the resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TagResourceResponse": {
+      "type": "structure",
+      "members": {}
+    },
+    "com.amazonaws.cloudwatchevents#TagValue": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#Target": {
+      "type": "structure",
+      "members": {
+        "Input": {
+          "target": "com.amazonaws.cloudwatchevents#TargetInput",
+          "traits": {
+            "smithy.api#documentation": "<p>Valid JSON text passed to the target. In this case, nothing from the event itself\n            is passed to the target. For more information, see <a href=\"http://www.rfc-editor.org/rfc/rfc7159.txt\">The JavaScript Object Notation\n                (JSON) Data Interchange Format</a>.</p>"
+          }
+        },
+        "InputPath": {
+          "target": "com.amazonaws.cloudwatchevents#TargetInputPath",
+          "traits": {
+            "smithy.api#documentation": "<p>The value of the JSONPath that is used for extracting part of the matched event\n            when passing it to the target. You must use JSON dot notation, not bracket notation. For\n            more information about JSON paths, see <a href=\"http://goessner.net/articles/JsonPath/\">JSONPath</a>.</p>"
+          }
+        },
+        "BatchParameters": {
+          "target": "com.amazonaws.cloudwatchevents#BatchParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>If the event target is an AWS Batch job, this contains the job definition, job\n            name, and other parameters. For more information, see <a href=\"https://docs.aws.amazon.com/batch/latest/userguide/jobs.html\">Jobs</a> in the <i>AWS Batch User\n                Guide</i>.</p>"
+          }
+        },
+        "KinesisParameters": {
+          "target": "com.amazonaws.cloudwatchevents#KinesisParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>The custom parameter you can use to control the shard assignment, when the target\n            is a Kinesis data stream. If you do not include this parameter, the default is to use\n            the <code>eventId</code> as the partition key.</p>"
+          }
+        },
+        "RoleArn": {
+          "target": "com.amazonaws.cloudwatchevents#RoleArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the IAM role to be used for this target when the\n            rule is triggered. If one rule triggers multiple targets, you can use a different IAM\n            role for each target.</p>"
+          }
+        },
+        "Id": {
+          "target": "com.amazonaws.cloudwatchevents#TargetId",
+          "traits": {
+            "smithy.api#documentation": "<p>The ID of the target.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "InputTransformer": {
+          "target": "com.amazonaws.cloudwatchevents#InputTransformer",
+          "traits": {
+            "smithy.api#documentation": "<p>Settings to enable you to provide custom input to a target based on certain event\n            data. You can extract one or more key-value pairs from the event and then use that data\n            to send customized input to the target.</p>"
+          }
+        },
+        "Arn": {
+          "target": "com.amazonaws.cloudwatchevents#TargetArn",
+          "traits": {
+            "smithy.api#documentation": "<p>The Amazon Resource Name (ARN) of the target.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "RunCommandParameters": {
+          "target": "com.amazonaws.cloudwatchevents#RunCommandParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Parameters used when you are using the rule to invoke Amazon EC2 Run\n            Command.</p>"
+          }
+        },
+        "HttpParameters": {
+          "target": "com.amazonaws.cloudwatchevents#HttpParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the HTTP parameters to use when the target is a API Gateway REST \n            endpoint.</p>\n        <p>If you specify an API Gateway REST API as a target, you can use this \n        parameter to specify headers, path parameter, query string keys/values as part of your target \n        invoking request.</p>"
+          }
+        },
+        "SqsParameters": {
+          "target": "com.amazonaws.cloudwatchevents#SqsParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the message group ID to use when the target is a FIFO queue.</p>\n        <p>If you specify an SQS FIFO queue as a target, the queue must have content-based\n            deduplication enabled.</p>"
+          }
+        },
+        "EcsParameters": {
+          "target": "com.amazonaws.cloudwatchevents#EcsParameters",
+          "traits": {
+            "smithy.api#documentation": "<p>Contains the Amazon ECS task definition and task count to be used, if the event\n            target is an Amazon ECS task. For more information about Amazon ECS tasks, see <a href=\"https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task_defintions.html\">Task\n                Definitions </a> in the <i>Amazon EC2 Container Service Developer\n                Guide</i>.</p>"
+          }
+        }
+      },
+      "traits": {
+        "smithy.api#documentation": "<p>Targets are the resources to be invoked when a rule is triggered. For a complete\n            list of services and resources that can be set as a target, see <a>PutTargets</a>.</p>\n\n        <p>If you are setting the event bus of another account as the target, and that account\n            granted permission to your account through an organization instead of directly by the\n            account ID, then you must specify a <code>RoleArn</code> with proper permissions in the\n                <code>Target</code> structure. For more information, see <a href=\"https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-cross-account-event-delivery.html\">Sending and Receiving Events Between AWS Accounts</a> in the <i>Amazon\n                EventBridge User Guide</i>.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TargetArn": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 1600
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TargetId": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 64
+        },
+        "smithy.api#pattern": "[\\.\\-_A-Za-z0-9]+"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TargetIdList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#TargetId"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TargetInput": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 8192
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TargetInputPath": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TargetList": {
+      "type": "list",
+      "member": {
+        "target": "com.amazonaws.cloudwatchevents#Target"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 100
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TargetPartitionKeyPath": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 256
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TestEventPattern": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#TestEventPatternRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#TestEventPatternResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InvalidEventPatternException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Tests whether the specified event pattern matches the provided event.</p>\n        <p>Most services in AWS treat : or / as the same character in Amazon Resource Names\n            (ARNs). However, EventBridge uses an exact match in event patterns and rules. Be sure to\n            use the correct ARN characters when creating event patterns so that they match the ARN\n            syntax in the event you want to match.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TestEventPatternRequest": {
+      "type": "structure",
+      "members": {
+        "Event": {
+          "target": "com.amazonaws.cloudwatchevents#String",
+          "traits": {
+            "smithy.api#documentation": "<p>The event, in JSON format, to test against the event pattern.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "EventPattern": {
+          "target": "com.amazonaws.cloudwatchevents#EventPattern",
+          "traits": {
+            "smithy.api#documentation": "<p>The event pattern. For more information, see <a href=\"https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html\">Events and\n                Event Patterns</a> in the <i>Amazon EventBridge User\n            Guide</i>.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TestEventPatternResponse": {
+      "type": "structure",
+      "members": {
+        "Result": {
+          "target": "com.amazonaws.cloudwatchevents#Boolean",
+          "traits": {
+            "smithy.api#documentation": "<p>Indicates whether the event matches the event pattern.</p>"
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#Timestamp": {
+      "type": "timestamp"
+    },
+    "com.amazonaws.cloudwatchevents#TransformerInput": {
+      "type": "string",
+      "traits": {
+        "smithy.api#length": {
+          "min": 1,
+          "max": 8192
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#TransformerPaths": {
+      "type": "map",
+      "key": {
+        "target": "com.amazonaws.cloudwatchevents#InputTransformerPathKey"
+      },
+      "value": {
+        "target": "com.amazonaws.cloudwatchevents#TargetInputPath"
+      },
+      "traits": {
+        "smithy.api#length": {
+          "min": 0,
+          "max": 10
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#UntagResource": {
+      "type": "operation",
+      "input": {
+        "target": "com.amazonaws.cloudwatchevents#UntagResourceRequest"
+      },
+      "output": {
+        "target": "com.amazonaws.cloudwatchevents#UntagResourceResponse"
+      },
+      "errors": [
+        {
+          "target": "com.amazonaws.cloudwatchevents#ConcurrentModificationException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#InternalException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ManagedRuleException"
+        },
+        {
+          "target": "com.amazonaws.cloudwatchevents#ResourceNotFoundException"
+        }
+      ],
+      "traits": {
+        "smithy.api#documentation": "<p>Removes one or more tags from the specified EventBridge resource. In Amazon EventBridge (CloudWatch\n            Events, rules and event buses can be tagged.</p>"
+      }
+    },
+    "com.amazonaws.cloudwatchevents#UntagResourceRequest": {
+      "type": "structure",
+      "members": {
+        "ResourceARN": {
+          "target": "com.amazonaws.cloudwatchevents#Arn",
+          "traits": {
+            "smithy.api#documentation": "<p>The ARN of the EventBridge resource from which you are removing tags.</p>",
+            "smithy.api#required": {}
+          }
+        },
+        "TagKeys": {
+          "target": "com.amazonaws.cloudwatchevents#TagKeyList",
+          "traits": {
+            "smithy.api#documentation": "<p>The list of tag keys to remove from the resource.</p>",
+            "smithy.api#required": {}
+          }
+        }
+      }
+    },
+    "com.amazonaws.cloudwatchevents#UntagResourceResponse": {
+      "type": "structure",
+      "members": {}
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
The models file for `cloudwatch-events` was deleted when clients were updated in https://github.com/aws/aws-sdk-js-v3/pull/1457
* Diff: https://github.com/aws/aws-sdk-js-v3/commit/f95cce338fcdc49ead6e3ca6d178a6fd58ae556f#diff-ea4b0a37b3ee6f8296d8557bf56bfb94
* The commit which removed cloudwatch-events model [`86d15d2` (#1457)](https://github.com/aws/aws-sdk-js-v3/pull/1457/commits/86d15d240809c1a4d9b43e7aac9bd68aeb149890)

This appears to be a miss when models were manually updated.
* Verified that the other two models files deleted `workmailmessageflow.2017-10-01.json` and `cloudfront.2019-03-26.json` were because their new versions were added.
* This issue won't happen once we integrate with internal scripts for updating clients.

*Description of changes:*
re-adds cloudwatch-events models file and runs CodeGen on it to get latest client code.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
