### PR TITLE
feat(util-dynamodb): marshall to convert JavaScript object into DynamoDB Record

### DIFF
--- a/packages/util-dynamodb/.gitignore
+++ b/packages/util-dynamodb/.gitignore
@@ -1,0 +1,8 @@
+/node_modules/
+/build/
+/coverage/
+/docs/
+*.tsbuildinfo
+*.tgz
+*.log
+package-lock.json

--- a/packages/util-dynamodb/.npmignore
+++ b/packages/util-dynamodb/.npmignore
@@ -1,0 +1,13 @@
+/src/
+/coverage/
+/docs/
+tsconfig.test.json
+*.tsbuildinfo
+
+*.spec.js
+*.spec.d.ts
+*.spec.js.map
+
+*.fixture.js
+*.fixture.d.ts
+*.fixture.js.map

--- a/packages/util-dynamodb/LICENSE
+++ b/packages/util-dynamodb/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/util-dynamodb/README.md
+++ b/packages/util-dynamodb/README.md
@@ -2,3 +2,27 @@
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-dynamodb/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-dynamodb)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-dynamodb.svg)](https://www.npmjs.com/package/@aws-sdk/util-dynamodb)
+
+This package provides utilities to be used with `@aws-sdk/client-dynamodb`
+
+## Convert JavaScript object into DynamoDB Record
+
+```js
+const { DynamoDB } = require("@aws-sdk/client-dynamodb");
+const { marshall } = require("@aws-sdk/util-dynamodb");
+
+const client = new DynamoDB(clientParams);
+const params = {
+  TableName: "Table",
+  Item: marshall({
+    HashKey: "hashKey",
+    NumAttribute: 1,
+    BoolAttribute: true,
+    ListAttribute: [1, "two", false],
+    MapAttribute: { foo: "bar" },
+    NullAttribute: null,
+  }),
+};
+
+await client.putItem(params);
+```

--- a/packages/util-dynamodb/README.md
+++ b/packages/util-dynamodb/README.md
@@ -1,0 +1,4 @@
+# @aws-sdk/util-dynamodb
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-dynamodb/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-dynamodb)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-dynamodb.svg)](https://www.npmjs.com/package/@aws-sdk/util-dynamodb)

--- a/packages/util-dynamodb/jest.config.js
+++ b/packages/util-dynamodb/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@aws-sdk/util-dynamodb",
+  "version": "1.0.0-gamma.0",
+  "scripts": {
+    "prepublishOnly": "yarn build:cjs && yarn build:es",
+    "pretest": "yarn build:cjs",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build": "yarn build:es && yarn build:cjs",
+    "test": "jest"
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "tslib": "^1.8.0"
+  },
+  "devDependencies": {
+    "@types/jest": "^26.0.4",
+    "jest": "^26.1.0",
+    "typescript": "~4.0.2"
+  }
+}

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "1.0.0-gamma.9",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -18,10 +18,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/client-dynamodb": "1.0.0-gamma.9",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/client-dynamodb": "1.0.0-gamma.9",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -19,6 +19,14 @@ describe("convertToAttr", () => {
     });
   });
 
+  [NaN, Infinity, -Infinity].forEach((num) => {
+    it(`throws for number (special numeric value): ${num}`, () => {
+      expect(() => {
+        convertToAttr(num);
+      }).toThrowError(`Special numeric value ${num} is not allowed`);
+    });
+  });
+
   it("returns for string", () => {
     const str = "str";
     expect(convertToAttr(str)).toEqual({ S: str });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -1,6 +1,12 @@
 import { convertToAttr } from "./convertToAttr";
 
 describe("convertToAttr", () => {
+  [true, false].forEach((bool) => {
+    it(`test boolean "${bool}"`, () => {
+      expect(convertToAttr(bool)).toEqual({ BOOL: bool });
+    });
+  });
+
   it("returns for number", () => {
     const num = 5;
     expect(convertToAttr(num)).toEqual({ N: num.toString() });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -1,0 +1,13 @@
+import { convertToAttr } from "./convertToAttr";
+
+describe("convertToAttr", () => {
+  it("returns for number", () => {
+    const num = 5;
+    expect(convertToAttr(num)).toEqual({ N: num.toString() });
+  });
+
+  it("returns for string", () => {
+    const str = "str";
+    expect(convertToAttr(str)).toEqual({ S: str });
+  });
+});

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -144,7 +144,8 @@ describe("convertToAttr", () => {
 
     it("bigint set", () => {
       // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
-      const set = new Set([1n, 2n, 3n]);
+      const bigNum = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
+      const set = new Set([bigNum, -bigNum]);
       expect(convertToAttr(set)).toEqual({ NS: Array.from(set).map((num) => num.toString()) });
     });
 

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -192,7 +192,15 @@ describe("convertToAttr", () => {
   });
 
   describe(`unsupported type`, () => {
-    [undefined].forEach((data) => {
+    class FooObj {
+      constructor() {
+        // @ts-ignore
+        this.foo = "foo";
+      }
+    }
+
+    // ToDo: Serialize ES6 class objects as string https://github.com/aws/aws-sdk-js-v3/issues/1535
+    [undefined, new Date(), new FooObj()].forEach((data) => {
       it(`throws for: ${String(data)}`, () => {
         expect(() => {
           // @ts-ignore Argument is not assignable to parameter of type 'NativeAttributeValue'

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -189,4 +189,15 @@ describe("convertToAttr", () => {
       expect(convertToAttr(str)).toEqual({ S: str });
     });
   });
+
+  describe(`unsupported type`, () => {
+    [undefined].forEach((data) => {
+      it(`throws for: ${String(data)}`, () => {
+        expect(() => {
+          // @ts-ignore Argument is not assignable to parameter of type 'NativeAttributeValue'
+          convertToAttr(data);
+        }).toThrowError(`Unsupported type passed: ${String(data)}`);
+      });
+    });
+  });
 });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -120,6 +120,16 @@ describe("convertToAttr", () => {
         [uint8Arr, biguintArr],
         [{ B: uint8Arr }, { B: biguintArr }],
       ],
+      [
+        [
+          { nullKey: null, boolKey: false },
+          { stringKey: "one", numberKey: 1.01, bigintKey: BigInt(9007199254740996) },
+        ],
+        [
+          { M: { nullKey: { NULL: true }, boolKey: { BOOL: false } } },
+          { M: { stringKey: { S: "one" }, numberKey: { N: "1.01" }, bigintKey: { N: "9007199254740996" } } },
+        ],
+      ],
     ].forEach(([input, output]) => {
       it(`testing list: ${input}`, () => {
         // @ts-ignore
@@ -182,19 +192,27 @@ describe("convertToAttr", () => {
     const biguintArr = new BigUint64Array(arr.map(BigInt));
     [
       [
-        { a: null, b: false },
-        { a: { NULL: true }, b: { BOOL: false } },
+        { nullKey: null, boolKey: false },
+        { nullKey: { NULL: true }, boolKey: { BOOL: false } },
       ],
       [
-        { a: 1.01, b: BigInt(1), c: "one" },
-        { a: { N: "1.01" }, b: { N: "1" }, c: { S: "one" } },
+        { stringKey: "one", numberKey: 1.01, bigintKey: BigInt(1) },
+        { stringKey: { S: "one" }, numberKey: { N: "1.01" }, bigintKey: { N: "1" } },
       ],
       [
-        { a: uint8Arr, b: biguintArr },
-        { a: { B: uint8Arr }, b: { B: biguintArr } },
+        { uint8ArrKey: uint8Arr, biguintArrKey: biguintArr },
+        { uint8ArrKey: { B: uint8Arr }, biguintArrKey: { B: biguintArr } },
+      ],
+      [
+        { list1: [null, false], list2: ["one", 1.01, BigInt(9007199254740996)] },
+        {
+          list1: { L: [{ NULL: true }, { BOOL: false }] },
+          list2: { L: [{ S: "one" }, { N: "1.01" }, { N: "9007199254740996" }] },
+        },
       ],
     ].forEach(([input, output]) => {
       it(`testing map: ${input}`, () => {
+        // @ts-ignore
         expect(convertToAttr(input)).toEqual({ M: output });
       });
     });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -38,17 +38,35 @@ describe("convertToAttr", () => {
 
     [Number.MAX_SAFE_INTEGER + 1, Number.MAX_VALUE].forEach((num) => {
       it(`throws for number greater than Number.MAX_SAFE_INTEGER: ${num}`, () => {
+        const errorPrefix = `Number ${num} is greater than Number.MAX_SAFE_INTEGER.`;
+
         expect(() => {
           convertToAttr(num);
-        }).toThrowError(`Number ${num} is greater than Number.MAX_SAFE_INTEGER. Use BigInt.`);
+        }).toThrowError(`${errorPrefix} Use BigInt.`);
+
+        const BigIntConstructor = BigInt;
+        (BigInt as any) = undefined;
+        expect(() => {
+          convertToAttr(num);
+        }).toThrowError(`${errorPrefix} Pass string value instead.`);
+        BigInt = BigIntConstructor;
       });
     });
 
     [Number.MIN_SAFE_INTEGER - 1].forEach((num) => {
       it(`throws for number lesser than Number.MIN_SAFE_INTEGER: ${num}`, () => {
+        const errorPrefix = `Number ${num} is lesser than Number.MIN_SAFE_INTEGER.`;
+
         expect(() => {
           convertToAttr(num);
-        }).toThrowError(`Number ${num} is lesser than Number.MIN_SAFE_INTEGER. Use BigInt.`);
+        }).toThrowError(`${errorPrefix} Use BigInt.`);
+
+        const BigIntConstructor = BigInt;
+        (BigInt as any) = undefined;
+        expect(() => {
+          convertToAttr(num);
+        }).toThrowError(`${errorPrefix} Pass string value instead.`);
+        BigInt = BigIntConstructor;
       });
     });
   });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -22,7 +22,7 @@ describe("convertToAttr", () => {
       });
     });
 
-    [3.14, Number.MIN_VALUE].forEach((num) => {
+    [1.01, Math.PI, Math.E, Number.MIN_VALUE, Number.EPSILON].forEach((num) => {
       it(`returns for number (floating point): ${num}`, () => {
         expect(convertToAttr(num)).toEqual({ N: num.toString() });
       });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -130,6 +130,20 @@ describe("convertToAttr", () => {
           { M: { stringKey: { S: "one" }, numberKey: { N: "1.01" }, bigintKey: { N: "9007199254740996" } } },
         ],
       ],
+      [
+        [
+          new Set([1, 2, 3]),
+          new Set([BigInt(9007199254740996), BigInt(-9007199254740996)]),
+          new Set([new Uint8Array([...Array(8).keys()]), new Uint8Array([...Array(16).keys()])]),
+          new Set(["one", "two", "three"]),
+        ],
+        [
+          { NS: ["1", "2", "3"] },
+          { NS: ["9007199254740996", "-9007199254740996"] },
+          { BS: [new Uint8Array([...Array(8).keys()]), new Uint8Array([...Array(16).keys()])] },
+          { SS: ["one", "two", "three"] },
+        ],
+      ],
     ].forEach(([input, output]) => {
       it(`testing list: ${input}`, () => {
         // @ts-ignore
@@ -208,6 +222,20 @@ describe("convertToAttr", () => {
         {
           list1: { L: [{ NULL: true }, { BOOL: false }] },
           list2: { L: [{ S: "one" }, { N: "1.01" }, { N: "9007199254740996" }] },
+        },
+      ],
+      [
+        {
+          numberSet: new Set([1, 2, 3]),
+          bigintSet: new Set([BigInt(9007199254740996), BigInt(-9007199254740996)]),
+          binarySet: new Set([new Uint8Array([...Array(8).keys()]), new Uint8Array([...Array(16).keys()])]),
+          stringSet: new Set(["one", "two", "three"]),
+        },
+        {
+          numberSet: { NS: ["1", "2", "3"] },
+          bigintSet: { NS: ["9007199254740996", "-9007199254740996"] },
+          binarySet: { BS: [new Uint8Array([...Array(8).keys()]), new Uint8Array([...Array(16).keys()])] },
+          stringSet: { SS: ["one", "two", "three"] },
         },
       ],
     ].forEach(([input, output]) => {

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -1,6 +1,12 @@
 import { convertToAttr } from "./convertToAttr";
 
 describe("convertToAttr", () => {
+  describe("null", () => {
+    it(`returns for null`, () => {
+      expect(convertToAttr(null)).toEqual({ NULL: true });
+    });
+  });
+
   describe("boolean", () => {
     [true, false].forEach((bool) => {
       it(`returns for boolean: ${bool}`, () => {

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -7,7 +7,7 @@ describe("convertToAttr", () => {
     });
   });
 
-  [1].forEach((num) => {
+  [1, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER].forEach((num) => {
     it(`returns for number (integer): ${num}`, () => {
       expect(convertToAttr(num)).toEqual({ N: num.toString() });
     });
@@ -24,6 +24,22 @@ describe("convertToAttr", () => {
       expect(() => {
         convertToAttr(num);
       }).toThrowError(`Special numeric value ${num} is not allowed`);
+    });
+  });
+
+  [Number.MAX_SAFE_INTEGER + 1].forEach((num) => {
+    it(`throws for number greater than Number.MAX_SAFE_INTEGER: ${num}`, () => {
+      expect(() => {
+        convertToAttr(num);
+      }).toThrowError(`Number ${num} is greater than Number.MAX_SAFE_INTEGER. Use BigInt.`);
+    });
+  });
+
+  [Number.MIN_SAFE_INTEGER - 1].forEach((num) => {
+    it(`throws for number lesser than Number.MIN_SAFE_INTEGER: ${num}`, () => {
+      expect(() => {
+        convertToAttr(num);
+      }).toThrowError(`Number ${num} is lesser than Number.MIN_SAFE_INTEGER. Use BigInt.`);
     });
   });
 

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -97,6 +97,10 @@ describe("convertToAttr", () => {
         expect(convertToAttr(data)).toEqual({ B: data });
       });
     });
+
+    it("returns null for Binary when options.convertEmptyValues=true", () => {
+      expect(convertToAttr(new Uint8Array(), { convertEmptyValues: true })).toEqual({ NULL: true });
+    });
   });
 
   describe("list", () => {
@@ -120,6 +124,14 @@ describe("convertToAttr", () => {
       it(`testing list: ${input}`, () => {
         // @ts-ignore
         expect(convertToAttr(input)).toEqual({ L: output });
+      });
+    });
+
+    it(`testing list with options.convertEmptyValues=true`, () => {
+      const input = ["", new Uint8Array(), new Set()];
+      // @ts-ignore
+      expect(convertToAttr(input, { convertEmptyValues: true })).toEqual({
+        L: [{ NULL: true }, { NULL: true }, { NULL: true }],
       });
     });
   });
@@ -146,10 +158,14 @@ describe("convertToAttr", () => {
       expect(convertToAttr(set)).toEqual({ SS: Array.from(set) });
     });
 
+    it("returns null for empty set for options.convertEmptyValues=true", () => {
+      expect(convertToAttr(new Set(), { convertEmptyValues: true })).toEqual({ NULL: true });
+    });
+
     it("throws error for empty set", () => {
       expect(() => {
         convertToAttr(new Set());
-      }).toThrowError(`Please pass a non-empty set`);
+      }).toThrowError(`Please pass a non-empty set, or set convertEmptyValues to true.`);
     });
 
     it("thows error for unallowed set", () => {
@@ -181,6 +197,14 @@ describe("convertToAttr", () => {
         expect(convertToAttr(input)).toEqual({ M: output });
       });
     });
+
+    it(`testing map with options.convertEmptyValues=true`, () => {
+      const input = { stringKey: "", binaryKey: new Uint8Array(), setKey: new Set() };
+      // @ts-ignore
+      expect(convertToAttr(input, { convertEmptyValues: true })).toEqual({
+        M: { stringKey: { NULL: true }, binaryKey: { NULL: true }, setKey: { NULL: true } },
+      });
+    });
   });
 
   describe("string", () => {
@@ -188,6 +212,10 @@ describe("convertToAttr", () => {
       it(`returns for string: ${str}`, () => {
         expect(convertToAttr(str)).toEqual({ S: str });
       });
+    });
+
+    it("returns null for string when options.convertEmptyValues=true", () => {
+      expect(convertToAttr("", { convertEmptyValues: true })).toEqual({ NULL: true });
     });
   });
 
@@ -207,22 +235,6 @@ describe("convertToAttr", () => {
           convertToAttr(data);
         }).toThrowError(`Unsupported type passed: ${String(data)}`);
       });
-    });
-  });
-
-  describe("convertEmptyValues set to true", () => {
-    const convertEmptyValues = true;
-
-    it(`returns null for Set`, () => {
-      expect(convertToAttr(new Set(), { convertEmptyValues })).toEqual({ NULL: true });
-    });
-
-    it(`returns null for String`, () => {
-      expect(convertToAttr("", { convertEmptyValues })).toEqual({ NULL: true });
-    });
-
-    it(`returns null for Binary`, () => {
-      expect(convertToAttr(new Uint8Array(), { convertEmptyValues })).toEqual({ NULL: true });
     });
   });
 });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -1,50 +1,56 @@
 import { convertToAttr } from "./convertToAttr";
 
 describe("convertToAttr", () => {
-  [true, false].forEach((bool) => {
-    it(`returns for boolean: ${bool}`, () => {
-      expect(convertToAttr(bool)).toEqual({ BOOL: bool });
+  describe("boolean", () => {
+    [true, false].forEach((bool) => {
+      it(`returns for boolean: ${bool}`, () => {
+        expect(convertToAttr(bool)).toEqual({ BOOL: bool });
+      });
     });
   });
 
-  [1, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER].forEach((num) => {
-    it(`returns for number (integer): ${num}`, () => {
-      expect(convertToAttr(num)).toEqual({ N: num.toString() });
+  describe("number", () => {
+    [1, Number.MAX_SAFE_INTEGER, Number.MIN_SAFE_INTEGER].forEach((num) => {
+      it(`returns for number (integer): ${num}`, () => {
+        expect(convertToAttr(num)).toEqual({ N: num.toString() });
+      });
+    });
+
+    [3.14].forEach((num) => {
+      it(`returns for number (floating point): ${num}`, () => {
+        expect(convertToAttr(num)).toEqual({ N: num.toString() });
+      });
+    });
+
+    [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach((num) => {
+      it(`throws for number (special numeric value): ${num}`, () => {
+        expect(() => {
+          convertToAttr(num);
+        }).toThrowError(`Special numeric value ${num} is not allowed`);
+      });
+    });
+
+    [Number.MAX_SAFE_INTEGER + 1].forEach((num) => {
+      it(`throws for number greater than Number.MAX_SAFE_INTEGER: ${num}`, () => {
+        expect(() => {
+          convertToAttr(num);
+        }).toThrowError(`Number ${num} is greater than Number.MAX_SAFE_INTEGER. Use BigInt.`);
+      });
+    });
+
+    [Number.MIN_SAFE_INTEGER - 1].forEach((num) => {
+      it(`throws for number lesser than Number.MIN_SAFE_INTEGER: ${num}`, () => {
+        expect(() => {
+          convertToAttr(num);
+        }).toThrowError(`Number ${num} is lesser than Number.MIN_SAFE_INTEGER. Use BigInt.`);
+      });
     });
   });
 
-  [3.14].forEach((num) => {
-    it(`returns for number (floating point): ${num}`, () => {
-      expect(convertToAttr(num)).toEqual({ N: num.toString() });
+  describe("string", () => {
+    it("returns for string", () => {
+      const str = "str";
+      expect(convertToAttr(str)).toEqual({ S: str });
     });
-  });
-
-  [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach((num) => {
-    it(`throws for number (special numeric value): ${num}`, () => {
-      expect(() => {
-        convertToAttr(num);
-      }).toThrowError(`Special numeric value ${num} is not allowed`);
-    });
-  });
-
-  [Number.MAX_SAFE_INTEGER + 1].forEach((num) => {
-    it(`throws for number greater than Number.MAX_SAFE_INTEGER: ${num}`, () => {
-      expect(() => {
-        convertToAttr(num);
-      }).toThrowError(`Number ${num} is greater than Number.MAX_SAFE_INTEGER. Use BigInt.`);
-    });
-  });
-
-  [Number.MIN_SAFE_INTEGER - 1].forEach((num) => {
-    it(`throws for number lesser than Number.MIN_SAFE_INTEGER: ${num}`, () => {
-      expect(() => {
-        convertToAttr(num);
-      }).toThrowError(`Number ${num} is lesser than Number.MIN_SAFE_INTEGER. Use BigInt.`);
-    });
-  });
-
-  it("returns for string", () => {
-    const str = "str";
-    expect(convertToAttr(str)).toEqual({ S: str });
   });
 });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -53,6 +53,14 @@ describe("convertToAttr", () => {
     });
   });
 
+  describe("bigint", () => {
+    it("returns for BigInt value", () => {
+      // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
+      const num = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
+      expect(convertToAttr(num)).toEqual({ N: num.toString() });
+    });
+  });
+
   describe("string", () => {
     it("returns for string", () => {
       const str = "str";

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -124,6 +124,29 @@ describe("convertToAttr", () => {
     });
   });
 
+  describe("set", () => {
+    it("number set", () => {
+      const set = new Set([1, 2, 3]);
+      expect(convertToAttr(set)).toEqual({ NS: Array.from(set).map((num) => num.toString()) });
+    });
+
+    it("bigint set", () => {
+      // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
+      const set = new Set([1n, 2n, 3n]);
+      expect(convertToAttr(set)).toEqual({ NS: Array.from(set).map((num) => num.toString()) });
+    });
+
+    it("binary set", () => {
+      const set = new Set([new ArrayBuffer(4), new ArrayBuffer(8), new ArrayBuffer(16)]);
+      expect(convertToAttr(set)).toEqual({ BS: Array.from(set) });
+    });
+
+    it("string set", () => {
+      const set = new Set(["one", "two", "three"]);
+      expect(convertToAttr(set)).toEqual({ SS: Array.from(set) });
+    });
+  });
+
   describe("string", () => {
     it("returns for string", () => {
       const str = "str";

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -2,14 +2,21 @@ import { convertToAttr } from "./convertToAttr";
 
 describe("convertToAttr", () => {
   [true, false].forEach((bool) => {
-    it(`test boolean "${bool}"`, () => {
+    it(`returns for boolean: ${bool}`, () => {
       expect(convertToAttr(bool)).toEqual({ BOOL: bool });
     });
   });
 
-  it("returns for number", () => {
-    const num = 5;
-    expect(convertToAttr(num)).toEqual({ N: num.toString() });
+  [1].forEach((num) => {
+    it(`returns for number (integer): ${num}`, () => {
+      expect(convertToAttr(num)).toEqual({ N: num.toString() });
+    });
+  });
+
+  [3.14].forEach((num) => {
+    it(`returns for number (floating point): ${num}`, () => {
+      expect(convertToAttr(num)).toEqual({ N: num.toString() });
+    });
   });
 
   it("returns for string", () => {

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -99,6 +99,31 @@ describe("convertToAttr", () => {
     });
   });
 
+  describe("list", () => {
+    const arr = [...Array(4).keys()];
+    const uint8Arr = new Uint32Array(arr);
+    const biguintArr = new BigUint64Array(arr.map(BigInt));
+    [
+      [
+        [null, false],
+        [{ NULL: true }, { BOOL: false }],
+      ],
+      [
+        [1.01, BigInt(1), "one"],
+        [{ N: "1.01" }, { N: "1" }, { S: "one" }],
+      ],
+      [
+        [uint8Arr, biguintArr],
+        [{ B: uint8Arr }, { B: biguintArr }],
+      ],
+    ].forEach(([input, output]) => {
+      it(`testing list: ${input}`, () => {
+        // @ts-ignore
+        expect(convertToAttr(input)).toEqual({ L: output });
+      });
+    });
+  });
+
   describe("string", () => {
     it("returns for string", () => {
       const str = "str";

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -1,4 +1,5 @@
 import { convertToAttr } from "./convertToAttr";
+import { NativeAttributeValue } from "./models";
 
 describe("convertToAttr", () => {
   describe("null", () => {
@@ -139,7 +140,7 @@ describe("convertToAttr", () => {
         output: [{ B: uint8Arr }, { B: biguintArr }],
       },
       {
-        input: [
+        input: <{ [key: string]: NativeAttributeValue }[]>[
           { nullKey: null, boolKey: false },
           { stringKey: "one", numberKey: 1.01, bigintKey: BigInt(9007199254740996) },
         ],
@@ -164,7 +165,6 @@ describe("convertToAttr", () => {
       },
     ].forEach(({ input, output }) => {
       it(`testing list: ${input}`, () => {
-        // @ts-expect-error Bug with complex types in TS https://github.com/microsoft/TypeScript/issues/40770
         expect(convertToAttr(input)).toEqual({ L: output });
       });
     });
@@ -201,17 +201,18 @@ describe("convertToAttr", () => {
     });
 
     it("returns null for empty set for options.convertEmptyValues=true", () => {
-      expect(convertToAttr(new Set(), { convertEmptyValues: true })).toEqual({ NULL: true });
+      expect(convertToAttr(new Set([]), { convertEmptyValues: true })).toEqual({ NULL: true });
     });
 
     it("throws error for empty set", () => {
       expect(() => {
-        convertToAttr(new Set());
+        convertToAttr(new Set([]));
       }).toThrowError(`Please pass a non-empty set, or set convertEmptyValues to true.`);
     });
 
     it("thows error for unallowed set", () => {
       expect(() => {
+        // @ts-expect-error Type 'Set<boolean>' is not assignable
         convertToAttr(new Set([true, false]));
       }).toThrowError(`Only Number Set (NS), Binary Set (BS) or String Set (SS) are allowed.`);
     });
@@ -223,26 +224,29 @@ describe("convertToAttr", () => {
     const biguintArr = new BigUint64Array(arr.map(BigInt));
     [
       {
-        input: { nullKey: null, boolKey: false },
+        input: <{ [key: string]: NativeAttributeValue }>{ nullKey: null, boolKey: false },
         output: { nullKey: { NULL: true }, boolKey: { BOOL: false } },
       },
       {
-        input: { stringKey: "one", numberKey: 1.01, bigintKey: BigInt(1) },
+        input: <{ [key: string]: NativeAttributeValue }>{ stringKey: "one", numberKey: 1.01, bigintKey: BigInt(1) },
         output: { stringKey: { S: "one" }, numberKey: { N: "1.01" }, bigintKey: { N: "1" } },
       },
       {
-        input: { uint8ArrKey: uint8Arr, biguintArrKey: biguintArr },
+        input: <{ [key: string]: NativeAttributeValue }>{ uint8ArrKey: uint8Arr, biguintArrKey: biguintArr },
         output: { uint8ArrKey: { B: uint8Arr }, biguintArrKey: { B: biguintArr } },
       },
       {
-        input: { list1: [null, false], list2: ["one", 1.01, BigInt(9007199254740996)] },
+        input: <{ [key: string]: NativeAttributeValue }>{
+          list1: [null, false],
+          list2: ["one", 1.01, BigInt(9007199254740996)],
+        },
         output: {
           list1: { L: [{ NULL: true }, { BOOL: false }] },
           list2: { L: [{ S: "one" }, { N: "1.01" }, { N: "9007199254740996" }] },
         },
       },
       {
-        input: {
+        input: <{ [key: string]: NativeAttributeValue }>{
           numberSet: new Set([1, 2, 3]),
           bigintSet: new Set([BigInt(9007199254740996), BigInt(-9007199254740996)]),
           binarySet: new Set([uint8Arr, biguintArr]),
@@ -257,7 +261,6 @@ describe("convertToAttr", () => {
       },
     ].forEach(({ input, output }) => {
       it(`testing map: ${input}`, () => {
-        // @ts-expect-error Bug with complex types in TS https://github.com/microsoft/TypeScript/issues/40770
         expect(convertToAttr(input)).toEqual({ M: output });
       });
     });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -72,6 +72,33 @@ describe("convertToAttr", () => {
     });
   });
 
+  describe("binary", () => {
+    const buffer = new ArrayBuffer(64);
+    const arr = [...Array(64).keys()];
+    const addPointOne = (num: number) => num + 0.1;
+    [
+      buffer,
+      new Blob([new Uint8Array(buffer)]),
+      Buffer.from(buffer),
+      new DataView(buffer),
+      new Int8Array(arr),
+      new Uint8Array(arr),
+      new Uint8ClampedArray(arr),
+      new Int16Array(arr),
+      new Uint16Array(arr),
+      new Int32Array(arr),
+      new Uint32Array(arr),
+      new Float32Array(arr.map(addPointOne)),
+      new Float64Array(arr.map(addPointOne)),
+      new BigInt64Array(arr.map(BigInt)),
+      new BigUint64Array(arr.map(BigInt)),
+    ].forEach((data) => {
+      it(`returns for binary: ${data.constructor.name}`, () => {
+        expect(convertToAttr(data)).toEqual({ B: data });
+      });
+    });
+  });
+
   describe("string", () => {
     it("returns for string", () => {
       const str = "str";

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -19,7 +19,7 @@ describe("convertToAttr", () => {
     });
   });
 
-  [NaN, Infinity, -Infinity].forEach((num) => {
+  [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].forEach((num) => {
     it(`throws for number (special numeric value): ${num}`, () => {
       expect(() => {
         convertToAttr(num);

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -159,6 +159,30 @@ describe("convertToAttr", () => {
     });
   });
 
+  describe("map", () => {
+    const arr = [...Array(4).keys()];
+    const uint8Arr = new Uint32Array(arr);
+    const biguintArr = new BigUint64Array(arr.map(BigInt));
+    [
+      [
+        { a: null, b: false },
+        { a: { NULL: true }, b: { BOOL: false } },
+      ],
+      [
+        { a: 1.01, b: BigInt(1), c: "one" },
+        { a: { N: "1.01" }, b: { N: "1" }, c: { S: "one" } },
+      ],
+      [
+        { a: uint8Arr, b: biguintArr },
+        { a: { B: uint8Arr }, b: { B: biguintArr } },
+      ],
+    ].forEach(([input, output]) => {
+      it(`testing map: ${input}`, () => {
+        expect(convertToAttr(input)).toEqual({ M: output });
+      });
+    });
+  });
+
   describe("string", () => {
     it("returns for string", () => {
       const str = "str";

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -126,52 +126,51 @@ describe("convertToAttr", () => {
     const uint8Arr = new Uint32Array(arr);
     const biguintArr = new BigUint64Array(arr.map(BigInt));
     [
-      [
-        [null, false],
-        [{ NULL: true }, { BOOL: false }],
-      ],
-      [
-        [1.01, BigInt(1), "one"],
-        [{ N: "1.01" }, { N: "1" }, { S: "one" }],
-      ],
-      [
-        [uint8Arr, biguintArr],
-        [{ B: uint8Arr }, { B: biguintArr }],
-      ],
-      [
-        [
+      {
+        input: [null, false],
+        output: [{ NULL: true }, { BOOL: false }],
+      },
+      {
+        input: [1.01, BigInt(1), "one"],
+        output: [{ N: "1.01" }, { N: "1" }, { S: "one" }],
+      },
+      {
+        input: [uint8Arr, biguintArr],
+        output: [{ B: uint8Arr }, { B: biguintArr }],
+      },
+      {
+        input: [
           { nullKey: null, boolKey: false },
           { stringKey: "one", numberKey: 1.01, bigintKey: BigInt(9007199254740996) },
         ],
-        [
+        output: [
           { M: { nullKey: { NULL: true }, boolKey: { BOOL: false } } },
           { M: { stringKey: { S: "one" }, numberKey: { N: "1.01" }, bigintKey: { N: "9007199254740996" } } },
         ],
-      ],
-      [
-        [
+      },
+      {
+        input: [
           new Set([1, 2, 3]),
           new Set([BigInt(9007199254740996), BigInt(-9007199254740996)]),
           new Set([uint8Arr, biguintArr]),
           new Set(["one", "two", "three"]),
         ],
-        [
+        output: [
           { NS: ["1", "2", "3"] },
           { NS: ["9007199254740996", "-9007199254740996"] },
           { BS: [uint8Arr, biguintArr] },
           { SS: ["one", "two", "three"] },
         ],
-      ],
-    ].forEach(([input, output]) => {
+      },
+    ].forEach(({ input, output }) => {
       it(`testing list: ${input}`, () => {
-        // @ts-ignore
+        // @ts-expect-error Bug with complex types in TS https://github.com/microsoft/TypeScript/issues/40770
         expect(convertToAttr(input)).toEqual({ L: output });
       });
     });
 
     it(`testing list with options.convertEmptyValues=true`, () => {
-      const input = ["", new Uint8Array(), new Set()];
-      // @ts-ignore
+      const input = ["", new Uint8Array(), new Set([])];
       expect(convertToAttr(input, { convertEmptyValues: true })).toEqual({
         L: [{ NULL: true }, { NULL: true }, { NULL: true }],
       });
@@ -223,49 +222,48 @@ describe("convertToAttr", () => {
     const uint8Arr = new Uint32Array(arr);
     const biguintArr = new BigUint64Array(arr.map(BigInt));
     [
-      [
-        { nullKey: null, boolKey: false },
-        { nullKey: { NULL: true }, boolKey: { BOOL: false } },
-      ],
-      [
-        { stringKey: "one", numberKey: 1.01, bigintKey: BigInt(1) },
-        { stringKey: { S: "one" }, numberKey: { N: "1.01" }, bigintKey: { N: "1" } },
-      ],
-      [
-        { uint8ArrKey: uint8Arr, biguintArrKey: biguintArr },
-        { uint8ArrKey: { B: uint8Arr }, biguintArrKey: { B: biguintArr } },
-      ],
-      [
-        { list1: [null, false], list2: ["one", 1.01, BigInt(9007199254740996)] },
-        {
+      {
+        input: { nullKey: null, boolKey: false },
+        output: { nullKey: { NULL: true }, boolKey: { BOOL: false } },
+      },
+      {
+        input: { stringKey: "one", numberKey: 1.01, bigintKey: BigInt(1) },
+        output: { stringKey: { S: "one" }, numberKey: { N: "1.01" }, bigintKey: { N: "1" } },
+      },
+      {
+        input: { uint8ArrKey: uint8Arr, biguintArrKey: biguintArr },
+        output: { uint8ArrKey: { B: uint8Arr }, biguintArrKey: { B: biguintArr } },
+      },
+      {
+        input: { list1: [null, false], list2: ["one", 1.01, BigInt(9007199254740996)] },
+        output: {
           list1: { L: [{ NULL: true }, { BOOL: false }] },
           list2: { L: [{ S: "one" }, { N: "1.01" }, { N: "9007199254740996" }] },
         },
-      ],
-      [
-        {
+      },
+      {
+        input: {
           numberSet: new Set([1, 2, 3]),
           bigintSet: new Set([BigInt(9007199254740996), BigInt(-9007199254740996)]),
           binarySet: new Set([uint8Arr, biguintArr]),
           stringSet: new Set(["one", "two", "three"]),
         },
-        {
+        output: {
           numberSet: { NS: ["1", "2", "3"] },
           bigintSet: { NS: ["9007199254740996", "-9007199254740996"] },
           binarySet: { BS: [uint8Arr, biguintArr] },
           stringSet: { SS: ["one", "two", "three"] },
         },
-      ],
-    ].forEach(([input, output]) => {
+      },
+    ].forEach(({ input, output }) => {
       it(`testing map: ${input}`, () => {
-        // @ts-ignore
+        // @ts-expect-error Bug with complex types in TS https://github.com/microsoft/TypeScript/issues/40770
         expect(convertToAttr(input)).toEqual({ M: output });
       });
     });
 
     it(`testing map with options.convertEmptyValues=true`, () => {
-      const input = { stringKey: "", binaryKey: new Uint8Array(), setKey: new Set() };
-      // @ts-ignore
+      const input = { stringKey: "", binaryKey: new Uint8Array(), setKey: new Set([]) };
       expect(convertToAttr(input, { convertEmptyValues: true })).toEqual({
         M: { stringKey: { NULL: true }, binaryKey: { NULL: true }, setKey: { NULL: true } },
       });
@@ -286,17 +284,14 @@ describe("convertToAttr", () => {
 
   describe(`unsupported type`, () => {
     class FooObj {
-      constructor() {
-        // @ts-ignore
-        this.foo = "foo";
-      }
+      constructor(private readonly foo: string) {}
     }
 
     // ToDo: Serialize ES6 class objects as string https://github.com/aws/aws-sdk-js-v3/issues/1535
-    [undefined, new Date(), new FooObj()].forEach((data) => {
+    [undefined, new Date(), new FooObj("foo")].forEach((data) => {
       it(`throws for: ${String(data)}`, () => {
         expect(() => {
-          // @ts-ignore Argument is not assignable to parameter of type 'NativeAttributeValue'
+          // @ts-expect-error Argument is not assignable to parameter of type 'NativeAttributeValue'
           convertToAttr(data);
         }).toThrowError(`Unsupported type passed: ${String(data)}`);
       });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -145,6 +145,18 @@ describe("convertToAttr", () => {
       const set = new Set(["one", "two", "three"]);
       expect(convertToAttr(set)).toEqual({ SS: Array.from(set) });
     });
+
+    it("throws error for empty set", () => {
+      expect(() => {
+        convertToAttr(new Set());
+      }).toThrowError(`Please pass a non-empty set`);
+    });
+
+    it("thows error for unallowed set", () => {
+      expect(() => {
+        convertToAttr(new Set([true, false]));
+      }).toThrowError(`Only Number Set (NS), Binary Set (BS) or String Set (SS) are allowed.`);
+    });
   });
 
   describe("string", () => {

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -184,9 +184,10 @@ describe("convertToAttr", () => {
   });
 
   describe("string", () => {
-    it("returns for string", () => {
-      const str = "str";
-      expect(convertToAttr(str)).toEqual({ S: str });
+    ["", "string", "'single-quote'", '"double-quote"'].forEach((str) => {
+      it(`returns for string: ${str}`, () => {
+        expect(convertToAttr(str)).toEqual({ S: str });
+      });
     });
   });
 
@@ -198,6 +199,22 @@ describe("convertToAttr", () => {
           convertToAttr(data);
         }).toThrowError(`Unsupported type passed: ${String(data)}`);
       });
+    });
+  });
+
+  describe("convertEmptyValues set to true", () => {
+    const convertEmptyValues = true;
+
+    it(`returns null for Set`, () => {
+      expect(convertToAttr(new Set(), { convertEmptyValues })).toEqual({ NULL: true });
+    });
+
+    it(`returns null for String`, () => {
+      expect(convertToAttr("", { convertEmptyValues })).toEqual({ NULL: true });
+    });
+
+    it(`returns null for Binary`, () => {
+      expect(convertToAttr(new Uint8Array(), { convertEmptyValues })).toEqual({ NULL: true });
     });
   });
 });

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -134,13 +134,13 @@ describe("convertToAttr", () => {
         [
           new Set([1, 2, 3]),
           new Set([BigInt(9007199254740996), BigInt(-9007199254740996)]),
-          new Set([new Uint8Array([...Array(8).keys()]), new Uint8Array([...Array(16).keys()])]),
+          new Set([uint8Arr, biguintArr]),
           new Set(["one", "two", "three"]),
         ],
         [
           { NS: ["1", "2", "3"] },
           { NS: ["9007199254740996", "-9007199254740996"] },
-          { BS: [new Uint8Array([...Array(8).keys()]), new Uint8Array([...Array(16).keys()])] },
+          { BS: [uint8Arr, biguintArr] },
           { SS: ["one", "two", "three"] },
         ],
       ],
@@ -228,13 +228,13 @@ describe("convertToAttr", () => {
         {
           numberSet: new Set([1, 2, 3]),
           bigintSet: new Set([BigInt(9007199254740996), BigInt(-9007199254740996)]),
-          binarySet: new Set([new Uint8Array([...Array(8).keys()]), new Uint8Array([...Array(16).keys()])]),
+          binarySet: new Set([uint8Arr, biguintArr]),
           stringSet: new Set(["one", "two", "three"]),
         },
         {
           numberSet: { NS: ["1", "2", "3"] },
           bigintSet: { NS: ["9007199254740996", "-9007199254740996"] },
-          binarySet: { BS: [new Uint8Array([...Array(8).keys()]), new Uint8Array([...Array(16).keys()])] },
+          binarySet: { BS: [uint8Arr, biguintArr] },
           stringSet: { SS: ["one", "two", "three"] },
         },
       ],

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -22,7 +22,7 @@ describe("convertToAttr", () => {
       });
     });
 
-    [3.14].forEach((num) => {
+    [3.14, Number.MIN_VALUE].forEach((num) => {
       it(`returns for number (floating point): ${num}`, () => {
         expect(convertToAttr(num)).toEqual({ N: num.toString() });
       });
@@ -36,7 +36,7 @@ describe("convertToAttr", () => {
       });
     });
 
-    [Number.MAX_SAFE_INTEGER + 1].forEach((num) => {
+    [Number.MAX_SAFE_INTEGER + 1, Number.MAX_VALUE].forEach((num) => {
       it(`throws for number greater than Number.MAX_SAFE_INTEGER: ${num}`, () => {
         expect(() => {
           convertToAttr(num);
@@ -54,10 +54,21 @@ describe("convertToAttr", () => {
   });
 
   describe("bigint", () => {
-    it("returns for BigInt value", () => {
+    const maxSafe = BigInt(Number.MAX_SAFE_INTEGER);
+    [
       // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
-      const num = BigInt(Number.MAX_SAFE_INTEGER) + 2n;
-      expect(convertToAttr(num)).toEqual({ N: num.toString() });
+      1n,
+      // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
+      maxSafe * 2n,
+      // @ts-expect-error BigInt literals are not available when targeting lower than ES2020.
+      maxSafe * -2n,
+      BigInt(Number.MAX_VALUE),
+      BigInt("0x1fffffffffffff"),
+      BigInt("0b11111111111111111111111111111111111111111111111111111"),
+    ].forEach((num) => {
+      it(`returns for bigint: ${num}`, () => {
+        expect(convertToAttr(num)).toEqual({ N: num.toString() });
+      });
     });
   });
 

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -3,7 +3,9 @@ import { AttributeValue } from "@aws-sdk/client-dynamodb";
 import { NativeAttributeValue } from "./models";
 
 export const convertToAttr = (inputVal: NativeAttributeValue): AttributeValue => {
-  if (typeof inputVal === "number") {
+  if (typeof inputVal === "boolean") {
+    return { BOOL: inputVal };
+  } else if (typeof inputVal === "number") {
     return { N: inputVal.toString() };
   } else {
     // @ts-ignore

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -14,7 +14,7 @@ export const convertToAttr = (inputVal: NativeAttributeValue): AttributeValue =>
 };
 
 const convertToNumberAttr = (num: number): { N: string } => {
-  if ([NaN, Infinity, -Infinity].includes(num)) {
+  if ([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].includes(num)) {
     throw new Error(`Special numeric value ${num} is not allowed`);
   } else if (num > Number.MAX_SAFE_INTEGER) {
     throw new Error(`Number ${num} is greater than Number.MAX_SAFE_INTEGER. Use BigInt.`);

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -122,13 +122,17 @@ const convertToBinaryAttr = (data: NativeAttributeBinary): { B: NativeAttributeB
 const convertToStringAttr = (data: string): { S: string } => ({ S: data });
 const convertToBigIntAttr = (data: bigint): { N: string } => ({ N: data.toString() });
 
+const validateBigIntAndThrow = (errorPrefix: string) => {
+  throw new Error(`${errorPrefix} ${typeof BigInt === "function" ? "Use BigInt." : "Pass string value instead."} `);
+};
+
 const convertToNumberAttr = (num: number): { N: string } => {
   if ([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].includes(num)) {
     throw new Error(`Special numeric value ${num} is not allowed`);
   } else if (num > Number.MAX_SAFE_INTEGER) {
-    throw new Error(`Number ${num} is greater than Number.MAX_SAFE_INTEGER. Use BigInt.`);
+    validateBigIntAndThrow(`Number ${num} is greater than Number.MAX_SAFE_INTEGER.`);
   } else if (num < Number.MIN_SAFE_INTEGER) {
-    throw new Error(`Number ${num} is lesser than Number.MIN_SAFE_INTEGER. Use BigInt.`);
+    validateBigIntAndThrow(`Number ${num} is lesser than Number.MIN_SAFE_INTEGER.`);
   }
   return { N: num.toString() };
 };

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -46,10 +46,16 @@ const convertToSetAttr = (
   }
 
   const item = set.values().next().value;
-  if (typeof item === "number" || typeof item === "bigint") {
+  if (typeof item === "number") {
     return {
       NS: Array.from(set)
         .map(convertToNumberAttr)
+        .map((item) => item.N),
+    };
+  } else if (typeof item === "bigint") {
+    return {
+      NS: Array.from(set)
+        .map(convertToBigIntAttr)
         .map((item) => item.N),
     };
   } else if (typeof item === "string") {
@@ -92,7 +98,7 @@ const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: convert
   } else if (typeof data === "number") {
     return convertToNumberAttr(data);
   } else if (typeof data === "bigint") {
-    return { N: data.toString() };
+    return convertToBigIntAttr(data);
   } else if (isBinary(data)) {
     // @ts-expect-error Property 'length' does not exist on type 'ArrayBuffer'.
     if (data.length === 0 && options?.convertEmptyValues) {
@@ -114,6 +120,7 @@ const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: convert
 const convertToNullAttr = (): { NULL: true } => ({ NULL: true });
 const convertToBinaryAttr = (data: NativeAttributeBinary): { B: NativeAttributeBinary } => ({ B: data });
 const convertToStringAttr = (data: string): { S: string } => ({ S: data });
+const convertToBigIntAttr = (data: bigint): { N: string } => ({ N: data.toString() });
 
 const convertToNumberAttr = (num: number): { N: string } => {
   if ([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].includes(num)) {

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -65,7 +65,7 @@ const isBinary = (data: any): boolean => {
 
 const convertToSetAttr = (set: Set<any>): { NS?: string[]; BS?: Uint8Array[]; SS?: string[] } => {
   if (set.size === 0) {
-    throw new Error(`Please pass non-empty set`);
+    throw new Error(`Please pass a non-empty set`);
   }
   const item = set.values().next().value;
   if (typeof item === "number" || typeof item === "bigint") {
@@ -76,6 +76,6 @@ const convertToSetAttr = (set: Set<any>): { NS?: string[]; BS?: Uint8Array[]; SS
     // @ts-ignore Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
     return { BS: Array.from(set) };
   } else {
-    throw new Error(`Only Number Set (NS), Binary Set (BS) or String Set (SS) are allowed`);
+    throw new Error(`Only Number Set (NS), Binary Set (BS) or String Set (SS) are allowed.`);
   }
 };

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -9,6 +9,8 @@ export const convertToAttr = (data: NativeAttributeValue): AttributeValue => {
     return { BOOL: data };
   } else if (typeof data === "number") {
     return convertToNumberAttr(data);
+  } else if (typeof data === "bigint") {
+    return { N: data.toString() };
   } else {
     // @ts-ignore
     return { S: data };

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -1,0 +1,12 @@
+import { AttributeValue } from "@aws-sdk/client-dynamodb";
+
+import { NativeAttributeValue } from "./models";
+
+export const convertToAttr = (inputVal: NativeAttributeValue): AttributeValue => {
+  if (typeof inputVal === "number") {
+    return { N: inputVal.toString() };
+  } else {
+    // @ts-ignore
+    return { S: inputVal };
+  }
+};

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -11,6 +11,9 @@ export const convertToAttr = (data: NativeAttributeValue): AttributeValue => {
     return convertToNumberAttr(data);
   } else if (typeof data === "bigint") {
     return { N: data.toString() };
+  } else if (isBinary(data)) {
+    // @ts-ignore Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
+    return { B: data };
   } else {
     // @ts-ignore
     return { S: data };
@@ -26,4 +29,30 @@ const convertToNumberAttr = (num: number): { N: string } => {
     throw new Error(`Number ${num} is lesser than Number.MIN_SAFE_INTEGER. Use BigInt.`);
   }
   return { N: num.toString() };
+};
+
+const isBinary = (data: any): boolean => {
+  const binaryTypes = [
+    "ArrayBuffer",
+    "Blob",
+    "Buffer",
+    "DataView",
+    "File",
+    "Int8Array",
+    "Uint8Array",
+    "Uint8ClampedArray",
+    "Int16Array",
+    "Uint16Array",
+    "Int32Array",
+    "Uint32Array",
+    "Float32Array",
+    "Float64Array",
+    "BigInt64Array",
+    "BigUint64Array",
+  ];
+
+  if (data.constructor) {
+    return binaryTypes.includes(data.constructor.name);
+  }
+  return false;
 };

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -2,14 +2,16 @@ import { AttributeValue } from "@aws-sdk/client-dynamodb";
 
 import { NativeAttributeValue } from "./models";
 
-export const convertToAttr = (inputVal: NativeAttributeValue): AttributeValue => {
-  if (typeof inputVal === "boolean") {
-    return { BOOL: inputVal };
-  } else if (typeof inputVal === "number") {
-    return convertToNumberAttr(inputVal);
+export const convertToAttr = (data: NativeAttributeValue): AttributeValue => {
+  if (data === null && typeof data === "object") {
+    return { NULL: true };
+  } else if (typeof data === "boolean") {
+    return { BOOL: data };
+  } else if (typeof data === "number") {
+    return convertToNumberAttr(data);
   } else {
     // @ts-ignore
-    return { S: inputVal };
+    return { S: data };
   }
 };
 

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -7,6 +7,16 @@ export const convertToAttr = (data: NativeAttributeValue): AttributeValue => {
     return { L: data.map(convertToAttr) };
   } else if (data?.constructor?.name === "Set") {
     return convertToSetAttr(data as Set<any>);
+  } else if (data?.constructor?.name === "Object") {
+    return {
+      M: Object.entries(data).reduce(
+        (acc: { [key: string]: AttributeValue }, [key, value]: [string, NativeAttributeValue]) => ({
+          ...acc,
+          [key]: convertToAttr(value),
+        }),
+        {}
+      ),
+    };
   } else {
     if (data === null && typeof data === "object") {
       return { NULL: true };

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -1,38 +1,33 @@
 import { AttributeValue } from "@aws-sdk/client-dynamodb";
 
-import { NativeAttributeValue } from "./models";
+import { NativeAttributeBinary, NativeAttributeValue } from "./models";
+
+/**
+ * An optional configuration object for `convertToAttr`
+ */
+export interface convertToAttrOptions {
+  /**
+   * Whether to automatically convert empty strings, blobs, and sets to `null`
+   */
+  convertEmptyValues?: boolean;
+}
 
 /**
  * Convert a JavaScript value to its equivalent DynamoDB AttributeValue type
  *
- * @param {NativeAttributeValue} data The data to convert to a DynamoDB AttributeValue
- * @param {Object} options
- * @param {boolean} options.convertEmptyValues Whether to automatically
- *                      convert empty strings, blobs, and sets to `null`
+ * @param {NativeAttributeValue} data - The data to convert to a DynamoDB AttributeValue
+ * @param {convertToAttrOptions} options - An optional configuration object for `convertToAttr`
  */
-export const convertToAttr = (
-  data: NativeAttributeValue,
-  options?: {
-    convertEmptyValues: boolean;
-  }
-): AttributeValue => {
+export const convertToAttr = (data: NativeAttributeValue, options?: convertToAttrOptions): AttributeValue => {
   if (Array.isArray(data)) {
-    return { L: data.map((item) => convertToAttr(item)) };
+    return convertToListAttr(data, options);
   } else if (data?.constructor?.name === "Set") {
-    return convertToSetAttr(data as Set<any>, options?.convertEmptyValues);
+    return convertToSetAttr(data as Set<any>, options);
   } else if (data?.constructor?.name === "Object") {
-    return {
-      M: Object.entries(data).reduce(
-        (acc: { [key: string]: AttributeValue }, [key, value]: [string, NativeAttributeValue]) => ({
-          ...acc,
-          [key]: convertToAttr(value),
-        }),
-        {}
-      ),
-    };
+    return converToMapAttr(data as { [key: string]: NativeAttributeValue }, options);
   } else {
     if (data === null && typeof data === "object") {
-      return { NULL: true };
+      return convertToNullAttr();
     } else if (typeof data === "boolean") {
       return { BOOL: data };
     } else if (typeof data === "number") {
@@ -42,19 +37,79 @@ export const convertToAttr = (
     } else if (isBinary(data)) {
       // @ts-expect-error Property 'length' does not exist on type 'ArrayBuffer'.
       if (data.length === 0 && options?.convertEmptyValues) {
-        return convertToAttr(null);
+        return convertToNullAttr();
       }
-      // @ts-ignore Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
-      return { B: data };
+      // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
+      // @ts-expect-error Type '{ B: NativeAttributeBinary; }' is not assignable to type 'AttributeValue'
+      return convertToBinaryAttr(data);
     } else if (typeof data === "string") {
       if (data.length === 0 && options?.convertEmptyValues) {
-        return convertToAttr(null);
+        return convertToNullAttr();
       }
-      return { S: data };
+      return convertToStringAttr(data);
     }
     throw new Error(`Unsupported type passed: ${data}`);
   }
 };
+
+const convertToListAttr = (data: NativeAttributeValue[], options?: convertToAttrOptions): { L: AttributeValue[] } => ({
+  L: data.map((item) => convertToAttr(item, options)),
+});
+
+const convertToSetAttr = (
+  set: Set<any>,
+  options?: convertToAttrOptions
+): { NS: string[] } | { BS: Uint8Array[] } | { SS: string[] } | { NULL: true } => {
+  if (set.size === 0) {
+    if (options?.convertEmptyValues) {
+      return convertToNullAttr();
+    }
+    throw new Error(`Please pass a non-empty set, or set convertEmptyValues to true.`);
+  }
+
+  const item = set.values().next().value;
+  if (typeof item === "number" || typeof item === "bigint") {
+    return {
+      NS: Array.from(set)
+        .map(convertToNumberAttr)
+        .map((item) => item.N),
+    };
+  } else if (typeof item === "string") {
+    return {
+      SS: Array.from(set)
+        .map(convertToStringAttr)
+        .map((item) => item.S),
+    };
+  } else if (isBinary(item)) {
+    return {
+      // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
+      // @ts-expect-error Type 'ArrayBuffer' is not assignable to type 'Uint8Array'
+      BS: Array.from(set)
+        .map(convertToBinaryAttr)
+        .map((item) => item.B),
+    };
+  } else {
+    throw new Error(`Only Number Set (NS), Binary Set (BS) or String Set (SS) are allowed.`);
+  }
+};
+
+const converToMapAttr = (
+  data: { [key: string]: NativeAttributeValue },
+  options?: convertToAttrOptions
+): { M: { [key: string]: AttributeValue } } => ({
+  M: Object.entries(data).reduce(
+    (acc: { [key: string]: AttributeValue }, [key, value]: [string, NativeAttributeValue]) => ({
+      ...acc,
+      [key]: convertToAttr(value, options),
+    }),
+    {}
+  ),
+});
+
+// For future-proofing: this functions are called from multiple places
+const convertToNullAttr = (): { NULL: true } => ({ NULL: true });
+const convertToBinaryAttr = (data: NativeAttributeBinary): { B: NativeAttributeBinary } => ({ B: data });
+const convertToStringAttr = (data: string): { S: string } => ({ S: data });
 
 const convertToNumberAttr = (num: number): { N: string } => {
   if ([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY].includes(num)) {
@@ -91,27 +146,4 @@ const isBinary = (data: any): boolean => {
     return binaryTypes.includes(data.constructor.name);
   }
   return false;
-};
-
-const convertToSetAttr = (
-  set: Set<any>,
-  convertEmptyValues?: boolean
-): { NS?: string[]; BS?: Uint8Array[]; SS?: string[] } => {
-  if (set.size === 0) {
-    if (convertEmptyValues) {
-      return convertToAttr(null);
-    }
-    throw new Error(`Please pass a non-empty set`);
-  }
-  const item = set.values().next().value;
-  if (typeof item === "number" || typeof item === "bigint") {
-    return { NS: Array.from(set).map((num) => num.toString()) };
-  } else if (typeof item === "string") {
-    return { SS: Array.from(set).map((str) => str.toString()) };
-  } else if (isBinary(item)) {
-    // @ts-ignore Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
-    return { BS: Array.from(set) };
-  } else {
-    throw new Error(`Only Number Set (NS), Binary Set (BS) or String Set (SS) are allowed.`);
-  }
 };

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -3,20 +3,24 @@ import { AttributeValue } from "@aws-sdk/client-dynamodb";
 import { NativeAttributeValue } from "./models";
 
 export const convertToAttr = (data: NativeAttributeValue): AttributeValue => {
-  if (data === null && typeof data === "object") {
-    return { NULL: true };
-  } else if (typeof data === "boolean") {
-    return { BOOL: data };
-  } else if (typeof data === "number") {
-    return convertToNumberAttr(data);
-  } else if (typeof data === "bigint") {
-    return { N: data.toString() };
-  } else if (isBinary(data)) {
-    // @ts-ignore Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
-    return { B: data };
+  if (Array.isArray(data)) {
+    return { L: data.map(convertToAttr) };
   } else {
-    // @ts-ignore
-    return { S: data };
+    if (data === null && typeof data === "object") {
+      return { NULL: true };
+    } else if (typeof data === "boolean") {
+      return { BOOL: data };
+    } else if (typeof data === "number") {
+      return convertToNumberAttr(data);
+    } else if (typeof data === "bigint") {
+      return { N: data.toString() };
+    } else if (isBinary(data)) {
+      // @ts-ignore Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
+      return { B: data };
+    } else {
+      // @ts-ignore
+      return { S: data };
+    }
   }
 };
 

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -6,16 +6,20 @@ export const convertToAttr = (inputVal: NativeAttributeValue): AttributeValue =>
   if (typeof inputVal === "boolean") {
     return { BOOL: inputVal };
   } else if (typeof inputVal === "number") {
-    return convertToNumber(inputVal);
+    return convertToNumberAttr(inputVal);
   } else {
     // @ts-ignore
     return { S: inputVal };
   }
 };
 
-const convertToNumber = (num: number): { N: string } => {
+const convertToNumberAttr = (num: number): { N: string } => {
   if ([NaN, Infinity, -Infinity].includes(num)) {
     throw new Error(`Special numeric value ${num} is not allowed`);
+  } else if (num > Number.MAX_SAFE_INTEGER) {
+    throw new Error(`Number ${num} is greater than Number.MAX_SAFE_INTEGER. Use BigInt.`);
+  } else if (num < Number.MIN_SAFE_INTEGER) {
+    throw new Error(`Number ${num} is lesser than Number.MIN_SAFE_INTEGER. Use BigInt.`);
   }
   return { N: num.toString() };
 };

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -6,9 +6,16 @@ export const convertToAttr = (inputVal: NativeAttributeValue): AttributeValue =>
   if (typeof inputVal === "boolean") {
     return { BOOL: inputVal };
   } else if (typeof inputVal === "number") {
-    return { N: inputVal.toString() };
+    return convertToNumber(inputVal);
   } else {
     // @ts-ignore
     return { S: inputVal };
   }
+};
+
+const convertToNumber = (num: number): { N: string } => {
+  if ([NaN, Infinity, -Infinity].includes(num)) {
+    throw new Error(`Special numeric value ${num} is not allowed`);
+  }
+  return { N: num.toString() };
 };

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -24,7 +24,7 @@ export const convertToAttr = (data: NativeAttributeValue, options?: convertToAtt
   } else if (data?.constructor?.name === "Set") {
     return convertToSetAttr(data as Set<any>, options);
   } else if (data?.constructor?.name === "Object") {
-    return converToMapAttr(data as { [key: string]: NativeAttributeValue }, options);
+    return convertToMapAttr(data as { [key: string]: NativeAttributeValue }, options);
   } else {
     return convertToScalarAttr(data as NativeScalarAttributeValue, options);
   }
@@ -71,7 +71,7 @@ const convertToSetAttr = (
   }
 };
 
-const converToMapAttr = (
+const convertToMapAttr = (
   data: { [key: string]: NativeAttributeValue },
   options?: convertToAttrOptions
 ): { M: { [key: string]: AttributeValue } } => ({

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -1,24 +1,15 @@
 import { AttributeValue } from "@aws-sdk/client-dynamodb";
 
+import { marshallOptions } from "./marshall";
 import { NativeAttributeBinary, NativeAttributeValue, NativeScalarAttributeValue } from "./models";
-
-/**
- * An optional configuration object for `convertToAttr`
- */
-export interface convertToAttrOptions {
-  /**
-   * Whether to automatically convert empty strings, blobs, and sets to `null`
-   */
-  convertEmptyValues?: boolean;
-}
 
 /**
  * Convert a JavaScript value to its equivalent DynamoDB AttributeValue type
  *
  * @param {NativeAttributeValue} data - The data to convert to a DynamoDB AttributeValue
- * @param {convertToAttrOptions} options - An optional configuration object for `convertToAttr`
+ * @param {marshallOptions} options - An optional configuration object for `convertToAttr`
  */
-export const convertToAttr = (data: NativeAttributeValue, options?: convertToAttrOptions): AttributeValue => {
+export const convertToAttr = (data: NativeAttributeValue, options?: marshallOptions): AttributeValue => {
   if (Array.isArray(data)) {
     return convertToListAttr(data, options);
   } else if (data?.constructor?.name === "Set") {
@@ -30,13 +21,13 @@ export const convertToAttr = (data: NativeAttributeValue, options?: convertToAtt
   }
 };
 
-const convertToListAttr = (data: NativeAttributeValue[], options?: convertToAttrOptions): { L: AttributeValue[] } => ({
+const convertToListAttr = (data: NativeAttributeValue[], options?: marshallOptions): { L: AttributeValue[] } => ({
   L: data.map((item) => convertToAttr(item, options)),
 });
 
 const convertToSetAttr = (
   set: Set<any>,
-  options?: convertToAttrOptions
+  options?: marshallOptions
 ): { NS: string[] } | { BS: Uint8Array[] } | { SS: string[] } | { NULL: true } => {
   if (set.size === 0) {
     if (options?.convertEmptyValues) {
@@ -79,7 +70,7 @@ const convertToSetAttr = (
 
 const convertToMapAttr = (
   data: { [key: string]: NativeAttributeValue },
-  options?: convertToAttrOptions
+  options?: marshallOptions
 ): { M: { [key: string]: AttributeValue } } => ({
   M: Object.entries(data).reduce(
     (acc: { [key: string]: AttributeValue }, [key, value]: [string, NativeAttributeValue]) => ({
@@ -90,7 +81,7 @@ const convertToMapAttr = (
   ),
 });
 
-const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: convertToAttrOptions): AttributeValue => {
+const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: marshallOptions): AttributeValue => {
   if (data === null && typeof data === "object") {
     return convertToNullAttr();
   } else if (typeof data === "boolean") {

--- a/packages/util-dynamodb/src/index.ts
+++ b/packages/util-dynamodb/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./convertToAttr";
+export * from "./marshall";
 export * from "./models";

--- a/packages/util-dynamodb/src/index.ts
+++ b/packages/util-dynamodb/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./convertToAttr";
+export * from "./models";

--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -1,0 +1,32 @@
+import { convertToAttr } from "./convertToAttr";
+import { marshall } from "./marshall";
+
+jest.mock("./convertToAttr");
+
+describe("marshall", () => {
+  const input = { a: "A", b: "B" };
+
+  beforeEach(() => {
+    (convertToAttr as jest.Mock).mockReturnValue({ M: input });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls convertToAttr", () => {
+    // @ts-ignore output mocked for testing
+    expect(marshall(input)).toEqual(input);
+    expect(convertToAttr).toHaveBeenCalledTimes(1);
+    expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
+  });
+
+  [false, true].forEach((convertEmptyValues) => {
+    it(`passes convertEmptyValues=${convertEmptyValues} to convertToAttr`, () => {
+      // @ts-ignore output mocked for testing
+      expect(marshall(input, { convertEmptyValues })).toEqual(input);
+      expect(convertToAttr).toHaveBeenCalledTimes(1);
+      expect(convertToAttr).toHaveBeenCalledWith(input, { convertEmptyValues });
+    });
+  });
+});

--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -1,0 +1,25 @@
+import { AttributeValue } from "@aws-sdk/client-dynamodb";
+
+import { convertToAttr } from "./convertToAttr";
+import { NativeAttributeValue } from "./models";
+
+/**
+ * An optional configuration object for `marshall`
+ */
+export interface marshallOptions {
+  /**
+   * Whether to automatically convert empty strings, blobs, and sets to `null`
+   */
+  convertEmptyValues?: boolean;
+}
+
+/**
+ * Convert a JavaScript object into a DynamoDB record.
+ *
+ * @param {any} data - The data to convert to a DynamoDB record
+ * @param {marshallOptions} options - An optional configuration object for `marshall`
+ */
+export const marshall = (
+  data: { [key: string]: NativeAttributeValue },
+  options?: marshallOptions
+): { [key: string]: AttributeValue } => convertToAttr(data, options).M as { [key: string]: AttributeValue };

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -6,7 +6,8 @@ export type NativeAttributeValue =
   | NativeAttributeBinary
   | string
   | { [key: string]: NativeAttributeValue }
-  | NativeAttributeValue[];
+  | NativeAttributeValue[]
+  | Set<NativeAttributeValue>;
 
 type NativeAttributeBinary =
   | ArrayBuffer

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -2,10 +2,8 @@ export type NativeAttributeValue =
   | null
   | boolean
   | number
-  | number[]
+  | bigint
   | Uint8Array
-  | Uint8Array[]
   | string
-  | string[]
   | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[];

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -1,0 +1,11 @@
+export type NativeAttributeValue =
+  | null
+  | boolean
+  | number
+  | number[]
+  | Uint8Array
+  | Uint8Array[]
+  | string
+  | string[]
+  | { [key: string]: NativeAttributeValue }
+  | NativeAttributeValue[];

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -3,7 +3,25 @@ export type NativeAttributeValue =
   | boolean
   | number
   | bigint
-  | Uint8Array
+  | NativeAttributeBinary
   | string
   | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[];
+
+type NativeAttributeBinary =
+  | ArrayBuffer
+  | Blob
+  | Buffer
+  | DataView
+  | File
+  | Int8Array
+  | Uint8Array
+  | Uint8ClampedArray
+  | Int16Array
+  | Uint16Array
+  | Int32Array
+  | Uint32Array
+  | Float32Array
+  | Float64Array
+  | BigInt64Array
+  | BigUint64Array;

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -9,7 +9,7 @@ export type NativeAttributeValue =
   | NativeAttributeValue[]
   | Set<NativeAttributeValue>;
 
-type NativeAttributeBinary =
+export type NativeAttributeBinary =
   | ArrayBuffer
   | Blob
   | Buffer

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -1,13 +1,10 @@
 export type NativeAttributeValue =
-  | null
-  | boolean
-  | number
-  | bigint
-  | NativeAttributeBinary
-  | string
+  | NativeScalarAttributeValue
   | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[]
   | Set<NativeAttributeValue>;
+
+export type NativeScalarAttributeValue = null | boolean | number | bigint | NativeAttributeBinary | string;
 
 export type NativeAttributeBinary =
   | ArrayBuffer

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -2,7 +2,7 @@ export type NativeAttributeValue =
   | NativeScalarAttributeValue
   | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[]
-  | Set<NativeAttributeValue>;
+  | Set<number | bigint | string | NativeAttributeBinary>;
 
 export type NativeScalarAttributeValue = null | boolean | number | bigint | NativeAttributeBinary | string;
 

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "strict": true,
+    "sourceMap": false,
+    "downlevelIteration": true,
+    "importHelpers": true,
+    "noEmitHelpers": true,
+    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "rootDir": "./src",
+    "outDir": "./dist/cjs",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -6,7 +6,7 @@
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/util-dynamodb/tsconfig.es.json
+++ b/packages/util-dynamodb/tsconfig.es.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "strict": true,
+    "sourceMap": false,
+    "downlevelIteration": true,
+    "importHelpers": true,
+    "noEmitHelpers": true,
+    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "inlineSourceMap": true,
+    "inlineSources": true,
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}

--- a/packages/util-dynamodb/tsconfig.es.json
+++ b/packages/util-dynamodb/tsconfig.es.json
@@ -6,7 +6,7 @@
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,
-    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
     "rootDir": "./src",
     "outDir": "./dist/es",
     "inlineSourceMap": true,


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1223

*Description of changes:*
Adds utility function marshall to convert JavaScript object into DynamoDB Record

```js
const { DynamoDB } = require("@aws-sdk/client-dynamodb");
const { marshall } = require("@aws-sdk/util-dynamodb");

const client = new DynamoDB(clientParams);
const params = {
  TableName: "Table",
  Item: marshall({
    HashKey: "hashKey",
    NumAttribute: 1,
    BoolAttribute: true,
    ListAttribute: [1, "two", false],
    MapAttribute: { foo: "bar" },
    NullAttribute: null,
  }),
};

await client.putItem(params);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
