### PR TITLE
chore: add fake credentials and regions to unit tests

### DIFF
--- a/clients/client-lex-runtime-service/LexRuntimeService.spec.ts
+++ b/clients/client-lex-runtime-service/LexRuntimeService.spec.ts
@@ -13,7 +13,9 @@ describe("@aws-sdk/client-lex-runtime-service", () => {
         expect(request.headers).to.have.property("x-amz-content-sha256", "UNSIGNED-PAYLOAD");
         return Promise.resolve({ output: {} as any, response: {} as any });
       };
-      const client = new LexRuntimeService({});
+      const client = new LexRuntimeService({
+        region: "us-west-2",
+      });
       client.middlewareStack.add(validator, {
         step: "serialize",
         name: "endpointValidator",

--- a/clients/client-mediastore-data/MidiaStoreData.spec.ts
+++ b/clients/client-mediastore-data/MidiaStoreData.spec.ts
@@ -13,7 +13,9 @@ describe("@aws-sdk/client-mediastore-data", () => {
         expect(request.headers).to.have.property("x-amz-content-sha256", "UNSIGNED-PAYLOAD");
         return Promise.resolve({ output: {} as any, response: {} as any });
       };
-      const client = new MediaStoreData({});
+      const client = new MediaStoreData({
+        region: "us-west-2",
+      });
       client.middlewareStack.add(validator, {
         step: "serialize",
         name: "endpointValidator",

--- a/clients/client-s3/S3.spec.ts
+++ b/clients/client-s3/S3.spec.ts
@@ -47,8 +47,8 @@ describe("Accesspoint ARN", async () => {
   };
 
   it("should succeed with access point ARN", async () => {
-    const client = new S3({});
-    client.middlewareStack.add(endpointValidator, { step: "finalizeRequest", priority: "low" });
+    const client = new S3({ region: "us-west-2" });
+    client.middlewareStack.add(endpointValidator, { step: "build", priority: "low" });
     const result: any = await client.putObject({
       Bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint",
       Key: "key",
@@ -58,7 +58,11 @@ describe("Accesspoint ARN", async () => {
   });
 
   it("should sign request with region from ARN is useArnRegion is set", async () => {
-    const client = new S3({ region: "us-east-1", useArnRegion: true });
+    const client = new S3({
+      region: "us-east-1",
+      useArnRegion: true,
+      credentials: { accessKeyId: "key", secretAccessKey: "secret" },
+    });
     client.middlewareStack.add(endpointValidator, { step: "finalizeRequest", priority: "low" });
     const result: any = await client.putObject({
       Bucket: "arn:aws:s3:us-west-2:123456789012:accesspoint:myendpoint",

--- a/packages/s3-request-presigner/src/getSignedUrl.spec.ts
+++ b/packages/s3-request-presigner/src/getSignedUrl.spec.ts
@@ -26,6 +26,8 @@ import { RequestPresigningArguments } from "@aws-sdk/types/src";
 import { getSignedUrl } from "./getSignedUrl";
 
 describe("getSignedUrl", () => {
+  const clientParams = { region: "us-foo-1" };
+
   beforeEach(() => {
     mockPresign.mockReset();
   });
@@ -33,7 +35,7 @@ describe("getSignedUrl", () => {
   it("should call S3Presigner.sign", async () => {
     const mockPresigned = "a presigned url";
     mockPresign.mockReturnValue(mockPresigned);
-    const client = new S3Client({});
+    const client = new S3Client(clientParams);
     const command = new GetObjectCommand({
       Bucket: "Bucket",
       Key: "Key",
@@ -53,7 +55,7 @@ describe("getSignedUrl", () => {
     mockPresign.mockReturnValue(mockPresigned);
     const signingRegion = "aws-foo-1";
     const signingService = "bar";
-    const client = new S3Client({});
+    const client = new S3Client(clientParams);
     client.middlewareStack.addRelativeTo(
       (next: any, context: any) => (args: any) => {
         context["signing_region"] = signingRegion;
@@ -88,7 +90,7 @@ describe("getSignedUrl", () => {
       signableHeaders: new Set(["head-1", "head-2"]),
       unsignableHeaders: new Set(["head-3", "head-4"]),
     };
-    const client = new S3Client({});
+    const client = new S3Client(clientParams);
     const command = new GetObjectCommand({
       Bucket: "Bucket",
       Key: "Key",

--- a/protocol_tests/aws-ec2/tests/functional/ec2query.spec.ts
+++ b/protocol_tests/aws-ec2/tests/functional/ec2query.spec.ts
@@ -140,11 +140,17 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   return true;
 };
 
+const clientParams = {
+  region: "us-west-2",
+  credentials: { accessKeyId: "key", secretAccessKey: "secret" },
+};
+
 /**
  * Empty input serializes no extra query params
  */
 it("Ec2QueryEmptyInputAndEmptyOutput:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -178,6 +184,7 @@ it("Ec2QueryEmptyInputAndEmptyOutput:Request", async () => {
  */
 it("Ec2QueryEmptyInputAndEmptyOutput:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -209,6 +216,7 @@ it("Ec2QueryEmptyInputAndEmptyOutput:Response", async () => {
  */
 it("Ec2GreetingWithErrors:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -250,6 +258,7 @@ it("Ec2GreetingWithErrors:Response", async () => {
  */
 it("Ec2InvalidGreetingError:Error:GreetingWithErrors", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       400,
@@ -298,6 +307,7 @@ it("Ec2InvalidGreetingError:Error:GreetingWithErrors", async () => {
 
 it("Ec2ComplexError:Error:GreetingWithErrors", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       400,
@@ -357,6 +367,7 @@ it("Ec2ComplexError:Error:GreetingWithErrors", async () => {
  */
 it("Ec2IgnoresWrappingXmlName:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -398,6 +409,7 @@ it("Ec2IgnoresWrappingXmlName:Response", async () => {
  */
 it("Ec2NestedStructures:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -444,6 +456,7 @@ it("Ec2NestedStructures:Request", async () => {
  */
 it("Ec2QueryNoInputAndOutput:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -477,6 +490,7 @@ it("Ec2QueryNoInputAndOutput:Request", async () => {
  */
 it("Ec2QueryNoInputAndOutput:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -508,6 +522,7 @@ it("Ec2QueryNoInputAndOutput:Response", async () => {
  */
 it("Ec2ProtocolIdempotencyTokenAutoFill:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -544,6 +559,7 @@ it("Ec2ProtocolIdempotencyTokenAutoFill:Request", async () => {
  */
 it("Ec2ProtocolIdempotencyTokenAutoFillIsSet:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -580,6 +596,7 @@ it("Ec2ProtocolIdempotencyTokenAutoFillIsSet:Request", async () => {
  */
 it("Ec2Lists:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -630,6 +647,7 @@ it("Ec2Lists:Request", async () => {
  */
 it("Ec2EmptyQueryLists:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -665,6 +683,7 @@ it("Ec2EmptyQueryLists:Request", async () => {
  */
 it("Ec2ListArgWithXmlNameMember:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -702,6 +721,7 @@ it("Ec2ListArgWithXmlNameMember:Request", async () => {
  */
 it("Ec2ListMemberWithXmlName:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -739,6 +759,7 @@ it("Ec2ListMemberWithXmlName:Request", async () => {
  */
 it("Ec2TimestampsInput:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -781,6 +802,7 @@ it("Ec2TimestampsInput:Request", async () => {
  */
 it("Ec2RecursiveShapes:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -847,6 +869,7 @@ it("Ec2RecursiveShapes:Response", async () => {
  */
 it("Ec2SimpleInputParamsStrings:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -886,6 +909,7 @@ it("Ec2SimpleInputParamsStrings:Request", async () => {
  */
 it("Ec2SimpleInputParamsStringAndBooleanTrue:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -925,6 +949,7 @@ it("Ec2SimpleInputParamsStringAndBooleanTrue:Request", async () => {
  */
 it("Ec2SimpleInputParamsStringsAndBooleanFalse:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -961,6 +986,7 @@ it("Ec2SimpleInputParamsStringsAndBooleanFalse:Request", async () => {
  */
 it("Ec2SimpleInputParamsInteger:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -997,6 +1023,7 @@ it("Ec2SimpleInputParamsInteger:Request", async () => {
  */
 it("Ec2SimpleInputParamsFloat:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1033,6 +1060,7 @@ it("Ec2SimpleInputParamsFloat:Request", async () => {
  */
 it("Ec2SimpleInputParamsBlob:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1069,6 +1097,7 @@ it("Ec2SimpleInputParamsBlob:Request", async () => {
  */
 it("Ec2Enums:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1105,6 +1134,7 @@ it("Ec2Enums:Request", async () => {
  */
 it("Ec2Query:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1141,6 +1171,7 @@ it("Ec2Query:Request", async () => {
  */
 it("Ec2QueryIsPreferred:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1177,6 +1208,7 @@ it("Ec2QueryIsPreferred:Request", async () => {
  */
 it("Ec2XmlNameIsUppercased:Request", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1213,6 +1245,7 @@ it("Ec2XmlNameIsUppercased:Request", async () => {
  */
 it("Ec2SimpleScalarProperties:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1281,6 +1314,7 @@ it("Ec2SimpleScalarProperties:Response", async () => {
  */
 it("Ec2XmlBlobs:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1322,6 +1356,7 @@ it("Ec2XmlBlobs:Response", async () => {
  */
 it("Ec2XmlEnums:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1397,6 +1432,7 @@ it("Ec2XmlEnums:Response", async () => {
  */
 it("Ec2XmlLists:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1525,6 +1561,7 @@ it("Ec2XmlLists:Response", async () => {
  */
 it("Ec2XmlNamespaces:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1576,6 +1613,7 @@ it("Ec2XmlNamespaces:Response", async () => {
  */
 it("Ec2XmlTimestamps:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1617,6 +1655,7 @@ it("Ec2XmlTimestamps:Response", async () => {
  */
 it("Ec2XmlTimestampsWithDateTimeFormat:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1658,6 +1697,7 @@ it("Ec2XmlTimestampsWithDateTimeFormat:Response", async () => {
  */
 it("Ec2XmlTimestampsWithEpochSecondsFormat:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1699,6 +1739,7 @@ it("Ec2XmlTimestampsWithEpochSecondsFormat:Response", async () => {
  */
 it("Ec2XmlTimestampsWithHttpDateFormat:Response", async () => {
   const client = new EC2ProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,

--- a/protocol_tests/aws-json/tests/functional/awsjson1_1.spec.ts
+++ b/protocol_tests/aws-json/tests/functional/awsjson1_1.spec.ts
@@ -126,11 +126,17 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   return true;
 };
 
+const clientParams = {
+  region: "us-west-2",
+  credentials: { accessKeyId: "key", secretAccessKey: "secret" },
+};
+
 /**
  * Sends requests to /
  */
 it("sends_requests_to_slash:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -155,6 +161,7 @@ it("sends_requests_to_slash:Request", async () => {
  */
 it("includes_x_amz_target_and_content_type:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -184,6 +191,7 @@ it("includes_x_amz_target_and_content_type:Request", async () => {
  */
 it("handles_empty_output_shape:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -212,6 +220,7 @@ it("handles_empty_output_shape:Response", async () => {
  */
 it("serializes_string_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -243,6 +252,7 @@ it("serializes_string_shapes:Request", async () => {
  */
 it("serializes_string_shapes_with_jsonvalue_trait:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -275,6 +285,7 @@ it("serializes_string_shapes_with_jsonvalue_trait:Request", async () => {
  */
 it("serializes_integer_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -306,6 +317,7 @@ it("serializes_integer_shapes:Request", async () => {
  */
 it("serializes_long_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -337,6 +349,7 @@ it("serializes_long_shapes:Request", async () => {
  */
 it("serializes_float_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -368,6 +381,7 @@ it("serializes_float_shapes:Request", async () => {
  */
 it("serializes_double_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -399,6 +413,7 @@ it("serializes_double_shapes:Request", async () => {
  */
 it("serializes_blob_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -430,6 +445,7 @@ it("serializes_blob_shapes:Request", async () => {
  */
 it("serializes_boolean_shapes_true:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -461,6 +477,7 @@ it("serializes_boolean_shapes_true:Request", async () => {
  */
 it("serializes_boolean_shapes_false:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -492,6 +509,7 @@ it("serializes_boolean_shapes_false:Request", async () => {
  */
 it("serializes_timestamp_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -523,6 +541,7 @@ it("serializes_timestamp_shapes:Request", async () => {
  */
 it("serializes_timestamp_shapes_with_iso8601_timestampformat:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -554,6 +573,7 @@ it("serializes_timestamp_shapes_with_iso8601_timestampformat:Request", async () 
  */
 it("serializes_timestamp_shapes_with_httpdate_timestampformat:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -585,6 +605,7 @@ it("serializes_timestamp_shapes_with_httpdate_timestampformat:Request", async ()
  */
 it("serializes_timestamp_shapes_with_unixtimestamp_timestampformat:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -616,6 +637,7 @@ it("serializes_timestamp_shapes_with_unixtimestamp_timestampformat:Request", asy
  */
 it("serializes_list_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -647,6 +669,7 @@ it("serializes_list_shapes:Request", async () => {
  */
 it("serializes_empty_list_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -678,6 +701,7 @@ it("serializes_empty_list_shapes:Request", async () => {
  */
 it("serializes_list_of_map_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -721,6 +745,7 @@ it("serializes_list_of_map_shapes:Request", async () => {
  */
 it("serializes_list_of_structure_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -764,6 +789,7 @@ it("serializes_list_of_structure_shapes:Request", async () => {
  */
 it("serializes_list_of_recursive_structure_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -807,6 +833,7 @@ it("serializes_list_of_recursive_structure_shapes:Request", async () => {
  */
 it("serializes_map_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -842,6 +869,7 @@ it("serializes_map_shapes:Request", async () => {
  */
 it("serializes_empty_map_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -873,6 +901,7 @@ it("serializes_empty_map_shapes:Request", async () => {
  */
 it("serializes_map_of_list_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -908,6 +937,7 @@ it("serializes_map_of_list_shapes:Request", async () => {
  */
 it("serializes_map_of_structure_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -947,6 +977,7 @@ it("serializes_map_of_structure_shapes:Request", async () => {
  */
 it("serializes_map_of_recursive_structure_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -990,6 +1021,7 @@ it("serializes_map_of_recursive_structure_shapes:Request", async () => {
  */
 it("serializes_structure_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1023,6 +1055,7 @@ it("serializes_structure_shapes:Request", async () => {
  */
 it("serializes_structure_members_with_locationname_traits:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1056,6 +1089,7 @@ it("serializes_structure_members_with_locationname_traits:Request", async () => 
  */
 it("serializes_empty_structure_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1087,6 +1121,7 @@ it("serializes_empty_structure_shapes:Request", async () => {
  */
 it("serializes_structure_which_have_no_members:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1118,6 +1153,7 @@ it("serializes_structure_which_have_no_members:Request", async () => {
  */
 it("serializes_recursive_structure_shapes:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1173,6 +1209,7 @@ it("serializes_recursive_structure_shapes:Request", async () => {
  */
 it("parses_operations_with_empty_json_bodies:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{}`),
   });
 
@@ -1194,6 +1231,7 @@ it("parses_operations_with_empty_json_bodies:Response", async () => {
  */
 it("parses_string_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{"String":"string-value"}`),
   });
 
@@ -1224,6 +1262,7 @@ it("parses_string_shapes:Response", async () => {
  */
 it("parses_integer_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{"Integer":1234}`),
   });
 
@@ -1254,6 +1293,7 @@ it("parses_integer_shapes:Response", async () => {
  */
 it("parses_long_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{"Long":1234567890123456789}`),
   });
 
@@ -1284,6 +1324,7 @@ it("parses_long_shapes:Response", async () => {
  */
 it("parses_float_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{"Float":1234.5}`),
   });
 
@@ -1314,6 +1355,7 @@ it("parses_float_shapes:Response", async () => {
  */
 it("parses_double_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{"Double":123456789.12345679}`),
   });
 
@@ -1344,6 +1386,7 @@ it("parses_double_shapes:Response", async () => {
  */
 it("parses_boolean_shapes_true:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{"Boolean":true}`),
   });
 
@@ -1374,6 +1417,7 @@ it("parses_boolean_shapes_true:Response", async () => {
  */
 it("parses_boolean_false:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{"Boolean":false}`),
   });
 
@@ -1404,6 +1448,7 @@ it("parses_boolean_false:Response", async () => {
  */
 it("parses_blob_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{"Blob":"YmluYXJ5LXZhbHVl"}`),
   });
 
@@ -1434,6 +1479,7 @@ it("parses_blob_shapes:Response", async () => {
  */
 it("parses_timestamp_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{"Timestamp":946845296}`),
   });
 
@@ -1464,6 +1510,7 @@ it("parses_timestamp_shapes:Response", async () => {
  */
 it("parses_iso8601_timestamps:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1499,6 +1546,7 @@ it("parses_iso8601_timestamps:Response", async () => {
  */
 it("parses_httpdate_timestamps:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1534,6 +1582,7 @@ it("parses_httpdate_timestamps:Response", async () => {
  */
 it("parses_list_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1569,6 +1618,7 @@ it("parses_list_shapes:Response", async () => {
  */
 it("parses_list_of_map_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1612,6 +1662,7 @@ it("parses_list_of_map_shapes:Response", async () => {
  */
 it("parses_list_of_list_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1651,6 +1702,7 @@ it("parses_list_of_list_shapes:Response", async () => {
  */
 it("parses_list_of_structure_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1694,6 +1746,7 @@ it("parses_list_of_structure_shapes:Response", async () => {
  */
 it("parses_list_of_recursive_structure_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1741,6 +1794,7 @@ it("parses_list_of_recursive_structure_shapes:Response", async () => {
  */
 it("parses_map_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1780,6 +1834,7 @@ it("parses_map_shapes:Response", async () => {
  */
 it("parses_map_of_list_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1819,6 +1874,7 @@ it("parses_map_of_list_shapes:Response", async () => {
  */
 it("parses_map_of_map_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1866,6 +1922,7 @@ it("parses_map_of_map_shapes:Response", async () => {
  */
 it("parses_map_of_structure_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1909,6 +1966,7 @@ it("parses_map_of_structure_shapes:Response", async () => {
  */
 it("parses_map_of_recursive_structure_shapes:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1956,6 +2014,7 @@ it("parses_map_of_recursive_structure_shapes:Response", async () => {
  */
 it("parses_the_request_id_from_the_response:Response", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1984,6 +2043,7 @@ it("parses_the_request_id_from_the_response:Response", async () => {
  */
 it("can_call_operation_with_no_input_or_output:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2018,6 +2078,7 @@ it("can_call_operation_with_no_input_or_output:Request", async () => {
  */
 it("can_call_operation_with_optional_input:Request", async () => {
   const client = new JsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 

--- a/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
+++ b/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
@@ -146,11 +146,17 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   return true;
 };
 
+const clientParams = {
+  region: "us-west-2",
+  credentials: { accessKeyId: "key", secretAccessKey: "secret" },
+};
+
 /**
  * Empty input serializes no extra query params
  */
 it("QueryEmptyInputAndEmptyOutput:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -184,6 +190,7 @@ it("QueryEmptyInputAndEmptyOutput:Request", async () => {
  */
 it("QueryEmptyInputAndEmptyOutput:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined),
   });
 
@@ -205,6 +212,7 @@ it("QueryEmptyInputAndEmptyOutput:Response", async () => {
  */
 it("QueryQueryFlattenedXmlMap:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -257,6 +265,7 @@ it("QueryQueryFlattenedXmlMap:Response", async () => {
  */
 it("QueryQueryFlattenedXmlMapWithXmlName:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -309,6 +318,7 @@ it("QueryQueryFlattenedXmlMapWithXmlName:Response", async () => {
  */
 it("QueryGreetingWithErrors:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -351,6 +361,7 @@ it("QueryGreetingWithErrors:Response", async () => {
  */
 it("QueryInvalidGreetingError:Error:GreetingWithErrors", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       400,
@@ -398,6 +409,7 @@ it("QueryInvalidGreetingError:Error:GreetingWithErrors", async () => {
 
 it("QueryComplexError:Error:GreetingWithErrors", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       400,
@@ -456,6 +468,7 @@ it("QueryComplexError:Error:GreetingWithErrors", async () => {
  */
 it("QueryIgnoresWrappingXmlName:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -498,6 +511,7 @@ it("QueryIgnoresWrappingXmlName:Response", async () => {
  */
 it("NestedStructures:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -544,6 +558,7 @@ it("NestedStructures:Request", async () => {
  */
 it("QueryNoInputAndNoOutput:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -577,6 +592,7 @@ it("QueryNoInputAndNoOutput:Request", async () => {
  */
 it("QueryNoInputAndNoOutput:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined),
   });
 
@@ -598,6 +614,7 @@ it("QueryNoInputAndNoOutput:Response", async () => {
  */
 it("QueryNoInputAndOutput:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -631,6 +648,7 @@ it("QueryNoInputAndOutput:Request", async () => {
  */
 it("QueryNoInputAndOutput:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined),
   });
 
@@ -652,6 +670,7 @@ it("QueryNoInputAndOutput:Response", async () => {
  */
 it("QueryProtocolIdempotencyTokenAutoFill:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -688,6 +707,7 @@ it("QueryProtocolIdempotencyTokenAutoFill:Request", async () => {
  */
 it("QueryProtocolIdempotencyTokenAutoFillIsSet:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -724,6 +744,7 @@ it("QueryProtocolIdempotencyTokenAutoFillIsSet:Request", async () => {
  */
 it("QueryLists:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -774,6 +795,7 @@ it("QueryLists:Request", async () => {
  */
 it("EmptyQueryLists:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -809,6 +831,7 @@ it("EmptyQueryLists:Request", async () => {
  */
 it("FlattenedQueryLists:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -846,6 +869,7 @@ it("FlattenedQueryLists:Request", async () => {
  */
 it("QueryListArgWithXmlNameMember:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -883,6 +907,7 @@ it("QueryListArgWithXmlNameMember:Request", async () => {
  */
 it("QueryFlattenedListArgWithXmlName:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -920,6 +945,7 @@ it("QueryFlattenedListArgWithXmlName:Request", async () => {
  */
 it("QuerySimpleQueryMaps:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -963,6 +989,7 @@ it("QuerySimpleQueryMaps:Request", async () => {
  */
 it("QuerySimpleQueryMapsWithXmlName:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1002,6 +1029,7 @@ it("QuerySimpleQueryMapsWithXmlName:Request", async () => {
  */
 it("QueryComplexQueryMaps:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1049,6 +1077,7 @@ it("QueryComplexQueryMaps:Request", async () => {
  */
 it("QueryEmptyQueryMaps:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1084,6 +1113,7 @@ it("QueryEmptyQueryMaps:Request", async () => {
  */
 it("QueryQueryMapWithMemberXmlName:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1127,6 +1157,7 @@ it("QueryQueryMapWithMemberXmlName:Request", async () => {
  */
 it("QueryFlattenedQueryMaps:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1170,6 +1201,7 @@ it("QueryFlattenedQueryMaps:Request", async () => {
  */
 it("QueryFlattenedQueryMapsWithXmlName:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1213,6 +1245,7 @@ it("QueryFlattenedQueryMapsWithXmlName:Request", async () => {
  */
 it("QueryQueryMapOfLists:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1258,6 +1291,7 @@ it("QueryQueryMapOfLists:Request", async () => {
  */
 it("QueryTimestampsInput:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1300,6 +1334,7 @@ it("QueryTimestampsInput:Request", async () => {
  */
 it("QueryRecursiveShapes:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1367,6 +1402,7 @@ it("QueryRecursiveShapes:Response", async () => {
  */
 it("QuerySimpleInputParamsStrings:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1406,6 +1442,7 @@ it("QuerySimpleInputParamsStrings:Request", async () => {
  */
 it("QuerySimpleInputParamsStringAndBooleanTrue:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1445,6 +1482,7 @@ it("QuerySimpleInputParamsStringAndBooleanTrue:Request", async () => {
  */
 it("QuerySimpleInputParamsStringsAndBooleanFalse:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1481,6 +1519,7 @@ it("QuerySimpleInputParamsStringsAndBooleanFalse:Request", async () => {
  */
 it("QuerySimpleInputParamsInteger:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1517,6 +1556,7 @@ it("QuerySimpleInputParamsInteger:Request", async () => {
  */
 it("QuerySimpleInputParamsFloat:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1553,6 +1593,7 @@ it("QuerySimpleInputParamsFloat:Request", async () => {
  */
 it("QuerySimpleInputParamsBlob:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1589,6 +1630,7 @@ it("QuerySimpleInputParamsBlob:Request", async () => {
  */
 it("QueryEnums:Request", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1625,6 +1667,7 @@ it("QueryEnums:Request", async () => {
  */
 it("QuerySimpleScalarProperties:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1694,6 +1737,7 @@ it("QuerySimpleScalarProperties:Response", async () => {
  */
 it("QueryXmlBlobs:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1736,6 +1780,7 @@ it("QueryXmlBlobs:Response", async () => {
  */
 it("QueryXmlEnums:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1812,6 +1857,7 @@ it("QueryXmlEnums:Response", async () => {
  */
 it("QueryXmlLists:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1941,6 +1987,7 @@ it("QueryXmlLists:Response", async () => {
  */
 it("QueryXmlMaps:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2004,6 +2051,7 @@ it("QueryXmlMaps:Response", async () => {
  */
 it("QueryQueryXmlMapsXmlName:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2067,6 +2115,7 @@ it("QueryQueryXmlMapsXmlName:Response", async () => {
  */
 it("QueryXmlNamespaces:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2119,6 +2168,7 @@ it("QueryXmlNamespaces:Response", async () => {
  */
 it("QueryXmlTimestamps:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2161,6 +2211,7 @@ it("QueryXmlTimestamps:Response", async () => {
  */
 it("QueryXmlTimestampsWithDateTimeFormat:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2203,6 +2254,7 @@ it("QueryXmlTimestampsWithDateTimeFormat:Response", async () => {
  */
 it("QueryXmlTimestampsWithEpochSecondsFormat:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2245,6 +2297,7 @@ it("QueryXmlTimestampsWithEpochSecondsFormat:Response", async () => {
  */
 it("QueryXmlTimestampsWithHttpDateFormat:Response", async () => {
   const client = new QueryProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,

--- a/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
+++ b/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
@@ -152,11 +152,17 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   return true;
 };
 
+const clientParams = {
+  region: "us-west-2",
+  credentials: { accessKeyId: "key", secretAccessKey: "secret" },
+};
+
 /**
  * Serializes query string parameters with all supported types
  */
 it("RestJsonAllQueryStringTypes:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -255,6 +261,7 @@ it("RestJsonAllQueryStringTypes:Request", async () => {
  */
 it("RestJsonConstantAndVariableQueryStringMissingOneValue:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -289,6 +296,7 @@ it("RestJsonConstantAndVariableQueryStringMissingOneValue:Request", async () => 
  */
 it("RestJsonConstantAndVariableQueryStringAllValues:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -324,6 +332,7 @@ it("RestJsonConstantAndVariableQueryStringAllValues:Request", async () => {
  */
 it("RestJsonConstantQueryString:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -356,6 +365,7 @@ it("RestJsonConstantQueryString:Request", async () => {
  */
 it("RestJsonEmptyInputAndEmptyOutput:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -385,6 +395,7 @@ it("RestJsonEmptyInputAndEmptyOutput:Request", async () => {
  */
 it("RestJsonEmptyInputAndEmptyOutput:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, `{}`),
   });
 
@@ -406,6 +417,7 @@ it("RestJsonEmptyInputAndEmptyOutput:Response", async () => {
  */
 it("RestJsonGreetingWithErrors:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -446,6 +458,7 @@ it("RestJsonGreetingWithErrors:Response", async () => {
  */
 it("RestJsonFooErrorUsingXAmznErrorType:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(false, 500, {
       "x-amzn-errortype": "FooError",
     }),
@@ -477,6 +490,7 @@ it("RestJsonFooErrorUsingXAmznErrorType:Error:GreetingWithErrors", async () => {
  */
 it("RestJsonFooErrorUsingXAmznErrorTypeWithUri:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(false, 500, {
       "x-amzn-errortype": "FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
     }),
@@ -505,6 +519,7 @@ it("RestJsonFooErrorUsingXAmznErrorTypeWithUri:Error:GreetingWithErrors", async 
  */
 it("RestJsonFooErrorUsingXAmznErrorTypeWithUriAndNamespace:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(false, 500, {
       "x-amzn-errortype":
         "aws.protocoltests.restjson#FooError:http://internal.amazon.com/coral/com.amazon.coral.validate/",
@@ -536,6 +551,7 @@ it("RestJsonFooErrorUsingXAmznErrorTypeWithUriAndNamespace:Error:GreetingWithErr
  */
 it("RestJsonFooErrorUsingCode:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       500,
@@ -571,6 +587,7 @@ it("RestJsonFooErrorUsingCode:Error:GreetingWithErrors", async () => {
  */
 it("RestJsonFooErrorUsingCodeAndNamespace:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       500,
@@ -606,6 +623,7 @@ it("RestJsonFooErrorUsingCodeAndNamespace:Error:GreetingWithErrors", async () =>
  */
 it("RestJsonFooErrorUsingCodeUriAndNamespace:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       500,
@@ -641,6 +659,7 @@ it("RestJsonFooErrorUsingCodeUriAndNamespace:Error:GreetingWithErrors", async ()
  */
 it("RestJsonFooErrorWithDunderType:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       500,
@@ -676,6 +695,7 @@ it("RestJsonFooErrorWithDunderType:Error:GreetingWithErrors", async () => {
  */
 it("RestJsonFooErrorWithDunderTypeAndNamespace:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       500,
@@ -711,6 +731,7 @@ it("RestJsonFooErrorWithDunderTypeAndNamespace:Error:GreetingWithErrors", async 
  */
 it("RestJsonFooErrorWithDunderTypeUriAndNamespace:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       500,
@@ -746,6 +767,7 @@ it("RestJsonFooErrorWithDunderTypeUriAndNamespace:Error:GreetingWithErrors", asy
  */
 it("RestJsonComplexErrorWithNoMessage:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       403,
@@ -798,6 +820,7 @@ it("RestJsonComplexErrorWithNoMessage:Error:GreetingWithErrors", async () => {
 
 it("RestJsonEmptyComplexErrorWithNoMessage:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       403,
@@ -832,6 +855,7 @@ it("RestJsonEmptyComplexErrorWithNoMessage:Error:GreetingWithErrors", async () =
  */
 it("RestJsonInvalidGreetingError:Error:GreetingWithErrors", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       400,
@@ -877,6 +901,7 @@ it("RestJsonInvalidGreetingError:Error:GreetingWithErrors", async () => {
  */
 it("RestJsonHttpPayloadTraitsWithBlob:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -911,6 +936,7 @@ it("RestJsonHttpPayloadTraitsWithBlob:Request", async () => {
  */
 it("RestJsonHttpPayloadTraitsWithNoBlobBody:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -942,6 +968,7 @@ it("RestJsonHttpPayloadTraitsWithNoBlobBody:Request", async () => {
  */
 it("RestJsonHttpPayloadTraitsWithBlob:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -981,6 +1008,7 @@ it("RestJsonHttpPayloadTraitsWithBlob:Response", async () => {
  */
 it("RestJsonHttpPayloadTraitsWithNoBlobBody:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1018,6 +1046,7 @@ it("RestJsonHttpPayloadTraitsWithNoBlobBody:Response", async () => {
  */
 it("RestJsonHttpPayloadTraitsWithMediaTypeWithBlob:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1054,6 +1083,7 @@ it("RestJsonHttpPayloadTraitsWithMediaTypeWithBlob:Request", async () => {
  */
 it("RestJsonHttpPayloadTraitsWithMediaTypeWithBlob:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1094,6 +1124,7 @@ it("RestJsonHttpPayloadTraitsWithMediaTypeWithBlob:Response", async () => {
  */
 it("RestJsonHttpPayloadWithStructure:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1135,6 +1166,7 @@ it("RestJsonHttpPayloadWithStructure:Request", async () => {
  */
 it("RestJsonHttpPayloadWithStructure:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1179,6 +1211,7 @@ it("RestJsonHttpPayloadWithStructure:Response", async () => {
  */
 it("RestJsonHttpPrefixHeadersArePresent:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1220,6 +1253,7 @@ it("RestJsonHttpPrefixHeadersArePresent:Request", async () => {
  */
 it("RestJsonHttpPrefixHeadersAreNotPresent:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1253,6 +1287,7 @@ it("RestJsonHttpPrefixHeadersAreNotPresent:Request", async () => {
  */
 it("RestJsonHttpPrefixHeadersArePresent:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1298,6 +1333,7 @@ it("RestJsonHttpPrefixHeadersArePresent:Response", async () => {
  */
 it("RestJsonHttpPrefixHeadersAreNotPresent:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1337,6 +1373,7 @@ it("RestJsonHttpPrefixHeadersAreNotPresent:Response", async () => {
  */
 it("RestJsonHttpRequestWithGreedyLabelInPath:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1367,6 +1404,7 @@ it("RestJsonHttpRequestWithGreedyLabelInPath:Request", async () => {
  */
 it("RestJsonInputWithHeadersAndAllParams:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1409,6 +1447,7 @@ it("RestJsonInputWithHeadersAndAllParams:Request", async () => {
  */
 it("RestJsonHttpRequestWithLabelsAndTimestampFormat:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1451,6 +1490,7 @@ it("RestJsonHttpRequestWithLabelsAndTimestampFormat:Request", async () => {
  */
 it("RestJsonIgnoreQueryParamsInResponse:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1479,6 +1519,7 @@ it("RestJsonIgnoreQueryParamsInResponse:Response", async () => {
  */
 it("RestJsonInputAndOutputWithStringHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1518,6 +1559,7 @@ it("RestJsonInputAndOutputWithStringHeaders:Request", async () => {
  */
 it("RestJsonInputAndOutputWithNumericHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1573,6 +1615,7 @@ it("RestJsonInputAndOutputWithNumericHeaders:Request", async () => {
  */
 it("RestJsonInputAndOutputWithBooleanHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1612,6 +1655,7 @@ it("RestJsonInputAndOutputWithBooleanHeaders:Request", async () => {
  */
 it("RestJsonInputAndOutputWithTimestampHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1643,6 +1687,7 @@ it("RestJsonInputAndOutputWithTimestampHeaders:Request", async () => {
  */
 it("RestJsonInputAndOutputWithEnumHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1678,6 +1723,7 @@ it("RestJsonInputAndOutputWithEnumHeaders:Request", async () => {
  */
 it("RestJsonInputAndOutputWithStringHeaders:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1721,6 +1767,7 @@ it("RestJsonInputAndOutputWithStringHeaders:Response", async () => {
  */
 it("RestJsonInputAndOutputWithNumericHeaders:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1776,6 +1823,7 @@ it("RestJsonInputAndOutputWithNumericHeaders:Response", async () => {
  */
 it("RestJsonInputAndOutputWithBooleanHeaders:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1819,6 +1867,7 @@ it("RestJsonInputAndOutputWithBooleanHeaders:Response", async () => {
  */
 it("RestJsonInputAndOutputWithTimestampHeaders:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1856,6 +1905,7 @@ it("RestJsonInputAndOutputWithTimestampHeaders:Response", async () => {
  */
 it("RestJsonInputAndOutputWithEnumHeaders:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1896,6 +1946,7 @@ it("RestJsonInputAndOutputWithEnumHeaders:Response", async () => {
  */
 it("RestJsonJsonBlobs:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1932,6 +1983,7 @@ it("RestJsonJsonBlobs:Request", async () => {
  */
 it("RestJsonJsonBlobs:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1971,6 +2023,7 @@ it("RestJsonJsonBlobs:Response", async () => {
  */
 it("RestJsonJsonEnums:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2035,6 +2088,7 @@ it("RestJsonJsonEnums:Request", async () => {
  */
 it("RestJsonJsonEnums:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2102,6 +2156,7 @@ it("RestJsonJsonEnums:Response", async () => {
  */
 it("RestJsonLists:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2211,6 +2266,7 @@ it("RestJsonLists:Request", async () => {
  */
 it("RestJsonListsEmpty:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2247,6 +2303,7 @@ it("RestJsonListsEmpty:Request", async () => {
  */
 it("RestJsonListsSerializeNull:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2285,6 +2342,7 @@ it("RestJsonListsSerializeNull:Request", async () => {
  */
 it("RestJsonLists:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2397,6 +2455,7 @@ it("RestJsonLists:Response", async () => {
  */
 it("RestJsonListsEmpty:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2436,6 +2495,7 @@ it("RestJsonListsEmpty:Response", async () => {
  */
 it("RestJsonListsSerializeNull:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2477,6 +2537,7 @@ it("RestJsonListsSerializeNull:Response", async () => {
  */
 it("RestJsonJsonMaps:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2528,6 +2589,7 @@ it("RestJsonJsonMaps:Request", async () => {
  */
 it("RestJsonJsonMaps:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2582,6 +2644,7 @@ it("RestJsonJsonMaps:Response", async () => {
  */
 it("RestJsonJsonTimestamps:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2618,6 +2681,7 @@ it("RestJsonJsonTimestamps:Request", async () => {
  */
 it("RestJsonJsonTimestampsWithDateTimeFormat:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2654,6 +2718,7 @@ it("RestJsonJsonTimestampsWithDateTimeFormat:Request", async () => {
  */
 it("RestJsonJsonTimestampsWithEpochSecondsFormat:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2690,6 +2755,7 @@ it("RestJsonJsonTimestampsWithEpochSecondsFormat:Request", async () => {
  */
 it("RestJsonJsonTimestampsWithHttpDateFormat:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2726,6 +2792,7 @@ it("RestJsonJsonTimestampsWithHttpDateFormat:Request", async () => {
  */
 it("RestJsonJsonTimestamps:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2765,6 +2832,7 @@ it("RestJsonJsonTimestamps:Response", async () => {
  */
 it("RestJsonJsonTimestampsWithDateTimeFormat:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2804,6 +2872,7 @@ it("RestJsonJsonTimestampsWithDateTimeFormat:Response", async () => {
  */
 it("RestJsonJsonTimestampsWithEpochSecondsFormat:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2843,6 +2912,7 @@ it("RestJsonJsonTimestampsWithEpochSecondsFormat:Response", async () => {
  */
 it("RestJsonJsonTimestampsWithHttpDateFormat:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2882,6 +2952,7 @@ it("RestJsonJsonTimestampsWithHttpDateFormat:Response", async () => {
  */
 it("RestJsonNoInputAndNoOutput:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2906,6 +2977,7 @@ it("RestJsonNoInputAndNoOutput:Request", async () => {
  */
 it("RestJsonNoInputAndNoOutput:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined),
   });
 
@@ -2927,6 +2999,7 @@ it("RestJsonNoInputAndNoOutput:Response", async () => {
  */
 it("RestJsonNoInputAndOutput:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2951,6 +3024,7 @@ it("RestJsonNoInputAndOutput:Request", async () => {
  */
 it("RestJsonNoInputAndOutput:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined),
   });
 
@@ -2972,6 +3046,7 @@ it("RestJsonNoInputAndOutput:Response", async () => {
  */
 it("RestJsonNullAndEmptyHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3008,6 +3083,7 @@ it("RestJsonNullAndEmptyHeaders:Request", async () => {
  */
 it("RestJsonOmitsNullSerializesEmptyString:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3041,6 +3117,7 @@ it("RestJsonOmitsNullSerializesEmptyString:Request", async () => {
  */
 it("RestJsonQueryIdempotencyTokenAutoFill:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3072,6 +3149,7 @@ it("RestJsonQueryIdempotencyTokenAutoFill:Request", async () => {
  */
 it("RestJsonQueryIdempotencyTokenAutoFillIsSet:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3103,6 +3181,7 @@ it("RestJsonQueryIdempotencyTokenAutoFillIsSet:Request", async () => {
  */
 it("RestJsonRecursiveShapes:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3164,6 +3243,7 @@ it("RestJsonRecursiveShapes:Request", async () => {
  */
 it("RestJsonRecursiveShapes:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -3228,6 +3308,7 @@ it("RestJsonRecursiveShapes:Response", async () => {
  */
 it("RestJsonSimpleScalarProperties:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3292,6 +3373,7 @@ it("RestJsonSimpleScalarProperties:Request", async () => {
  */
 it("RestJsonSimpleScalarProperties:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -3358,6 +3440,7 @@ it("RestJsonSimpleScalarProperties:Response", async () => {
  */
 it("RestJsonTimestampFormatHeaders:Request", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3413,6 +3496,7 @@ it("RestJsonTimestampFormatHeaders:Request", async () => {
  */
 it("RestJsonTimestampFormatHeaders:Response", async () => {
   const client = new RestJsonProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,

--- a/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
+++ b/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
@@ -162,11 +162,17 @@ const equivalentContents = (expected: any, generated: any): boolean => {
   return true;
 };
 
+const clientParams = {
+  region: "us-west-2",
+  credentials: { accessKeyId: "key", secretAccessKey: "secret" },
+};
+
 /**
  * Serializes query string parameters with all supported types
  */
 it("AllQueryStringTypes:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -265,6 +271,7 @@ it("AllQueryStringTypes:Request", async () => {
  */
 it("ConstantAndVariableQueryStringMissingOneValue:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -299,6 +306,7 @@ it("ConstantAndVariableQueryStringMissingOneValue:Request", async () => {
  */
 it("ConstantAndVariableQueryStringAllValues:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -334,6 +342,7 @@ it("ConstantAndVariableQueryStringAllValues:Request", async () => {
  */
 it("ConstantQueryString:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -366,6 +375,7 @@ it("ConstantQueryString:Request", async () => {
  */
 it("EmptyInputAndEmptyOutput:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -392,6 +402,7 @@ it("EmptyInputAndEmptyOutput:Request", async () => {
  */
 it("EmptyInputAndEmptyOutput:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, ``),
   });
 
@@ -413,6 +424,7 @@ it("EmptyInputAndEmptyOutput:Response", async () => {
  */
 it("FlattenedXmlMap:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -460,6 +472,7 @@ it("FlattenedXmlMap:Request", async () => {
  */
 it("FlattenedXmlMap:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -510,6 +523,7 @@ it("FlattenedXmlMap:Response", async () => {
  */
 it("FlattenedXmlMapWithXmlName:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -557,6 +571,7 @@ it("FlattenedXmlMapWithXmlName:Request", async () => {
  */
 it("FlattenedXmlMapWithXmlName:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -607,6 +622,7 @@ it("FlattenedXmlMapWithXmlName:Response", async () => {
  */
 it("GreetingWithErrors:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -644,6 +660,7 @@ it("GreetingWithErrors:Response", async () => {
  */
 it("InvalidGreetingError:Error:GreetingWithErrors", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       400,
@@ -692,6 +709,7 @@ it("InvalidGreetingError:Error:GreetingWithErrors", async () => {
 
 it("ComplexError:Error:GreetingWithErrors", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       false,
       400,
@@ -753,6 +771,7 @@ it("ComplexError:Error:GreetingWithErrors", async () => {
  */
 it("HttpPayloadTraitsWithBlob:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -787,6 +806,7 @@ it("HttpPayloadTraitsWithBlob:Request", async () => {
  */
 it("HttpPayloadTraitsWithNoBlobBody:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -818,6 +838,7 @@ it("HttpPayloadTraitsWithNoBlobBody:Request", async () => {
  */
 it("HttpPayloadTraitsWithBlob:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -857,6 +878,7 @@ it("HttpPayloadTraitsWithBlob:Response", async () => {
  */
 it("HttpPayloadTraitsWithNoBlobBody:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -894,6 +916,7 @@ it("HttpPayloadTraitsWithNoBlobBody:Response", async () => {
  */
 it("HttpPayloadTraitsWithMediaTypeWithBlob:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -930,6 +953,7 @@ it("HttpPayloadTraitsWithMediaTypeWithBlob:Request", async () => {
  */
 it("HttpPayloadTraitsWithMediaTypeWithBlob:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -970,6 +994,7 @@ it("HttpPayloadTraitsWithMediaTypeWithBlob:Response", async () => {
  */
 it("HttpPayloadWithStructure:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1012,6 +1037,7 @@ it("HttpPayloadWithStructure:Request", async () => {
  */
 it("HttpPayloadWithStructure:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1057,6 +1083,7 @@ it("HttpPayloadWithStructure:Response", async () => {
  */
 it("HttpPayloadWithXmlName:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1093,6 +1120,7 @@ it("HttpPayloadWithXmlName:Request", async () => {
  */
 it("HttpPayloadWithXmlName:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1132,6 +1160,7 @@ it("HttpPayloadWithXmlName:Response", async () => {
  */
 it("HttpPayloadWithXmlNamespace:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1170,6 +1199,7 @@ it("HttpPayloadWithXmlNamespace:Request", async () => {
  */
 it("HttpPayloadWithXmlNamespace:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1211,6 +1241,7 @@ it("HttpPayloadWithXmlNamespace:Response", async () => {
  */
 it("HttpPayloadWithXmlNamespaceAndPrefix:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1249,6 +1280,7 @@ it("HttpPayloadWithXmlNamespaceAndPrefix:Request", async () => {
  */
 it("HttpPayloadWithXmlNamespaceAndPrefix:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1290,6 +1322,7 @@ it("HttpPayloadWithXmlNamespaceAndPrefix:Response", async () => {
  */
 it("HttpPrefixHeadersArePresent:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1331,6 +1364,7 @@ it("HttpPrefixHeadersArePresent:Request", async () => {
  */
 it("HttpPrefixHeadersAreNotPresent:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1364,6 +1398,7 @@ it("HttpPrefixHeadersAreNotPresent:Request", async () => {
  */
 it("HttpPrefixHeadersArePresent:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1409,6 +1444,7 @@ it("HttpPrefixHeadersArePresent:Response", async () => {
  */
 it("HttpPrefixHeadersAreNotPresent:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1448,6 +1484,7 @@ it("HttpPrefixHeadersAreNotPresent:Response", async () => {
  */
 it("HttpRequestWithGreedyLabelInPath:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1478,6 +1515,7 @@ it("HttpRequestWithGreedyLabelInPath:Request", async () => {
  */
 it("InputWithHeadersAndAllParams:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1520,6 +1558,7 @@ it("InputWithHeadersAndAllParams:Request", async () => {
  */
 it("HttpRequestWithLabelsAndTimestampFormat:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1562,6 +1601,7 @@ it("HttpRequestWithLabelsAndTimestampFormat:Request", async () => {
  */
 it("IgnoreQueryParamsInResponse:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1599,6 +1639,7 @@ it("IgnoreQueryParamsInResponse:Response", async () => {
  */
 it("InputAndOutputWithStringHeaders:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1638,6 +1679,7 @@ it("InputAndOutputWithStringHeaders:Request", async () => {
  */
 it("InputAndOutputWithNumericHeaders:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1693,6 +1735,7 @@ it("InputAndOutputWithNumericHeaders:Request", async () => {
  */
 it("InputAndOutputWithBooleanHeaders:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1732,6 +1775,7 @@ it("InputAndOutputWithBooleanHeaders:Request", async () => {
  */
 it("InputAndOutputWithTimestampHeaders:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1763,6 +1807,7 @@ it("InputAndOutputWithTimestampHeaders:Request", async () => {
  */
 it("InputAndOutputWithEnumHeaders:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -1798,6 +1843,7 @@ it("InputAndOutputWithEnumHeaders:Request", async () => {
  */
 it("InputAndOutputWithStringHeaders:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1841,6 +1887,7 @@ it("InputAndOutputWithStringHeaders:Response", async () => {
  */
 it("InputAndOutputWithNumericHeaders:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1896,6 +1943,7 @@ it("InputAndOutputWithNumericHeaders:Response", async () => {
  */
 it("InputAndOutputWithBooleanHeaders:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1939,6 +1987,7 @@ it("InputAndOutputWithBooleanHeaders:Response", async () => {
  */
 it("InputAndOutputWithTimestampHeaders:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -1976,6 +2025,7 @@ it("InputAndOutputWithTimestampHeaders:Response", async () => {
  */
 it("InputAndOutputWithEnumHeaders:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2016,6 +2066,7 @@ it("InputAndOutputWithEnumHeaders:Response", async () => {
  */
 it("NoInputAndNoOutput:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2042,6 +2093,7 @@ it("NoInputAndNoOutput:Request", async () => {
  */
 it("NoInputAndNoOutput:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, ``),
   });
 
@@ -2063,6 +2115,7 @@ it("NoInputAndNoOutput:Response", async () => {
  */
 it("NoInputAndOutput:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2089,6 +2142,7 @@ it("NoInputAndOutput:Request", async () => {
  */
 it("NoInputAndOutput:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(true, 200, undefined, ``),
   });
 
@@ -2110,6 +2164,7 @@ it("NoInputAndOutput:Response", async () => {
  */
 it("NullAndEmptyHeaders:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2146,6 +2201,7 @@ it("NullAndEmptyHeaders:Request", async () => {
  */
 it("OmitsNullSerializesEmptyString:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2179,6 +2235,7 @@ it("OmitsNullSerializesEmptyString:Request", async () => {
  */
 it("QueryIdempotencyTokenAutoFill:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2210,6 +2267,7 @@ it("QueryIdempotencyTokenAutoFill:Request", async () => {
  */
 it("QueryIdempotencyTokenAutoFillIsSet:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2241,6 +2299,7 @@ it("QueryIdempotencyTokenAutoFillIsSet:Request", async () => {
  */
 it("RecursiveShapes:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2303,6 +2362,7 @@ it("RecursiveShapes:Request", async () => {
  */
 it("RecursiveShapes:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2368,6 +2428,7 @@ it("RecursiveShapes:Response", async () => {
  */
 it("SimpleScalarProperties:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2433,6 +2494,7 @@ it("SimpleScalarProperties:Request", async () => {
  */
 it("SimpleScalarProperties:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2500,6 +2562,7 @@ it("SimpleScalarProperties:Response", async () => {
  */
 it("TimestampFormatHeaders:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2555,6 +2618,7 @@ it("TimestampFormatHeaders:Request", async () => {
  */
 it("TimestampFormatHeaders:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2610,6 +2674,7 @@ it("TimestampFormatHeaders:Response", async () => {
  */
 it("XmlAttributes:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2649,6 +2714,7 @@ it("XmlAttributes:Request", async () => {
  */
 it("XmlAttributes:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2691,6 +2757,7 @@ it("XmlAttributes:Response", async () => {
  */
 it("XmlAttributesOnPayload:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2732,6 +2799,7 @@ it("XmlAttributesOnPayload:Request", async () => {
  */
 it("XmlAttributesOnPayload:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2776,6 +2844,7 @@ it("XmlAttributesOnPayload:Response", async () => {
  */
 it("XmlBlobs:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2813,6 +2882,7 @@ it("XmlBlobs:Request", async () => {
  */
 it("XmlBlobs:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2853,6 +2923,7 @@ it("XmlBlobs:Response", async () => {
  */
 it("XmlEnums:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -2924,6 +2995,7 @@ it("XmlEnums:Request", async () => {
  */
 it("XmlEnums:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -2998,6 +3070,7 @@ it("XmlEnums:Response", async () => {
  */
 it("XmlLists:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3122,6 +3195,7 @@ it("XmlLists:Request", async () => {
  */
 it("XmlLists:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -3249,6 +3323,7 @@ it("XmlLists:Response", async () => {
  */
 it("XmlMaps:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3307,6 +3382,7 @@ it("XmlMaps:Request", async () => {
  */
 it("XmlMaps:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -3368,6 +3444,7 @@ it("XmlMaps:Response", async () => {
  */
 it("XmlMapsXmlName:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3426,6 +3503,7 @@ it("XmlMapsXmlName:Request", async () => {
  */
 it("XmlMapsXmlName:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -3487,6 +3565,7 @@ it("XmlMapsXmlName:Response", async () => {
  */
 it("XmlNamespaces:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3534,6 +3613,7 @@ it("XmlNamespaces:Request", async () => {
  */
 it("XmlNamespaces:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -3584,6 +3664,7 @@ it("XmlNamespaces:Response", async () => {
  */
 it("XmlTimestamps:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3621,6 +3702,7 @@ it("XmlTimestamps:Request", async () => {
  */
 it("XmlTimestampsWithDateTimeFormat:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3658,6 +3740,7 @@ it("XmlTimestampsWithDateTimeFormat:Request", async () => {
  */
 it("XmlTimestampsWithEpochSecondsFormat:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3695,6 +3778,7 @@ it("XmlTimestampsWithEpochSecondsFormat:Request", async () => {
  */
 it("XmlTimestampsWithHttpDateFormat:Request", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new RequestSerializationTestHandler(),
   });
 
@@ -3732,6 +3816,7 @@ it("XmlTimestampsWithHttpDateFormat:Request", async () => {
  */
 it("XmlTimestamps:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -3772,6 +3857,7 @@ it("XmlTimestamps:Response", async () => {
  */
 it("XmlTimestampsWithDateTimeFormat:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -3812,6 +3898,7 @@ it("XmlTimestampsWithDateTimeFormat:Response", async () => {
  */
 it("XmlTimestampsWithEpochSecondsFormat:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,
@@ -3852,6 +3939,7 @@ it("XmlTimestampsWithEpochSecondsFormat:Response", async () => {
  */
 it("XmlTimestampsWithHttpDateFormat:Response", async () => {
   const client = new RestXmlProtocolClient({
+    ...clientParams,
     requestHandler: new ResponseDeserializationTestHandler(
       true,
       200,


### PR DESCRIPTION
Some functional tests, unit tests and protocol tests constructs new clients
in test suites. If these tests run in environment without any AWS configs,
they will fail with region is missing or cannot resolve credentials. This
change add fake regions and credentials to this test so SDK won't try to
resolve them in the test. It enables the test:all script to be runnable on
for example, a fresh EC2 instance


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
