### PR TITLE
chore: target Node.js >=10.0.0

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -72,7 +72,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -71,7 +71,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -74,7 +74,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -85,7 +85,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -68,7 +68,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -75,7 +75,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -67,7 +67,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -32,5 +32,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -25,5 +25,8 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -28,5 +28,8 @@
     "@aws-sdk/signature-v4": "1.0.0-gamma.8",
     "@aws-sdk/types": "1.0.0-gamma.7",
     "tslib": "^1.8.0"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -28,5 +28,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -32,5 +32,8 @@
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
   },
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -33,5 +33,8 @@
     "nock": "^13.0.2",
     "typescript": "~4.0.2"
   },
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -33,5 +33,8 @@
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
   },
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-gamma.9",
   "description": "AWS credential provider that sources credentials from a Node.JS environment. ",
   "engines": {
-    "node": ">=8.10"
+    "node": ">=10.0.0"
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -34,5 +34,8 @@
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
   },
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -28,5 +28,8 @@
     "@aws-sdk/types": "1.0.0-gamma.7",
     "@aws-sdk/util-buffer-from": "1.0.0-gamma.7",
     "tslib": "^1.8.0"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -28,5 +28,8 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -25,5 +25,8 @@
   "types": "./dist/cjs/index.d.ts",
   "dependencies": {
     "tslib": "^1.8.0"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -26,5 +26,8 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -27,5 +27,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -29,5 +29,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -27,5 +27,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -25,5 +25,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -27,5 +27,8 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -31,5 +31,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -28,5 +28,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -29,5 +29,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -25,5 +25,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -29,5 +29,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -27,5 +27,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -34,5 +34,8 @@
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "^9.0.3",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -25,5 +25,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -27,5 +27,8 @@
     "@aws-sdk/signature-v4": "1.0.0-gamma.8",
     "@aws-sdk/types": "1.0.0-gamma.7",
     "tslib": "^1.8.0"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -25,5 +25,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -27,5 +27,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -30,5 +30,8 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -37,5 +37,8 @@
       "/node_modules/",
       "<rootDir>/*.mock.ts"
     ]
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -25,5 +25,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -25,5 +25,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -33,5 +33,8 @@
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -22,5 +22,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -28,5 +28,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -25,5 +25,8 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -32,5 +32,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -20,5 +20,8 @@
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
   },
-  "license": "Apache-2.0"
+  "license": "Apache-2.0",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/url-parser-node/package.json
+++ b/packages/url-parser-node/package.json
@@ -31,5 +31,8 @@
   },
   "react-native": {
     "url": "url/"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -26,5 +26,8 @@
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
   },
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -27,5 +27,8 @@
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
   },
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -26,5 +26,8 @@
   "license": "Apache-2.0",
   "dependencies": {
     "tslib": "^1.8.0"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -26,5 +26,8 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -29,5 +29,8 @@
     "@types/node": "^10.0.3",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -25,5 +25,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -26,5 +26,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -25,5 +25,8 @@
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
   },
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -25,5 +25,8 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -24,5 +24,8 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -27,5 +27,8 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
   }
 }

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -30,5 +30,8 @@
   "jest": {
     "testEnvironment": "node"
   },
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -25,5 +25,8 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts"
+  "types": "./dist/cjs/index.d.ts",
+  "engines": {
+    "node": ">= 10.0.0"
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*
Internal issue JS-2132

Reasons shared in PR:
* Node.js 8 was end-of-life on 2019-12-31: https://github.com/nodejs/Release#end-of-life-releases
* Significant numbers of users of AWS SDK for JavaScript v2 have moved to Node.js v10 and v12.
* Some existing utility packages in v3 already support Node.js >10.0.0

*Description of changes:*
* target Node.js >=10.0.0
* ensured that functional and integration tests are successful in my workspace.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
