### PR TITLE
feat(config-resolver): add isCustomEndpoint resolved config

### DIFF
--- a/packages/config-resolver/src/EndpointsConfig.spec.ts
+++ b/packages/config-resolver/src/EndpointsConfig.spec.ts
@@ -32,7 +32,9 @@ describe("EndpointsConfig", () => {
       it("returns output of urlParser if endpoint is of type string", async () => {
         const endpoint = "endpoint";
         urlParser.mockReturnValueOnce(mockEndpoint);
-        const endpointOutput = await resolveEndpointsConfig({ ...input, endpoint }).endpoint();
+        const { endpoint: endpointProvider, isCustomEndpoint } = resolveEndpointsConfig({ ...input, endpoint });
+        expect(isCustomEndpoint).toBe(true);
+        const endpointOutput = await endpointProvider();
         expect(endpointOutput).toStrictEqual(mockEndpoint);
         expect(urlParser).toHaveBeenCalledTimes(1);
         expect(urlParser).toHaveBeenCalledWith(endpoint);
@@ -40,14 +42,18 @@ describe("EndpointsConfig", () => {
 
       it("returns promisified endpoint if it's of type object", async () => {
         const endpoint = mockEndpoint;
-        const endpointOutput = await resolveEndpointsConfig({ ...input, endpoint }).endpoint();
+        const { endpoint: endpointProvider, isCustomEndpoint } = resolveEndpointsConfig({ ...input, endpoint });
+        expect(isCustomEndpoint).toBe(true);
+        const endpointOutput = await endpointProvider();
         expect(endpointOutput).toStrictEqual(endpoint);
         expect(urlParser).not.toHaveBeenCalled();
       });
 
       it("returns endpoint if it's already Provider<Endpoint>", async () => {
         const endpoint = () => Promise.resolve(mockEndpoint);
-        const endpointOutput = await resolveEndpointsConfig({ ...input, endpoint }).endpoint();
+        const { endpoint: endpointProvider, isCustomEndpoint } = resolveEndpointsConfig({ ...input, endpoint });
+        expect(isCustomEndpoint).toBe(true);
+        const endpointOutput = await endpointProvider();
         expect(endpointOutput).toStrictEqual(mockEndpoint);
         expect(urlParser).not.toHaveBeenCalled();
       });
@@ -57,6 +63,11 @@ describe("EndpointsConfig", () => {
       const mockRegion = "mockRegion";
       const mockHostname = "mockHostname";
       const mockEndpoint: Endpoint = { protocol: "protocol", hostname: "hostname", path: "path" };
+
+      it("isCustomEndpoint should be false", () => {
+        const { isCustomEndpoint } = resolveEndpointsConfig({ ...input });
+        expect(isCustomEndpoint).toBe(false);
+      });
 
       describe("returns endpoint", () => {
         beforeEach(() => {

--- a/packages/config-resolver/src/EndpointsConfig.ts
+++ b/packages/config-resolver/src/EndpointsConfig.ts
@@ -20,6 +20,7 @@ interface PreviouslyResolved {
 
 export interface EndpointsResolvedConfig extends Required<EndpointsInputConfig> {
   endpoint: Provider<Endpoint>;
+  isCustomEndpoint: boolean;
 }
 
 export const resolveEndpointsConfig = <T>(
@@ -28,6 +29,7 @@ export const resolveEndpointsConfig = <T>(
   ...input,
   tls: input.tls ?? true,
   endpoint: input.endpoint ? normalizeEndpoint(input) : () => getEndPointFromRegion(input),
+  isCustomEndpoint: input.endpoint ? true : false,
 });
 
 const normalizeEndpoint = (input: EndpointsInputConfig & PreviouslyResolved): Provider<Endpoint> => {


### PR DESCRIPTION
Some customizations requires information that whether the endpoint
is explicitly set by the user, and behave accordingly. `isCustomEndpoint`
is added in inform these customizations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
