### PR TITLE
chore(prototol_tests): target Node.js >=10.0.0 and ES2018

### DIFF
--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/protocol_tests/aws-ec2/tsconfig.json
+++ b/protocol_tests/aws-ec2/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "target": "es2017",
+    "target": "ES2018",
     "module": "commonjs",
     "declaration": true,
     "strict": true,

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -69,7 +69,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/protocol_tests/aws-json/tsconfig.json
+++ b/protocol_tests/aws-json/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "target": "es2017",
+    "target": "ES2018",
     "module": "commonjs",
     "declaration": true,
     "strict": true,

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/protocol_tests/aws-query/tsconfig.json
+++ b/protocol_tests/aws-query/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "target": "es2017",
+    "target": "ES2018",
     "module": "commonjs",
     "declaration": true,
     "strict": true,

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -70,7 +70,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/protocol_tests/aws-restjson/tsconfig.json
+++ b/protocol_tests/aws-restjson/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "target": "es2017",
+    "target": "ES2018",
     "module": "commonjs",
     "declaration": true,
     "strict": true,

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -72,7 +72,7 @@
     "typescript": "~4.0.2"
   },
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/protocol_tests/aws-restxml/tsconfig.json
+++ b/protocol_tests/aws-restxml/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "alwaysStrict": true,
-    "target": "es2017",
+    "target": "ES2018",
     "module": "commonjs",
     "declaration": true,
     "strict": true,


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1559

Updates were missed in protocol_tests packages:
* https://github.com/aws/aws-sdk-js-v3/pull/1558
* https://github.com/aws/aws-sdk-js-v3/pull/1560
* https://github.com/aws/aws-sdk-js-v3/pull/1562

*Description of changes:*
target Node.js >=10.0.0 and ES2018 in protocol_tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
