### PR TITLE
chore(tsconfig): move common values to root tsconfig.cjs.json

### DIFF
--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "sourceMap": false,
     "declaration": true,
     "stripInternal": true,
     "rootDir": "./src",

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "sourceMap": false,
     "declaration": true,
     "stripInternal": true,

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "strict": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -6,7 +6,6 @@
     "outDir": "./dist/cjs",
     "experimentalDecorators": true,
     "pretty": true,
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "strict": false,
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "experimentalDecorators": true,

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -6,7 +6,6 @@
     "outDir": "./dist/cjs",
     "experimentalDecorators": true,
     "pretty": true,
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "strict": false,
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "experimentalDecorators": true,

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "strict": false,
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": true,
     "strict": false,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": true,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "sourceMap": true,
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "declarationDir": "./dist/cjs",

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "sourceMap": true,
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "sourceMap": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "declarationDir": "./dist/cjs",

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "sourceMap": true,
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "declarationDir": "./dist/cjs",

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "sourceMap": true,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "noEmitHelpers": true,

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "importHelpers": true,
     "rootDir": "./src",

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "noEmitHelpers": true,

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "importHelpers": true,
     "rootDir": "./src",

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "noEmitHelpers": true,

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "importHelpers": true,
     "rootDir": "./src",

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "declaration": false,
     "strict": false,
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "declaration": false,
     "strict": false,
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -5,7 +5,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": false,
     "strict": false,
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -5,7 +5,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": false,
     "strict": false,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "exclude": ["./build/**"],

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "noEmitHelpers": true,
     "importHelpers": true,

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "downlevelIteration": true,
     "noEmitHelpers": true,
-    "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "noEmitHelpers": true,
     "importHelpers": true,

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "noEmitHelpers": true,

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "noUnusedLocals": true,
     "rootDir": "./src",

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "sourceMap": true,
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "baseUrl": "."
   },

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "sourceMap": true,
     "stripInternal": true,
     "rootDir": "./src",

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": true,
-    "strict": true,
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "noEmitHelpers": true,
     "importHelpers": true,

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "downlevelIteration": true,
     "noEmitHelpers": true,
-    "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "noEmitHelpers": true,
     "importHelpers": true,

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "noEmitHelpers": true,

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "noEmitHelpers": true,
     "importHelpers": true,

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "downlevelIteration": true,
     "noEmitHelpers": true,
-    "importHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "noEmitHelpers": true,
     "importHelpers": true,

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "noEmitHelpers": true,

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "downlevelIteration": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "downlevelIteration": true,
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "downlevelIteration": true,
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "noUnusedLocals": true,
     "rootDir": "./src",

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "sourceMap": false,
     "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "sourceMap": false,
     "declaration": true,
     "rootDir": "./src",

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "sourceMap": true,
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "noUnusedLocals": true,
     "baseUrl": "."

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "sourceMap": true,
     "stripInternal": true,
     "rootDir": "./src",

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": true,
-    "strict": true,
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "stripInternal": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "noUnusedLocals": true,
     "baseUrl": "."
   },

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -4,7 +4,6 @@
     "noUnusedLocals": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "noUnusedLocals": true,
     "rootDir": "./src",

--- a/packages/types/tsconfig.cjs.json
+++ b/packages/types/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/types/tsconfig.cjs.json
+++ b/packages/types/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/url-parser-browser/tsconfig.cjs.json
+++ b/packages/url-parser-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/url-parser-browser/tsconfig.cjs.json
+++ b/packages/url-parser-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/url-parser-browser/tsconfig.cjs.json
+++ b/packages/url-parser-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/url-parser-browser/tsconfig.cjs.json
+++ b/packages/url-parser-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/url-parser-browser/tsconfig.cjs.json
+++ b/packages/url-parser-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/url-parser-browser/tsconfig.cjs.json
+++ b/packages/url-parser-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/url-parser-browser/tsconfig.cjs.json
+++ b/packages/url-parser-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/url-parser-browser/tsconfig.cjs.json
+++ b/packages/url-parser-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/url-parser-node/tsconfig.cjs.json
+++ b/packages/url-parser-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/url-parser-node/tsconfig.cjs.json
+++ b/packages/url-parser-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/url-parser-node/tsconfig.cjs.json
+++ b/packages/url-parser-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/url-parser-node/tsconfig.cjs.json
+++ b/packages/url-parser-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/url-parser-node/tsconfig.cjs.json
+++ b/packages/url-parser-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/url-parser-node/tsconfig.cjs.json
+++ b/packages/url-parser-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/url-parser-node/tsconfig.cjs.json
+++ b/packages/url-parser-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/url-parser-node/tsconfig.cjs.json
+++ b/packages/url-parser-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": false,
-    "strict": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": false,
-    "strict": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": false,
-    "strict": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": false,
-    "strict": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-create-request/src/foo.fixture.ts
+++ b/packages/util-create-request/src/foo.fixture.ts
@@ -28,9 +28,10 @@ export const fooClient: Client<any, InputTypesUnion, OutputTypesUnion, any> = {
   destroy: () => {},
 };
 
-export const operationCommand: Command<InputTypesUnion, OutputTypesUnion, any, OperationInput, OperationOutput> = {
-  middlewareStack: constructStack<object, OutputTypesUnion>(),
+export const operationCommand: Command<InputTypesUnion, OutputTypesUnion, any, OperationInput, MetadataBearer> = {
+  middlewareStack: constructStack<OperationInput, OutputTypesUnion>(),
   input: {} as any,
+  // @ts-ignore
   resolveMiddleware: (stack: MiddlewareStack<InputTypesUnion, OutputTypesUnion>) => {
     const concatStack = stack.concat(operationCommand.middlewareStack);
     return concatStack.resolve(() => Promise.resolve({ output, response: {} }), {} as any);

--- a/packages/util-create-request/src/index.spec.ts
+++ b/packages/util-create-request/src/index.spec.ts
@@ -106,7 +106,7 @@ describe("create-request", () => {
       }
     );
     const request = await createRequest(
-      fooClient as Client<any, InputTypesUnion, MetadataBearer, any>,
+      (fooClient as unknown) as Client<any, InputTypesUnion, MetadataBearer, any>,
       operationCommand
     );
     expect(request).toEqual({

--- a/packages/util-create-request/src/index.ts
+++ b/packages/util-create-request/src/index.ts
@@ -15,7 +15,7 @@ export async function createRequest<
   };
   const clientStack = client.middlewareStack.clone();
 
-  //add middleware to the last of 'build' step
+  // @ts-ignore: add middleware to the last of 'build' step
   clientStack.add(interceptMiddleware, {
     step: "build",
     priority: "low",
@@ -23,6 +23,6 @@ export async function createRequest<
 
   const handler = command.resolveMiddleware(clientStack, client.config, undefined);
 
-  //@ts-ignore
+  // @ts-ignore
   return await handler(command).then((output) => output.output.request);
 }

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "noImplicitUseStrict": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "strict": false,
     "noImplicitUseStrict": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -6,7 +6,6 @@
     "strictNullChecks": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -6,7 +6,6 @@
     "strictNullChecks": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "noImplicitUseStrict": true,
     "noImplicitAny": true,
     "noImplicitThis": true,

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -6,7 +6,6 @@
     "strictNullChecks": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -6,7 +6,6 @@
     "strictNullChecks": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "inlineSourceMap": true,

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -3,7 +3,6 @@
     "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "downlevelIteration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "strict": true,
     "sourceMap": false,
     "downlevelIteration": true,
     "importHelpers": true,

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "downlevelIteration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "downlevelIteration": true,
-    "importHelpers": true,
     "noEmitHelpers": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": false,
-    "strict": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "declaration": true,
     "sourceMap": false,
-    "strict": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "declaration": true,
-    "sourceMap": false,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."
   },

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "sourceMap": false,
     "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "strict": true,
     "sourceMap": false,
     "declaration": true,
     "rootDir": "./src",

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "importHelpers": true,
     "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "noEmitHelpers": true,
     "inlineSourceMap": true,
     "inlineSources": true,
     "baseUrl": "."

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": true,
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "rootDir": "./src",
     "outDir": "./dist/cjs",
-    "inlineSources": true,
     "baseUrl": "."
   },
   "extends": "../../tsconfig.cjs.json",

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -5,7 +5,6 @@
     "moduleResolution": "node",
     "target": "ES2018",
     "strict": true,
-    "sourceMap": false,
     "declaration": true,
     "importHelpers": true,
     "noEmitHelpers": true,

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "importHelpers": true,
     "noEmitHelpers": true,
+    "sourceMap": false,
     "inlineSourceMap": true,
     "inlineSources": true
   }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -5,6 +5,7 @@
     "moduleResolution": "node",
     "target": "ES2018",
     "strict": true,
-    "sourceMap": false
+    "sourceMap": false,
+    "declaration": true
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",
-    "target": "ES2018"
+    "target": "ES2018",
+    "strict": true
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -8,6 +8,7 @@
     "sourceMap": false,
     "declaration": true,
     "importHelpers": true,
-    "noEmitHelpers": true
+    "noEmitHelpers": true,
+    "inlineSourceMap": true
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -4,6 +4,7 @@
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "ES2018",
-    "strict": true
+    "strict": true,
+    "sourceMap": false
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -7,6 +7,7 @@
     "strict": true,
     "sourceMap": false,
     "declaration": true,
-    "importHelpers": true
+    "importHelpers": true,
+    "noEmitHelpers": true
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -9,6 +9,7 @@
     "declaration": true,
     "importHelpers": true,
     "noEmitHelpers": true,
-    "inlineSourceMap": true
+    "inlineSourceMap": true,
+    "inlineSources": true
   }
 }

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -6,6 +6,7 @@
     "target": "ES2018",
     "strict": true,
     "sourceMap": false,
-    "declaration": true
+    "declaration": true,
+    "importHelpers": true
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1563

*Description of changes:*
* move common values to root tsconfig.cjs.json
* `downloevelIteration` is removed as we now target `ES2018`, and it's no longer required. Docs: https://www.typescriptlang.org/tsconfig#downlevelIteration

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
