### PR TITLE
fix: default import package.json for spec compatibility

### DIFF
--- a/clients/client-accessanalyzer/runtimeConfig.browser.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-accessanalyzer/runtimeConfig.browser.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-accessanalyzer/runtimeConfig.native.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AccessAnalyzerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-accessanalyzer/runtimeConfig.native.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AccessAnalyzerClient";

--- a/clients/client-accessanalyzer/runtimeConfig.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-accessanalyzer/runtimeConfig.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-acm-pca/runtimeConfig.browser.ts
+++ b/clients/client-acm-pca/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-acm-pca/runtimeConfig.browser.ts
+++ b/clients/client-acm-pca/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-acm-pca/runtimeConfig.native.ts
+++ b/clients/client-acm-pca/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ACMPCAClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-acm-pca/runtimeConfig.native.ts
+++ b/clients/client-acm-pca/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ACMPCAClient";

--- a/clients/client-acm-pca/runtimeConfig.ts
+++ b/clients/client-acm-pca/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-acm-pca/runtimeConfig.ts
+++ b/clients/client-acm-pca/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-acm/runtimeConfig.browser.ts
+++ b/clients/client-acm/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-acm/runtimeConfig.browser.ts
+++ b/clients/client-acm/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-acm/runtimeConfig.native.ts
+++ b/clients/client-acm/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ACMClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-acm/runtimeConfig.native.ts
+++ b/clients/client-acm/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ACMClient";

--- a/clients/client-acm/runtimeConfig.ts
+++ b/clients/client-acm/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-acm/runtimeConfig.ts
+++ b/clients/client-acm/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-alexa-for-business/runtimeConfig.browser.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-alexa-for-business/runtimeConfig.browser.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-alexa-for-business/runtimeConfig.native.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AlexaForBusinessClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-alexa-for-business/runtimeConfig.native.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AlexaForBusinessClient";

--- a/clients/client-alexa-for-business/runtimeConfig.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-alexa-for-business/runtimeConfig.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-amplify/runtimeConfig.browser.ts
+++ b/clients/client-amplify/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-amplify/runtimeConfig.browser.ts
+++ b/clients/client-amplify/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-amplify/runtimeConfig.native.ts
+++ b/clients/client-amplify/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AmplifyClient";

--- a/clients/client-amplify/runtimeConfig.native.ts
+++ b/clients/client-amplify/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AmplifyClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-amplify/runtimeConfig.ts
+++ b/clients/client-amplify/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-amplify/runtimeConfig.ts
+++ b/clients/client-amplify/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-api-gateway/runtimeConfig.browser.ts
+++ b/clients/client-api-gateway/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-api-gateway/runtimeConfig.browser.ts
+++ b/clients/client-api-gateway/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-api-gateway/runtimeConfig.native.ts
+++ b/clients/client-api-gateway/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./APIGatewayClient";

--- a/clients/client-api-gateway/runtimeConfig.native.ts
+++ b/clients/client-api-gateway/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./APIGatewayClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-api-gateway/runtimeConfig.ts
+++ b/clients/client-api-gateway/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-api-gateway/runtimeConfig.ts
+++ b/clients/client-api-gateway/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.browser.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.browser.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.native.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApiGatewayManagementApiClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.native.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApiGatewayManagementApiClient";

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-apigatewayv2/runtimeConfig.browser.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-apigatewayv2/runtimeConfig.browser.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-apigatewayv2/runtimeConfig.native.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApiGatewayV2Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-apigatewayv2/runtimeConfig.native.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApiGatewayV2Client";

--- a/clients/client-apigatewayv2/runtimeConfig.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-apigatewayv2/runtimeConfig.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-app-mesh/runtimeConfig.browser.ts
+++ b/clients/client-app-mesh/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-app-mesh/runtimeConfig.browser.ts
+++ b/clients/client-app-mesh/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-app-mesh/runtimeConfig.native.ts
+++ b/clients/client-app-mesh/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppMeshClient";

--- a/clients/client-app-mesh/runtimeConfig.native.ts
+++ b/clients/client-app-mesh/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppMeshClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-app-mesh/runtimeConfig.ts
+++ b/clients/client-app-mesh/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-app-mesh/runtimeConfig.ts
+++ b/clients/client-app-mesh/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-appconfig/runtimeConfig.browser.ts
+++ b/clients/client-appconfig/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-appconfig/runtimeConfig.browser.ts
+++ b/clients/client-appconfig/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-appconfig/runtimeConfig.native.ts
+++ b/clients/client-appconfig/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppConfigClient";

--- a/clients/client-appconfig/runtimeConfig.native.ts
+++ b/clients/client-appconfig/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppConfigClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-appconfig/runtimeConfig.ts
+++ b/clients/client-appconfig/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-appconfig/runtimeConfig.ts
+++ b/clients/client-appconfig/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-application-auto-scaling/runtimeConfig.browser.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-application-auto-scaling/runtimeConfig.browser.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-application-auto-scaling/runtimeConfig.native.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApplicationAutoScalingClient";

--- a/clients/client-application-auto-scaling/runtimeConfig.native.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApplicationAutoScalingClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-application-auto-scaling/runtimeConfig.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-application-auto-scaling/runtimeConfig.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-application-discovery-service/runtimeConfig.browser.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-application-discovery-service/runtimeConfig.browser.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-application-discovery-service/runtimeConfig.native.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApplicationDiscoveryServiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-application-discovery-service/runtimeConfig.native.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApplicationDiscoveryServiceClient";

--- a/clients/client-application-discovery-service/runtimeConfig.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-application-discovery-service/runtimeConfig.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-application-insights/runtimeConfig.browser.ts
+++ b/clients/client-application-insights/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-application-insights/runtimeConfig.browser.ts
+++ b/clients/client-application-insights/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-application-insights/runtimeConfig.native.ts
+++ b/clients/client-application-insights/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApplicationInsightsClient";

--- a/clients/client-application-insights/runtimeConfig.native.ts
+++ b/clients/client-application-insights/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ApplicationInsightsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-application-insights/runtimeConfig.ts
+++ b/clients/client-application-insights/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-application-insights/runtimeConfig.ts
+++ b/clients/client-application-insights/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-appstream/runtimeConfig.browser.ts
+++ b/clients/client-appstream/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-appstream/runtimeConfig.browser.ts
+++ b/clients/client-appstream/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-appstream/runtimeConfig.native.ts
+++ b/clients/client-appstream/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppStreamClient";

--- a/clients/client-appstream/runtimeConfig.native.ts
+++ b/clients/client-appstream/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppStreamClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-appstream/runtimeConfig.ts
+++ b/clients/client-appstream/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-appstream/runtimeConfig.ts
+++ b/clients/client-appstream/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-appsync/runtimeConfig.browser.ts
+++ b/clients/client-appsync/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-appsync/runtimeConfig.browser.ts
+++ b/clients/client-appsync/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-appsync/runtimeConfig.native.ts
+++ b/clients/client-appsync/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppSyncClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-appsync/runtimeConfig.native.ts
+++ b/clients/client-appsync/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AppSyncClient";

--- a/clients/client-appsync/runtimeConfig.ts
+++ b/clients/client-appsync/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-appsync/runtimeConfig.ts
+++ b/clients/client-appsync/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-athena/runtimeConfig.browser.ts
+++ b/clients/client-athena/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-athena/runtimeConfig.browser.ts
+++ b/clients/client-athena/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-athena/runtimeConfig.native.ts
+++ b/clients/client-athena/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AthenaClient";

--- a/clients/client-athena/runtimeConfig.native.ts
+++ b/clients/client-athena/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AthenaClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-athena/runtimeConfig.ts
+++ b/clients/client-athena/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-athena/runtimeConfig.ts
+++ b/clients/client-athena/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-auto-scaling-plans/runtimeConfig.browser.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-auto-scaling-plans/runtimeConfig.browser.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-auto-scaling-plans/runtimeConfig.native.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AutoScalingPlansClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-auto-scaling-plans/runtimeConfig.native.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AutoScalingPlansClient";

--- a/clients/client-auto-scaling-plans/runtimeConfig.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-auto-scaling-plans/runtimeConfig.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-auto-scaling/runtimeConfig.browser.ts
+++ b/clients/client-auto-scaling/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-auto-scaling/runtimeConfig.browser.ts
+++ b/clients/client-auto-scaling/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-auto-scaling/runtimeConfig.native.ts
+++ b/clients/client-auto-scaling/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AutoScalingClient";

--- a/clients/client-auto-scaling/runtimeConfig.native.ts
+++ b/clients/client-auto-scaling/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./AutoScalingClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-auto-scaling/runtimeConfig.ts
+++ b/clients/client-auto-scaling/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-auto-scaling/runtimeConfig.ts
+++ b/clients/client-auto-scaling/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-backup/runtimeConfig.browser.ts
+++ b/clients/client-backup/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-backup/runtimeConfig.browser.ts
+++ b/clients/client-backup/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-backup/runtimeConfig.native.ts
+++ b/clients/client-backup/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BackupClient";

--- a/clients/client-backup/runtimeConfig.native.ts
+++ b/clients/client-backup/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BackupClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-backup/runtimeConfig.ts
+++ b/clients/client-backup/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-backup/runtimeConfig.ts
+++ b/clients/client-backup/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-batch/runtimeConfig.browser.ts
+++ b/clients/client-batch/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-batch/runtimeConfig.browser.ts
+++ b/clients/client-batch/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-batch/runtimeConfig.native.ts
+++ b/clients/client-batch/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BatchClient";

--- a/clients/client-batch/runtimeConfig.native.ts
+++ b/clients/client-batch/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BatchClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-batch/runtimeConfig.ts
+++ b/clients/client-batch/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-batch/runtimeConfig.ts
+++ b/clients/client-batch/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-braket/runtimeConfig.browser.ts
+++ b/clients/client-braket/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-braket/runtimeConfig.browser.ts
+++ b/clients/client-braket/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-braket/runtimeConfig.native.ts
+++ b/clients/client-braket/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BraketClient";

--- a/clients/client-braket/runtimeConfig.native.ts
+++ b/clients/client-braket/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BraketClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-braket/runtimeConfig.ts
+++ b/clients/client-braket/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-braket/runtimeConfig.ts
+++ b/clients/client-braket/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-budgets/runtimeConfig.browser.ts
+++ b/clients/client-budgets/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-budgets/runtimeConfig.browser.ts
+++ b/clients/client-budgets/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-budgets/runtimeConfig.native.ts
+++ b/clients/client-budgets/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BudgetsClient";

--- a/clients/client-budgets/runtimeConfig.native.ts
+++ b/clients/client-budgets/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./BudgetsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-budgets/runtimeConfig.ts
+++ b/clients/client-budgets/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-budgets/runtimeConfig.ts
+++ b/clients/client-budgets/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-chime/runtimeConfig.browser.ts
+++ b/clients/client-chime/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-chime/runtimeConfig.browser.ts
+++ b/clients/client-chime/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-chime/runtimeConfig.native.ts
+++ b/clients/client-chime/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ChimeClient";

--- a/clients/client-chime/runtimeConfig.native.ts
+++ b/clients/client-chime/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ChimeClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-chime/runtimeConfig.ts
+++ b/clients/client-chime/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-chime/runtimeConfig.ts
+++ b/clients/client-chime/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloud9/runtimeConfig.browser.ts
+++ b/clients/client-cloud9/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloud9/runtimeConfig.browser.ts
+++ b/clients/client-cloud9/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloud9/runtimeConfig.native.ts
+++ b/clients/client-cloud9/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Cloud9Client";

--- a/clients/client-cloud9/runtimeConfig.native.ts
+++ b/clients/client-cloud9/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Cloud9Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloud9/runtimeConfig.ts
+++ b/clients/client-cloud9/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloud9/runtimeConfig.ts
+++ b/clients/client-cloud9/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-clouddirectory/runtimeConfig.browser.ts
+++ b/clients/client-clouddirectory/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-clouddirectory/runtimeConfig.browser.ts
+++ b/clients/client-clouddirectory/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-clouddirectory/runtimeConfig.native.ts
+++ b/clients/client-clouddirectory/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudDirectoryClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-clouddirectory/runtimeConfig.native.ts
+++ b/clients/client-clouddirectory/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudDirectoryClient";

--- a/clients/client-clouddirectory/runtimeConfig.ts
+++ b/clients/client-clouddirectory/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-clouddirectory/runtimeConfig.ts
+++ b/clients/client-clouddirectory/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloudformation/runtimeConfig.browser.ts
+++ b/clients/client-cloudformation/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloudformation/runtimeConfig.browser.ts
+++ b/clients/client-cloudformation/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloudformation/runtimeConfig.native.ts
+++ b/clients/client-cloudformation/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudFormationClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloudformation/runtimeConfig.native.ts
+++ b/clients/client-cloudformation/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudFormationClient";

--- a/clients/client-cloudformation/runtimeConfig.ts
+++ b/clients/client-cloudformation/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloudformation/runtimeConfig.ts
+++ b/clients/client-cloudformation/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloudfront/runtimeConfig.browser.ts
+++ b/clients/client-cloudfront/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloudfront/runtimeConfig.browser.ts
+++ b/clients/client-cloudfront/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloudfront/runtimeConfig.native.ts
+++ b/clients/client-cloudfront/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudFrontClient";

--- a/clients/client-cloudfront/runtimeConfig.native.ts
+++ b/clients/client-cloudfront/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudFrontClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloudfront/runtimeConfig.ts
+++ b/clients/client-cloudfront/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloudfront/runtimeConfig.ts
+++ b/clients/client-cloudfront/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloudhsm-v2/runtimeConfig.browser.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloudhsm-v2/runtimeConfig.browser.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloudhsm-v2/runtimeConfig.native.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudHSMV2Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloudhsm-v2/runtimeConfig.native.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudHSMV2Client";

--- a/clients/client-cloudhsm-v2/runtimeConfig.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloudhsm-v2/runtimeConfig.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloudhsm/runtimeConfig.browser.ts
+++ b/clients/client-cloudhsm/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloudhsm/runtimeConfig.browser.ts
+++ b/clients/client-cloudhsm/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloudhsm/runtimeConfig.native.ts
+++ b/clients/client-cloudhsm/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudHSMClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloudhsm/runtimeConfig.native.ts
+++ b/clients/client-cloudhsm/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudHSMClient";

--- a/clients/client-cloudhsm/runtimeConfig.ts
+++ b/clients/client-cloudhsm/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloudhsm/runtimeConfig.ts
+++ b/clients/client-cloudhsm/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloudsearch-domain/runtimeConfig.browser.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloudsearch-domain/runtimeConfig.browser.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloudsearch-domain/runtimeConfig.native.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudSearchDomainClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloudsearch-domain/runtimeConfig.native.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudSearchDomainClient";

--- a/clients/client-cloudsearch-domain/runtimeConfig.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloudsearch-domain/runtimeConfig.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloudsearch/runtimeConfig.browser.ts
+++ b/clients/client-cloudsearch/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloudsearch/runtimeConfig.browser.ts
+++ b/clients/client-cloudsearch/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloudsearch/runtimeConfig.native.ts
+++ b/clients/client-cloudsearch/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudSearchClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloudsearch/runtimeConfig.native.ts
+++ b/clients/client-cloudsearch/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudSearchClient";

--- a/clients/client-cloudsearch/runtimeConfig.ts
+++ b/clients/client-cloudsearch/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloudsearch/runtimeConfig.ts
+++ b/clients/client-cloudsearch/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloudtrail/runtimeConfig.browser.ts
+++ b/clients/client-cloudtrail/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloudtrail/runtimeConfig.browser.ts
+++ b/clients/client-cloudtrail/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloudtrail/runtimeConfig.native.ts
+++ b/clients/client-cloudtrail/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudTrailClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloudtrail/runtimeConfig.native.ts
+++ b/clients/client-cloudtrail/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudTrailClient";

--- a/clients/client-cloudtrail/runtimeConfig.ts
+++ b/clients/client-cloudtrail/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloudtrail/runtimeConfig.ts
+++ b/clients/client-cloudtrail/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloudwatch-events/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloudwatch-events/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloudwatch-events/runtimeConfig.native.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudWatchEventsClient";

--- a/clients/client-cloudwatch-events/runtimeConfig.native.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudWatchEventsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloudwatch-events/runtimeConfig.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloudwatch-events/runtimeConfig.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloudwatch-logs/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloudwatch-logs/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloudwatch-logs/runtimeConfig.native.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudWatchLogsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloudwatch-logs/runtimeConfig.native.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudWatchLogsClient";

--- a/clients/client-cloudwatch-logs/runtimeConfig.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloudwatch-logs/runtimeConfig.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cloudwatch/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cloudwatch/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cloudwatch/runtimeConfig.native.ts
+++ b/clients/client-cloudwatch/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudWatchClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cloudwatch/runtimeConfig.native.ts
+++ b/clients/client-cloudwatch/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CloudWatchClient";

--- a/clients/client-cloudwatch/runtimeConfig.ts
+++ b/clients/client-cloudwatch/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cloudwatch/runtimeConfig.ts
+++ b/clients/client-cloudwatch/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-codeartifact/runtimeConfig.browser.ts
+++ b/clients/client-codeartifact/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-codeartifact/runtimeConfig.browser.ts
+++ b/clients/client-codeartifact/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-codeartifact/runtimeConfig.native.ts
+++ b/clients/client-codeartifact/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeartifactClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-codeartifact/runtimeConfig.native.ts
+++ b/clients/client-codeartifact/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeartifactClient";

--- a/clients/client-codeartifact/runtimeConfig.ts
+++ b/clients/client-codeartifact/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-codeartifact/runtimeConfig.ts
+++ b/clients/client-codeartifact/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-codebuild/runtimeConfig.browser.ts
+++ b/clients/client-codebuild/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-codebuild/runtimeConfig.browser.ts
+++ b/clients/client-codebuild/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-codebuild/runtimeConfig.native.ts
+++ b/clients/client-codebuild/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeBuildClient";

--- a/clients/client-codebuild/runtimeConfig.native.ts
+++ b/clients/client-codebuild/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeBuildClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-codebuild/runtimeConfig.ts
+++ b/clients/client-codebuild/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-codebuild/runtimeConfig.ts
+++ b/clients/client-codebuild/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-codecommit/runtimeConfig.browser.ts
+++ b/clients/client-codecommit/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-codecommit/runtimeConfig.browser.ts
+++ b/clients/client-codecommit/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-codecommit/runtimeConfig.native.ts
+++ b/clients/client-codecommit/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeCommitClient";

--- a/clients/client-codecommit/runtimeConfig.native.ts
+++ b/clients/client-codecommit/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeCommitClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-codecommit/runtimeConfig.ts
+++ b/clients/client-codecommit/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-codecommit/runtimeConfig.ts
+++ b/clients/client-codecommit/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-codedeploy/runtimeConfig.browser.ts
+++ b/clients/client-codedeploy/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-codedeploy/runtimeConfig.browser.ts
+++ b/clients/client-codedeploy/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-codedeploy/runtimeConfig.native.ts
+++ b/clients/client-codedeploy/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeDeployClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-codedeploy/runtimeConfig.native.ts
+++ b/clients/client-codedeploy/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeDeployClient";

--- a/clients/client-codedeploy/runtimeConfig.ts
+++ b/clients/client-codedeploy/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-codedeploy/runtimeConfig.ts
+++ b/clients/client-codedeploy/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-codeguru-reviewer/runtimeConfig.browser.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-codeguru-reviewer/runtimeConfig.browser.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-codeguru-reviewer/runtimeConfig.native.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeGuruReviewerClient";

--- a/clients/client-codeguru-reviewer/runtimeConfig.native.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeGuruReviewerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-codeguru-reviewer/runtimeConfig.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-codeguru-reviewer/runtimeConfig.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-codeguruprofiler/runtimeConfig.browser.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-codeguruprofiler/runtimeConfig.browser.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-codeguruprofiler/runtimeConfig.native.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeGuruProfilerClient";

--- a/clients/client-codeguruprofiler/runtimeConfig.native.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeGuruProfilerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-codeguruprofiler/runtimeConfig.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-codeguruprofiler/runtimeConfig.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-codepipeline/runtimeConfig.browser.ts
+++ b/clients/client-codepipeline/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-codepipeline/runtimeConfig.browser.ts
+++ b/clients/client-codepipeline/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-codepipeline/runtimeConfig.native.ts
+++ b/clients/client-codepipeline/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodePipelineClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-codepipeline/runtimeConfig.native.ts
+++ b/clients/client-codepipeline/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodePipelineClient";

--- a/clients/client-codepipeline/runtimeConfig.ts
+++ b/clients/client-codepipeline/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-codepipeline/runtimeConfig.ts
+++ b/clients/client-codepipeline/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-codestar-connections/runtimeConfig.browser.ts
+++ b/clients/client-codestar-connections/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-codestar-connections/runtimeConfig.browser.ts
+++ b/clients/client-codestar-connections/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-codestar-connections/runtimeConfig.native.ts
+++ b/clients/client-codestar-connections/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeStarConnectionsClient";

--- a/clients/client-codestar-connections/runtimeConfig.native.ts
+++ b/clients/client-codestar-connections/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeStarConnectionsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-codestar-connections/runtimeConfig.ts
+++ b/clients/client-codestar-connections/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-codestar-connections/runtimeConfig.ts
+++ b/clients/client-codestar-connections/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-codestar-notifications/runtimeConfig.browser.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-codestar-notifications/runtimeConfig.browser.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-codestar-notifications/runtimeConfig.native.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodestarNotificationsClient";

--- a/clients/client-codestar-notifications/runtimeConfig.native.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodestarNotificationsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-codestar-notifications/runtimeConfig.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-codestar-notifications/runtimeConfig.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-codestar/runtimeConfig.browser.ts
+++ b/clients/client-codestar/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-codestar/runtimeConfig.browser.ts
+++ b/clients/client-codestar/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-codestar/runtimeConfig.native.ts
+++ b/clients/client-codestar/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeStarClient";

--- a/clients/client-codestar/runtimeConfig.native.ts
+++ b/clients/client-codestar/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CodeStarClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-codestar/runtimeConfig.ts
+++ b/clients/client-codestar/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-codestar/runtimeConfig.ts
+++ b/clients/client-codestar/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cognito-identity-provider/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cognito-identity-provider/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cognito-identity-provider/runtimeConfig.native.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CognitoIdentityProviderClient";

--- a/clients/client-cognito-identity-provider/runtimeConfig.native.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CognitoIdentityProviderClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cognito-identity-provider/runtimeConfig.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cognito-identity-provider/runtimeConfig.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cognito-identity/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cognito-identity/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: (() => {}) as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cognito-identity/runtimeConfig.native.ts
+++ b/clients/client-cognito-identity/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CognitoIdentityClient";

--- a/clients/client-cognito-identity/runtimeConfig.native.ts
+++ b/clients/client-cognito-identity/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CognitoIdentityClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cognito-identity/runtimeConfig.ts
+++ b/clients/client-cognito-identity/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cognito-identity/runtimeConfig.ts
+++ b/clients/client-cognito-identity/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -25,7 +25,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
     } catch (e) {}
     return {};
   }) as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cognito-sync/runtimeConfig.browser.ts
+++ b/clients/client-cognito-sync/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cognito-sync/runtimeConfig.browser.ts
+++ b/clients/client-cognito-sync/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cognito-sync/runtimeConfig.native.ts
+++ b/clients/client-cognito-sync/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CognitoSyncClient";

--- a/clients/client-cognito-sync/runtimeConfig.native.ts
+++ b/clients/client-cognito-sync/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CognitoSyncClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cognito-sync/runtimeConfig.ts
+++ b/clients/client-cognito-sync/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cognito-sync/runtimeConfig.ts
+++ b/clients/client-cognito-sync/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-comprehend/runtimeConfig.browser.ts
+++ b/clients/client-comprehend/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-comprehend/runtimeConfig.browser.ts
+++ b/clients/client-comprehend/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-comprehend/runtimeConfig.native.ts
+++ b/clients/client-comprehend/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ComprehendClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-comprehend/runtimeConfig.native.ts
+++ b/clients/client-comprehend/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ComprehendClient";

--- a/clients/client-comprehend/runtimeConfig.ts
+++ b/clients/client-comprehend/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-comprehend/runtimeConfig.ts
+++ b/clients/client-comprehend/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-comprehendmedical/runtimeConfig.browser.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-comprehendmedical/runtimeConfig.browser.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-comprehendmedical/runtimeConfig.native.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ComprehendMedicalClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-comprehendmedical/runtimeConfig.native.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ComprehendMedicalClient";

--- a/clients/client-comprehendmedical/runtimeConfig.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-comprehendmedical/runtimeConfig.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-compute-optimizer/runtimeConfig.browser.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-compute-optimizer/runtimeConfig.browser.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-compute-optimizer/runtimeConfig.native.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ComputeOptimizerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-compute-optimizer/runtimeConfig.native.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ComputeOptimizerClient";

--- a/clients/client-compute-optimizer/runtimeConfig.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-compute-optimizer/runtimeConfig.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-config-service/runtimeConfig.browser.ts
+++ b/clients/client-config-service/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-config-service/runtimeConfig.browser.ts
+++ b/clients/client-config-service/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-config-service/runtimeConfig.native.ts
+++ b/clients/client-config-service/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ConfigServiceClient";

--- a/clients/client-config-service/runtimeConfig.native.ts
+++ b/clients/client-config-service/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ConfigServiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-config-service/runtimeConfig.ts
+++ b/clients/client-config-service/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-config-service/runtimeConfig.ts
+++ b/clients/client-config-service/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-connect/runtimeConfig.browser.ts
+++ b/clients/client-connect/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-connect/runtimeConfig.browser.ts
+++ b/clients/client-connect/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-connect/runtimeConfig.native.ts
+++ b/clients/client-connect/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ConnectClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-connect/runtimeConfig.native.ts
+++ b/clients/client-connect/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ConnectClient";

--- a/clients/client-connect/runtimeConfig.ts
+++ b/clients/client-connect/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-connect/runtimeConfig.ts
+++ b/clients/client-connect/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-connectparticipant/runtimeConfig.browser.ts
+++ b/clients/client-connectparticipant/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-connectparticipant/runtimeConfig.browser.ts
+++ b/clients/client-connectparticipant/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-connectparticipant/runtimeConfig.native.ts
+++ b/clients/client-connectparticipant/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ConnectParticipantClient";

--- a/clients/client-connectparticipant/runtimeConfig.native.ts
+++ b/clients/client-connectparticipant/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ConnectParticipantClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-connectparticipant/runtimeConfig.ts
+++ b/clients/client-connectparticipant/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-connectparticipant/runtimeConfig.ts
+++ b/clients/client-connectparticipant/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.browser.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.browser.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.native.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CostAndUsageReportServiceClient";

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.native.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CostAndUsageReportServiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-cost-explorer/runtimeConfig.browser.ts
+++ b/clients/client-cost-explorer/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-cost-explorer/runtimeConfig.browser.ts
+++ b/clients/client-cost-explorer/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-cost-explorer/runtimeConfig.native.ts
+++ b/clients/client-cost-explorer/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CostExplorerClient";

--- a/clients/client-cost-explorer/runtimeConfig.native.ts
+++ b/clients/client-cost-explorer/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./CostExplorerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-cost-explorer/runtimeConfig.ts
+++ b/clients/client-cost-explorer/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-cost-explorer/runtimeConfig.ts
+++ b/clients/client-cost-explorer/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-data-pipeline/runtimeConfig.browser.ts
+++ b/clients/client-data-pipeline/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-data-pipeline/runtimeConfig.browser.ts
+++ b/clients/client-data-pipeline/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-data-pipeline/runtimeConfig.native.ts
+++ b/clients/client-data-pipeline/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DataPipelineClient";

--- a/clients/client-data-pipeline/runtimeConfig.native.ts
+++ b/clients/client-data-pipeline/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DataPipelineClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-data-pipeline/runtimeConfig.ts
+++ b/clients/client-data-pipeline/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-data-pipeline/runtimeConfig.ts
+++ b/clients/client-data-pipeline/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-database-migration-service/runtimeConfig.browser.ts
+++ b/clients/client-database-migration-service/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-database-migration-service/runtimeConfig.browser.ts
+++ b/clients/client-database-migration-service/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-database-migration-service/runtimeConfig.native.ts
+++ b/clients/client-database-migration-service/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DatabaseMigrationServiceClient";

--- a/clients/client-database-migration-service/runtimeConfig.native.ts
+++ b/clients/client-database-migration-service/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DatabaseMigrationServiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-database-migration-service/runtimeConfig.ts
+++ b/clients/client-database-migration-service/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-database-migration-service/runtimeConfig.ts
+++ b/clients/client-database-migration-service/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-dataexchange/runtimeConfig.browser.ts
+++ b/clients/client-dataexchange/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-dataexchange/runtimeConfig.browser.ts
+++ b/clients/client-dataexchange/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-dataexchange/runtimeConfig.native.ts
+++ b/clients/client-dataexchange/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DataExchangeClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-dataexchange/runtimeConfig.native.ts
+++ b/clients/client-dataexchange/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DataExchangeClient";

--- a/clients/client-dataexchange/runtimeConfig.ts
+++ b/clients/client-dataexchange/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-dataexchange/runtimeConfig.ts
+++ b/clients/client-dataexchange/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-datasync/runtimeConfig.browser.ts
+++ b/clients/client-datasync/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-datasync/runtimeConfig.browser.ts
+++ b/clients/client-datasync/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-datasync/runtimeConfig.native.ts
+++ b/clients/client-datasync/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DataSyncClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-datasync/runtimeConfig.native.ts
+++ b/clients/client-datasync/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DataSyncClient";

--- a/clients/client-datasync/runtimeConfig.ts
+++ b/clients/client-datasync/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-datasync/runtimeConfig.ts
+++ b/clients/client-datasync/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-dax/runtimeConfig.browser.ts
+++ b/clients/client-dax/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-dax/runtimeConfig.browser.ts
+++ b/clients/client-dax/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-dax/runtimeConfig.native.ts
+++ b/clients/client-dax/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DAXClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-dax/runtimeConfig.native.ts
+++ b/clients/client-dax/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DAXClient";

--- a/clients/client-dax/runtimeConfig.ts
+++ b/clients/client-dax/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-dax/runtimeConfig.ts
+++ b/clients/client-dax/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-detective/runtimeConfig.browser.ts
+++ b/clients/client-detective/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-detective/runtimeConfig.browser.ts
+++ b/clients/client-detective/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-detective/runtimeConfig.native.ts
+++ b/clients/client-detective/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DetectiveClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-detective/runtimeConfig.native.ts
+++ b/clients/client-detective/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DetectiveClient";

--- a/clients/client-detective/runtimeConfig.ts
+++ b/clients/client-detective/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-detective/runtimeConfig.ts
+++ b/clients/client-detective/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-device-farm/runtimeConfig.browser.ts
+++ b/clients/client-device-farm/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-device-farm/runtimeConfig.browser.ts
+++ b/clients/client-device-farm/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-device-farm/runtimeConfig.native.ts
+++ b/clients/client-device-farm/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DeviceFarmClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-device-farm/runtimeConfig.native.ts
+++ b/clients/client-device-farm/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DeviceFarmClient";

--- a/clients/client-device-farm/runtimeConfig.ts
+++ b/clients/client-device-farm/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-device-farm/runtimeConfig.ts
+++ b/clients/client-device-farm/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-direct-connect/runtimeConfig.browser.ts
+++ b/clients/client-direct-connect/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-direct-connect/runtimeConfig.browser.ts
+++ b/clients/client-direct-connect/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-direct-connect/runtimeConfig.native.ts
+++ b/clients/client-direct-connect/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DirectConnectClient";

--- a/clients/client-direct-connect/runtimeConfig.native.ts
+++ b/clients/client-direct-connect/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DirectConnectClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-direct-connect/runtimeConfig.ts
+++ b/clients/client-direct-connect/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-direct-connect/runtimeConfig.ts
+++ b/clients/client-direct-connect/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-directory-service/runtimeConfig.browser.ts
+++ b/clients/client-directory-service/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-directory-service/runtimeConfig.browser.ts
+++ b/clients/client-directory-service/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-directory-service/runtimeConfig.native.ts
+++ b/clients/client-directory-service/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DirectoryServiceClient";

--- a/clients/client-directory-service/runtimeConfig.native.ts
+++ b/clients/client-directory-service/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DirectoryServiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-directory-service/runtimeConfig.ts
+++ b/clients/client-directory-service/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-directory-service/runtimeConfig.ts
+++ b/clients/client-directory-service/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-dlm/runtimeConfig.browser.ts
+++ b/clients/client-dlm/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-dlm/runtimeConfig.browser.ts
+++ b/clients/client-dlm/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-dlm/runtimeConfig.native.ts
+++ b/clients/client-dlm/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DLMClient";

--- a/clients/client-dlm/runtimeConfig.native.ts
+++ b/clients/client-dlm/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DLMClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-dlm/runtimeConfig.ts
+++ b/clients/client-dlm/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-dlm/runtimeConfig.ts
+++ b/clients/client-dlm/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-docdb/runtimeConfig.browser.ts
+++ b/clients/client-docdb/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-docdb/runtimeConfig.browser.ts
+++ b/clients/client-docdb/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-docdb/runtimeConfig.native.ts
+++ b/clients/client-docdb/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DocDBClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-docdb/runtimeConfig.native.ts
+++ b/clients/client-docdb/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DocDBClient";

--- a/clients/client-docdb/runtimeConfig.ts
+++ b/clients/client-docdb/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-docdb/runtimeConfig.ts
+++ b/clients/client-docdb/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-dynamodb-streams/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-dynamodb-streams/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-dynamodb-streams/runtimeConfig.native.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DynamoDBStreamsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-dynamodb-streams/runtimeConfig.native.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DynamoDBStreamsClient";

--- a/clients/client-dynamodb-streams/runtimeConfig.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-dynamodb-streams/runtimeConfig.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-dynamodb/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-dynamodb/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-dynamodb/runtimeConfig.native.ts
+++ b/clients/client-dynamodb/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DynamoDBClient";

--- a/clients/client-dynamodb/runtimeConfig.native.ts
+++ b/clients/client-dynamodb/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./DynamoDBClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-dynamodb/runtimeConfig.ts
+++ b/clients/client-dynamodb/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-dynamodb/runtimeConfig.ts
+++ b/clients/client-dynamodb/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-ebs/runtimeConfig.browser.ts
+++ b/clients/client-ebs/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-ebs/runtimeConfig.browser.ts
+++ b/clients/client-ebs/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-ebs/runtimeConfig.native.ts
+++ b/clients/client-ebs/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EBSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-ebs/runtimeConfig.native.ts
+++ b/clients/client-ebs/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EBSClient";

--- a/clients/client-ebs/runtimeConfig.ts
+++ b/clients/client-ebs/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-ebs/runtimeConfig.ts
+++ b/clients/client-ebs/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-ec2-instance-connect/runtimeConfig.browser.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-ec2-instance-connect/runtimeConfig.browser.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-ec2-instance-connect/runtimeConfig.native.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EC2InstanceConnectClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-ec2-instance-connect/runtimeConfig.native.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EC2InstanceConnectClient";

--- a/clients/client-ec2-instance-connect/runtimeConfig.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-ec2-instance-connect/runtimeConfig.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-ec2/runtimeConfig.browser.ts
+++ b/clients/client-ec2/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-ec2/runtimeConfig.browser.ts
+++ b/clients/client-ec2/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-ec2/runtimeConfig.native.ts
+++ b/clients/client-ec2/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EC2Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-ec2/runtimeConfig.native.ts
+++ b/clients/client-ec2/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EC2Client";

--- a/clients/client-ec2/runtimeConfig.ts
+++ b/clients/client-ec2/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-ec2/runtimeConfig.ts
+++ b/clients/client-ec2/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-ecr/runtimeConfig.browser.ts
+++ b/clients/client-ecr/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-ecr/runtimeConfig.browser.ts
+++ b/clients/client-ecr/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-ecr/runtimeConfig.native.ts
+++ b/clients/client-ecr/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ECRClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-ecr/runtimeConfig.native.ts
+++ b/clients/client-ecr/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ECRClient";

--- a/clients/client-ecr/runtimeConfig.ts
+++ b/clients/client-ecr/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-ecr/runtimeConfig.ts
+++ b/clients/client-ecr/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-ecs/runtimeConfig.browser.ts
+++ b/clients/client-ecs/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-ecs/runtimeConfig.browser.ts
+++ b/clients/client-ecs/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-ecs/runtimeConfig.native.ts
+++ b/clients/client-ecs/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ECSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-ecs/runtimeConfig.native.ts
+++ b/clients/client-ecs/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ECSClient";

--- a/clients/client-ecs/runtimeConfig.ts
+++ b/clients/client-ecs/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-ecs/runtimeConfig.ts
+++ b/clients/client-ecs/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-efs/runtimeConfig.browser.ts
+++ b/clients/client-efs/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-efs/runtimeConfig.browser.ts
+++ b/clients/client-efs/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-efs/runtimeConfig.native.ts
+++ b/clients/client-efs/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EFSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-efs/runtimeConfig.native.ts
+++ b/clients/client-efs/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EFSClient";

--- a/clients/client-efs/runtimeConfig.ts
+++ b/clients/client-efs/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-efs/runtimeConfig.ts
+++ b/clients/client-efs/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-eks/runtimeConfig.browser.ts
+++ b/clients/client-eks/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-eks/runtimeConfig.browser.ts
+++ b/clients/client-eks/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-eks/runtimeConfig.native.ts
+++ b/clients/client-eks/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EKSClient";

--- a/clients/client-eks/runtimeConfig.native.ts
+++ b/clients/client-eks/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EKSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-eks/runtimeConfig.ts
+++ b/clients/client-eks/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-eks/runtimeConfig.ts
+++ b/clients/client-eks/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-elastic-beanstalk/runtimeConfig.browser.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-elastic-beanstalk/runtimeConfig.browser.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-elastic-beanstalk/runtimeConfig.native.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticBeanstalkClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-elastic-beanstalk/runtimeConfig.native.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticBeanstalkClient";

--- a/clients/client-elastic-beanstalk/runtimeConfig.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-elastic-beanstalk/runtimeConfig.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-elastic-inference/runtimeConfig.browser.ts
+++ b/clients/client-elastic-inference/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-elastic-inference/runtimeConfig.browser.ts
+++ b/clients/client-elastic-inference/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-elastic-inference/runtimeConfig.native.ts
+++ b/clients/client-elastic-inference/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticInferenceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-elastic-inference/runtimeConfig.native.ts
+++ b/clients/client-elastic-inference/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticInferenceClient";

--- a/clients/client-elastic-inference/runtimeConfig.ts
+++ b/clients/client-elastic-inference/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-elastic-inference/runtimeConfig.ts
+++ b/clients/client-elastic-inference/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.browser.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.browser.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.native.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticLoadBalancingV2Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.native.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticLoadBalancingV2Client";

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-elastic-load-balancing/runtimeConfig.browser.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-elastic-load-balancing/runtimeConfig.browser.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-elastic-load-balancing/runtimeConfig.native.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticLoadBalancingClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-elastic-load-balancing/runtimeConfig.native.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticLoadBalancingClient";

--- a/clients/client-elastic-load-balancing/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-elastic-load-balancing/runtimeConfig.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-elastic-transcoder/runtimeConfig.browser.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-elastic-transcoder/runtimeConfig.browser.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-elastic-transcoder/runtimeConfig.native.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticTranscoderClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-elastic-transcoder/runtimeConfig.native.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticTranscoderClient";

--- a/clients/client-elastic-transcoder/runtimeConfig.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-elastic-transcoder/runtimeConfig.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-elasticache/runtimeConfig.browser.ts
+++ b/clients/client-elasticache/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-elasticache/runtimeConfig.browser.ts
+++ b/clients/client-elasticache/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-elasticache/runtimeConfig.native.ts
+++ b/clients/client-elasticache/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElastiCacheClient";

--- a/clients/client-elasticache/runtimeConfig.native.ts
+++ b/clients/client-elasticache/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElastiCacheClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-elasticache/runtimeConfig.ts
+++ b/clients/client-elasticache/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-elasticache/runtimeConfig.ts
+++ b/clients/client-elasticache/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-elasticsearch-service/runtimeConfig.browser.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-elasticsearch-service/runtimeConfig.browser.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-elasticsearch-service/runtimeConfig.native.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticsearchServiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-elasticsearch-service/runtimeConfig.native.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ElasticsearchServiceClient";

--- a/clients/client-elasticsearch-service/runtimeConfig.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-elasticsearch-service/runtimeConfig.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-emr/runtimeConfig.browser.ts
+++ b/clients/client-emr/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-emr/runtimeConfig.browser.ts
+++ b/clients/client-emr/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-emr/runtimeConfig.native.ts
+++ b/clients/client-emr/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EMRClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-emr/runtimeConfig.native.ts
+++ b/clients/client-emr/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EMRClient";

--- a/clients/client-emr/runtimeConfig.ts
+++ b/clients/client-emr/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-emr/runtimeConfig.ts
+++ b/clients/client-emr/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-eventbridge/runtimeConfig.browser.ts
+++ b/clients/client-eventbridge/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-eventbridge/runtimeConfig.browser.ts
+++ b/clients/client-eventbridge/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-eventbridge/runtimeConfig.native.ts
+++ b/clients/client-eventbridge/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EventBridgeClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-eventbridge/runtimeConfig.native.ts
+++ b/clients/client-eventbridge/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EventBridgeClient";

--- a/clients/client-eventbridge/runtimeConfig.ts
+++ b/clients/client-eventbridge/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-eventbridge/runtimeConfig.ts
+++ b/clients/client-eventbridge/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-firehose/runtimeConfig.browser.ts
+++ b/clients/client-firehose/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-firehose/runtimeConfig.browser.ts
+++ b/clients/client-firehose/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-firehose/runtimeConfig.native.ts
+++ b/clients/client-firehose/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FirehoseClient";

--- a/clients/client-firehose/runtimeConfig.native.ts
+++ b/clients/client-firehose/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FirehoseClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-firehose/runtimeConfig.ts
+++ b/clients/client-firehose/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-firehose/runtimeConfig.ts
+++ b/clients/client-firehose/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-fms/runtimeConfig.browser.ts
+++ b/clients/client-fms/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-fms/runtimeConfig.browser.ts
+++ b/clients/client-fms/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-fms/runtimeConfig.native.ts
+++ b/clients/client-fms/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FMSClient";

--- a/clients/client-fms/runtimeConfig.native.ts
+++ b/clients/client-fms/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FMSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-fms/runtimeConfig.ts
+++ b/clients/client-fms/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-fms/runtimeConfig.ts
+++ b/clients/client-fms/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-forecast/runtimeConfig.browser.ts
+++ b/clients/client-forecast/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-forecast/runtimeConfig.browser.ts
+++ b/clients/client-forecast/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-forecast/runtimeConfig.native.ts
+++ b/clients/client-forecast/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ForecastClient";

--- a/clients/client-forecast/runtimeConfig.native.ts
+++ b/clients/client-forecast/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ForecastClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-forecast/runtimeConfig.ts
+++ b/clients/client-forecast/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-forecast/runtimeConfig.ts
+++ b/clients/client-forecast/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-forecastquery/runtimeConfig.browser.ts
+++ b/clients/client-forecastquery/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-forecastquery/runtimeConfig.browser.ts
+++ b/clients/client-forecastquery/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-forecastquery/runtimeConfig.native.ts
+++ b/clients/client-forecastquery/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ForecastqueryClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-forecastquery/runtimeConfig.native.ts
+++ b/clients/client-forecastquery/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ForecastqueryClient";

--- a/clients/client-forecastquery/runtimeConfig.ts
+++ b/clients/client-forecastquery/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-forecastquery/runtimeConfig.ts
+++ b/clients/client-forecastquery/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-frauddetector/runtimeConfig.browser.ts
+++ b/clients/client-frauddetector/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-frauddetector/runtimeConfig.browser.ts
+++ b/clients/client-frauddetector/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-frauddetector/runtimeConfig.native.ts
+++ b/clients/client-frauddetector/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FraudDetectorClient";

--- a/clients/client-frauddetector/runtimeConfig.native.ts
+++ b/clients/client-frauddetector/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FraudDetectorClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-frauddetector/runtimeConfig.ts
+++ b/clients/client-frauddetector/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-frauddetector/runtimeConfig.ts
+++ b/clients/client-frauddetector/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-fsx/runtimeConfig.browser.ts
+++ b/clients/client-fsx/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-fsx/runtimeConfig.browser.ts
+++ b/clients/client-fsx/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-fsx/runtimeConfig.native.ts
+++ b/clients/client-fsx/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FSxClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-fsx/runtimeConfig.native.ts
+++ b/clients/client-fsx/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./FSxClient";

--- a/clients/client-fsx/runtimeConfig.ts
+++ b/clients/client-fsx/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-fsx/runtimeConfig.ts
+++ b/clients/client-fsx/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-gamelift/runtimeConfig.browser.ts
+++ b/clients/client-gamelift/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-gamelift/runtimeConfig.browser.ts
+++ b/clients/client-gamelift/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-gamelift/runtimeConfig.native.ts
+++ b/clients/client-gamelift/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GameLiftClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-gamelift/runtimeConfig.native.ts
+++ b/clients/client-gamelift/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GameLiftClient";

--- a/clients/client-gamelift/runtimeConfig.ts
+++ b/clients/client-gamelift/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-gamelift/runtimeConfig.ts
+++ b/clients/client-gamelift/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-glacier/runtimeConfig.browser.ts
+++ b/clients/client-glacier/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   bodyChecksumGenerator,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-glacier/runtimeConfig.browser.ts
+++ b/clients/client-glacier/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";

--- a/clients/client-glacier/runtimeConfig.native.ts
+++ b/clients/client-glacier/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GlacierClient";

--- a/clients/client-glacier/runtimeConfig.native.ts
+++ b/clients/client-glacier/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GlacierClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-glacier/runtimeConfig.ts
+++ b/clients/client-glacier/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-node";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
@@ -22,7 +22,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   bodyChecksumGenerator,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-glacier/runtimeConfig.ts
+++ b/clients/client-glacier/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-node";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";

--- a/clients/client-global-accelerator/runtimeConfig.browser.ts
+++ b/clients/client-global-accelerator/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-global-accelerator/runtimeConfig.browser.ts
+++ b/clients/client-global-accelerator/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-global-accelerator/runtimeConfig.native.ts
+++ b/clients/client-global-accelerator/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GlobalAcceleratorClient";

--- a/clients/client-global-accelerator/runtimeConfig.native.ts
+++ b/clients/client-global-accelerator/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GlobalAcceleratorClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-global-accelerator/runtimeConfig.ts
+++ b/clients/client-global-accelerator/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-global-accelerator/runtimeConfig.ts
+++ b/clients/client-global-accelerator/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-glue/runtimeConfig.browser.ts
+++ b/clients/client-glue/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-glue/runtimeConfig.browser.ts
+++ b/clients/client-glue/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-glue/runtimeConfig.native.ts
+++ b/clients/client-glue/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GlueClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-glue/runtimeConfig.native.ts
+++ b/clients/client-glue/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GlueClient";

--- a/clients/client-glue/runtimeConfig.ts
+++ b/clients/client-glue/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-glue/runtimeConfig.ts
+++ b/clients/client-glue/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-greengrass/runtimeConfig.browser.ts
+++ b/clients/client-greengrass/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-greengrass/runtimeConfig.browser.ts
+++ b/clients/client-greengrass/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-greengrass/runtimeConfig.native.ts
+++ b/clients/client-greengrass/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GreengrassClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-greengrass/runtimeConfig.native.ts
+++ b/clients/client-greengrass/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GreengrassClient";

--- a/clients/client-greengrass/runtimeConfig.ts
+++ b/clients/client-greengrass/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-greengrass/runtimeConfig.ts
+++ b/clients/client-greengrass/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-groundstation/runtimeConfig.browser.ts
+++ b/clients/client-groundstation/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-groundstation/runtimeConfig.browser.ts
+++ b/clients/client-groundstation/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-groundstation/runtimeConfig.native.ts
+++ b/clients/client-groundstation/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GroundStationClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-groundstation/runtimeConfig.native.ts
+++ b/clients/client-groundstation/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GroundStationClient";

--- a/clients/client-groundstation/runtimeConfig.ts
+++ b/clients/client-groundstation/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-groundstation/runtimeConfig.ts
+++ b/clients/client-groundstation/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-guardduty/runtimeConfig.browser.ts
+++ b/clients/client-guardduty/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-guardduty/runtimeConfig.browser.ts
+++ b/clients/client-guardduty/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-guardduty/runtimeConfig.native.ts
+++ b/clients/client-guardduty/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GuardDutyClient";

--- a/clients/client-guardduty/runtimeConfig.native.ts
+++ b/clients/client-guardduty/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./GuardDutyClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-guardduty/runtimeConfig.ts
+++ b/clients/client-guardduty/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-guardduty/runtimeConfig.ts
+++ b/clients/client-guardduty/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-health/runtimeConfig.browser.ts
+++ b/clients/client-health/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-health/runtimeConfig.browser.ts
+++ b/clients/client-health/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-health/runtimeConfig.native.ts
+++ b/clients/client-health/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./HealthClient";

--- a/clients/client-health/runtimeConfig.native.ts
+++ b/clients/client-health/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./HealthClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-health/runtimeConfig.ts
+++ b/clients/client-health/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-health/runtimeConfig.ts
+++ b/clients/client-health/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-honeycode/runtimeConfig.browser.ts
+++ b/clients/client-honeycode/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-honeycode/runtimeConfig.browser.ts
+++ b/clients/client-honeycode/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-honeycode/runtimeConfig.native.ts
+++ b/clients/client-honeycode/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./HoneycodeClient";

--- a/clients/client-honeycode/runtimeConfig.native.ts
+++ b/clients/client-honeycode/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./HoneycodeClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-honeycode/runtimeConfig.ts
+++ b/clients/client-honeycode/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-honeycode/runtimeConfig.ts
+++ b/clients/client-honeycode/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iam/runtimeConfig.browser.ts
+++ b/clients/client-iam/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iam/runtimeConfig.browser.ts
+++ b/clients/client-iam/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iam/runtimeConfig.native.ts
+++ b/clients/client-iam/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IAMClient";

--- a/clients/client-iam/runtimeConfig.native.ts
+++ b/clients/client-iam/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IAMClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iam/runtimeConfig.ts
+++ b/clients/client-iam/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iam/runtimeConfig.ts
+++ b/clients/client-iam/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-imagebuilder/runtimeConfig.browser.ts
+++ b/clients/client-imagebuilder/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-imagebuilder/runtimeConfig.browser.ts
+++ b/clients/client-imagebuilder/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-imagebuilder/runtimeConfig.native.ts
+++ b/clients/client-imagebuilder/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ImagebuilderClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-imagebuilder/runtimeConfig.native.ts
+++ b/clients/client-imagebuilder/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ImagebuilderClient";

--- a/clients/client-imagebuilder/runtimeConfig.ts
+++ b/clients/client-imagebuilder/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-imagebuilder/runtimeConfig.ts
+++ b/clients/client-imagebuilder/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-inspector/runtimeConfig.browser.ts
+++ b/clients/client-inspector/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-inspector/runtimeConfig.browser.ts
+++ b/clients/client-inspector/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-inspector/runtimeConfig.native.ts
+++ b/clients/client-inspector/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./InspectorClient";

--- a/clients/client-inspector/runtimeConfig.native.ts
+++ b/clients/client-inspector/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./InspectorClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-inspector/runtimeConfig.ts
+++ b/clients/client-inspector/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-inspector/runtimeConfig.ts
+++ b/clients/client-inspector/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iot-1click-devices-service/runtimeConfig.browser.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iot-1click-devices-service/runtimeConfig.browser.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iot-1click-devices-service/runtimeConfig.native.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoT1ClickDevicesServiceClient";

--- a/clients/client-iot-1click-devices-service/runtimeConfig.native.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoT1ClickDevicesServiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iot-1click-devices-service/runtimeConfig.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iot-1click-devices-service/runtimeConfig.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iot-1click-projects/runtimeConfig.browser.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iot-1click-projects/runtimeConfig.browser.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iot-1click-projects/runtimeConfig.native.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoT1ClickProjectsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iot-1click-projects/runtimeConfig.native.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoT1ClickProjectsClient";

--- a/clients/client-iot-1click-projects/runtimeConfig.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iot-1click-projects/runtimeConfig.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iot-data-plane/runtimeConfig.browser.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iot-data-plane/runtimeConfig.browser.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iot-data-plane/runtimeConfig.native.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTDataPlaneClient";

--- a/clients/client-iot-data-plane/runtimeConfig.native.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTDataPlaneClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iot-data-plane/runtimeConfig.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iot-data-plane/runtimeConfig.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iot-events-data/runtimeConfig.browser.ts
+++ b/clients/client-iot-events-data/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iot-events-data/runtimeConfig.browser.ts
+++ b/clients/client-iot-events-data/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iot-events-data/runtimeConfig.native.ts
+++ b/clients/client-iot-events-data/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTEventsDataClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iot-events-data/runtimeConfig.native.ts
+++ b/clients/client-iot-events-data/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTEventsDataClient";

--- a/clients/client-iot-events-data/runtimeConfig.ts
+++ b/clients/client-iot-events-data/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iot-events-data/runtimeConfig.ts
+++ b/clients/client-iot-events-data/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iot-events/runtimeConfig.browser.ts
+++ b/clients/client-iot-events/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iot-events/runtimeConfig.browser.ts
+++ b/clients/client-iot-events/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iot-events/runtimeConfig.native.ts
+++ b/clients/client-iot-events/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTEventsClient";

--- a/clients/client-iot-events/runtimeConfig.native.ts
+++ b/clients/client-iot-events/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTEventsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iot-events/runtimeConfig.ts
+++ b/clients/client-iot-events/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iot-events/runtimeConfig.ts
+++ b/clients/client-iot-events/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.browser.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.browser.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.native.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTJobsDataPlaneClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.native.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTJobsDataPlaneClient";

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iot/runtimeConfig.browser.ts
+++ b/clients/client-iot/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iot/runtimeConfig.browser.ts
+++ b/clients/client-iot/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iot/runtimeConfig.native.ts
+++ b/clients/client-iot/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTClient";

--- a/clients/client-iot/runtimeConfig.native.ts
+++ b/clients/client-iot/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iot/runtimeConfig.ts
+++ b/clients/client-iot/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iot/runtimeConfig.ts
+++ b/clients/client-iot/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iotanalytics/runtimeConfig.browser.ts
+++ b/clients/client-iotanalytics/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iotanalytics/runtimeConfig.browser.ts
+++ b/clients/client-iotanalytics/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iotanalytics/runtimeConfig.native.ts
+++ b/clients/client-iotanalytics/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTAnalyticsClient";

--- a/clients/client-iotanalytics/runtimeConfig.native.ts
+++ b/clients/client-iotanalytics/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTAnalyticsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iotanalytics/runtimeConfig.ts
+++ b/clients/client-iotanalytics/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iotanalytics/runtimeConfig.ts
+++ b/clients/client-iotanalytics/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iotsecuretunneling/runtimeConfig.browser.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iotsecuretunneling/runtimeConfig.browser.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iotsecuretunneling/runtimeConfig.native.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTSecureTunnelingClient";

--- a/clients/client-iotsecuretunneling/runtimeConfig.native.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTSecureTunnelingClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iotsecuretunneling/runtimeConfig.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iotsecuretunneling/runtimeConfig.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iotsitewise/runtimeConfig.browser.ts
+++ b/clients/client-iotsitewise/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iotsitewise/runtimeConfig.browser.ts
+++ b/clients/client-iotsitewise/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iotsitewise/runtimeConfig.native.ts
+++ b/clients/client-iotsitewise/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTSiteWiseClient";

--- a/clients/client-iotsitewise/runtimeConfig.native.ts
+++ b/clients/client-iotsitewise/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTSiteWiseClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iotsitewise/runtimeConfig.ts
+++ b/clients/client-iotsitewise/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iotsitewise/runtimeConfig.ts
+++ b/clients/client-iotsitewise/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-iotthingsgraph/runtimeConfig.browser.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-iotthingsgraph/runtimeConfig.browser.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-iotthingsgraph/runtimeConfig.native.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTThingsGraphClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-iotthingsgraph/runtimeConfig.native.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IoTThingsGraphClient";

--- a/clients/client-iotthingsgraph/runtimeConfig.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-iotthingsgraph/runtimeConfig.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-ivs/runtimeConfig.browser.ts
+++ b/clients/client-ivs/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-ivs/runtimeConfig.browser.ts
+++ b/clients/client-ivs/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-ivs/runtimeConfig.native.ts
+++ b/clients/client-ivs/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IvsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-ivs/runtimeConfig.native.ts
+++ b/clients/client-ivs/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./IvsClient";

--- a/clients/client-ivs/runtimeConfig.ts
+++ b/clients/client-ivs/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-ivs/runtimeConfig.ts
+++ b/clients/client-ivs/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-kafka/runtimeConfig.browser.ts
+++ b/clients/client-kafka/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-kafka/runtimeConfig.browser.ts
+++ b/clients/client-kafka/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-kafka/runtimeConfig.native.ts
+++ b/clients/client-kafka/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KafkaClient";

--- a/clients/client-kafka/runtimeConfig.native.ts
+++ b/clients/client-kafka/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KafkaClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-kafka/runtimeConfig.ts
+++ b/clients/client-kafka/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-kafka/runtimeConfig.ts
+++ b/clients/client-kafka/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-kendra/runtimeConfig.browser.ts
+++ b/clients/client-kendra/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-kendra/runtimeConfig.browser.ts
+++ b/clients/client-kendra/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-kendra/runtimeConfig.native.ts
+++ b/clients/client-kendra/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KendraClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-kendra/runtimeConfig.native.ts
+++ b/clients/client-kendra/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KendraClient";

--- a/clients/client-kendra/runtimeConfig.ts
+++ b/clients/client-kendra/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-kendra/runtimeConfig.ts
+++ b/clients/client-kendra/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.native.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisAnalyticsV2Client";

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.native.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisAnalyticsV2Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-kinesis-analytics/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-kinesis-analytics/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-kinesis-analytics/runtimeConfig.native.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisAnalyticsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-kinesis-analytics/runtimeConfig.native.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisAnalyticsClient";

--- a/clients/client-kinesis-analytics/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-kinesis-analytics/runtimeConfig.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoArchivedMediaClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoArchivedMediaClient";

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-kinesis-video-media/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-kinesis-video-media/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-kinesis-video-media/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoMediaClient";

--- a/clients/client-kinesis-video-media/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoMediaClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-kinesis-video-media/runtimeConfig.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-kinesis-video-media/runtimeConfig.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-kinesis-video-signaling/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-kinesis-video-signaling/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-kinesis-video-signaling/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoSignalingClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-kinesis-video-signaling/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoSignalingClient";

--- a/clients/client-kinesis-video-signaling/runtimeConfig.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-kinesis-video-signaling/runtimeConfig.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-kinesis-video/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-kinesis-video/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-kinesis-video/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoClient";

--- a/clients/client-kinesis-video/runtimeConfig.native.ts
+++ b/clients/client-kinesis-video/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisVideoClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-kinesis-video/runtimeConfig.ts
+++ b/clients/client-kinesis-video/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-kinesis-video/runtimeConfig.ts
+++ b/clients/client-kinesis-video/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-kinesis/runtimeConfig.browser.ts
+++ b/clients/client-kinesis/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";

--- a/clients/client-kinesis/runtimeConfig.browser.ts
+++ b/clients/client-kinesis/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
@@ -19,7 +19,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   eventStreamSerdeProvider,
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,

--- a/clients/client-kinesis/runtimeConfig.native.ts
+++ b/clients/client-kinesis/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisClient";

--- a/clients/client-kinesis/runtimeConfig.native.ts
+++ b/clients/client-kinesis/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KinesisClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-kinesis/runtimeConfig.ts
+++ b/clients/client-kinesis/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
@@ -21,7 +21,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   eventStreamSerdeProvider,
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),

--- a/clients/client-kinesis/runtimeConfig.ts
+++ b/clients/client-kinesis/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";

--- a/clients/client-kms/runtimeConfig.browser.ts
+++ b/clients/client-kms/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-kms/runtimeConfig.browser.ts
+++ b/clients/client-kms/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-kms/runtimeConfig.native.ts
+++ b/clients/client-kms/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KMSClient";

--- a/clients/client-kms/runtimeConfig.native.ts
+++ b/clients/client-kms/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./KMSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-kms/runtimeConfig.ts
+++ b/clients/client-kms/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-kms/runtimeConfig.ts
+++ b/clients/client-kms/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-lakeformation/runtimeConfig.browser.ts
+++ b/clients/client-lakeformation/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-lakeformation/runtimeConfig.browser.ts
+++ b/clients/client-lakeformation/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-lakeformation/runtimeConfig.native.ts
+++ b/clients/client-lakeformation/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LakeFormationClient";

--- a/clients/client-lakeformation/runtimeConfig.native.ts
+++ b/clients/client-lakeformation/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LakeFormationClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-lakeformation/runtimeConfig.ts
+++ b/clients/client-lakeformation/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-lakeformation/runtimeConfig.ts
+++ b/clients/client-lakeformation/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-lambda/runtimeConfig.browser.ts
+++ b/clients/client-lambda/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-lambda/runtimeConfig.browser.ts
+++ b/clients/client-lambda/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-lambda/runtimeConfig.native.ts
+++ b/clients/client-lambda/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LambdaClient";

--- a/clients/client-lambda/runtimeConfig.native.ts
+++ b/clients/client-lambda/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LambdaClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-lambda/runtimeConfig.ts
+++ b/clients/client-lambda/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-lambda/runtimeConfig.ts
+++ b/clients/client-lambda/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-lex-model-building-service/runtimeConfig.browser.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-lex-model-building-service/runtimeConfig.browser.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-lex-model-building-service/runtimeConfig.native.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LexModelBuildingServiceClient";

--- a/clients/client-lex-model-building-service/runtimeConfig.native.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LexModelBuildingServiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-lex-model-building-service/runtimeConfig.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-lex-model-building-service/runtimeConfig.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-lex-runtime-service/runtimeConfig.browser.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-lex-runtime-service/runtimeConfig.browser.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-lex-runtime-service/runtimeConfig.native.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LexRuntimeServiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-lex-runtime-service/runtimeConfig.native.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LexRuntimeServiceClient";

--- a/clients/client-lex-runtime-service/runtimeConfig.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-lex-runtime-service/runtimeConfig.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-license-manager/runtimeConfig.browser.ts
+++ b/clients/client-license-manager/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-license-manager/runtimeConfig.browser.ts
+++ b/clients/client-license-manager/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-license-manager/runtimeConfig.native.ts
+++ b/clients/client-license-manager/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LicenseManagerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-license-manager/runtimeConfig.native.ts
+++ b/clients/client-license-manager/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LicenseManagerClient";

--- a/clients/client-license-manager/runtimeConfig.ts
+++ b/clients/client-license-manager/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-license-manager/runtimeConfig.ts
+++ b/clients/client-license-manager/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-lightsail/runtimeConfig.browser.ts
+++ b/clients/client-lightsail/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-lightsail/runtimeConfig.browser.ts
+++ b/clients/client-lightsail/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-lightsail/runtimeConfig.native.ts
+++ b/clients/client-lightsail/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LightsailClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-lightsail/runtimeConfig.native.ts
+++ b/clients/client-lightsail/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./LightsailClient";

--- a/clients/client-lightsail/runtimeConfig.ts
+++ b/clients/client-lightsail/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-lightsail/runtimeConfig.ts
+++ b/clients/client-lightsail/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-machine-learning/runtimeConfig.browser.ts
+++ b/clients/client-machine-learning/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-machine-learning/runtimeConfig.browser.ts
+++ b/clients/client-machine-learning/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-machine-learning/runtimeConfig.native.ts
+++ b/clients/client-machine-learning/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MachineLearningClient";

--- a/clients/client-machine-learning/runtimeConfig.native.ts
+++ b/clients/client-machine-learning/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MachineLearningClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-machine-learning/runtimeConfig.ts
+++ b/clients/client-machine-learning/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-machine-learning/runtimeConfig.ts
+++ b/clients/client-machine-learning/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-macie/runtimeConfig.browser.ts
+++ b/clients/client-macie/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-macie/runtimeConfig.browser.ts
+++ b/clients/client-macie/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-macie/runtimeConfig.native.ts
+++ b/clients/client-macie/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MacieClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-macie/runtimeConfig.native.ts
+++ b/clients/client-macie/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MacieClient";

--- a/clients/client-macie/runtimeConfig.ts
+++ b/clients/client-macie/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-macie/runtimeConfig.ts
+++ b/clients/client-macie/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-macie2/runtimeConfig.browser.ts
+++ b/clients/client-macie2/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-macie2/runtimeConfig.browser.ts
+++ b/clients/client-macie2/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-macie2/runtimeConfig.native.ts
+++ b/clients/client-macie2/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Macie2Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-macie2/runtimeConfig.native.ts
+++ b/clients/client-macie2/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Macie2Client";

--- a/clients/client-macie2/runtimeConfig.ts
+++ b/clients/client-macie2/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-macie2/runtimeConfig.ts
+++ b/clients/client-macie2/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-managedblockchain/runtimeConfig.browser.ts
+++ b/clients/client-managedblockchain/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-managedblockchain/runtimeConfig.browser.ts
+++ b/clients/client-managedblockchain/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-managedblockchain/runtimeConfig.native.ts
+++ b/clients/client-managedblockchain/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ManagedBlockchainClient";

--- a/clients/client-managedblockchain/runtimeConfig.native.ts
+++ b/clients/client-managedblockchain/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ManagedBlockchainClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-managedblockchain/runtimeConfig.ts
+++ b/clients/client-managedblockchain/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-managedblockchain/runtimeConfig.ts
+++ b/clients/client-managedblockchain/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-marketplace-catalog/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-marketplace-catalog/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-marketplace-catalog/runtimeConfig.native.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceCatalogClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-marketplace-catalog/runtimeConfig.native.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceCatalogClient";

--- a/clients/client-marketplace-catalog/runtimeConfig.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-marketplace-catalog/runtimeConfig.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.native.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceCommerceAnalyticsClient";

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.native.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceCommerceAnalyticsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.native.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceEntitlementServiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.native.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceEntitlementServiceClient";

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-marketplace-metering/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-marketplace-metering/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-marketplace-metering/runtimeConfig.native.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceMeteringClient";

--- a/clients/client-marketplace-metering/runtimeConfig.native.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MarketplaceMeteringClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-marketplace-metering/runtimeConfig.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-marketplace-metering/runtimeConfig.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-mediaconnect/runtimeConfig.browser.ts
+++ b/clients/client-mediaconnect/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-mediaconnect/runtimeConfig.browser.ts
+++ b/clients/client-mediaconnect/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-mediaconnect/runtimeConfig.native.ts
+++ b/clients/client-mediaconnect/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaConnectClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-mediaconnect/runtimeConfig.native.ts
+++ b/clients/client-mediaconnect/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaConnectClient";

--- a/clients/client-mediaconnect/runtimeConfig.ts
+++ b/clients/client-mediaconnect/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-mediaconnect/runtimeConfig.ts
+++ b/clients/client-mediaconnect/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-mediaconvert/runtimeConfig.browser.ts
+++ b/clients/client-mediaconvert/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-mediaconvert/runtimeConfig.browser.ts
+++ b/clients/client-mediaconvert/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-mediaconvert/runtimeConfig.native.ts
+++ b/clients/client-mediaconvert/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaConvertClient";

--- a/clients/client-mediaconvert/runtimeConfig.native.ts
+++ b/clients/client-mediaconvert/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaConvertClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-mediaconvert/runtimeConfig.ts
+++ b/clients/client-mediaconvert/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-mediaconvert/runtimeConfig.ts
+++ b/clients/client-mediaconvert/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-medialive/runtimeConfig.browser.ts
+++ b/clients/client-medialive/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-medialive/runtimeConfig.browser.ts
+++ b/clients/client-medialive/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-medialive/runtimeConfig.native.ts
+++ b/clients/client-medialive/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaLiveClient";

--- a/clients/client-medialive/runtimeConfig.native.ts
+++ b/clients/client-medialive/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaLiveClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-medialive/runtimeConfig.ts
+++ b/clients/client-medialive/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-medialive/runtimeConfig.ts
+++ b/clients/client-medialive/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-mediapackage-vod/runtimeConfig.browser.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-mediapackage-vod/runtimeConfig.browser.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-mediapackage-vod/runtimeConfig.native.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaPackageVodClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-mediapackage-vod/runtimeConfig.native.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaPackageVodClient";

--- a/clients/client-mediapackage-vod/runtimeConfig.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-mediapackage-vod/runtimeConfig.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-mediapackage/runtimeConfig.browser.ts
+++ b/clients/client-mediapackage/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-mediapackage/runtimeConfig.browser.ts
+++ b/clients/client-mediapackage/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-mediapackage/runtimeConfig.native.ts
+++ b/clients/client-mediapackage/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaPackageClient";

--- a/clients/client-mediapackage/runtimeConfig.native.ts
+++ b/clients/client-mediapackage/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaPackageClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-mediapackage/runtimeConfig.ts
+++ b/clients/client-mediapackage/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-mediapackage/runtimeConfig.ts
+++ b/clients/client-mediapackage/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-mediastore-data/runtimeConfig.browser.ts
+++ b/clients/client-mediastore-data/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-mediastore-data/runtimeConfig.browser.ts
+++ b/clients/client-mediastore-data/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-mediastore-data/runtimeConfig.native.ts
+++ b/clients/client-mediastore-data/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaStoreDataClient";

--- a/clients/client-mediastore-data/runtimeConfig.native.ts
+++ b/clients/client-mediastore-data/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaStoreDataClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-mediastore-data/runtimeConfig.ts
+++ b/clients/client-mediastore-data/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-mediastore-data/runtimeConfig.ts
+++ b/clients/client-mediastore-data/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-mediastore/runtimeConfig.browser.ts
+++ b/clients/client-mediastore/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-mediastore/runtimeConfig.browser.ts
+++ b/clients/client-mediastore/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-mediastore/runtimeConfig.native.ts
+++ b/clients/client-mediastore/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaStoreClient";

--- a/clients/client-mediastore/runtimeConfig.native.ts
+++ b/clients/client-mediastore/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaStoreClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-mediastore/runtimeConfig.ts
+++ b/clients/client-mediastore/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-mediastore/runtimeConfig.ts
+++ b/clients/client-mediastore/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-mediatailor/runtimeConfig.browser.ts
+++ b/clients/client-mediatailor/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-mediatailor/runtimeConfig.browser.ts
+++ b/clients/client-mediatailor/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-mediatailor/runtimeConfig.native.ts
+++ b/clients/client-mediatailor/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaTailorClient";

--- a/clients/client-mediatailor/runtimeConfig.native.ts
+++ b/clients/client-mediatailor/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MediaTailorClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-mediatailor/runtimeConfig.ts
+++ b/clients/client-mediatailor/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-mediatailor/runtimeConfig.ts
+++ b/clients/client-mediatailor/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-migration-hub/runtimeConfig.browser.ts
+++ b/clients/client-migration-hub/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-migration-hub/runtimeConfig.browser.ts
+++ b/clients/client-migration-hub/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-migration-hub/runtimeConfig.native.ts
+++ b/clients/client-migration-hub/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MigrationHubClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-migration-hub/runtimeConfig.native.ts
+++ b/clients/client-migration-hub/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MigrationHubClient";

--- a/clients/client-migration-hub/runtimeConfig.ts
+++ b/clients/client-migration-hub/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-migration-hub/runtimeConfig.ts
+++ b/clients/client-migration-hub/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-migrationhub-config/runtimeConfig.browser.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-migrationhub-config/runtimeConfig.browser.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-migrationhub-config/runtimeConfig.native.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MigrationHubConfigClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-migrationhub-config/runtimeConfig.native.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MigrationHubConfigClient";

--- a/clients/client-migrationhub-config/runtimeConfig.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-migrationhub-config/runtimeConfig.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-mobile/runtimeConfig.browser.ts
+++ b/clients/client-mobile/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-mobile/runtimeConfig.browser.ts
+++ b/clients/client-mobile/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-mobile/runtimeConfig.native.ts
+++ b/clients/client-mobile/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MobileClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-mobile/runtimeConfig.native.ts
+++ b/clients/client-mobile/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MobileClient";

--- a/clients/client-mobile/runtimeConfig.ts
+++ b/clients/client-mobile/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-mobile/runtimeConfig.ts
+++ b/clients/client-mobile/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-mq/runtimeConfig.browser.ts
+++ b/clients/client-mq/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-mq/runtimeConfig.browser.ts
+++ b/clients/client-mq/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-mq/runtimeConfig.native.ts
+++ b/clients/client-mq/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MqClient";

--- a/clients/client-mq/runtimeConfig.native.ts
+++ b/clients/client-mq/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MqClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-mq/runtimeConfig.ts
+++ b/clients/client-mq/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-mq/runtimeConfig.ts
+++ b/clients/client-mq/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-mturk/runtimeConfig.browser.ts
+++ b/clients/client-mturk/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-mturk/runtimeConfig.browser.ts
+++ b/clients/client-mturk/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-mturk/runtimeConfig.native.ts
+++ b/clients/client-mturk/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MTurkClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-mturk/runtimeConfig.native.ts
+++ b/clients/client-mturk/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./MTurkClient";

--- a/clients/client-mturk/runtimeConfig.ts
+++ b/clients/client-mturk/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-mturk/runtimeConfig.ts
+++ b/clients/client-mturk/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-neptune/runtimeConfig.browser.ts
+++ b/clients/client-neptune/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-neptune/runtimeConfig.browser.ts
+++ b/clients/client-neptune/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-neptune/runtimeConfig.native.ts
+++ b/clients/client-neptune/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./NeptuneClient";

--- a/clients/client-neptune/runtimeConfig.native.ts
+++ b/clients/client-neptune/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./NeptuneClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-neptune/runtimeConfig.ts
+++ b/clients/client-neptune/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-neptune/runtimeConfig.ts
+++ b/clients/client-neptune/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-networkmanager/runtimeConfig.browser.ts
+++ b/clients/client-networkmanager/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-networkmanager/runtimeConfig.browser.ts
+++ b/clients/client-networkmanager/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-networkmanager/runtimeConfig.native.ts
+++ b/clients/client-networkmanager/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./NetworkManagerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-networkmanager/runtimeConfig.native.ts
+++ b/clients/client-networkmanager/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./NetworkManagerClient";

--- a/clients/client-networkmanager/runtimeConfig.ts
+++ b/clients/client-networkmanager/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-networkmanager/runtimeConfig.ts
+++ b/clients/client-networkmanager/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-opsworks/runtimeConfig.browser.ts
+++ b/clients/client-opsworks/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-opsworks/runtimeConfig.browser.ts
+++ b/clients/client-opsworks/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-opsworks/runtimeConfig.native.ts
+++ b/clients/client-opsworks/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OpsWorksClient";

--- a/clients/client-opsworks/runtimeConfig.native.ts
+++ b/clients/client-opsworks/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OpsWorksClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-opsworks/runtimeConfig.ts
+++ b/clients/client-opsworks/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-opsworks/runtimeConfig.ts
+++ b/clients/client-opsworks/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-opsworkscm/runtimeConfig.browser.ts
+++ b/clients/client-opsworkscm/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-opsworkscm/runtimeConfig.browser.ts
+++ b/clients/client-opsworkscm/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-opsworkscm/runtimeConfig.native.ts
+++ b/clients/client-opsworkscm/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OpsWorksCMClient";

--- a/clients/client-opsworkscm/runtimeConfig.native.ts
+++ b/clients/client-opsworkscm/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OpsWorksCMClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-opsworkscm/runtimeConfig.ts
+++ b/clients/client-opsworkscm/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-opsworkscm/runtimeConfig.ts
+++ b/clients/client-opsworkscm/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-organizations/runtimeConfig.browser.ts
+++ b/clients/client-organizations/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-organizations/runtimeConfig.browser.ts
+++ b/clients/client-organizations/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-organizations/runtimeConfig.native.ts
+++ b/clients/client-organizations/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OrganizationsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-organizations/runtimeConfig.native.ts
+++ b/clients/client-organizations/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OrganizationsClient";

--- a/clients/client-organizations/runtimeConfig.ts
+++ b/clients/client-organizations/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-organizations/runtimeConfig.ts
+++ b/clients/client-organizations/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-outposts/runtimeConfig.browser.ts
+++ b/clients/client-outposts/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-outposts/runtimeConfig.browser.ts
+++ b/clients/client-outposts/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-outposts/runtimeConfig.native.ts
+++ b/clients/client-outposts/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OutpostsClient";

--- a/clients/client-outposts/runtimeConfig.native.ts
+++ b/clients/client-outposts/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./OutpostsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-outposts/runtimeConfig.ts
+++ b/clients/client-outposts/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-outposts/runtimeConfig.ts
+++ b/clients/client-outposts/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-personalize-events/runtimeConfig.browser.ts
+++ b/clients/client-personalize-events/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-personalize-events/runtimeConfig.browser.ts
+++ b/clients/client-personalize-events/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-personalize-events/runtimeConfig.native.ts
+++ b/clients/client-personalize-events/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PersonalizeEventsClient";

--- a/clients/client-personalize-events/runtimeConfig.native.ts
+++ b/clients/client-personalize-events/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PersonalizeEventsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-personalize-events/runtimeConfig.ts
+++ b/clients/client-personalize-events/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-personalize-events/runtimeConfig.ts
+++ b/clients/client-personalize-events/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-personalize-runtime/runtimeConfig.browser.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-personalize-runtime/runtimeConfig.browser.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-personalize-runtime/runtimeConfig.native.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PersonalizeRuntimeClient";

--- a/clients/client-personalize-runtime/runtimeConfig.native.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PersonalizeRuntimeClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-personalize-runtime/runtimeConfig.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-personalize-runtime/runtimeConfig.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-personalize/runtimeConfig.browser.ts
+++ b/clients/client-personalize/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-personalize/runtimeConfig.browser.ts
+++ b/clients/client-personalize/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-personalize/runtimeConfig.native.ts
+++ b/clients/client-personalize/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PersonalizeClient";

--- a/clients/client-personalize/runtimeConfig.native.ts
+++ b/clients/client-personalize/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PersonalizeClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-personalize/runtimeConfig.ts
+++ b/clients/client-personalize/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-personalize/runtimeConfig.ts
+++ b/clients/client-personalize/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-pi/runtimeConfig.browser.ts
+++ b/clients/client-pi/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-pi/runtimeConfig.browser.ts
+++ b/clients/client-pi/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-pi/runtimeConfig.native.ts
+++ b/clients/client-pi/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PIClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-pi/runtimeConfig.native.ts
+++ b/clients/client-pi/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PIClient";

--- a/clients/client-pi/runtimeConfig.ts
+++ b/clients/client-pi/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-pi/runtimeConfig.ts
+++ b/clients/client-pi/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-pinpoint-email/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-pinpoint-email/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-pinpoint-email/runtimeConfig.native.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PinpointEmailClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-pinpoint-email/runtimeConfig.native.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PinpointEmailClient";

--- a/clients/client-pinpoint-email/runtimeConfig.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-pinpoint-email/runtimeConfig.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.native.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PinpointSMSVoiceClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.native.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PinpointSMSVoiceClient";

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-pinpoint/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-pinpoint/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-pinpoint/runtimeConfig.native.ts
+++ b/clients/client-pinpoint/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PinpointClient";

--- a/clients/client-pinpoint/runtimeConfig.native.ts
+++ b/clients/client-pinpoint/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PinpointClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-pinpoint/runtimeConfig.ts
+++ b/clients/client-pinpoint/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-pinpoint/runtimeConfig.ts
+++ b/clients/client-pinpoint/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-polly/runtimeConfig.browser.ts
+++ b/clients/client-polly/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-polly/runtimeConfig.browser.ts
+++ b/clients/client-polly/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-polly/runtimeConfig.native.ts
+++ b/clients/client-polly/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PollyClient";

--- a/clients/client-polly/runtimeConfig.native.ts
+++ b/clients/client-polly/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PollyClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-polly/runtimeConfig.ts
+++ b/clients/client-polly/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-polly/runtimeConfig.ts
+++ b/clients/client-polly/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-pricing/runtimeConfig.browser.ts
+++ b/clients/client-pricing/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-pricing/runtimeConfig.browser.ts
+++ b/clients/client-pricing/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-pricing/runtimeConfig.native.ts
+++ b/clients/client-pricing/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PricingClient";

--- a/clients/client-pricing/runtimeConfig.native.ts
+++ b/clients/client-pricing/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./PricingClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-pricing/runtimeConfig.ts
+++ b/clients/client-pricing/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-pricing/runtimeConfig.ts
+++ b/clients/client-pricing/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-qldb-session/runtimeConfig.browser.ts
+++ b/clients/client-qldb-session/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-qldb-session/runtimeConfig.browser.ts
+++ b/clients/client-qldb-session/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-qldb-session/runtimeConfig.native.ts
+++ b/clients/client-qldb-session/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QLDBSessionClient";

--- a/clients/client-qldb-session/runtimeConfig.native.ts
+++ b/clients/client-qldb-session/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QLDBSessionClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-qldb-session/runtimeConfig.ts
+++ b/clients/client-qldb-session/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-qldb-session/runtimeConfig.ts
+++ b/clients/client-qldb-session/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-qldb/runtimeConfig.browser.ts
+++ b/clients/client-qldb/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-qldb/runtimeConfig.browser.ts
+++ b/clients/client-qldb/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-qldb/runtimeConfig.native.ts
+++ b/clients/client-qldb/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QLDBClient";

--- a/clients/client-qldb/runtimeConfig.native.ts
+++ b/clients/client-qldb/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QLDBClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-qldb/runtimeConfig.ts
+++ b/clients/client-qldb/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-qldb/runtimeConfig.ts
+++ b/clients/client-qldb/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-quicksight/runtimeConfig.browser.ts
+++ b/clients/client-quicksight/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-quicksight/runtimeConfig.browser.ts
+++ b/clients/client-quicksight/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-quicksight/runtimeConfig.native.ts
+++ b/clients/client-quicksight/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QuickSightClient";

--- a/clients/client-quicksight/runtimeConfig.native.ts
+++ b/clients/client-quicksight/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QuickSightClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-quicksight/runtimeConfig.ts
+++ b/clients/client-quicksight/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-quicksight/runtimeConfig.ts
+++ b/clients/client-quicksight/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-ram/runtimeConfig.browser.ts
+++ b/clients/client-ram/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-ram/runtimeConfig.browser.ts
+++ b/clients/client-ram/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-ram/runtimeConfig.native.ts
+++ b/clients/client-ram/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RAMClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-ram/runtimeConfig.native.ts
+++ b/clients/client-ram/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RAMClient";

--- a/clients/client-ram/runtimeConfig.ts
+++ b/clients/client-ram/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-ram/runtimeConfig.ts
+++ b/clients/client-ram/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-rds-data/runtimeConfig.browser.ts
+++ b/clients/client-rds-data/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-rds-data/runtimeConfig.browser.ts
+++ b/clients/client-rds-data/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-rds-data/runtimeConfig.native.ts
+++ b/clients/client-rds-data/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RDSDataClient";

--- a/clients/client-rds-data/runtimeConfig.native.ts
+++ b/clients/client-rds-data/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RDSDataClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-rds-data/runtimeConfig.ts
+++ b/clients/client-rds-data/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-rds-data/runtimeConfig.ts
+++ b/clients/client-rds-data/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-rds/runtimeConfig.browser.ts
+++ b/clients/client-rds/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-rds/runtimeConfig.browser.ts
+++ b/clients/client-rds/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-rds/runtimeConfig.native.ts
+++ b/clients/client-rds/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RDSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-rds/runtimeConfig.native.ts
+++ b/clients/client-rds/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RDSClient";

--- a/clients/client-rds/runtimeConfig.ts
+++ b/clients/client-rds/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-rds/runtimeConfig.ts
+++ b/clients/client-rds/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-redshift/runtimeConfig.browser.ts
+++ b/clients/client-redshift/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-redshift/runtimeConfig.browser.ts
+++ b/clients/client-redshift/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-redshift/runtimeConfig.native.ts
+++ b/clients/client-redshift/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RedshiftClient";

--- a/clients/client-redshift/runtimeConfig.native.ts
+++ b/clients/client-redshift/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RedshiftClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-redshift/runtimeConfig.ts
+++ b/clients/client-redshift/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-redshift/runtimeConfig.ts
+++ b/clients/client-redshift/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-rekognition/runtimeConfig.browser.ts
+++ b/clients/client-rekognition/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-rekognition/runtimeConfig.browser.ts
+++ b/clients/client-rekognition/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-rekognition/runtimeConfig.native.ts
+++ b/clients/client-rekognition/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RekognitionClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-rekognition/runtimeConfig.native.ts
+++ b/clients/client-rekognition/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RekognitionClient";

--- a/clients/client-rekognition/runtimeConfig.ts
+++ b/clients/client-rekognition/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-rekognition/runtimeConfig.ts
+++ b/clients/client-rekognition/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.browser.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.browser.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.native.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ResourceGroupsTaggingAPIClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.native.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ResourceGroupsTaggingAPIClient";

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-resource-groups/runtimeConfig.browser.ts
+++ b/clients/client-resource-groups/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-resource-groups/runtimeConfig.browser.ts
+++ b/clients/client-resource-groups/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-resource-groups/runtimeConfig.native.ts
+++ b/clients/client-resource-groups/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ResourceGroupsClient";

--- a/clients/client-resource-groups/runtimeConfig.native.ts
+++ b/clients/client-resource-groups/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ResourceGroupsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-resource-groups/runtimeConfig.ts
+++ b/clients/client-resource-groups/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-resource-groups/runtimeConfig.ts
+++ b/clients/client-resource-groups/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-robomaker/runtimeConfig.browser.ts
+++ b/clients/client-robomaker/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-robomaker/runtimeConfig.browser.ts
+++ b/clients/client-robomaker/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-robomaker/runtimeConfig.native.ts
+++ b/clients/client-robomaker/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RoboMakerClient";

--- a/clients/client-robomaker/runtimeConfig.native.ts
+++ b/clients/client-robomaker/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RoboMakerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-robomaker/runtimeConfig.ts
+++ b/clients/client-robomaker/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-robomaker/runtimeConfig.ts
+++ b/clients/client-robomaker/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-route-53-domains/runtimeConfig.browser.ts
+++ b/clients/client-route-53-domains/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-route-53-domains/runtimeConfig.browser.ts
+++ b/clients/client-route-53-domains/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-route-53-domains/runtimeConfig.native.ts
+++ b/clients/client-route-53-domains/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Route53DomainsClient";

--- a/clients/client-route-53-domains/runtimeConfig.native.ts
+++ b/clients/client-route-53-domains/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Route53DomainsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-route-53-domains/runtimeConfig.ts
+++ b/clients/client-route-53-domains/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-route-53-domains/runtimeConfig.ts
+++ b/clients/client-route-53-domains/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-route-53/runtimeConfig.browser.ts
+++ b/clients/client-route-53/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-route-53/runtimeConfig.browser.ts
+++ b/clients/client-route-53/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-route-53/runtimeConfig.native.ts
+++ b/clients/client-route-53/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Route53Client";

--- a/clients/client-route-53/runtimeConfig.native.ts
+++ b/clients/client-route-53/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Route53Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-route-53/runtimeConfig.ts
+++ b/clients/client-route-53/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-route-53/runtimeConfig.ts
+++ b/clients/client-route-53/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-route53resolver/runtimeConfig.browser.ts
+++ b/clients/client-route53resolver/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-route53resolver/runtimeConfig.browser.ts
+++ b/clients/client-route53resolver/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-route53resolver/runtimeConfig.native.ts
+++ b/clients/client-route53resolver/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Route53ResolverClient";

--- a/clients/client-route53resolver/runtimeConfig.native.ts
+++ b/clients/client-route53resolver/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./Route53ResolverClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-route53resolver/runtimeConfig.ts
+++ b/clients/client-route53resolver/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-route53resolver/runtimeConfig.ts
+++ b/clients/client-route53resolver/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-s3-control/runtimeConfig.browser.ts
+++ b/clients/client-s3-control/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-s3-control/runtimeConfig.browser.ts
+++ b/clients/client-s3-control/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-s3-control/runtimeConfig.native.ts
+++ b/clients/client-s3-control/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./S3ControlClient";

--- a/clients/client-s3-control/runtimeConfig.native.ts
+++ b/clients/client-s3-control/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./S3ControlClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-s3-control/runtimeConfig.ts
+++ b/clients/client-s3-control/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-s3-control/runtimeConfig.ts
+++ b/clients/client-s3-control/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-s3/runtimeConfig.browser.ts
+++ b/clients/client-s3/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";

--- a/clients/client-s3/runtimeConfig.browser.ts
+++ b/clients/client-s3/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
@@ -21,7 +21,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   eventStreamSerdeProvider,
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   md5: Md5,

--- a/clients/client-s3/runtimeConfig.native.ts
+++ b/clients/client-s3/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./S3Client";

--- a/clients/client-s3/runtimeConfig.native.ts
+++ b/clients/client-s3/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./S3Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-s3/runtimeConfig.ts
+++ b/clients/client-s3/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";
@@ -24,7 +24,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   eventStreamSerdeProvider,
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   md5: Hash.bind(null, "md5"),

--- a/clients/client-s3/runtimeConfig.ts
+++ b/clients/client-s3/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-node";

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.native.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SageMakerA2IRuntimeClient";

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.native.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SageMakerA2IRuntimeClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-sagemaker-runtime/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sagemaker-runtime/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-sagemaker-runtime/runtimeConfig.native.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SageMakerRuntimeClient";

--- a/clients/client-sagemaker-runtime/runtimeConfig.native.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SageMakerRuntimeClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sagemaker-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sagemaker-runtime/runtimeConfig.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-sagemaker/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sagemaker/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-sagemaker/runtimeConfig.native.ts
+++ b/clients/client-sagemaker/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SageMakerClient";

--- a/clients/client-sagemaker/runtimeConfig.native.ts
+++ b/clients/client-sagemaker/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SageMakerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sagemaker/runtimeConfig.ts
+++ b/clients/client-sagemaker/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sagemaker/runtimeConfig.ts
+++ b/clients/client-sagemaker/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-savingsplans/runtimeConfig.browser.ts
+++ b/clients/client-savingsplans/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-savingsplans/runtimeConfig.browser.ts
+++ b/clients/client-savingsplans/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-savingsplans/runtimeConfig.native.ts
+++ b/clients/client-savingsplans/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SavingsplansClient";

--- a/clients/client-savingsplans/runtimeConfig.native.ts
+++ b/clients/client-savingsplans/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SavingsplansClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-savingsplans/runtimeConfig.ts
+++ b/clients/client-savingsplans/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-savingsplans/runtimeConfig.ts
+++ b/clients/client-savingsplans/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-schemas/runtimeConfig.browser.ts
+++ b/clients/client-schemas/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-schemas/runtimeConfig.browser.ts
+++ b/clients/client-schemas/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-schemas/runtimeConfig.native.ts
+++ b/clients/client-schemas/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SchemasClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-schemas/runtimeConfig.native.ts
+++ b/clients/client-schemas/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SchemasClient";

--- a/clients/client-schemas/runtimeConfig.ts
+++ b/clients/client-schemas/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-schemas/runtimeConfig.ts
+++ b/clients/client-schemas/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-secrets-manager/runtimeConfig.browser.ts
+++ b/clients/client-secrets-manager/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-secrets-manager/runtimeConfig.browser.ts
+++ b/clients/client-secrets-manager/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-secrets-manager/runtimeConfig.native.ts
+++ b/clients/client-secrets-manager/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SecretsManagerClient";

--- a/clients/client-secrets-manager/runtimeConfig.native.ts
+++ b/clients/client-secrets-manager/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SecretsManagerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-secrets-manager/runtimeConfig.ts
+++ b/clients/client-secrets-manager/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-secrets-manager/runtimeConfig.ts
+++ b/clients/client-secrets-manager/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-securityhub/runtimeConfig.browser.ts
+++ b/clients/client-securityhub/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-securityhub/runtimeConfig.browser.ts
+++ b/clients/client-securityhub/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-securityhub/runtimeConfig.native.ts
+++ b/clients/client-securityhub/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SecurityHubClient";

--- a/clients/client-securityhub/runtimeConfig.native.ts
+++ b/clients/client-securityhub/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SecurityHubClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-securityhub/runtimeConfig.ts
+++ b/clients/client-securityhub/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-securityhub/runtimeConfig.ts
+++ b/clients/client-securityhub/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.browser.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.browser.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.native.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServerlessApplicationRepositoryClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.native.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServerlessApplicationRepositoryClient";

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-service-catalog/runtimeConfig.browser.ts
+++ b/clients/client-service-catalog/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-service-catalog/runtimeConfig.browser.ts
+++ b/clients/client-service-catalog/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-service-catalog/runtimeConfig.native.ts
+++ b/clients/client-service-catalog/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServiceCatalogClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-service-catalog/runtimeConfig.native.ts
+++ b/clients/client-service-catalog/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServiceCatalogClient";

--- a/clients/client-service-catalog/runtimeConfig.ts
+++ b/clients/client-service-catalog/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-service-catalog/runtimeConfig.ts
+++ b/clients/client-service-catalog/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-service-quotas/runtimeConfig.browser.ts
+++ b/clients/client-service-quotas/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-service-quotas/runtimeConfig.browser.ts
+++ b/clients/client-service-quotas/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-service-quotas/runtimeConfig.native.ts
+++ b/clients/client-service-quotas/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServiceQuotasClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-service-quotas/runtimeConfig.native.ts
+++ b/clients/client-service-quotas/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServiceQuotasClient";

--- a/clients/client-service-quotas/runtimeConfig.ts
+++ b/clients/client-service-quotas/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-service-quotas/runtimeConfig.ts
+++ b/clients/client-service-quotas/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-servicediscovery/runtimeConfig.browser.ts
+++ b/clients/client-servicediscovery/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-servicediscovery/runtimeConfig.browser.ts
+++ b/clients/client-servicediscovery/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-servicediscovery/runtimeConfig.native.ts
+++ b/clients/client-servicediscovery/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServiceDiscoveryClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-servicediscovery/runtimeConfig.native.ts
+++ b/clients/client-servicediscovery/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ServiceDiscoveryClient";

--- a/clients/client-servicediscovery/runtimeConfig.ts
+++ b/clients/client-servicediscovery/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-servicediscovery/runtimeConfig.ts
+++ b/clients/client-servicediscovery/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-ses/runtimeConfig.browser.ts
+++ b/clients/client-ses/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-ses/runtimeConfig.browser.ts
+++ b/clients/client-ses/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-ses/runtimeConfig.native.ts
+++ b/clients/client-ses/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SESClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-ses/runtimeConfig.native.ts
+++ b/clients/client-ses/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SESClient";

--- a/clients/client-ses/runtimeConfig.ts
+++ b/clients/client-ses/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-ses/runtimeConfig.ts
+++ b/clients/client-ses/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-sesv2/runtimeConfig.browser.ts
+++ b/clients/client-sesv2/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sesv2/runtimeConfig.browser.ts
+++ b/clients/client-sesv2/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-sesv2/runtimeConfig.native.ts
+++ b/clients/client-sesv2/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SESv2Client";

--- a/clients/client-sesv2/runtimeConfig.native.ts
+++ b/clients/client-sesv2/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SESv2Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sesv2/runtimeConfig.ts
+++ b/clients/client-sesv2/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sesv2/runtimeConfig.ts
+++ b/clients/client-sesv2/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-sfn/runtimeConfig.browser.ts
+++ b/clients/client-sfn/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sfn/runtimeConfig.browser.ts
+++ b/clients/client-sfn/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-sfn/runtimeConfig.native.ts
+++ b/clients/client-sfn/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SFNClient";

--- a/clients/client-sfn/runtimeConfig.native.ts
+++ b/clients/client-sfn/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SFNClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sfn/runtimeConfig.ts
+++ b/clients/client-sfn/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sfn/runtimeConfig.ts
+++ b/clients/client-sfn/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-shield/runtimeConfig.browser.ts
+++ b/clients/client-shield/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-shield/runtimeConfig.browser.ts
+++ b/clients/client-shield/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-shield/runtimeConfig.native.ts
+++ b/clients/client-shield/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ShieldClient";

--- a/clients/client-shield/runtimeConfig.native.ts
+++ b/clients/client-shield/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./ShieldClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-shield/runtimeConfig.ts
+++ b/clients/client-shield/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-shield/runtimeConfig.ts
+++ b/clients/client-shield/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-signer/runtimeConfig.browser.ts
+++ b/clients/client-signer/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-signer/runtimeConfig.browser.ts
+++ b/clients/client-signer/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-signer/runtimeConfig.native.ts
+++ b/clients/client-signer/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SignerClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-signer/runtimeConfig.native.ts
+++ b/clients/client-signer/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SignerClient";

--- a/clients/client-signer/runtimeConfig.ts
+++ b/clients/client-signer/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-signer/runtimeConfig.ts
+++ b/clients/client-signer/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-sms/runtimeConfig.browser.ts
+++ b/clients/client-sms/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sms/runtimeConfig.browser.ts
+++ b/clients/client-sms/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-sms/runtimeConfig.native.ts
+++ b/clients/client-sms/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SMSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sms/runtimeConfig.native.ts
+++ b/clients/client-sms/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SMSClient";

--- a/clients/client-sms/runtimeConfig.ts
+++ b/clients/client-sms/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sms/runtimeConfig.ts
+++ b/clients/client-sms/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-snowball/runtimeConfig.browser.ts
+++ b/clients/client-snowball/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-snowball/runtimeConfig.browser.ts
+++ b/clients/client-snowball/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-snowball/runtimeConfig.native.ts
+++ b/clients/client-snowball/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SnowballClient";

--- a/clients/client-snowball/runtimeConfig.native.ts
+++ b/clients/client-snowball/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SnowballClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-snowball/runtimeConfig.ts
+++ b/clients/client-snowball/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-snowball/runtimeConfig.ts
+++ b/clients/client-snowball/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-sns/runtimeConfig.browser.ts
+++ b/clients/client-sns/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sns/runtimeConfig.browser.ts
+++ b/clients/client-sns/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-sns/runtimeConfig.native.ts
+++ b/clients/client-sns/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SNSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sns/runtimeConfig.native.ts
+++ b/clients/client-sns/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SNSClient";

--- a/clients/client-sns/runtimeConfig.ts
+++ b/clients/client-sns/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sns/runtimeConfig.ts
+++ b/clients/client-sns/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-sqs/runtimeConfig.browser.ts
+++ b/clients/client-sqs/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sqs/runtimeConfig.browser.ts
+++ b/clients/client-sqs/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -19,7 +19,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   md5: Md5,
   region: invalidFunction("Region is missing") as any,

--- a/clients/client-sqs/runtimeConfig.native.ts
+++ b/clients/client-sqs/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SQSClient";

--- a/clients/client-sqs/runtimeConfig.native.ts
+++ b/clients/client-sqs/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SQSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sqs/runtimeConfig.ts
+++ b/clients/client-sqs/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sqs/runtimeConfig.ts
+++ b/clients/client-sqs/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -21,7 +21,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   md5: Hash.bind(null, "md5"),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),

--- a/clients/client-ssm/runtimeConfig.browser.ts
+++ b/clients/client-ssm/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-ssm/runtimeConfig.browser.ts
+++ b/clients/client-ssm/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-ssm/runtimeConfig.native.ts
+++ b/clients/client-ssm/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SSMClient";

--- a/clients/client-ssm/runtimeConfig.native.ts
+++ b/clients/client-ssm/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SSMClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-ssm/runtimeConfig.ts
+++ b/clients/client-ssm/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-ssm/runtimeConfig.ts
+++ b/clients/client-ssm/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-sso-oidc/runtimeConfig.browser.ts
+++ b/clients/client-sso-oidc/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sso-oidc/runtimeConfig.browser.ts
+++ b/clients/client-sso-oidc/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-sso-oidc/runtimeConfig.native.ts
+++ b/clients/client-sso-oidc/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SSOOIDCClient";

--- a/clients/client-sso-oidc/runtimeConfig.native.ts
+++ b/clients/client-sso-oidc/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SSOOIDCClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sso-oidc/runtimeConfig.ts
+++ b/clients/client-sso-oidc/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sso-oidc/runtimeConfig.ts
+++ b/clients/client-sso-oidc/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-sso/runtimeConfig.browser.ts
+++ b/clients/client-sso/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sso/runtimeConfig.browser.ts
+++ b/clients/client-sso/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-sso/runtimeConfig.native.ts
+++ b/clients/client-sso/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SSOClient";

--- a/clients/client-sso/runtimeConfig.native.ts
+++ b/clients/client-sso/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SSOClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sso/runtimeConfig.ts
+++ b/clients/client-sso/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sso/runtimeConfig.ts
+++ b/clients/client-sso/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-storage-gateway/runtimeConfig.browser.ts
+++ b/clients/client-storage-gateway/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-storage-gateway/runtimeConfig.browser.ts
+++ b/clients/client-storage-gateway/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-storage-gateway/runtimeConfig.native.ts
+++ b/clients/client-storage-gateway/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./StorageGatewayClient";

--- a/clients/client-storage-gateway/runtimeConfig.native.ts
+++ b/clients/client-storage-gateway/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./StorageGatewayClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-storage-gateway/runtimeConfig.ts
+++ b/clients/client-storage-gateway/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-storage-gateway/runtimeConfig.ts
+++ b/clients/client-storage-gateway/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-sts/runtimeConfig.browser.ts
+++ b/clients/client-sts/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-sts/runtimeConfig.browser.ts
+++ b/clients/client-sts/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-sts/runtimeConfig.native.ts
+++ b/clients/client-sts/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./STSClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-sts/runtimeConfig.native.ts
+++ b/clients/client-sts/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./STSClient";

--- a/clients/client-sts/runtimeConfig.ts
+++ b/clients/client-sts/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-sts/runtimeConfig.ts
+++ b/clients/client-sts/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-support/runtimeConfig.browser.ts
+++ b/clients/client-support/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-support/runtimeConfig.browser.ts
+++ b/clients/client-support/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-support/runtimeConfig.native.ts
+++ b/clients/client-support/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SupportClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-support/runtimeConfig.native.ts
+++ b/clients/client-support/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SupportClient";

--- a/clients/client-support/runtimeConfig.ts
+++ b/clients/client-support/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-support/runtimeConfig.ts
+++ b/clients/client-support/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-swf/runtimeConfig.browser.ts
+++ b/clients/client-swf/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-swf/runtimeConfig.browser.ts
+++ b/clients/client-swf/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-swf/runtimeConfig.native.ts
+++ b/clients/client-swf/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SWFClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-swf/runtimeConfig.native.ts
+++ b/clients/client-swf/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SWFClient";

--- a/clients/client-swf/runtimeConfig.ts
+++ b/clients/client-swf/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-swf/runtimeConfig.ts
+++ b/clients/client-swf/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-synthetics/runtimeConfig.browser.ts
+++ b/clients/client-synthetics/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-synthetics/runtimeConfig.browser.ts
+++ b/clients/client-synthetics/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-synthetics/runtimeConfig.native.ts
+++ b/clients/client-synthetics/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SyntheticsClient";

--- a/clients/client-synthetics/runtimeConfig.native.ts
+++ b/clients/client-synthetics/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./SyntheticsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-synthetics/runtimeConfig.ts
+++ b/clients/client-synthetics/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-synthetics/runtimeConfig.ts
+++ b/clients/client-synthetics/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-textract/runtimeConfig.browser.ts
+++ b/clients/client-textract/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-textract/runtimeConfig.browser.ts
+++ b/clients/client-textract/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-textract/runtimeConfig.native.ts
+++ b/clients/client-textract/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TextractClient";

--- a/clients/client-textract/runtimeConfig.native.ts
+++ b/clients/client-textract/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TextractClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-textract/runtimeConfig.ts
+++ b/clients/client-textract/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-textract/runtimeConfig.ts
+++ b/clients/client-textract/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-transcribe-streaming/runtimeConfig.browser.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { streamCollector } from "@aws-sdk/fetch-http-handler";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   eventStreamPayloadHandlerProvider: () => eventStreamPayloadHandler,
   eventStreamSerdeProvider,
   maxAttempts: DEFAULT_MAX_ATTEMPTS,

--- a/clients/client-transcribe-streaming/runtimeConfig.browser.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { streamCollector } from "@aws-sdk/fetch-http-handler";

--- a/clients/client-transcribe-streaming/runtimeConfig.native.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { WebSocketHandler, eventStreamPayloadHandler } from "@aws-sdk/middleware-sdk-transcribe-streaming";
 import { parseUrl } from "@aws-sdk/url-parser-node";
@@ -8,7 +8,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   eventStreamPayloadHandlerProvider: () => eventStreamPayloadHandler,
   requestHandler: new WebSocketHandler(),
   sha256: Sha256,

--- a/clients/client-transcribe-streaming/runtimeConfig.native.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { WebSocketHandler, eventStreamPayloadHandler } from "@aws-sdk/middleware-sdk-transcribe-streaming";
 import { parseUrl } from "@aws-sdk/url-parser-node";

--- a/clients/client-transcribe-streaming/runtimeConfig.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";

--- a/clients/client-transcribe-streaming/runtimeConfig.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { eventStreamPayloadHandlerProvider } from "@aws-sdk/eventstream-handler-node";
@@ -22,7 +22,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   eventStreamPayloadHandlerProvider,
   eventStreamSerdeProvider,
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),

--- a/clients/client-transcribe/runtimeConfig.browser.ts
+++ b/clients/client-transcribe/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-transcribe/runtimeConfig.browser.ts
+++ b/clients/client-transcribe/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-transcribe/runtimeConfig.native.ts
+++ b/clients/client-transcribe/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TranscribeClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-transcribe/runtimeConfig.native.ts
+++ b/clients/client-transcribe/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TranscribeClient";

--- a/clients/client-transcribe/runtimeConfig.ts
+++ b/clients/client-transcribe/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-transcribe/runtimeConfig.ts
+++ b/clients/client-transcribe/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-transfer/runtimeConfig.browser.ts
+++ b/clients/client-transfer/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-transfer/runtimeConfig.browser.ts
+++ b/clients/client-transfer/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-transfer/runtimeConfig.native.ts
+++ b/clients/client-transfer/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TransferClient";

--- a/clients/client-transfer/runtimeConfig.native.ts
+++ b/clients/client-transfer/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TransferClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-transfer/runtimeConfig.ts
+++ b/clients/client-transfer/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-transfer/runtimeConfig.ts
+++ b/clients/client-transfer/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-translate/runtimeConfig.browser.ts
+++ b/clients/client-translate/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-translate/runtimeConfig.browser.ts
+++ b/clients/client-translate/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-translate/runtimeConfig.native.ts
+++ b/clients/client-translate/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TranslateClient";

--- a/clients/client-translate/runtimeConfig.native.ts
+++ b/clients/client-translate/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./TranslateClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-translate/runtimeConfig.ts
+++ b/clients/client-translate/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-translate/runtimeConfig.ts
+++ b/clients/client-translate/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-waf-regional/runtimeConfig.browser.ts
+++ b/clients/client-waf-regional/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-waf-regional/runtimeConfig.browser.ts
+++ b/clients/client-waf-regional/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-waf-regional/runtimeConfig.native.ts
+++ b/clients/client-waf-regional/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WAFRegionalClient";

--- a/clients/client-waf-regional/runtimeConfig.native.ts
+++ b/clients/client-waf-regional/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WAFRegionalClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-waf-regional/runtimeConfig.ts
+++ b/clients/client-waf-regional/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-waf-regional/runtimeConfig.ts
+++ b/clients/client-waf-regional/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-waf/runtimeConfig.browser.ts
+++ b/clients/client-waf/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-waf/runtimeConfig.browser.ts
+++ b/clients/client-waf/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-waf/runtimeConfig.native.ts
+++ b/clients/client-waf/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WAFClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-waf/runtimeConfig.native.ts
+++ b/clients/client-waf/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WAFClient";

--- a/clients/client-waf/runtimeConfig.ts
+++ b/clients/client-waf/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-waf/runtimeConfig.ts
+++ b/clients/client-waf/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-wafv2/runtimeConfig.browser.ts
+++ b/clients/client-wafv2/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-wafv2/runtimeConfig.browser.ts
+++ b/clients/client-wafv2/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-wafv2/runtimeConfig.native.ts
+++ b/clients/client-wafv2/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WAFV2Client";

--- a/clients/client-wafv2/runtimeConfig.native.ts
+++ b/clients/client-wafv2/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WAFV2Client";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-wafv2/runtimeConfig.ts
+++ b/clients/client-wafv2/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-wafv2/runtimeConfig.ts
+++ b/clients/client-wafv2/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-workdocs/runtimeConfig.browser.ts
+++ b/clients/client-workdocs/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-workdocs/runtimeConfig.browser.ts
+++ b/clients/client-workdocs/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-workdocs/runtimeConfig.native.ts
+++ b/clients/client-workdocs/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkDocsClient";

--- a/clients/client-workdocs/runtimeConfig.native.ts
+++ b/clients/client-workdocs/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkDocsClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-workdocs/runtimeConfig.ts
+++ b/clients/client-workdocs/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-workdocs/runtimeConfig.ts
+++ b/clients/client-workdocs/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-worklink/runtimeConfig.browser.ts
+++ b/clients/client-worklink/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-worklink/runtimeConfig.browser.ts
+++ b/clients/client-worklink/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-worklink/runtimeConfig.native.ts
+++ b/clients/client-worklink/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkLinkClient";

--- a/clients/client-worklink/runtimeConfig.native.ts
+++ b/clients/client-worklink/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkLinkClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-worklink/runtimeConfig.ts
+++ b/clients/client-worklink/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-worklink/runtimeConfig.ts
+++ b/clients/client-worklink/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-workmail/runtimeConfig.browser.ts
+++ b/clients/client-workmail/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-workmail/runtimeConfig.browser.ts
+++ b/clients/client-workmail/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-workmail/runtimeConfig.native.ts
+++ b/clients/client-workmail/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkMailClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-workmail/runtimeConfig.native.ts
+++ b/clients/client-workmail/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkMailClient";

--- a/clients/client-workmail/runtimeConfig.ts
+++ b/clients/client-workmail/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-workmail/runtimeConfig.ts
+++ b/clients/client-workmail/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-workmailmessageflow/runtimeConfig.browser.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-workmailmessageflow/runtimeConfig.browser.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-workmailmessageflow/runtimeConfig.native.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkMailMessageFlowClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-workmailmessageflow/runtimeConfig.native.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkMailMessageFlowClient";

--- a/clients/client-workmailmessageflow/runtimeConfig.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-workmailmessageflow/runtimeConfig.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-workspaces/runtimeConfig.browser.ts
+++ b/clients/client-workspaces/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-workspaces/runtimeConfig.browser.ts
+++ b/clients/client-workspaces/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-workspaces/runtimeConfig.native.ts
+++ b/clients/client-workspaces/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkSpacesClient";

--- a/clients/client-workspaces/runtimeConfig.native.ts
+++ b/clients/client-workspaces/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./WorkSpacesClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-workspaces/runtimeConfig.ts
+++ b/clients/client-workspaces/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-workspaces/runtimeConfig.ts
+++ b/clients/client-workspaces/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/clients/client-xray/runtimeConfig.browser.ts
+++ b/clients/client-xray/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/clients/client-xray/runtimeConfig.browser.ts
+++ b/clients/client-xray/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/clients/client-xray/runtimeConfig.native.ts
+++ b/clients/client-xray/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./XRayClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/clients/client-xray/runtimeConfig.native.ts
+++ b/clients/client-xray/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./XRayClient";

--- a/clients/client-xray/runtimeConfig.ts
+++ b/clients/client-xray/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/clients/client-xray/runtimeConfig.ts
+++ b/clients/client-xray/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/protocol_tests/aws-ec2/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/protocol_tests/aws-ec2/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/protocol_tests/aws-ec2/runtimeConfig.native.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EC2ProtocolClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/protocol_tests/aws-ec2/runtimeConfig.native.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./EC2ProtocolClient";

--- a/protocol_tests/aws-ec2/runtimeConfig.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/protocol_tests/aws-ec2/runtimeConfig.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/protocol_tests/aws-json/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-json/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/protocol_tests/aws-json/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-json/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/protocol_tests/aws-json/runtimeConfig.native.ts
+++ b/protocol_tests/aws-json/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./JsonProtocolClient";

--- a/protocol_tests/aws-json/runtimeConfig.native.ts
+++ b/protocol_tests/aws-json/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./JsonProtocolClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/protocol_tests/aws-json/runtimeConfig.ts
+++ b/protocol_tests/aws-json/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/protocol_tests/aws-json/runtimeConfig.ts
+++ b/protocol_tests/aws-json/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/protocol_tests/aws-query/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-query/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/protocol_tests/aws-query/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-query/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/protocol_tests/aws-query/runtimeConfig.native.ts
+++ b/protocol_tests/aws-query/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QueryProtocolClient";

--- a/protocol_tests/aws-query/runtimeConfig.native.ts
+++ b/protocol_tests/aws-query/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./QueryProtocolClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/protocol_tests/aws-query/runtimeConfig.ts
+++ b/protocol_tests/aws-query/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/protocol_tests/aws-query/runtimeConfig.ts
+++ b/protocol_tests/aws-query/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/protocol_tests/aws-restjson/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/protocol_tests/aws-restjson/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/protocol_tests/aws-restjson/runtimeConfig.native.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RestJsonProtocolClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/protocol_tests/aws-restjson/runtimeConfig.native.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RestJsonProtocolClient";

--- a/protocol_tests/aws-restjson/runtimeConfig.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/protocol_tests/aws-restjson/runtimeConfig.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),

--- a/protocol_tests/aws-restxml/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.browser.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";

--- a/protocol_tests/aws-restxml/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.browser.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { invalidFunction } from "@aws-sdk/invalid-dependency";
@@ -18,7 +18,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider: invalidFunction("Credential is missing") as any,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,
   requestHandler: new FetchHttpHandler(),

--- a/protocol_tests/aws-restxml/runtimeConfig.native.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.native.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RestXmlProtocolClient";

--- a/protocol_tests/aws-restxml/runtimeConfig.native.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.native.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-js";
 import { parseUrl } from "@aws-sdk/url-parser-node";
 import { ClientDefaults } from "./RestXmlProtocolClient";
@@ -7,7 +7,7 @@ import { ClientDefaultValues as BrowserDefaults } from "./runtimeConfig.browser"
 export const ClientDefaultValues: Required<ClientDefaults> = {
   ...BrowserDefaults,
   runtime: "react-native",
-  defaultUserAgent: `aws-sdk-js-v3-react-native-${name}/${version}`,
+  defaultUserAgent: `aws-sdk-js-v3-react-native-${packageInfo.name}/${packageInfo.version}`,
   sha256: Sha256,
   urlParser: parseUrl,
 };

--- a/protocol_tests/aws-restxml/runtimeConfig.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.ts
@@ -1,4 +1,5 @@
-import * as packageInfo from "./package.json";
+import packageInfo from "./package.json";
+
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";

--- a/protocol_tests/aws-restxml/runtimeConfig.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.ts
@@ -1,4 +1,4 @@
-import { name, version } from "./package.json";
+import * as packageInfo from "./package.json";
 import { NODE_REGION_CONFIG_FILE_OPTIONS, NODE_REGION_CONFIG_OPTIONS } from "@aws-sdk/config-resolver";
 import { defaultProvider as credentialDefaultProvider } from "@aws-sdk/credential-provider-node";
 import { Hash } from "@aws-sdk/hash-node";
@@ -20,7 +20,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
   credentialDefaultProvider,
-  defaultUserAgent: defaultUserAgent(name, version),
+  defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),
   requestHandler: new NodeHttpHandler(),


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1504
Replaces: https://github.com/aws/aws-sdk-js-v3/pull/1503

*Description of changes:*
default import package.json for spec compatibility

Special thanks to Co-author @rvaronos

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
