### PR TITLE
chore(util-buffer-from): remove usage of deprecated Buffer constructor

### DIFF
--- a/packages/util-buffer-from/src/index.spec.ts
+++ b/packages/util-buffer-from/src/index.spec.ts
@@ -10,7 +10,11 @@ afterEach(() => {
 
 describe("fromArrayBuffer", () => {
   it("throws if argument is not an ArrayBuffer", () => {
-    expect(() => fromArrayBuffer(255 as any)).toThrow();
+    const input = 255;
+    // @ts-expect-error is not assignable to parameter of type 'ArrayBuffer'
+    expect(() => fromArrayBuffer(input)).toThrow(
+      new TypeError(`The "input" argument must be ArrayBuffer. Received type ${typeof input} (${input})`)
+    );
   });
 
   describe("returns if argument is an ArrayBuffer", () => {
@@ -41,7 +45,11 @@ describe("fromArrayBuffer", () => {
 
 describe("fromString", () => {
   it("throws if argument is not an ArrayBuffer", () => {
-    expect(() => fromString(255 as any)).toThrow();
+    const input = 255;
+    // @ts-expect-error is not assignable to parameter of type 'ArrayBuffer'
+    expect(() => fromString(input)).toThrow(
+      new TypeError(`The "input" argument must be of type string. Received type ${typeof input} (${input})`)
+    );
   });
 
   describe("returns if argument is an ArrayBuffer", () => {

--- a/packages/util-buffer-from/src/index.spec.ts
+++ b/packages/util-buffer-from/src/index.spec.ts
@@ -9,7 +9,7 @@ import { Buffer } from "buffer";
 import { fromArrayBuffer, fromString } from "./";
 
 describe("fromArrayBuffer", () => {
-  it("should throw if provided an argument that is not an ArrayBuffer", () => {
+  it("throws if argument is not an ArrayBuffer", () => {
     expect(() => fromArrayBuffer(255 as any)).toThrow();
   });
 
@@ -18,7 +18,7 @@ describe("fromArrayBuffer", () => {
       (Buffer.from as any).mockClear();
     });
 
-    it("should use Buffer.from if available", () => {
+    it("returns if argument is an ArrayBuffer", () => {
       const underlyingBuffer = new ArrayBuffer(0);
       const offsetArg = 12;
       const lengthArg = 13;
@@ -37,7 +37,7 @@ describe("fromArrayBuffer", () => {
 });
 
 describe("fromString", () => {
-  it("should throw if provided an argument that is not an ArrayBuffer", () => {
+  it("throws if argument is not an ArrayBuffer", () => {
     expect(() => fromString(255 as any)).toThrow();
   });
 
@@ -46,7 +46,7 @@ describe("fromString", () => {
       (Buffer.from as any).mockClear();
     });
 
-    it("should use Buffer.from if available", () => {
+    it("returns if argument is an ArrayBuffer", () => {
       const inputArg = "a string";
       const encodingArg = "utf16le";
       fromString(inputArg, encodingArg);

--- a/packages/util-buffer-from/src/index.spec.ts
+++ b/packages/util-buffer-from/src/index.spec.ts
@@ -34,57 +34,6 @@ describe("fromArrayBuffer", () => {
       expect(length).toBe(lengthArg);
     });
   });
-
-  describe("new Buffer", () => {
-    const bufferDotFrom = Buffer.from;
-
-    beforeEach(() => {
-      (Buffer as any).mockClear();
-      // @ts-ignore TODO: remove support as v3 is going to support Node.js v10+
-      delete Buffer.from;
-    });
-
-    afterAll(() => {
-      Buffer.from = bufferDotFrom;
-    });
-
-    it("should use the Buffer constructor if Buffer.from is not defined", () => {
-      const underlyingBuffer = new ArrayBuffer(0);
-      fromArrayBuffer(underlyingBuffer);
-
-      const { calls } = (Buffer as any).mock;
-      expect(calls.length).toBe(1);
-      expect(calls[0].length).toBe(1);
-      expect(calls[0][0]).toBe(underlyingBuffer);
-    });
-
-    it("should use the Buffer constructor if Buffer.from is inherited from Uint8Array", () => {
-      Buffer.from = Uint8Array.from as any;
-      const underlyingBuffer = new ArrayBuffer(0);
-      fromArrayBuffer(underlyingBuffer);
-
-      const { calls } = (Buffer as any).mock;
-      expect(calls.length).toBe(1);
-      expect(calls[0].length).toBe(1);
-      expect(calls[0][0]).toBe(underlyingBuffer);
-    });
-
-    it("should throw if Buffer.from is undefined and a non-zero offset is provided", () => {
-      expect(() => fromArrayBuffer(new ArrayBuffer(0), 1)).toThrow();
-    });
-
-    it("should not throw if Buffer.from is undefined and an offset of 0 is provided", () => {
-      expect(() => fromArrayBuffer(new ArrayBuffer(0), 0)).not.toThrow();
-    });
-
-    it("should throw if Buffer.from is undefined and a length other than the length of the underlying buffer is provided", () => {
-      expect(() => fromArrayBuffer(new ArrayBuffer(10), 0, 9)).toThrow();
-    });
-
-    it("should not throw if Buffer.from is undefined and a length of the length of the underlying buffer is provided", () => {
-      expect(() => fromArrayBuffer(new ArrayBuffer(10), 0, 10)).not.toThrow();
-    });
-  });
 });
 
 describe("fromString", () => {
@@ -109,37 +58,6 @@ describe("fromString", () => {
       const [input, encoding] = calls[0];
       expect(input).toBe(inputArg);
       expect(encoding).toBe(encodingArg);
-    });
-  });
-
-  describe("new Buffer", () => {
-    const bufferDotFrom = Buffer.from;
-
-    beforeEach(() => {
-      (Buffer as any).mockClear();
-      // @ts-ignore TODO: remove support as v3 is going to support Node.js v10+
-      delete Buffer.from;
-    });
-
-    afterAll(() => {
-      Buffer.from = bufferDotFrom;
-    });
-
-    it("should use the Buffer constructor if Buffer.from is not defined", () => {
-      fromString("string", "hex");
-
-      const { calls } = (Buffer as any).mock;
-      expect(calls.length).toBe(1);
-      expect(calls[0]).toEqual(["string", "hex"]);
-    });
-
-    it("should use the Buffer constructor if Buffer.from is inherited from Uint8Array", () => {
-      Buffer.from = Uint8Array.from as any;
-      fromString("string", "utf8");
-
-      const { calls } = (Buffer as any).mock;
-      expect(calls.length).toBe(1);
-      expect(calls[0]).toEqual(["string", "utf8"]);
     });
   });
 });

--- a/packages/util-buffer-from/src/index.spec.ts
+++ b/packages/util-buffer-from/src/index.spec.ts
@@ -1,38 +1,25 @@
-jest.mock("buffer", () => {
-  const Buffer = jest.fn().mockReturnValue(new Uint8Array(0));
-  (Buffer as any).from = jest.fn().mockReturnValue(new Uint8Array(0));
-
-  return { Buffer };
-});
 import { Buffer } from "buffer";
 
 import { fromArrayBuffer, fromString } from "./";
+
+jest.mock("buffer");
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
 
 describe("fromArrayBuffer", () => {
   it("throws if argument is not an ArrayBuffer", () => {
     expect(() => fromArrayBuffer(255 as any)).toThrow();
   });
 
-  describe("Buffer.from", () => {
-    beforeEach(() => {
-      (Buffer.from as any).mockClear();
-    });
-
-    it("returns if argument is an ArrayBuffer", () => {
-      const underlyingBuffer = new ArrayBuffer(0);
-      const offsetArg = 12;
-      const lengthArg = 13;
-      fromArrayBuffer(underlyingBuffer, offsetArg, lengthArg);
-
-      const { calls } = (Buffer.from as any).mock;
-      expect(calls.length).toBe(1);
-      expect(calls[0].length).toBe(3);
-
-      const [buffer, offset, length] = calls[0];
-      expect(buffer).toBe(underlyingBuffer);
-      expect(offset).toBe(offsetArg);
-      expect(length).toBe(lengthArg);
-    });
+  it("returns if argument is an ArrayBuffer", () => {
+    const underlyingBuffer = new ArrayBuffer(0);
+    const offsetArg = 12;
+    const lengthArg = 13;
+    fromArrayBuffer(underlyingBuffer, offsetArg, lengthArg);
+    expect(Buffer.from).toHaveBeenCalledTimes(1);
+    expect(Buffer.from).toHaveBeenCalledWith(underlyingBuffer, offsetArg, lengthArg);
   });
 });
 
@@ -41,23 +28,12 @@ describe("fromString", () => {
     expect(() => fromString(255 as any)).toThrow();
   });
 
-  describe("Buffer.from", () => {
-    beforeEach(() => {
-      (Buffer.from as any).mockClear();
-    });
+  it("returns if argument is an ArrayBuffer", () => {
+    const inputArg = "a string";
+    const encodingArg = "utf16le";
+    fromString(inputArg, encodingArg);
 
-    it("returns if argument is an ArrayBuffer", () => {
-      const inputArg = "a string";
-      const encodingArg = "utf16le";
-      fromString(inputArg, encodingArg);
-
-      const { calls } = (Buffer.from as any).mock;
-      expect(calls.length).toBe(1);
-      expect(calls[0].length).toBe(2);
-
-      const [input, encoding] = calls[0];
-      expect(input).toBe(inputArg);
-      expect(encoding).toBe(encodingArg);
-    });
+    expect(Buffer.from).toHaveBeenCalledTimes(1);
+    expect(Buffer.from).toHaveBeenCalledWith(inputArg, encodingArg);
   });
 });

--- a/packages/util-buffer-from/src/index.spec.ts
+++ b/packages/util-buffer-from/src/index.spec.ts
@@ -13,13 +13,29 @@ describe("fromArrayBuffer", () => {
     expect(() => fromArrayBuffer(255 as any)).toThrow();
   });
 
-  it("returns if argument is an ArrayBuffer", () => {
-    const underlyingBuffer = new ArrayBuffer(0);
-    const offsetArg = 12;
-    const lengthArg = 13;
-    fromArrayBuffer(underlyingBuffer, offsetArg, lengthArg);
-    expect(Buffer.from).toHaveBeenCalledTimes(1);
-    expect(Buffer.from).toHaveBeenCalledWith(underlyingBuffer, offsetArg, lengthArg);
+  describe("returns if argument is an ArrayBuffer", () => {
+    const buffer = new ArrayBuffer(16);
+
+    it("with one arg", () => {
+      fromArrayBuffer(buffer);
+      expect(Buffer.from).toHaveBeenCalledTimes(1);
+      expect(Buffer.from).toHaveBeenCalledWith(buffer, 0, buffer.byteLength);
+    });
+
+    it("with two args", () => {
+      const offset = 12;
+      fromArrayBuffer(buffer, offset);
+      expect(Buffer.from).toHaveBeenCalledTimes(1);
+      expect(Buffer.from).toHaveBeenCalledWith(buffer, offset, buffer.byteLength - offset);
+    });
+
+    it("with three args", () => {
+      const offset = 12;
+      const length = 13;
+      fromArrayBuffer(buffer, offset, length);
+      expect(Buffer.from).toHaveBeenCalledTimes(1);
+      expect(Buffer.from).toHaveBeenCalledWith(buffer, offset, length);
+    });
   });
 });
 
@@ -28,12 +44,20 @@ describe("fromString", () => {
     expect(() => fromString(255 as any)).toThrow();
   });
 
-  it("returns if argument is an ArrayBuffer", () => {
-    const inputArg = "a string";
-    const encodingArg = "utf16le";
-    fromString(inputArg, encodingArg);
+  describe("returns if argument is an ArrayBuffer", () => {
+    const input = "a string";
 
-    expect(Buffer.from).toHaveBeenCalledTimes(1);
-    expect(Buffer.from).toHaveBeenCalledWith(inputArg, encodingArg);
+    it("without explicit encoding", () => {
+      fromString(input);
+      expect(Buffer.from).toHaveBeenCalledTimes(1);
+      expect(Buffer.from).toHaveBeenCalledWith(input);
+    });
+
+    it("with encoding", () => {
+      const encoding = "utf16le";
+      fromString(input, encoding);
+      expect(Buffer.from).toHaveBeenCalledTimes(1);
+      expect(Buffer.from).toHaveBeenCalledWith(input, encoding);
+    });
   });
 });

--- a/packages/util-buffer-from/src/index.ts
+++ b/packages/util-buffer-from/src/index.ts
@@ -6,28 +6,15 @@ export function fromArrayBuffer(input: ArrayBuffer, offset = 0, length: number =
     throw new Error("argument passed to fromArrayBuffer was not an ArrayBuffer");
   }
 
-  if (typeof Buffer.from === "function" && Buffer.from !== Uint8Array.from) {
-    return Buffer.from(input, offset, length);
-  }
-
-  // Any version of node that supports the optional offset and length
-  // parameters, which were added in Node 6.0.0, will support Buffer.from and
-  // have already returned. Throw if offset is not 0 or if length differs from
-  // the underlying buffer's length.
-  if (offset !== 0 || length !== input.byteLength) {
-    throw new Error(`Unable to convert TypedArray to Buffer in Node ${process.version}`);
-  }
-  return new Buffer(input);
+  return Buffer.from(input, offset, length);
 }
+
 export type StringEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "latin1" | "binary" | "hex";
-export function fromString(input: string, encoding?: StringEncoding): Buffer {
+
+export const fromString = (input: string, encoding?: StringEncoding): Buffer => {
   if (typeof input !== "string") {
     throw new Error("argument passed to fromString was not a string");
   }
 
-  if (typeof Buffer.from === "function" && Buffer.from !== Uint8Array.from) {
-    return Buffer.from(input, encoding as any);
-  }
-
-  return new Buffer(input, encoding as any);
-}
+  return Buffer.from(input, encoding as any);
+};

--- a/packages/util-buffer-from/src/index.ts
+++ b/packages/util-buffer-from/src/index.ts
@@ -16,5 +16,5 @@ export const fromString = (input: string, encoding?: StringEncoding): Buffer => 
     throw new Error("argument passed to fromString was not a string");
   }
 
-  return Buffer.from(input, encoding as any);
+  return encoding ? Buffer.from(input, encoding) : Buffer.from(input);
 };

--- a/packages/util-buffer-from/src/index.ts
+++ b/packages/util-buffer-from/src/index.ts
@@ -1,19 +1,19 @@
 import { isArrayBuffer } from "@aws-sdk/is-array-buffer";
 import { Buffer } from "buffer";
 
-export function fromArrayBuffer(input: ArrayBuffer, offset = 0, length: number = input.byteLength - offset): Buffer {
+export const fromArrayBuffer = (input: ArrayBuffer, offset = 0, length: number = input.byteLength - offset): Buffer => {
   if (!isArrayBuffer(input)) {
-    throw new Error("argument passed to fromArrayBuffer was not an ArrayBuffer");
+    throw new TypeError(`The "input" argument must be ArrayBuffer. Received type ${typeof input} (${input})`);
   }
 
   return Buffer.from(input, offset, length);
-}
+};
 
 export type StringEncoding = "ascii" | "utf8" | "utf16le" | "ucs2" | "base64" | "latin1" | "binary" | "hex";
 
 export const fromString = (input: string, encoding?: StringEncoding): Buffer => {
   if (typeof input !== "string") {
-    throw new Error("argument passed to fromString was not a string");
+    throw new TypeError(`The "input" argument must be of type string. Received type ${typeof input} (${input})`);
   }
 
   return encoding ? Buffer.from(input, encoding) : Buffer.from(input);


### PR DESCRIPTION
*Issue #, if available:*
No longer required as we now target Node.js >=10.0.0 in https://github.com/aws/aws-sdk-js-v3/pull/1558
Node.js doc guide: https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/

*Description of changes:*
* removes usage of deprecated Buffer constructor
* adds extensive tests for util-buffer-from
* throws more descriptive TypeError, referred from [ERR_INVALID_ARG_TYPE](https://nodejs.org/api/errors.html#errors_err_invalid_arg_type)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
