### PR TITLE
chore(middleware-host-header): move to low priority

### DIFF
--- a/packages/middleware-host-header/src/index.ts
+++ b/packages/middleware-host-header/src/index.ts
@@ -35,6 +35,7 @@ export const hostHeaderMiddleware = <Input extends object, Output extends object
 export const hostHeaderMiddlewareOptions: BuildHandlerOptions & AbsoluteLocation = {
   name: "hostHeaderMiddleware",
   step: "build",
+  priority: "low",
   tags: ["HOST"],
 };
 


### PR DESCRIPTION
*Description of changes:*

AWS Signer requires a request to contain a `host` header, mostly the same as the request's `hostname`. 
For the customizations that modifies the request's `hostname`, they need to be applied before this 
middleware, Otherwise the `hostname` and `host` header would mismatch. It mean these middleware
**must** be applied relatively before this middleware. By moving it low priority, it reduce the possibility 
of mistakenly adding customizations applied after this middleware. Developers only need to apply the
customizations to the `build` step, and they will be applied before this middleware by default.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
