### PR TITLE
chore: use lerna fixed versioning

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,4 @@
 {
-  "lerna": "3.13.4",
   "version": "independent",
   "npmClient": "yarn",
   "useWorkspaces": true,

--- a/lerna.json
+++ b/lerna.json
@@ -1,14 +1,10 @@
 {
-  "version": "independent",
+  "version": "1.0.0-rc.0",
   "npmClient": "yarn",
   "useWorkspaces": true,
   "command": {
-    "bootstrap": {
-      "nohoist": ["@types/*", "typedoc", "karma*"]
-    },
     "run": {
       "npmClient": "yarn"
     }
-  },
-  "nohoist": ["@types/*", "typedoc", "karma*"]
+  }
 }


### PR DESCRIPTION
*Description of changes:*
Move to Lerna's default [fixed versioning](https://github.com/lerna/lerna#fixedlocked-mode-default) from independent versioning. Reason outlined in #1248. This change also cleans up the lerna.json


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
