### PR TITLE
feat(middleware-bucket-endpoint): support Outposts buckets

### DIFF
--- a/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.spec.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.spec.ts
@@ -165,10 +165,14 @@ describe("bucketEndpointMiddleware", () => {
     });
 
     it("should set signing_region to middleware context if the request will use region from ARN", async () => {
+      mockBucketHostname.mockReturnValue({
+        bucketEndpoint: true,
+        hostname: "myendpoint-123456789012.s3-accesspoint.us-west-2.amazonaws.com",
+        signingService: "s3-foo",
+        signingRegion: "us-bar-1",
+      });
       const request = new HttpRequest(requestInput);
       previouslyResolvedConfig.useArnRegion.mockReturnValue(true);
-      const arnRegion = "us-west-2";
-      mockArnParse.mockReturnValue({ region: arnRegion });
       const handlerContext = {} as any;
       const handler = bucketEndpointMiddleware(
         resolveBucketEndpointConfig({
@@ -176,10 +180,10 @@ describe("bucketEndpointMiddleware", () => {
         })
       )(next, handlerContext);
       await handler({
-        input: { Bucket: `myendpoint-123456789012.s3-accesspoint.${arnRegion}.amazonaws.com` },
+        input: { Bucket: "Bucket" },
         request,
       });
-      expect(handlerContext).toMatchObject({ signing_region: arnRegion });
+      expect(handlerContext).toMatchObject({ signing_region: "us-bar-1", signing_service: "s3-foo" });
     });
   });
 });

--- a/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketEndpointMiddleware.ts
@@ -15,67 +15,70 @@ import { bucketHostname } from "./bucketHostname";
 import { getPseudoRegion } from "./bucketHostnameUtils";
 import { BucketEndpointResolvedConfig } from "./configurations";
 
-export function bucketEndpointMiddleware(options: BucketEndpointResolvedConfig): BuildMiddleware<any, any> {
-  return <Output extends MetadataBearer>(
-    next: BuildHandler<any, Output>,
-    context: HandlerExecutionContext
-  ): BuildHandler<any, Output> => async (args: BuildHandlerArguments<any>): Promise<BuildHandlerOutput<Output>> => {
-    const { Bucket: bucketName } = args.input as { Bucket: string };
-    let replaceBucketInPath = options.bucketEndpoint;
-    const request = args.request;
-    if (HttpRequest.isInstance(request)) {
-      if (options.bucketEndpoint) {
-        request.hostname = bucketName;
-      } else if (validateArn(bucketName)) {
-        const bucketArn = parseArn(bucketName);
-        const clientRegion = getPseudoRegion(await options.region());
-        const { partition, signingRegion } = (await options.regionInfoProvider(clientRegion)) || {};
-        const useArnRegion = await options.useArnRegion();
-        const { hostname, bucketEndpoint } = bucketHostname({
-          bucketName: bucketArn,
-          baseHostname: request.hostname,
-          accelerateEndpoint: options.useAccelerateEndpoint,
-          dualstackEndpoint: options.useDualstackEndpoint,
-          pathStyleEndpoint: options.forcePathStyle,
-          tlsCompatible: request.protocol === "https:",
-          useArnRegion,
-          clientPartition: partition,
-          clientSigningRegion: signingRegion,
-        });
+export const bucketEndpointMiddleware = (options: BucketEndpointResolvedConfig): BuildMiddleware<any, any> => <
+  Output extends MetadataBearer
+>(
+  next: BuildHandler<any, Output>,
+  context: HandlerExecutionContext
+): BuildHandler<any, Output> => async (args: BuildHandlerArguments<any>): Promise<BuildHandlerOutput<Output>> => {
+  const { Bucket: bucketName } = args.input as { Bucket: string };
+  let replaceBucketInPath = options.bucketEndpoint;
+  const request = args.request;
+  if (HttpRequest.isInstance(request)) {
+    if (options.bucketEndpoint) {
+      request.hostname = bucketName;
+    } else if (validateArn(bucketName)) {
+      const bucketArn = parseArn(bucketName);
+      const clientRegion = getPseudoRegion(await options.region());
+      const { partition, signingRegion = clientRegion } = (await options.regionInfoProvider(clientRegion)) || {};
+      const useArnRegion = await options.useArnRegion();
+      const { hostname, bucketEndpoint, signingRegion: modifiedSigningRegion, signingService } = bucketHostname({
+        bucketName: bucketArn,
+        baseHostname: request.hostname,
+        accelerateEndpoint: options.useAccelerateEndpoint,
+        dualstackEndpoint: options.useDualstackEndpoint,
+        pathStyleEndpoint: options.forcePathStyle,
+        tlsCompatible: request.protocol === "https:",
+        useArnRegion,
+        clientPartition: partition,
+        clientSigningRegion: signingRegion,
+      });
 
-        // If the request needs to use a region inferred from ARN that different from client region, we need to set
-        // them in the handler context so the signer will use them
-        if (useArnRegion && clientRegion !== bucketArn.region) {
-          context["signing_region"] = bucketArn.region;
-        }
-
-        request.hostname = hostname;
-        replaceBucketInPath = bucketEndpoint;
-      } else {
-        const { hostname, bucketEndpoint } = bucketHostname({
-          bucketName,
-          baseHostname: request.hostname,
-          accelerateEndpoint: options.useAccelerateEndpoint,
-          dualstackEndpoint: options.useDualstackEndpoint,
-          pathStyleEndpoint: options.forcePathStyle,
-          tlsCompatible: request.protocol === "https:",
-        });
-
-        request.hostname = hostname;
-        replaceBucketInPath = bucketEndpoint;
+      // If the request needs to use a region or service name inferred from ARN that different from client region, we
+      // need to set them in the handler context so the signer will use them
+      if (modifiedSigningRegion && modifiedSigningRegion !== signingRegion) {
+        context["signing_region"] = modifiedSigningRegion;
+      }
+      if (signingService && signingService !== "s3") {
+        context["signing_service"] = signingService;
       }
 
-      if (replaceBucketInPath) {
-        request.path = request.path.replace(/^(\/)?[^\/]+/, "");
-        if (request.path === "") {
-          request.path = "/";
-        }
-      }
+      request.hostname = hostname;
+      replaceBucketInPath = bucketEndpoint;
+    } else {
+      const { hostname, bucketEndpoint } = bucketHostname({
+        bucketName,
+        baseHostname: request.hostname,
+        accelerateEndpoint: options.useAccelerateEndpoint,
+        dualstackEndpoint: options.useDualstackEndpoint,
+        pathStyleEndpoint: options.forcePathStyle,
+        tlsCompatible: request.protocol === "https:",
+      });
+
+      request.hostname = hostname;
+      replaceBucketInPath = bucketEndpoint;
     }
 
-    return next({ ...args, request });
-  };
-}
+    if (replaceBucketInPath) {
+      request.path = request.path.replace(/^(\/)?[^\/]+/, "");
+      if (request.path === "") {
+        request.path = "/";
+      }
+    }
+  }
+
+  return next({ ...args, request });
+};
 
 export const bucketEndpointMiddlewareOptions: RelativeMiddlewareOptions = {
   tags: ["BUCKET_ENDPOINT"],

--- a/packages/middleware-bucket-endpoint/src/bucketHostname.ts
+++ b/packages/middleware-bucket-endpoint/src/bucketHostname.ts
@@ -2,7 +2,7 @@ import {
   ArnHostnameParams,
   BucketHostnameParams,
   DOT_PATTERN,
-  getAccessPointName,
+  getArnResources,
   getSuffix,
   getSuffixForArnEndpoint,
   isBucketNameOptions,
@@ -69,12 +69,15 @@ const getEndpointFromAccessPoint = (options: ArnHostnameParams): string => {
   validateRegion(region, { useArnRegion, clientRegion, clientSigningRegion });
   validatePartition(partition, { clientPartition });
   validateAccountId(accountId);
-  const accessPointName = getAccessPointName(resource);
-  validateDNSHostLabel(`${accessPointName}-${accountId}`, { tlsCompatible });
 
-  return `${accessPointName}-${accountId}.s3-accesspoint${dualstackEndpoint ? ".dualstack" : ""}.${
-    useArnRegion ? region : clientRegion
-  }.${hostnameSuffix}`;
+  const { accesspointName, outpostId } = getArnResources(resource);
+  validateDNSHostLabel(`${accesspointName}-${accountId}`, { tlsCompatible });
+  const endpointRegion = useArnRegion ? region : clientRegion;
+  return outpostId
+    ? `${accesspointName}-${accountId}.${outpostId}.s3-outposts.${endpointRegion}.${hostnameSuffix}`
+    : `${accesspointName}-${accountId}.s3-accesspoint${
+        dualstackEndpoint ? ".dualstack" : ""
+      }.${endpointRegion}.${hostnameSuffix}`;
 };
 
 const getEndpointFromBucketName = ({

--- a/packages/middleware-bucket-endpoint/src/index.ts
+++ b/packages/middleware-bucket-endpoint/src/index.ts
@@ -1,3 +1,15 @@
 export * from "./bucketEndpointMiddleware";
 export * from "./bucketHostname";
 export * from "./configurations";
+export {
+  getArnResources,
+  getPseudoRegion,
+  getSuffixForArnEndpoint,
+  validateOutpostService,
+  validatePartition,
+  validateAccountId,
+  validateRegion,
+  validateDNSHostLabel,
+  validateNoDualstack,
+  validateNoFIPS,
+} from "./bucketHostnameUtils";


### PR DESCRIPTION
*Description of changes:*
This change implements the data plane for [S3 Outposts](https://aws.amazon.com/blogs/aws/amazon-s3-on-outposts-now-available/). Now `bucketHostname` also supports generating outpost endpoint if supplied with an Outpost ARN. It also export some internal util functions that would be useful when validating the other ARN-based features.(e.g. Outposts control plane)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
