### PR TITLE
chore: set esModuleInterop to true in clients

### DIFF
--- a/clients/client-accessanalyzer/tsconfig.json
+++ b/clients/client-accessanalyzer/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-acm-pca/tsconfig.json
+++ b/clients/client-acm-pca/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-acm/tsconfig.json
+++ b/clients/client-acm/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-alexa-for-business/tsconfig.json
+++ b/clients/client-alexa-for-business/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-amplify/tsconfig.json
+++ b/clients/client-amplify/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-api-gateway/tsconfig.json
+++ b/clients/client-api-gateway/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-apigatewaymanagementapi/tsconfig.json
+++ b/clients/client-apigatewaymanagementapi/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-apigatewayv2/tsconfig.json
+++ b/clients/client-apigatewayv2/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-app-mesh/tsconfig.json
+++ b/clients/client-app-mesh/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-appconfig/tsconfig.json
+++ b/clients/client-appconfig/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-application-auto-scaling/tsconfig.json
+++ b/clients/client-application-auto-scaling/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-application-discovery-service/tsconfig.json
+++ b/clients/client-application-discovery-service/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-application-insights/tsconfig.json
+++ b/clients/client-application-insights/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-appstream/tsconfig.json
+++ b/clients/client-appstream/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-appsync/tsconfig.json
+++ b/clients/client-appsync/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-athena/tsconfig.json
+++ b/clients/client-athena/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-auto-scaling-plans/tsconfig.json
+++ b/clients/client-auto-scaling-plans/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-auto-scaling/tsconfig.json
+++ b/clients/client-auto-scaling/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-backup/tsconfig.json
+++ b/clients/client-backup/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-batch/tsconfig.json
+++ b/clients/client-batch/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-braket/tsconfig.json
+++ b/clients/client-braket/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-budgets/tsconfig.json
+++ b/clients/client-budgets/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-chime/tsconfig.json
+++ b/clients/client-chime/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloud9/tsconfig.json
+++ b/clients/client-cloud9/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-clouddirectory/tsconfig.json
+++ b/clients/client-clouddirectory/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloudformation/tsconfig.json
+++ b/clients/client-cloudformation/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloudfront/tsconfig.json
+++ b/clients/client-cloudfront/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloudhsm-v2/tsconfig.json
+++ b/clients/client-cloudhsm-v2/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloudhsm/tsconfig.json
+++ b/clients/client-cloudhsm/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloudsearch-domain/tsconfig.json
+++ b/clients/client-cloudsearch-domain/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloudsearch/tsconfig.json
+++ b/clients/client-cloudsearch/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloudtrail/tsconfig.json
+++ b/clients/client-cloudtrail/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloudwatch-events/tsconfig.json
+++ b/clients/client-cloudwatch-events/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloudwatch-logs/tsconfig.json
+++ b/clients/client-cloudwatch-logs/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cloudwatch/tsconfig.json
+++ b/clients/client-cloudwatch/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-codeartifact/tsconfig.json
+++ b/clients/client-codeartifact/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-codebuild/tsconfig.json
+++ b/clients/client-codebuild/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-codecommit/tsconfig.json
+++ b/clients/client-codecommit/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-codedeploy/tsconfig.json
+++ b/clients/client-codedeploy/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-codeguru-reviewer/tsconfig.json
+++ b/clients/client-codeguru-reviewer/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-codeguruprofiler/tsconfig.json
+++ b/clients/client-codeguruprofiler/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-codepipeline/tsconfig.json
+++ b/clients/client-codepipeline/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-codestar-connections/tsconfig.json
+++ b/clients/client-codestar-connections/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-codestar-notifications/tsconfig.json
+++ b/clients/client-codestar-notifications/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-codestar/tsconfig.json
+++ b/clients/client-codestar/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cognito-identity-provider/tsconfig.json
+++ b/clients/client-cognito-identity-provider/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cognito-identity/tsconfig.json
+++ b/clients/client-cognito-identity/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs",
     "types": ["mocha", "node"]

--- a/clients/client-cognito-sync/tsconfig.json
+++ b/clients/client-cognito-sync/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-comprehend/tsconfig.json
+++ b/clients/client-comprehend/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-comprehendmedical/tsconfig.json
+++ b/clients/client-comprehendmedical/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-compute-optimizer/tsconfig.json
+++ b/clients/client-compute-optimizer/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-config-service/tsconfig.json
+++ b/clients/client-config-service/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-connect/tsconfig.json
+++ b/clients/client-connect/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-connectparticipant/tsconfig.json
+++ b/clients/client-connectparticipant/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cost-and-usage-report-service/tsconfig.json
+++ b/clients/client-cost-and-usage-report-service/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-cost-explorer/tsconfig.json
+++ b/clients/client-cost-explorer/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-data-pipeline/tsconfig.json
+++ b/clients/client-data-pipeline/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-database-migration-service/tsconfig.json
+++ b/clients/client-database-migration-service/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-dataexchange/tsconfig.json
+++ b/clients/client-dataexchange/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-datasync/tsconfig.json
+++ b/clients/client-datasync/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-dax/tsconfig.json
+++ b/clients/client-dax/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-detective/tsconfig.json
+++ b/clients/client-detective/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-device-farm/tsconfig.json
+++ b/clients/client-device-farm/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-direct-connect/tsconfig.json
+++ b/clients/client-direct-connect/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-directory-service/tsconfig.json
+++ b/clients/client-directory-service/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-dlm/tsconfig.json
+++ b/clients/client-dlm/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-docdb/tsconfig.json
+++ b/clients/client-docdb/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-dynamodb-streams/tsconfig.json
+++ b/clients/client-dynamodb-streams/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-dynamodb/tsconfig.json
+++ b/clients/client-dynamodb/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-ebs/tsconfig.json
+++ b/clients/client-ebs/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-ec2-instance-connect/tsconfig.json
+++ b/clients/client-ec2-instance-connect/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-ec2/tsconfig.json
+++ b/clients/client-ec2/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-ecr/tsconfig.json
+++ b/clients/client-ecr/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-ecs/tsconfig.json
+++ b/clients/client-ecs/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-efs/tsconfig.json
+++ b/clients/client-efs/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-eks/tsconfig.json
+++ b/clients/client-eks/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-elastic-beanstalk/tsconfig.json
+++ b/clients/client-elastic-beanstalk/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-elastic-inference/tsconfig.json
+++ b/clients/client-elastic-inference/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-elastic-load-balancing-v2/tsconfig.json
+++ b/clients/client-elastic-load-balancing-v2/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-elastic-load-balancing/tsconfig.json
+++ b/clients/client-elastic-load-balancing/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-elastic-transcoder/tsconfig.json
+++ b/clients/client-elastic-transcoder/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-elasticache/tsconfig.json
+++ b/clients/client-elasticache/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-elasticsearch-service/tsconfig.json
+++ b/clients/client-elasticsearch-service/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-emr/tsconfig.json
+++ b/clients/client-emr/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-eventbridge/tsconfig.json
+++ b/clients/client-eventbridge/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-firehose/tsconfig.json
+++ b/clients/client-firehose/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-fms/tsconfig.json
+++ b/clients/client-fms/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-forecast/tsconfig.json
+++ b/clients/client-forecast/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-forecastquery/tsconfig.json
+++ b/clients/client-forecastquery/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-frauddetector/tsconfig.json
+++ b/clients/client-frauddetector/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-fsx/tsconfig.json
+++ b/clients/client-fsx/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-gamelift/tsconfig.json
+++ b/clients/client-gamelift/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-glacier/tsconfig.json
+++ b/clients/client-glacier/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-global-accelerator/tsconfig.json
+++ b/clients/client-global-accelerator/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-glue/tsconfig.json
+++ b/clients/client-glue/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-greengrass/tsconfig.json
+++ b/clients/client-greengrass/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-groundstation/tsconfig.json
+++ b/clients/client-groundstation/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-guardduty/tsconfig.json
+++ b/clients/client-guardduty/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-health/tsconfig.json
+++ b/clients/client-health/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-honeycode/tsconfig.json
+++ b/clients/client-honeycode/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iam/tsconfig.json
+++ b/clients/client-iam/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-imagebuilder/tsconfig.json
+++ b/clients/client-imagebuilder/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-inspector/tsconfig.json
+++ b/clients/client-inspector/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iot-1click-devices-service/tsconfig.json
+++ b/clients/client-iot-1click-devices-service/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iot-1click-projects/tsconfig.json
+++ b/clients/client-iot-1click-projects/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iot-data-plane/tsconfig.json
+++ b/clients/client-iot-data-plane/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iot-events-data/tsconfig.json
+++ b/clients/client-iot-events-data/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iot-events/tsconfig.json
+++ b/clients/client-iot-events/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iot-jobs-data-plane/tsconfig.json
+++ b/clients/client-iot-jobs-data-plane/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iot/tsconfig.json
+++ b/clients/client-iot/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iotanalytics/tsconfig.json
+++ b/clients/client-iotanalytics/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iotsecuretunneling/tsconfig.json
+++ b/clients/client-iotsecuretunneling/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iotsitewise/tsconfig.json
+++ b/clients/client-iotsitewise/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-iotthingsgraph/tsconfig.json
+++ b/clients/client-iotthingsgraph/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-ivs/tsconfig.json
+++ b/clients/client-ivs/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-kafka/tsconfig.json
+++ b/clients/client-kafka/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-kendra/tsconfig.json
+++ b/clients/client-kendra/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-kinesis-analytics-v2/tsconfig.json
+++ b/clients/client-kinesis-analytics-v2/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-kinesis-analytics/tsconfig.json
+++ b/clients/client-kinesis-analytics/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-kinesis-video-archived-media/tsconfig.json
+++ b/clients/client-kinesis-video-archived-media/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-kinesis-video-media/tsconfig.json
+++ b/clients/client-kinesis-video-media/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-kinesis-video-signaling/tsconfig.json
+++ b/clients/client-kinesis-video-signaling/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-kinesis-video/tsconfig.json
+++ b/clients/client-kinesis-video/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-kinesis/tsconfig.json
+++ b/clients/client-kinesis/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-kms/tsconfig.json
+++ b/clients/client-kms/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-lakeformation/tsconfig.json
+++ b/clients/client-lakeformation/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-lambda/tsconfig.json
+++ b/clients/client-lambda/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-lex-model-building-service/tsconfig.json
+++ b/clients/client-lex-model-building-service/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-lex-runtime-service/tsconfig.json
+++ b/clients/client-lex-runtime-service/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs",
     "types": ["mocha", "node"]

--- a/clients/client-license-manager/tsconfig.json
+++ b/clients/client-license-manager/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-lightsail/tsconfig.json
+++ b/clients/client-lightsail/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-machine-learning/tsconfig.json
+++ b/clients/client-machine-learning/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-macie/tsconfig.json
+++ b/clients/client-macie/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-macie2/tsconfig.json
+++ b/clients/client-macie2/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-managedblockchain/tsconfig.json
+++ b/clients/client-managedblockchain/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-marketplace-catalog/tsconfig.json
+++ b/clients/client-marketplace-catalog/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-marketplace-commerce-analytics/tsconfig.json
+++ b/clients/client-marketplace-commerce-analytics/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-marketplace-entitlement-service/tsconfig.json
+++ b/clients/client-marketplace-entitlement-service/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-marketplace-metering/tsconfig.json
+++ b/clients/client-marketplace-metering/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-mediaconnect/tsconfig.json
+++ b/clients/client-mediaconnect/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-mediaconvert/tsconfig.json
+++ b/clients/client-mediaconvert/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-medialive/tsconfig.json
+++ b/clients/client-medialive/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-mediapackage-vod/tsconfig.json
+++ b/clients/client-mediapackage-vod/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-mediapackage/tsconfig.json
+++ b/clients/client-mediapackage/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-mediastore-data/tsconfig.json
+++ b/clients/client-mediastore-data/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs",
     "types": ["mocha"]

--- a/clients/client-mediastore/tsconfig.json
+++ b/clients/client-mediastore/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-mediatailor/tsconfig.json
+++ b/clients/client-mediatailor/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-migration-hub/tsconfig.json
+++ b/clients/client-migration-hub/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-migrationhub-config/tsconfig.json
+++ b/clients/client-migrationhub-config/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-mobile/tsconfig.json
+++ b/clients/client-mobile/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-mq/tsconfig.json
+++ b/clients/client-mq/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-mturk/tsconfig.json
+++ b/clients/client-mturk/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-neptune/tsconfig.json
+++ b/clients/client-neptune/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-networkmanager/tsconfig.json
+++ b/clients/client-networkmanager/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-opsworks/tsconfig.json
+++ b/clients/client-opsworks/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-opsworkscm/tsconfig.json
+++ b/clients/client-opsworkscm/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-organizations/tsconfig.json
+++ b/clients/client-organizations/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-outposts/tsconfig.json
+++ b/clients/client-outposts/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-personalize-events/tsconfig.json
+++ b/clients/client-personalize-events/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-personalize-runtime/tsconfig.json
+++ b/clients/client-personalize-runtime/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-personalize/tsconfig.json
+++ b/clients/client-personalize/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-pi/tsconfig.json
+++ b/clients/client-pi/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-pinpoint-email/tsconfig.json
+++ b/clients/client-pinpoint-email/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-pinpoint-sms-voice/tsconfig.json
+++ b/clients/client-pinpoint-sms-voice/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-pinpoint/tsconfig.json
+++ b/clients/client-pinpoint/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-polly/tsconfig.json
+++ b/clients/client-polly/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-pricing/tsconfig.json
+++ b/clients/client-pricing/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-qldb-session/tsconfig.json
+++ b/clients/client-qldb-session/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-qldb/tsconfig.json
+++ b/clients/client-qldb/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-quicksight/tsconfig.json
+++ b/clients/client-quicksight/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-ram/tsconfig.json
+++ b/clients/client-ram/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-rds-data/tsconfig.json
+++ b/clients/client-rds-data/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-rds/tsconfig.json
+++ b/clients/client-rds/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-redshift/tsconfig.json
+++ b/clients/client-redshift/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-rekognition/tsconfig.json
+++ b/clients/client-rekognition/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-resource-groups-tagging-api/tsconfig.json
+++ b/clients/client-resource-groups-tagging-api/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-resource-groups/tsconfig.json
+++ b/clients/client-resource-groups/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-robomaker/tsconfig.json
+++ b/clients/client-robomaker/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-route-53-domains/tsconfig.json
+++ b/clients/client-route-53-domains/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-route-53/tsconfig.json
+++ b/clients/client-route-53/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-route53resolver/tsconfig.json
+++ b/clients/client-route53resolver/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-s3-control/tsconfig.json
+++ b/clients/client-s3-control/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-s3/e2e/S3.ispec.ts
+++ b/clients/client-s3/e2e/S3.ispec.ts
@@ -3,8 +3,8 @@
  * This is the integration test that make sure the client can make request cross-platform-ly
  * in NodeJS, Chromium and Firefox. This test is written in mocha.
  */
-import * as chai from "chai";
-import * as chaiAsPromised from "chai-as-promised";
+import chai from "chai";
+import chaiAsPromised from "chai-as-promised";
 import { S3 } from "../index";
 import { Credentials } from "@aws-sdk/types";
 import { createBuffer } from "./helpers";

--- a/clients/client-s3/tsconfig.json
+++ b/clients/client-s3/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs",
     "types": ["mocha", "node"]

--- a/clients/client-sagemaker-a2i-runtime/tsconfig.json
+++ b/clients/client-sagemaker-a2i-runtime/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-sagemaker-runtime/tsconfig.json
+++ b/clients/client-sagemaker-runtime/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-sagemaker/tsconfig.json
+++ b/clients/client-sagemaker/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-savingsplans/tsconfig.json
+++ b/clients/client-savingsplans/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-schemas/tsconfig.json
+++ b/clients/client-schemas/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-secrets-manager/tsconfig.json
+++ b/clients/client-secrets-manager/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-securityhub/tsconfig.json
+++ b/clients/client-securityhub/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-serverlessapplicationrepository/tsconfig.json
+++ b/clients/client-serverlessapplicationrepository/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-service-catalog/tsconfig.json
+++ b/clients/client-service-catalog/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-service-quotas/tsconfig.json
+++ b/clients/client-service-quotas/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-servicediscovery/tsconfig.json
+++ b/clients/client-servicediscovery/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-ses/tsconfig.json
+++ b/clients/client-ses/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-sesv2/tsconfig.json
+++ b/clients/client-sesv2/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-sfn/tsconfig.json
+++ b/clients/client-sfn/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-shield/tsconfig.json
+++ b/clients/client-shield/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-signer/tsconfig.json
+++ b/clients/client-signer/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-sms/tsconfig.json
+++ b/clients/client-sms/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-snowball/tsconfig.json
+++ b/clients/client-snowball/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-sns/tsconfig.json
+++ b/clients/client-sns/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-sqs/tsconfig.json
+++ b/clients/client-sqs/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-ssm/tsconfig.json
+++ b/clients/client-ssm/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-sso-oidc/tsconfig.json
+++ b/clients/client-sso-oidc/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-sso/tsconfig.json
+++ b/clients/client-sso/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-storage-gateway/tsconfig.json
+++ b/clients/client-storage-gateway/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-sts/tsconfig.json
+++ b/clients/client-sts/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-support/tsconfig.json
+++ b/clients/client-support/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-swf/tsconfig.json
+++ b/clients/client-swf/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-synthetics/tsconfig.json
+++ b/clients/client-synthetics/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-textract/tsconfig.json
+++ b/clients/client-textract/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-transcribe-streaming/tsconfig.json
+++ b/clients/client-transcribe-streaming/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-transcribe/tsconfig.json
+++ b/clients/client-transcribe/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-transfer/tsconfig.json
+++ b/clients/client-transfer/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-translate/tsconfig.json
+++ b/clients/client-translate/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-waf-regional/tsconfig.json
+++ b/clients/client-waf-regional/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-waf/tsconfig.json
+++ b/clients/client-waf/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-wafv2/tsconfig.json
+++ b/clients/client-wafv2/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-workdocs/tsconfig.json
+++ b/clients/client-workdocs/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-worklink/tsconfig.json
+++ b/clients/client-worklink/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-workmail/tsconfig.json
+++ b/clients/client-workmail/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-workmailmessageflow/tsconfig.json
+++ b/clients/client-workmailmessageflow/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-workspaces/tsconfig.json
+++ b/clients/client-workspaces/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/clients/client-xray/tsconfig.json
+++ b/clients/client-xray/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/protocol_tests/aws-ec2/tsconfig.json
+++ b/protocol_tests/aws-ec2/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/protocol_tests/aws-json/tsconfig.json
+++ b/protocol_tests/aws-json/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/protocol_tests/aws-query/tsconfig.json
+++ b/protocol_tests/aws-query/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/protocol_tests/aws-restjson/tsconfig.json
+++ b/protocol_tests/aws-restjson/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },

--- a/protocol_tests/aws-restxml/tsconfig.json
+++ b/protocol_tests/aws-restxml/tsconfig.json
@@ -11,6 +11,7 @@
     "noEmitHelpers": true,
     "incremental": true,
     "resolveJsonModule": true,
+    "esModuleInterop": true,
     "declarationDir": "./types",
     "outDir": "dist/cjs"
   },


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/awslabs/smithy-typescript/pull/212
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1511

*Description of changes:*
set esModuleInterop to true in clients

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
