### PR TITLE
fix: move logging of input/output and req/res to serde

### DIFF
--- a/packages/middleware-logger/src/loggerMiddleware.spec.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.spec.ts
@@ -1,4 +1,4 @@
-import { BuildHandlerArguments, Logger, MiddlewareStack } from "@aws-sdk/types";
+import { Logger, MiddlewareStack } from "@aws-sdk/types";
 
 import { getLoggerPlugin, loggerMiddleware, loggerMiddlewareOptions } from "./loggerMiddleware";
 
@@ -19,9 +19,18 @@ describe("getLoggerPlugin", () => {
 });
 
 describe("loggerMiddleware", () => {
-  const next = jest.fn();
+  const mockNext = jest.fn();
 
-  const args = {};
+  const mockArgs = {
+    input: {
+      inputKey: "inputValue",
+    },
+    request: {
+      method: "GET",
+      headers: {},
+    },
+  };
+
   const mockResponse = {
     output: {
       $metadata: {
@@ -33,7 +42,7 @@ describe("loggerMiddleware", () => {
   };
 
   beforeEach(() => {
-    next.mockResolvedValueOnce(mockResponse);
+    mockNext.mockResolvedValueOnce(mockResponse);
   });
 
   afterEach(() => {
@@ -41,15 +50,15 @@ describe("loggerMiddleware", () => {
   });
 
   it("returns without logging if context.logger is not defined", async () => {
-    const response = await loggerMiddleware()(next, {})(args as BuildHandlerArguments<any>);
-    expect(next).toHaveBeenCalledTimes(1);
+    const response = await loggerMiddleware()(mockNext, {})(mockArgs);
+    expect(mockNext).toHaveBeenCalledTimes(1);
     expect(response).toStrictEqual(mockResponse);
   });
 
   it("returns without logging if context.logger doesn't have info function", async () => {
     const logger = {} as Logger;
-    const response = await loggerMiddleware()(next, { logger })(args as BuildHandlerArguments<any>);
-    expect(next).toHaveBeenCalledTimes(1);
+    const response = await loggerMiddleware()(mockNext, { logger })(mockArgs);
+    expect(mockNext).toHaveBeenCalledTimes(1);
     expect(response).toStrictEqual(mockResponse);
   });
 
@@ -60,8 +69,8 @@ describe("loggerMiddleware", () => {
       logger,
     };
 
-    const response = await loggerMiddleware()(next, context)(args as BuildHandlerArguments<any>);
-    expect(next).toHaveBeenCalledTimes(1);
+    const response = await loggerMiddleware()(mockNext, context)(mockArgs);
+    expect(mockNext).toHaveBeenCalledTimes(1);
     expect(response).toStrictEqual(mockResponse);
 
     expect(logger.info).toHaveBeenCalledTimes(1);

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -27,9 +27,6 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
 
   if (typeof logger.debug === "function") {
     logger.debug({
-      httpRequest: args.request,
-    });
-    logger.debug({
       httpResponse: response.response,
     });
   }
@@ -37,7 +34,6 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
   if (typeof logger.info === "function") {
     logger.info({
       $metadata,
-      input: inputFilterSensitiveLog(args.input),
       output: outputFilterSensitiveLog(outputWithoutMetadata),
     });
   }

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -13,7 +13,7 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
   next: BuildHandler<any, Output>,
   context: HandlerExecutionContext
 ): BuildHandler<any, Output> => async (args: BuildHandlerArguments<any>): Promise<BuildHandlerOutput<Output>> => {
-  const { logger, inputFilterSensitiveLog, outputFilterSensitiveLog } = context;
+  const { logger } = context;
 
   const response = await next(args);
 
@@ -22,19 +22,13 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
   }
 
   const {
-    output: { $metadata, ...outputWithoutMetadata },
+    output: { $metadata },
   } = response;
 
-  if (typeof logger.debug === "function") {
-    logger.debug({
-      httpResponse: response.response,
-    });
-  }
-
+  // Suggested custom metadata in https://github.com/aws/aws-sdk-js-v3/issues/1491#issuecomment-692174256
   if (typeof logger.info === "function") {
     logger.info({
       $metadata,
-      output: outputFilterSensitiveLog(outputWithoutMetadata),
     });
   }
 

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -25,7 +25,8 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
     output: { $metadata },
   } = response;
 
-  // Suggested custom metadata in https://github.com/aws/aws-sdk-js-v3/issues/1491#issuecomment-692174256
+  // TODO: Populate custom metadata in https://github.com/aws/aws-sdk-js-v3/issues/1491#issuecomment-692174256
+  // $metadata will be removed in https://github.com/aws/aws-sdk-js-v3/issues/1490
   if (typeof logger.info === "function") {
     logger.info({
       $metadata,

--- a/packages/middleware-serde/jest.config.js
+++ b/packages/middleware-serde/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/middleware-serde/src/deserializerMiddleware.spec.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.spec.ts
@@ -25,11 +25,6 @@ describe("deserializerMiddleware", () => {
     },
   };
 
-  // const mockRequest = {
-  //   method: "GET",
-  //   headers: {},
-  // };
-
   const mockOutput = {
     $metadata: {
       statusCode: 200,

--- a/packages/middleware-serde/src/deserializerMiddleware.spec.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.spec.ts
@@ -1,0 +1,103 @@
+import { Logger } from "@aws-sdk/types";
+
+import { deserializerMiddleware } from "./deserializerMiddleware";
+
+describe("deserializerMiddleware", () => {
+  const mockNext = jest.fn();
+  const mockDeserializer = jest.fn();
+
+  const mockOptions = {
+    endpoint: () =>
+      Promise.resolve({
+        protocol: "protocol",
+        hostname: "hostname",
+        path: "path",
+      }),
+  };
+
+  const mockArgs = {
+    input: {
+      inputKey: "inputValue",
+    },
+    request: {
+      method: "GET",
+      headers: {},
+    },
+  };
+
+  // const mockRequest = {
+  //   method: "GET",
+  //   headers: {},
+  // };
+
+  const mockOutput = {
+    $metadata: {
+      statusCode: 200,
+      requestId: "requestId",
+    },
+    outputKey: "outputValue",
+  };
+
+  const mockNextResponse = {
+    response: {
+      statusCode: 200,
+      headers: {},
+    },
+  };
+
+  const mockResponse = {
+    response: mockNextResponse.response,
+    output: mockOutput,
+  };
+
+  beforeEach(() => {
+    mockNext.mockResolvedValueOnce(mockNextResponse);
+    mockDeserializer.mockResolvedValueOnce(mockOutput);
+  });
+
+  afterEach(() => {
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(mockNext).toHaveBeenCalledWith(mockArgs);
+    expect(mockDeserializer).toHaveBeenCalledTimes(1);
+    expect(mockDeserializer).toHaveBeenCalledWith(mockNextResponse.response, mockOptions);
+    jest.clearAllMocks();
+  });
+
+  it("returns without logging if context.logger is not defined", async () => {
+    const response = await deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, {})(mockArgs);
+    expect(response).toStrictEqual(mockResponse);
+  });
+
+  it("returns without logging if context.logger doesn't have debug/info function", async () => {
+    const logger = {} as Logger;
+    const response = await deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, { logger })(mockArgs);
+    expect(response).toStrictEqual(mockResponse);
+  });
+
+  it("logs output if context.logger has info function", async () => {
+    const logger = ({ info: jest.fn() } as unknown) as Logger;
+
+    const outputFilterSensitiveLog = jest.fn().mockImplementationOnce((output) => output);
+    const response = await deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, {
+      logger,
+      outputFilterSensitiveLog: outputFilterSensitiveLog,
+    })(mockArgs);
+
+    const { $metadata, ...outputWithoutMetadata } = mockOutput;
+    expect(response).toStrictEqual(mockResponse);
+    expect(outputFilterSensitiveLog).toHaveBeenCalledTimes(1);
+    expect(outputFilterSensitiveLog).toHaveBeenCalledWith(outputWithoutMetadata);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith({ output: outputWithoutMetadata });
+  });
+
+  it("logs response if context.logger has debug function", async () => {
+    const logger = ({ debug: jest.fn() } as unknown) as Logger;
+
+    const response = await deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, { logger })(mockArgs);
+
+    expect(response).toStrictEqual(mockResponse);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith({ httpResponse: mockNextResponse.response });
+  });
+});

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -3,21 +3,42 @@ import {
   DeserializeHandlerArguments,
   DeserializeHandlerOutput,
   DeserializeMiddleware,
+  HandlerExecutionContext,
   ResponseDeserializer,
 } from "@aws-sdk/types";
 
-export function deserializerMiddleware<Input extends object, Output extends object, RuntimeUtils = any>(
+export const deserializerMiddleware = <Input extends object, Output extends object, RuntimeUtils = any>(
   options: RuntimeUtils,
   deserializer: ResponseDeserializer<any, any, RuntimeUtils>
-): DeserializeMiddleware<Input, Output> {
-  return (next: DeserializeHandler<Input, Output>): DeserializeHandler<Input, Output> => async (
-    args: DeserializeHandlerArguments<Input>
-  ): Promise<DeserializeHandlerOutput<Output>> => {
-    const { response } = await next(args);
-    const parsed = await deserializer(response, options);
-    return {
-      response,
-      output: parsed as Output,
-    };
+): DeserializeMiddleware<Input, Output> => (
+  next: DeserializeHandler<Input, Output>,
+  context: HandlerExecutionContext
+): DeserializeHandler<Input, Output> => async (
+  args: DeserializeHandlerArguments<Input>
+): Promise<DeserializeHandlerOutput<Output>> => {
+  const { logger, outputFilterSensitiveLog } = context;
+
+  const { response } = await next(args);
+
+  if (typeof logger?.debug === "function") {
+    logger.debug({
+      httpResponse: response,
+    });
+  }
+
+  const parsed = await deserializer(response, options);
+
+  // Log parsed after $metadata is removed in https://github.com/aws/aws-sdk-js-v3/issues/1490
+  const { $metadata, ...outputWithoutMetadata } = parsed;
+
+  if (typeof logger?.info === "function") {
+    logger.info({
+      output: outputFilterSensitiveLog(outputWithoutMetadata),
+    });
+  }
+
+  return {
+    response,
+    output: parsed as Output,
   };
-}
+};

--- a/packages/middleware-serde/src/serializerMiddleware.spec.ts
+++ b/packages/middleware-serde/src/serializerMiddleware.spec.ts
@@ -1,0 +1,96 @@
+import { Logger } from "@aws-sdk/types";
+
+import { serializerMiddleware } from "./serializerMiddleware";
+
+describe("serializerMiddleware", () => {
+  const mockNext = jest.fn();
+  const mockSerializer = jest.fn();
+
+  const mockOptions = {
+    endpoint: () =>
+      Promise.resolve({
+        protocol: "protocol",
+        hostname: "hostname",
+        path: "path",
+      }),
+  };
+
+  const mockArgs = {
+    input: {
+      inputKey: "inputValue",
+    },
+  };
+
+  const mockRequest = {
+    method: "GET",
+    headers: {},
+  };
+
+  const mockResponse = {
+    statusCode: 200,
+    headers: {},
+  };
+
+  const mockOutput = {
+    $metadata: {
+      statusCode: 200,
+      requestId: "requestId",
+    },
+    outputKey: "outputValue",
+  };
+
+  const mockReturn = {
+    response: mockResponse,
+    output: mockOutput,
+  };
+
+  beforeEach(() => {
+    mockNext.mockResolvedValueOnce(mockReturn);
+    mockSerializer.mockResolvedValueOnce(mockRequest);
+  });
+
+  afterEach(() => {
+    expect(mockSerializer).toHaveBeenCalledTimes(1);
+    expect(mockSerializer).toHaveBeenCalledWith(mockArgs.input, mockOptions);
+    expect(mockNext).toHaveBeenCalledTimes(1);
+    expect(mockNext).toHaveBeenCalledWith({ ...mockArgs, request: mockRequest });
+    jest.clearAllMocks();
+  });
+
+  it("returns without logging if context.logger is not defined", async () => {
+    const response = await serializerMiddleware(mockOptions, mockSerializer)(mockNext, {})(mockArgs);
+    expect(response).toStrictEqual(mockReturn);
+  });
+
+  it("returns without logging if context.logger doesn't have debug/info function", async () => {
+    const logger = {} as Logger;
+    const response = await serializerMiddleware(mockOptions, mockSerializer)(mockNext, { logger })(mockArgs);
+    expect(response).toStrictEqual(mockReturn);
+  });
+
+  it("logs input if context.logger has info function", async () => {
+    const logger = ({ info: jest.fn() } as unknown) as Logger;
+
+    const inputFilterSensitiveLog = jest.fn().mockImplementationOnce((input) => input);
+    const response = await serializerMiddleware(mockOptions, mockSerializer)(mockNext, {
+      logger,
+      inputFilterSensitiveLog,
+    })(mockArgs);
+
+    expect(response).toStrictEqual(mockReturn);
+    expect(inputFilterSensitiveLog).toHaveBeenCalledTimes(1);
+    expect(inputFilterSensitiveLog).toHaveBeenCalledWith(mockArgs.input);
+    expect(logger.info).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith({ input: mockArgs.input });
+  });
+
+  it("logs request if context.logger has debug function", async () => {
+    const logger = ({ debug: jest.fn() } as unknown) as Logger;
+
+    const response = await serializerMiddleware(mockOptions, mockSerializer)(mockNext, { logger })(mockArgs);
+
+    expect(response).toStrictEqual(mockReturn);
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.debug).toHaveBeenCalledWith({ httpRequest: mockRequest });
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*
Follow up to https://github.com/aws/aws-sdk-js-v3/pull/1478

*Description of changes:*
move logging of input/output and req/res to serde

**What does it do?**
It moves logging of input before just before serializing and request just after serializing. It also moves logging of response just before deserializing, and output just after deserializing. It also converts deser to arrow functions and adds unit tests for them.

**Why is it helpful?**
The current logger middleware logs input/output/request/response in build step, and they may be edited by other middleware (like several s3 customization middleware now, or DynamoDB Document Client in future). This PR ensures that the actually sent/received values are logged.

<details>
<summary>Test code</summary>

```js
const { DynamoDB } = require("@aws-sdk/client-dynamodb");

// We're using Pino, customer can pass any logger
const logger = require("pino")({
  level: process.env.LOG_LEVEL || "info",
  prettyPrint: true,
});

(async () => {
  const client = new DynamoDB({ logger });
  await client.listTables({ Limit: 1 });
})();

```

</details>

<details>
<summary>Output with default LOG_LEVEL=info</summary>

```
[1600118095663] INFO  (70609 on 186590ce2139):
    input: {
      "Limit": 1
    }
[1600118096387] INFO  (70609 on 186590ce2139):
    output: {
      "__type": "ListTablesOutput",
      "LastEvaluatedTableName": "CUSTOMER_LIST",
      "TableNames": [
        "CUSTOMER_LIST"
      ]
    }
[1600118096387] INFO  (70609 on 186590ce2139):
    $metadata: {
      "httpStatusCode": 200,
      "httpHeaders": {
        "server": "Server",
        "date": "Mon, 14 Sep 2020 21:14:41 GMT",
        "content-type": "application/x-amz-json-1.0",
        "content-length": "73",
        "connection": "keep-alive",
        "x-amzn-requestid": "0IG5NTHKJS423VET0CJVG8LF1NVV4KQNSO5AEMVJF66Q9ASUAAJG",
        "x-amz-crc32": "773170490"
      },
      "requestId": "0IG5NTHKJS423VET0CJVG8LF1NVV4KQNSO5AEMVJF66Q9ASUAAJG",
      "attempts": 1,
      "totalRetryDelay": 0
    }
```

</details>

<details>
<summary>Output with LOG_LEVEL=debug</summary>

```
[1600118145240] INFO  (71284 on 186590ce2139):
    input: {
      "Limit": 1
    }
[1600118145247] DEBUG (71284 on 186590ce2139):
    httpRequest: {
      "method": "POST",
      "hostname": "dynamodb.us-west-2.amazonaws.com",
      "query": {},
      "headers": {
        "Content-Type": "application/x-amz-json-1.0",
        "X-Amz-Target": "DynamoDB_20120810.ListTables"
      },
      "body": "{\"Limit\":1}",
      "protocol": "https:",
      "path": "/"
    }
[1600118146024] DEBUG (71284 on 186590ce2139):
    httpResponse: {
      "statusCode": 200,
      "headers": {
        "server": "Server",
        "date": "Mon, 14 Sep 2020 21:15:31 GMT",
        "content-type": "application/x-amz-json-1.0",
        "content-length": "73",
        "connection": "keep-alive",
        "x-amzn-requestid": "EE8GSKGB44RASB525APL32B6TVVV4KQNSO5AEMVJF66Q9ASUAAJG",
        "x-amz-crc32": "773170490"
      },
      "body": { ...<BODY>... }
    }
[1600118146056] INFO  (71284 on 186590ce2139):
    output: {
      "__type": "ListTablesOutput",
      "LastEvaluatedTableName": "CUSTOMER_LIST",
      "TableNames": [
        "CUSTOMER_LIST"
      ]
    }
[1600118146058] INFO  (71284 on 186590ce2139):
    $metadata: {
      "httpStatusCode": 200,
      "httpHeaders": {
        "server": "Server",
        "date": "Mon, 14 Sep 2020 21:15:31 GMT",
        "content-type": "application/x-amz-json-1.0",
        "content-length": "73",
        "connection": "keep-alive",
        "x-amzn-requestid": "EE8GSKGB44RASB525APL32B6TVVV4KQNSO5AEMVJF66Q9ASUAAJG",
        "x-amz-crc32": "773170490"
      },
      "requestId": "EE8GSKGB44RASB525APL32B6TVVV4KQNSO5AEMVJF66Q9ASUAAJG",
      "attempts": 1,
      "totalRetryDelay": 0
    }
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
