### PR TITLE
Compatibility with Webpack 5

### DIFF
--- a/clients/client-cognito-identity/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import * as packageInfo from './package.json'; 
+import packageInfo from "./package.json"; 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cognito-identity/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import packageInfo from './package.json'; 
+import * as packageInfo from './package.json'; 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cognito-identity/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import package from './package.json'; 
+import packageInfo from './package.json'; 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -11,7 +11,7 @@ import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { ClientDefaults } from "./CognitoIdentityClient";
 import { ClientSharedValues } from "./runtimeConfig.shared";
 
-const { name, version } = package;
+const { name, version } = packageInfo;
 
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...ClientSharedValues,

--- a/clients/client-cognito-identity/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import package from './package.json'; 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -10,6 +10,8 @@ import { defaultUserAgent } from "@aws-sdk/util-user-agent-browser";
 import { fromUtf8, toUtf8 } from "@aws-sdk/util-utf8-browser";
 import { ClientDefaults } from "./CognitoIdentityClient";
 import { ClientSharedValues } from "./runtimeConfig.shared";
+
+const { name, version } = package;
 
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...ClientSharedValues,

--- a/clients/client-cognito-identity/tsconfig.json
+++ b/clients/client-cognito-identity/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "esModuleInterop": true,
     "alwaysStrict": true,
     "target": "es2017",
     "module": "commonjs",


### PR DESCRIPTION
On my Next.js project I am migrating to webpack 5. I get the following error that on my side is not possible to fix:
``Should not import the named export 'name' (imported as 'name') from default-exporting module (only default export is available soon)``

In the documentation page from webpack "To v5 from v4" the following is mentioned:
``Using named exports from JSON modules: this is not supported by the new specification and you will get a warning. Instead of import { version } from './package.json' use import package from './package.json'; const { version } = package;``

This should fix the error not just for me but also for others who are attempting:
https://github.com/vercel/next.js/issues/13341#issuecomment-665761510