### PR TITLE
fix(util-dynamodb): create BigInt from string value instead of number

### DIFF
--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -64,8 +64,8 @@ describe("convertToNative", () => {
         });
       });
 
-    [Number.MAX_SAFE_INTEGER + 1, Number.MIN_SAFE_INTEGER - 1]
-      .map((num) => num.toString())
+    [Number.MAX_SAFE_INTEGER + 1, Number.MAX_VALUE, Number.MIN_SAFE_INTEGER - 1]
+      .map((num) => BigInt(num).toString())
       .forEach((numString) => {
         it(`returns bigint for numbers outside SAFE_INTEGER range: ${numString}`, () => {
           expect(convertToNative({ ...emptyAttr, N: numString })).toEqual(BigInt(numString));

--- a/packages/util-dynamodb/src/convertToNative.spec.ts
+++ b/packages/util-dynamodb/src/convertToNative.spec.ts
@@ -64,11 +64,11 @@ describe("convertToNative", () => {
         });
       });
 
-    [Number.MAX_SAFE_INTEGER + 1, Number.MAX_VALUE, Number.MIN_SAFE_INTEGER - 1]
+    [Number.MAX_SAFE_INTEGER + 1, Number.MIN_SAFE_INTEGER - 1]
       .map((num) => num.toString())
       .forEach((numString) => {
         it(`returns bigint for numbers outside SAFE_INTEGER range: ${numString}`, () => {
-          expect(convertToNative({ ...emptyAttr, N: numString })).toEqual(BigInt(Number(numString)));
+          expect(convertToNative({ ...emptyAttr, N: numString })).toEqual(BigInt(numString));
         });
 
         it(`throws error for numbers outside SAFE_INTEGER range when BigInt is not defined: ${numString}`, () => {

--- a/packages/util-dynamodb/src/convertToNative.ts
+++ b/packages/util-dynamodb/src/convertToNative.ts
@@ -50,7 +50,7 @@ const convertNumber = (numString: string, options?: unmarshallOptions): number |
   const infinityValues = [Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY];
   if ((num > Number.MAX_SAFE_INTEGER || num < Number.MIN_SAFE_INTEGER) && !infinityValues.includes(num)) {
     if (typeof BigInt === "function") {
-      return BigInt(num);
+      return BigInt(numString);
     } else {
       throw new Error(`${numString} is outside SAFE_INTEGER bounds. Set options.wrapNumbers to get string value.`);
     }


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1543

*Description of changes:*
creates BigInt from string value instead of number

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
