### PR TITLE
fix: add loggerMiddleware in build step

### DIFF
--- a/packages/middleware-logger/src/loggerMiddleware.spec.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.spec.ts
@@ -1,4 +1,4 @@
-import { FinalizeHandlerArguments, Logger, MiddlewareStack } from "@aws-sdk/types";
+import { BuildHandlerArguments, Logger, MiddlewareStack } from "@aws-sdk/types";
 
 import { getLoggerPlugin, loggerMiddleware, loggerMiddlewareOptions } from "./loggerMiddleware";
 
@@ -54,14 +54,14 @@ describe("loggerMiddleware", () => {
   });
 
   it("returns without logging if context.logger is not defined", async () => {
-    const response = await loggerMiddleware()(next, {})(args as FinalizeHandlerArguments<any>);
+    const response = await loggerMiddleware()(next, {})(args as BuildHandlerArguments<any>);
     expect(next).toHaveBeenCalledTimes(1);
     expect(response).toStrictEqual(mockResponse);
   });
 
   it("returns without logging if context.logger doesn't have debug/info functions", async () => {
     const logger = {} as Logger;
-    const response = await loggerMiddleware()(next, { logger })(args as FinalizeHandlerArguments<any>);
+    const response = await loggerMiddleware()(next, { logger })(args as BuildHandlerArguments<any>);
     expect(next).toHaveBeenCalledTimes(1);
     expect(response).toStrictEqual(mockResponse);
   });
@@ -77,7 +77,7 @@ describe("loggerMiddleware", () => {
       outputFilterSensitiveLog,
     };
 
-    const response = await loggerMiddleware()(next, context)(args as FinalizeHandlerArguments<any>);
+    const response = await loggerMiddleware()(next, context)(args as BuildHandlerArguments<any>);
     expect(next).toHaveBeenCalledTimes(1);
     expect(response).toStrictEqual(mockResponse);
 
@@ -97,7 +97,7 @@ describe("loggerMiddleware", () => {
 
   it("logs httpRequest, httpResponse if context.logger has debug function", async () => {
     const logger = ({ debug: jest.fn() } as unknown) as Logger;
-    const response = await loggerMiddleware()(next, { logger })(args as FinalizeHandlerArguments<any>);
+    const response = await loggerMiddleware()(next, { logger })(args as BuildHandlerArguments<any>);
     expect(next).toHaveBeenCalledTimes(1);
     expect(response).toStrictEqual(mockResponse);
 

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -1,20 +1,18 @@
 import {
   AbsoluteLocation,
-  FinalizeHandler,
-  FinalizeHandlerArguments,
-  FinalizeHandlerOutput,
-  FinalizeRequestHandlerOptions,
+  BuildHandler,
+  BuildHandlerArguments,
+  BuildHandlerOptions,
+  BuildHandlerOutput,
   HandlerExecutionContext,
   MetadataBearer,
   Pluggable,
 } from "@aws-sdk/types";
 
 export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataBearer>(
-  next: FinalizeHandler<any, Output>,
+  next: BuildHandler<any, Output>,
   context: HandlerExecutionContext
-): FinalizeHandler<any, Output> => async (
-  args: FinalizeHandlerArguments<any>
-): Promise<FinalizeHandlerOutput<Output>> => {
+): BuildHandler<any, Output> => async (args: BuildHandlerArguments<any>): Promise<BuildHandlerOutput<Output>> => {
   const { logger, inputFilterSensitiveLog, outputFilterSensitiveLog } = context;
 
   const response = await next(args);
@@ -47,10 +45,10 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
   return response;
 };
 
-export const loggerMiddlewareOptions: FinalizeRequestHandlerOptions & AbsoluteLocation = {
+export const loggerMiddlewareOptions: BuildHandlerOptions & AbsoluteLocation = {
   name: "loggerMiddleware",
   tags: ["LOGGER"],
-  step: "finalizeRequest",
+  step: "build",
 };
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1488#issuecomment-692151662

*Description of changes:*
adds loggerMiddleware in build step so that values populated in metadata by retryMiddleware (attempts and totalRetryDelay) are visible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
