### PR TITLE
fix(node-http-handler): fix type error sending Uint8Array as payload

### DIFF
--- a/packages/node-http-handler/src/write-request-body.ts
+++ b/packages/node-http-handler/src/write-request-body.ts
@@ -16,13 +16,13 @@ export function writeRequestBody(httpRequest: ClientRequest | ClientHttp2Stream,
 
 function writeBody(
   httpRequest: ClientRequest | ClientHttp2Stream,
-  body?: string | ArrayBuffer | ArrayBufferView | Readable
+  body?: string | ArrayBuffer | ArrayBufferView | Readable | Uint8Array
 ) {
   if (body instanceof Readable) {
     // pipe automatically handles end
     body.pipe(httpRequest);
   } else if (body) {
-    httpRequest.end(body);
+    httpRequest.end(Buffer.from(body));
   } else {
     httpRequest.end();
   }


### PR DESCRIPTION
Resolves #1433 

*Description of changes:*
Root cause is mentioned here: https://github.com/aws/aws-sdk-js-v3/issues/1433#issuecomment-705874894. This change converts non streaming binary data(string, Uint8Array, ArrayBuffer, ArrayBufferView) into a buffer before sending on the wire.

This change also move commented https unit tetss to http test to increase some test coverage.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
