### PR TITLE
fix: throw 3XX redirection as errors explicitly

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
@@ -645,7 +645,7 @@ export const deserializeAws_restJson1CreateAnalyzerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAnalyzerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAnalyzerCommandError(output, context);
   }
   const contents: CreateAnalyzerCommandOutput = {
@@ -740,7 +740,7 @@ export const deserializeAws_restJson1CreateArchiveRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateArchiveRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateArchiveRuleCommandError(output, context);
   }
   const contents: CreateArchiveRuleCommandOutput = {
@@ -839,7 +839,7 @@ export const deserializeAws_restJson1DeleteAnalyzerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAnalyzerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAnalyzerCommandError(output, context);
   }
   const contents: DeleteAnalyzerCommandOutput = {
@@ -922,7 +922,7 @@ export const deserializeAws_restJson1DeleteArchiveRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteArchiveRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteArchiveRuleCommandError(output, context);
   }
   const contents: DeleteArchiveRuleCommandOutput = {
@@ -1005,7 +1005,7 @@ export const deserializeAws_restJson1GetAnalyzedResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAnalyzedResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAnalyzedResourceCommandError(output, context);
   }
   const contents: GetAnalyzedResourceCommandOutput = {
@@ -1092,7 +1092,7 @@ export const deserializeAws_restJson1GetAnalyzerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAnalyzerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAnalyzerCommandError(output, context);
   }
   const contents: GetAnalyzerCommandOutput = {
@@ -1179,7 +1179,7 @@ export const deserializeAws_restJson1GetArchiveRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetArchiveRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetArchiveRuleCommandError(output, context);
   }
   const contents: GetArchiveRuleCommandOutput = {
@@ -1266,7 +1266,7 @@ export const deserializeAws_restJson1GetFindingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFindingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFindingCommandError(output, context);
   }
   const contents: GetFindingCommandOutput = {
@@ -1353,7 +1353,7 @@ export const deserializeAws_restJson1ListAnalyzedResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAnalyzedResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAnalyzedResourcesCommandError(output, context);
   }
   const contents: ListAnalyzedResourcesCommandOutput = {
@@ -1444,7 +1444,7 @@ export const deserializeAws_restJson1ListAnalyzersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAnalyzersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAnalyzersCommandError(output, context);
   }
   const contents: ListAnalyzersCommandOutput = {
@@ -1527,7 +1527,7 @@ export const deserializeAws_restJson1ListArchiveRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListArchiveRulesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListArchiveRulesCommandError(output, context);
   }
   const contents: ListArchiveRulesCommandOutput = {
@@ -1610,7 +1610,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFindingsCommandError(output, context);
   }
   const contents: ListFindingsCommandOutput = {
@@ -1701,7 +1701,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1788,7 +1788,7 @@ export const deserializeAws_restJson1StartResourceScanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartResourceScanCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartResourceScanCommandError(output, context);
   }
   const contents: StartResourceScanCommandOutput = {
@@ -1871,7 +1871,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1954,7 +1954,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -2037,7 +2037,7 @@ export const deserializeAws_restJson1UpdateArchiveRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateArchiveRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateArchiveRuleCommandError(output, context);
   }
   const contents: UpdateArchiveRuleCommandOutput = {
@@ -2120,7 +2120,7 @@ export const deserializeAws_restJson1UpdateFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFindingsCommandError(output, context);
   }
   const contents: UpdateFindingsCommandOutput = {

--- a/clients/client-acm-pca/protocols/Aws_json1_1.ts
+++ b/clients/client-acm-pca/protocols/Aws_json1_1.ts
@@ -391,7 +391,7 @@ export const deserializeAws_json1_1CreateCertificateAuthorityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCertificateAuthorityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCertificateAuthorityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -470,7 +470,7 @@ export const deserializeAws_json1_1CreateCertificateAuthorityAuditReportCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCertificateAuthorityAuditReportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCertificateAuthorityAuditReportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -565,7 +565,7 @@ export const deserializeAws_json1_1CreatePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -657,7 +657,7 @@ export const deserializeAws_json1_1DeleteCertificateAuthorityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCertificateAuthorityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCertificateAuthorityCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -733,7 +733,7 @@ export const deserializeAws_json1_1DeletePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -809,7 +809,7 @@ export const deserializeAws_json1_1DescribeCertificateAuthorityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCertificateAuthorityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCertificateAuthorityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -872,7 +872,7 @@ export const deserializeAws_json1_1DescribeCertificateAuthorityAuditReportComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCertificateAuthorityAuditReportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCertificateAuthorityAuditReportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -943,7 +943,7 @@ export const deserializeAws_json1_1GetCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1030,7 +1030,7 @@ export const deserializeAws_json1_1GetCertificateAuthorityCertificateCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCertificateAuthorityCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCertificateAuthorityCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1101,7 +1101,7 @@ export const deserializeAws_json1_1GetCertificateAuthorityCsrCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCertificateAuthorityCsrCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCertificateAuthorityCsrCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1188,7 +1188,7 @@ export const deserializeAws_json1_1ImportCertificateAuthorityCertificateCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportCertificateAuthorityCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportCertificateAuthorityCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1304,7 +1304,7 @@ export const deserializeAws_json1_1IssueCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IssueCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1IssueCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1399,7 +1399,7 @@ export const deserializeAws_json1_1ListCertificateAuthoritiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCertificateAuthoritiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCertificateAuthoritiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1454,7 +1454,7 @@ export const deserializeAws_json1_1ListPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1541,7 +1541,7 @@ export const deserializeAws_json1_1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1612,7 +1612,7 @@ export const deserializeAws_json1_1RestoreCertificateAuthorityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreCertificateAuthorityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RestoreCertificateAuthorityCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1680,7 +1680,7 @@ export const deserializeAws_json1_1RevokeCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RevokeCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1796,7 +1796,7 @@ export const deserializeAws_json1_1TagCertificateAuthorityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagCertificateAuthorityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagCertificateAuthorityCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1880,7 +1880,7 @@ export const deserializeAws_json1_1UntagCertificateAuthorityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagCertificateAuthorityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagCertificateAuthorityCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1956,7 +1956,7 @@ export const deserializeAws_json1_1UpdateCertificateAuthorityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCertificateAuthorityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateCertificateAuthorityCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-acm/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/protocols/Aws_json1_1.ts
@@ -261,7 +261,7 @@ export const deserializeAws_json1_1AddTagsToCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsToCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -353,7 +353,7 @@ export const deserializeAws_json1_1DeleteCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -421,7 +421,7 @@ export const deserializeAws_json1_1DescribeCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -484,7 +484,7 @@ export const deserializeAws_json1_1ExportCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ExportCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -555,7 +555,7 @@ export const deserializeAws_json1_1GetCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -626,7 +626,7 @@ export const deserializeAws_json1_1ImportCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -721,7 +721,7 @@ export const deserializeAws_json1_1ListCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -776,7 +776,7 @@ export const deserializeAws_json1_1ListTagsForCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -839,7 +839,7 @@ export const deserializeAws_json1_1RemoveTagsFromCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsFromCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -923,7 +923,7 @@ export const deserializeAws_json1_1RenewCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RenewCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RenewCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -983,7 +983,7 @@ export const deserializeAws_json1_1RequestCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RequestCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RequestCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1086,7 +1086,7 @@ export const deserializeAws_json1_1ResendValidationEmailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResendValidationEmailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResendValidationEmailCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1162,7 +1162,7 @@ export const deserializeAws_json1_1UpdateCertificateOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCertificateOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateCertificateOptionsCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
@@ -1697,7 +1697,7 @@ export const deserializeAws_json1_1ApproveSkillCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ApproveSkillCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ApproveSkillCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1768,7 +1768,7 @@ export const deserializeAws_json1_1AssociateContactWithAddressBookCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateContactWithAddressBookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateContactWithAddressBookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1823,7 +1823,7 @@ export const deserializeAws_json1_1AssociateDeviceWithNetworkProfileCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateDeviceWithNetworkProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateDeviceWithNetworkProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1894,7 +1894,7 @@ export const deserializeAws_json1_1AssociateDeviceWithRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateDeviceWithRoomCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateDeviceWithRoomCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1965,7 +1965,7 @@ export const deserializeAws_json1_1AssociateSkillGroupWithRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateSkillGroupWithRoomCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateSkillGroupWithRoomCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2020,7 +2020,7 @@ export const deserializeAws_json1_1AssociateSkillWithSkillGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateSkillWithSkillGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateSkillWithSkillGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2091,7 +2091,7 @@ export const deserializeAws_json1_1AssociateSkillWithUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateSkillWithUsersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateSkillWithUsersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2154,7 +2154,7 @@ export const deserializeAws_json1_1CreateAddressBookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAddressBookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAddressBookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2217,7 +2217,7 @@ export const deserializeAws_json1_1CreateBusinessReportScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBusinessReportScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateBusinessReportScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2272,7 +2272,7 @@ export const deserializeAws_json1_1CreateConferenceProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConferenceProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateConferenceProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2327,7 +2327,7 @@ export const deserializeAws_json1_1CreateContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateContactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateContactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2390,7 +2390,7 @@ export const deserializeAws_json1_1CreateGatewayGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGatewayGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateGatewayGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2453,7 +2453,7 @@ export const deserializeAws_json1_1CreateNetworkProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNetworkProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateNetworkProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2540,7 +2540,7 @@ export const deserializeAws_json1_1CreateProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2611,7 +2611,7 @@ export const deserializeAws_json1_1CreateRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRoomCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRoomCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2674,7 +2674,7 @@ export const deserializeAws_json1_1CreateSkillGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSkillGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSkillGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2745,7 +2745,7 @@ export const deserializeAws_json1_1CreateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2816,7 +2816,7 @@ export const deserializeAws_json1_1DeleteAddressBookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAddressBookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAddressBookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2879,7 +2879,7 @@ export const deserializeAws_json1_1DeleteBusinessReportScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBusinessReportScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBusinessReportScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2942,7 +2942,7 @@ export const deserializeAws_json1_1DeleteConferenceProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConferenceProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteConferenceProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2997,7 +2997,7 @@ export const deserializeAws_json1_1DeleteContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteContactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteContactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3060,7 +3060,7 @@ export const deserializeAws_json1_1DeleteDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDeviceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3131,7 +3131,7 @@ export const deserializeAws_json1_1DeleteDeviceUsageDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeviceUsageDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDeviceUsageDataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3202,7 +3202,7 @@ export const deserializeAws_json1_1DeleteGatewayGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGatewayGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteGatewayGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3257,7 +3257,7 @@ export const deserializeAws_json1_1DeleteNetworkProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNetworkProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteNetworkProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3328,7 +3328,7 @@ export const deserializeAws_json1_1DeleteProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3391,7 +3391,7 @@ export const deserializeAws_json1_1DeleteRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRoomCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRoomCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3454,7 +3454,7 @@ export const deserializeAws_json1_1DeleteRoomSkillParameterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRoomSkillParameterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRoomSkillParameterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3509,7 +3509,7 @@ export const deserializeAws_json1_1DeleteSkillAuthorizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSkillAuthorizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSkillAuthorizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3572,7 +3572,7 @@ export const deserializeAws_json1_1DeleteSkillGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSkillGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSkillGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3635,7 +3635,7 @@ export const deserializeAws_json1_1DeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3698,7 +3698,7 @@ export const deserializeAws_json1_1DisassociateContactFromAddressBookCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateContactFromAddressBookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateContactFromAddressBookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3745,7 +3745,7 @@ export const deserializeAws_json1_1DisassociateDeviceFromRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateDeviceFromRoomCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateDeviceFromRoomCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3808,7 +3808,7 @@ export const deserializeAws_json1_1DisassociateSkillFromSkillGroupCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateSkillFromSkillGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateSkillFromSkillGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3871,7 +3871,7 @@ export const deserializeAws_json1_1DisassociateSkillFromUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateSkillFromUsersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateSkillFromUsersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3934,7 +3934,7 @@ export const deserializeAws_json1_1DisassociateSkillGroupFromRoomCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateSkillGroupFromRoomCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateSkillGroupFromRoomCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3989,7 +3989,7 @@ export const deserializeAws_json1_1ForgetSmartHomeAppliancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ForgetSmartHomeAppliancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ForgetSmartHomeAppliancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4044,7 +4044,7 @@ export const deserializeAws_json1_1GetAddressBookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAddressBookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAddressBookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4099,7 +4099,7 @@ export const deserializeAws_json1_1GetConferencePreferenceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConferencePreferenceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetConferencePreferenceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4154,7 +4154,7 @@ export const deserializeAws_json1_1GetConferenceProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConferenceProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetConferenceProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4209,7 +4209,7 @@ export const deserializeAws_json1_1GetContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetContactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetContactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4264,7 +4264,7 @@ export const deserializeAws_json1_1GetDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDeviceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4319,7 +4319,7 @@ export const deserializeAws_json1_1GetGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4374,7 +4374,7 @@ export const deserializeAws_json1_1GetGatewayGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGatewayGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetGatewayGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4429,7 +4429,7 @@ export const deserializeAws_json1_1GetInvitationConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInvitationConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInvitationConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4484,7 +4484,7 @@ export const deserializeAws_json1_1GetNetworkProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetNetworkProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetNetworkProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4547,7 +4547,7 @@ export const deserializeAws_json1_1GetProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4602,7 +4602,7 @@ export const deserializeAws_json1_1GetRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRoomCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRoomCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4657,7 +4657,7 @@ export const deserializeAws_json1_1GetRoomSkillParameterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRoomSkillParameterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRoomSkillParameterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4712,7 +4712,7 @@ export const deserializeAws_json1_1GetSkillGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSkillGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSkillGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4767,7 +4767,7 @@ export const deserializeAws_json1_1ListBusinessReportSchedulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBusinessReportSchedulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBusinessReportSchedulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4814,7 +4814,7 @@ export const deserializeAws_json1_1ListConferenceProvidersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConferenceProvidersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListConferenceProvidersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4861,7 +4861,7 @@ export const deserializeAws_json1_1ListDeviceEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeviceEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDeviceEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4916,7 +4916,7 @@ export const deserializeAws_json1_1ListGatewayGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGatewayGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGatewayGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4963,7 +4963,7 @@ export const deserializeAws_json1_1ListGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5010,7 +5010,7 @@ export const deserializeAws_json1_1ListSkillsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSkillsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSkillsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5057,7 +5057,7 @@ export const deserializeAws_json1_1ListSkillsStoreCategoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSkillsStoreCategoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSkillsStoreCategoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5104,7 +5104,7 @@ export const deserializeAws_json1_1ListSkillsStoreSkillsByCategoryCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSkillsStoreSkillsByCategoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSkillsStoreSkillsByCategoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5151,7 +5151,7 @@ export const deserializeAws_json1_1ListSmartHomeAppliancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSmartHomeAppliancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSmartHomeAppliancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5206,7 +5206,7 @@ export const deserializeAws_json1_1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5261,7 +5261,7 @@ export const deserializeAws_json1_1PutConferencePreferenceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConferencePreferenceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutConferencePreferenceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5316,7 +5316,7 @@ export const deserializeAws_json1_1PutInvitationConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutInvitationConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutInvitationConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5379,7 +5379,7 @@ export const deserializeAws_json1_1PutRoomSkillParameterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRoomSkillParameterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRoomSkillParameterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5434,7 +5434,7 @@ export const deserializeAws_json1_1PutSkillAuthorizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutSkillAuthorizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutSkillAuthorizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5497,7 +5497,7 @@ export const deserializeAws_json1_1RegisterAVSDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterAVSDeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterAVSDeviceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5576,7 +5576,7 @@ export const deserializeAws_json1_1RejectSkillCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectSkillCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RejectSkillCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5639,7 +5639,7 @@ export const deserializeAws_json1_1ResolveRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResolveRoomCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResolveRoomCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5694,7 +5694,7 @@ export const deserializeAws_json1_1RevokeInvitationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeInvitationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RevokeInvitationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5757,7 +5757,7 @@ export const deserializeAws_json1_1SearchAddressBooksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchAddressBooksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchAddressBooksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5804,7 +5804,7 @@ export const deserializeAws_json1_1SearchContactsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchContactsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchContactsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5851,7 +5851,7 @@ export const deserializeAws_json1_1SearchDevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchDevicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchDevicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5898,7 +5898,7 @@ export const deserializeAws_json1_1SearchNetworkProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchNetworkProfilesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchNetworkProfilesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5945,7 +5945,7 @@ export const deserializeAws_json1_1SearchProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchProfilesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchProfilesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5992,7 +5992,7 @@ export const deserializeAws_json1_1SearchRoomsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchRoomsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchRoomsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6039,7 +6039,7 @@ export const deserializeAws_json1_1SearchSkillGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchSkillGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchSkillGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6086,7 +6086,7 @@ export const deserializeAws_json1_1SearchUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchUsersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchUsersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6133,7 +6133,7 @@ export const deserializeAws_json1_1SendAnnouncementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendAnnouncementCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SendAnnouncementCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6196,7 +6196,7 @@ export const deserializeAws_json1_1SendInvitationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendInvitationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SendInvitationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6267,7 +6267,7 @@ export const deserializeAws_json1_1StartDeviceSyncCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDeviceSyncCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartDeviceSyncCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6322,7 +6322,7 @@ export const deserializeAws_json1_1StartSmartHomeApplianceDiscoveryCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSmartHomeApplianceDiscoveryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartSmartHomeApplianceDiscoveryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6377,7 +6377,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6432,7 +6432,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6487,7 +6487,7 @@ export const deserializeAws_json1_1UpdateAddressBookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAddressBookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAddressBookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6558,7 +6558,7 @@ export const deserializeAws_json1_1UpdateBusinessReportScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBusinessReportScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateBusinessReportScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6621,7 +6621,7 @@ export const deserializeAws_json1_1UpdateConferenceProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConferenceProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateConferenceProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6676,7 +6676,7 @@ export const deserializeAws_json1_1UpdateContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateContactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateContactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6739,7 +6739,7 @@ export const deserializeAws_json1_1UpdateDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDeviceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6810,7 +6810,7 @@ export const deserializeAws_json1_1UpdateGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6873,7 +6873,7 @@ export const deserializeAws_json1_1UpdateGatewayGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGatewayGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGatewayGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6936,7 +6936,7 @@ export const deserializeAws_json1_1UpdateNetworkProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNetworkProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateNetworkProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7023,7 +7023,7 @@ export const deserializeAws_json1_1UpdateProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7094,7 +7094,7 @@ export const deserializeAws_json1_1UpdateRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRoomCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRoomCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7157,7 +7157,7 @@ export const deserializeAws_json1_1UpdateSkillGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSkillGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSkillGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-amplify/protocols/Aws_restJson1.ts
+++ b/clients/client-amplify/protocols/Aws_restJson1.ts
@@ -1582,7 +1582,7 @@ export const deserializeAws_restJson1CreateAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAppCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAppCommandError(output, context);
   }
   const contents: CreateAppCommandOutput = {
@@ -1669,7 +1669,7 @@ export const deserializeAws_restJson1CreateBackendEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBackendEnvironmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateBackendEnvironmentCommandError(output, context);
   }
   const contents: CreateBackendEnvironmentCommandOutput = {
@@ -1756,7 +1756,7 @@ export const deserializeAws_restJson1CreateBranchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBranchCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateBranchCommandError(output, context);
   }
   const contents: CreateBranchCommandOutput = {
@@ -1851,7 +1851,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeploymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeploymentCommandError(output, context);
   }
   const contents: CreateDeploymentCommandOutput = {
@@ -1938,7 +1938,7 @@ export const deserializeAws_restJson1CreateDomainAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDomainAssociationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDomainAssociationCommandError(output, context);
   }
   const contents: CreateDomainAssociationCommandOutput = {
@@ -2033,7 +2033,7 @@ export const deserializeAws_restJson1CreateWebhookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWebhookCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateWebhookCommandError(output, context);
   }
   const contents: CreateWebhookCommandOutput = {
@@ -2128,7 +2128,7 @@ export const deserializeAws_restJson1DeleteAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAppCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAppCommandError(output, context);
   }
   const contents: DeleteAppCommandOutput = {
@@ -2215,7 +2215,7 @@ export const deserializeAws_restJson1DeleteBackendEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBackendEnvironmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBackendEnvironmentCommandError(output, context);
   }
   const contents: DeleteBackendEnvironmentCommandOutput = {
@@ -2302,7 +2302,7 @@ export const deserializeAws_restJson1DeleteBranchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBranchCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBranchCommandError(output, context);
   }
   const contents: DeleteBranchCommandOutput = {
@@ -2389,7 +2389,7 @@ export const deserializeAws_restJson1DeleteDomainAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDomainAssociationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDomainAssociationCommandError(output, context);
   }
   const contents: DeleteDomainAssociationCommandOutput = {
@@ -2476,7 +2476,7 @@ export const deserializeAws_restJson1DeleteJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteJobCommandError(output, context);
   }
   const contents: DeleteJobCommandOutput = {
@@ -2563,7 +2563,7 @@ export const deserializeAws_restJson1DeleteWebhookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWebhookCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteWebhookCommandError(output, context);
   }
   const contents: DeleteWebhookCommandOutput = {
@@ -2650,7 +2650,7 @@ export const deserializeAws_restJson1GenerateAccessLogsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateAccessLogsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GenerateAccessLogsCommandError(output, context);
   }
   const contents: GenerateAccessLogsCommandOutput = {
@@ -2729,7 +2729,7 @@ export const deserializeAws_restJson1GetAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAppCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAppCommandError(output, context);
   }
   const contents: GetAppCommandOutput = {
@@ -2808,7 +2808,7 @@ export const deserializeAws_restJson1GetArtifactUrlCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetArtifactUrlCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetArtifactUrlCommandError(output, context);
   }
   const contents: GetArtifactUrlCommandOutput = {
@@ -2899,7 +2899,7 @@ export const deserializeAws_restJson1GetBackendEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBackendEnvironmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBackendEnvironmentCommandError(output, context);
   }
   const contents: GetBackendEnvironmentCommandOutput = {
@@ -2978,7 +2978,7 @@ export const deserializeAws_restJson1GetBranchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBranchCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBranchCommandError(output, context);
   }
   const contents: GetBranchCommandOutput = {
@@ -3057,7 +3057,7 @@ export const deserializeAws_restJson1GetDomainAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainAssociationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDomainAssociationCommandError(output, context);
   }
   const contents: GetDomainAssociationCommandOutput = {
@@ -3136,7 +3136,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJobCommandError(output, context);
   }
   const contents: GetJobCommandOutput = {
@@ -3223,7 +3223,7 @@ export const deserializeAws_restJson1GetWebhookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWebhookCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetWebhookCommandError(output, context);
   }
   const contents: GetWebhookCommandOutput = {
@@ -3310,7 +3310,7 @@ export const deserializeAws_restJson1ListAppsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAppsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAppsCommandError(output, context);
   }
   const contents: ListAppsCommandOutput = {
@@ -3385,7 +3385,7 @@ export const deserializeAws_restJson1ListArtifactsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListArtifactsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListArtifactsCommandError(output, context);
   }
   const contents: ListArtifactsCommandOutput = {
@@ -3468,7 +3468,7 @@ export const deserializeAws_restJson1ListBackendEnvironmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBackendEnvironmentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBackendEnvironmentsCommandError(output, context);
   }
   const contents: ListBackendEnvironmentsCommandOutput = {
@@ -3543,7 +3543,7 @@ export const deserializeAws_restJson1ListBranchesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBranchesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBranchesCommandError(output, context);
   }
   const contents: ListBranchesCommandOutput = {
@@ -3618,7 +3618,7 @@ export const deserializeAws_restJson1ListDomainAssociationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainAssociationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDomainAssociationsCommandError(output, context);
   }
   const contents: ListDomainAssociationsCommandOutput = {
@@ -3693,7 +3693,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobsCommandError(output, context);
   }
   const contents: ListJobsCommandOutput = {
@@ -3776,7 +3776,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -3847,7 +3847,7 @@ export const deserializeAws_restJson1ListWebhooksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWebhooksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListWebhooksCommandError(output, context);
   }
   const contents: ListWebhooksCommandOutput = {
@@ -3930,7 +3930,7 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDeploymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartDeploymentCommandError(output, context);
   }
   const contents: StartDeploymentCommandOutput = {
@@ -4017,7 +4017,7 @@ export const deserializeAws_restJson1StartJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartJobCommandError(output, context);
   }
   const contents: StartJobCommandOutput = {
@@ -4104,7 +4104,7 @@ export const deserializeAws_restJson1StopJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopJobCommandError(output, context);
   }
   const contents: StopJobCommandOutput = {
@@ -4191,7 +4191,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -4258,7 +4258,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -4325,7 +4325,7 @@ export const deserializeAws_restJson1UpdateAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAppCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAppCommandError(output, context);
   }
   const contents: UpdateAppCommandOutput = {
@@ -4404,7 +4404,7 @@ export const deserializeAws_restJson1UpdateBranchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBranchCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateBranchCommandError(output, context);
   }
   const contents: UpdateBranchCommandOutput = {
@@ -4491,7 +4491,7 @@ export const deserializeAws_restJson1UpdateDomainAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainAssociationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDomainAssociationCommandError(output, context);
   }
   const contents: UpdateDomainAssociationCommandOutput = {
@@ -4578,7 +4578,7 @@ export const deserializeAws_restJson1UpdateWebhookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateWebhookCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateWebhookCommandError(output, context);
   }
   const contents: UpdateWebhookCommandOutput = {

--- a/clients/client-api-gateway/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1.ts
@@ -5857,7 +5857,7 @@ export const deserializeAws_restJson1CreateApiKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApiKeyCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateApiKeyCommandError(output, context);
   }
   const contents: CreateApiKeyCommandOutput = {
@@ -5988,7 +5988,7 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAuthorizerCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAuthorizerCommandError(output, context);
   }
   const contents: CreateAuthorizerCommandOutput = {
@@ -6111,7 +6111,7 @@ export const deserializeAws_restJson1CreateBasePathMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBasePathMappingCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateBasePathMappingCommandError(output, context);
   }
   const contents: CreateBasePathMappingCommandOutput = {
@@ -6206,7 +6206,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeploymentCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeploymentCommandError(output, context);
   }
   const contents: CreateDeploymentCommandOutput = {
@@ -6321,7 +6321,7 @@ export const deserializeAws_restJson1CreateDocumentationPartCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDocumentationPartCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDocumentationPartCommandError(output, context);
   }
   const contents: CreateDocumentationPartCommandOutput = {
@@ -6424,7 +6424,7 @@ export const deserializeAws_restJson1CreateDocumentationVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDocumentationVersionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDocumentationVersionCommandError(output, context);
   }
   const contents: CreateDocumentationVersionCommandOutput = {
@@ -6527,7 +6527,7 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDomainNameCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDomainNameCommandError(output, context);
   }
   const contents: CreateDomainNameCommandOutput = {
@@ -6662,7 +6662,7 @@ export const deserializeAws_restJson1CreateModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateModelCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateModelCommandError(output, context);
   }
   const contents: CreateModelCommandOutput = {
@@ -6773,7 +6773,7 @@ export const deserializeAws_restJson1CreateRequestValidatorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRequestValidatorCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRequestValidatorCommandError(output, context);
   }
   const contents: CreateRequestValidatorCommandOutput = {
@@ -6872,7 +6872,7 @@ export const deserializeAws_restJson1CreateResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResourceCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateResourceCommandError(output, context);
   }
   const contents: CreateResourceCommandOutput = {
@@ -6983,7 +6983,7 @@ export const deserializeAws_restJson1CreateRestApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRestApiCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRestApiCommandError(output, context);
   }
   const contents: CreateRestApiCommandOutput = {
@@ -7106,7 +7106,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStageCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateStageCommandError(output, context);
   }
   const contents: CreateStageCommandOutput = {
@@ -7265,7 +7265,7 @@ export const deserializeAws_restJson1CreateUsagePlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUsagePlanCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateUsagePlanCommandError(output, context);
   }
   const contents: CreateUsagePlanCommandOutput = {
@@ -7388,7 +7388,7 @@ export const deserializeAws_restJson1CreateUsagePlanKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUsagePlanKeyCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateUsagePlanKeyCommandError(output, context);
   }
   const contents: CreateUsagePlanKeyCommandOutput = {
@@ -7487,7 +7487,7 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpcLinkCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateVpcLinkCommandError(output, context);
   }
   const contents: CreateVpcLinkCommandOutput = {
@@ -7582,7 +7582,7 @@ export const deserializeAws_restJson1DeleteApiKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApiKeyCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApiKeyCommandError(output, context);
   }
   const contents: DeleteApiKeyCommandOutput = {
@@ -7649,7 +7649,7 @@ export const deserializeAws_restJson1DeleteAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAuthorizerCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAuthorizerCommandError(output, context);
   }
   const contents: DeleteAuthorizerCommandOutput = {
@@ -7732,7 +7732,7 @@ export const deserializeAws_restJson1DeleteBasePathMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBasePathMappingCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBasePathMappingCommandError(output, context);
   }
   const contents: DeleteBasePathMappingCommandOutput = {
@@ -7815,7 +7815,7 @@ export const deserializeAws_restJson1DeleteClientCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClientCertificateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteClientCertificateCommandError(output, context);
   }
   const contents: DeleteClientCertificateCommandOutput = {
@@ -7890,7 +7890,7 @@ export const deserializeAws_restJson1DeleteDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeploymentCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDeploymentCommandError(output, context);
   }
   const contents: DeleteDeploymentCommandOutput = {
@@ -7965,7 +7965,7 @@ export const deserializeAws_restJson1DeleteDocumentationPartCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDocumentationPartCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDocumentationPartCommandError(output, context);
   }
   const contents: DeleteDocumentationPartCommandOutput = {
@@ -8048,7 +8048,7 @@ export const deserializeAws_restJson1DeleteDocumentationVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDocumentationVersionCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDocumentationVersionCommandError(output, context);
   }
   const contents: DeleteDocumentationVersionCommandOutput = {
@@ -8131,7 +8131,7 @@ export const deserializeAws_restJson1DeleteDomainNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDomainNameCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDomainNameCommandError(output, context);
   }
   const contents: DeleteDomainNameCommandOutput = {
@@ -8206,7 +8206,7 @@ export const deserializeAws_restJson1DeleteGatewayResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGatewayResponseCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGatewayResponseCommandError(output, context);
   }
   const contents: DeleteGatewayResponseCommandOutput = {
@@ -8289,7 +8289,7 @@ export const deserializeAws_restJson1DeleteIntegrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIntegrationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteIntegrationCommandError(output, context);
   }
   const contents: DeleteIntegrationCommandOutput = {
@@ -8364,7 +8364,7 @@ export const deserializeAws_restJson1DeleteIntegrationResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIntegrationResponseCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteIntegrationResponseCommandError(output, context);
   }
   const contents: DeleteIntegrationResponseCommandOutput = {
@@ -8447,7 +8447,7 @@ export const deserializeAws_restJson1DeleteMethodCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMethodCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMethodCommandError(output, context);
   }
   const contents: DeleteMethodCommandOutput = {
@@ -8522,7 +8522,7 @@ export const deserializeAws_restJson1DeleteMethodResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMethodResponseCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMethodResponseCommandError(output, context);
   }
   const contents: DeleteMethodResponseCommandOutput = {
@@ -8605,7 +8605,7 @@ export const deserializeAws_restJson1DeleteModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteModelCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteModelCommandError(output, context);
   }
   const contents: DeleteModelCommandOutput = {
@@ -8688,7 +8688,7 @@ export const deserializeAws_restJson1DeleteRequestValidatorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRequestValidatorCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRequestValidatorCommandError(output, context);
   }
   const contents: DeleteRequestValidatorCommandOutput = {
@@ -8771,7 +8771,7 @@ export const deserializeAws_restJson1DeleteResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourceCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteResourceCommandError(output, context);
   }
   const contents: DeleteResourceCommandOutput = {
@@ -8854,7 +8854,7 @@ export const deserializeAws_restJson1DeleteRestApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRestApiCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRestApiCommandError(output, context);
   }
   const contents: DeleteRestApiCommandOutput = {
@@ -8929,7 +8929,7 @@ export const deserializeAws_restJson1DeleteStageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStageCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteStageCommandError(output, context);
   }
   const contents: DeleteStageCommandOutput = {
@@ -9004,7 +9004,7 @@ export const deserializeAws_restJson1DeleteUsagePlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUsagePlanCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteUsagePlanCommandError(output, context);
   }
   const contents: DeleteUsagePlanCommandOutput = {
@@ -9079,7 +9079,7 @@ export const deserializeAws_restJson1DeleteUsagePlanKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUsagePlanKeyCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteUsagePlanKeyCommandError(output, context);
   }
   const contents: DeleteUsagePlanKeyCommandOutput = {
@@ -9162,7 +9162,7 @@ export const deserializeAws_restJson1DeleteVpcLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpcLinkCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVpcLinkCommandError(output, context);
   }
   const contents: DeleteVpcLinkCommandOutput = {
@@ -9237,7 +9237,7 @@ export const deserializeAws_restJson1FlushStageAuthorizersCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FlushStageAuthorizersCacheCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1FlushStageAuthorizersCacheCommandError(output, context);
   }
   const contents: FlushStageAuthorizersCacheCommandOutput = {
@@ -9312,7 +9312,7 @@ export const deserializeAws_restJson1FlushStageCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FlushStageCacheCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1FlushStageCacheCommandError(output, context);
   }
   const contents: FlushStageCacheCommandOutput = {
@@ -9387,7 +9387,7 @@ export const deserializeAws_restJson1GenerateClientCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateClientCertificateCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1GenerateClientCertificateCommandError(output, context);
   }
   const contents: GenerateClientCertificateCommandOutput = {
@@ -9478,7 +9478,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAccountCommandError(output, context);
   }
   const contents: GetAccountCommandOutput = {
@@ -9561,7 +9561,7 @@ export const deserializeAws_restJson1GetApiKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApiKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApiKeyCommandError(output, context);
   }
   const contents: GetApiKeyCommandOutput = {
@@ -9668,7 +9668,7 @@ export const deserializeAws_restJson1GetApiKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApiKeysCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApiKeysCommandError(output, context);
   }
   const contents: GetApiKeysCommandOutput = {
@@ -9747,7 +9747,7 @@ export const deserializeAws_restJson1GetAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAuthorizerCommandError(output, context);
   }
   const contents: GetAuthorizerCommandOutput = {
@@ -9854,7 +9854,7 @@ export const deserializeAws_restJson1GetAuthorizersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAuthorizersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAuthorizersCommandError(output, context);
   }
   const contents: GetAuthorizersCommandOutput = {
@@ -9937,7 +9937,7 @@ export const deserializeAws_restJson1GetBasePathMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBasePathMappingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBasePathMappingCommandError(output, context);
   }
   const contents: GetBasePathMappingCommandOutput = {
@@ -10016,7 +10016,7 @@ export const deserializeAws_restJson1GetBasePathMappingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBasePathMappingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBasePathMappingsCommandError(output, context);
   }
   const contents: GetBasePathMappingsCommandOutput = {
@@ -10091,7 +10091,7 @@ export const deserializeAws_restJson1GetClientCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetClientCertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetClientCertificateCommandError(output, context);
   }
   const contents: GetClientCertificateCommandOutput = {
@@ -10182,7 +10182,7 @@ export const deserializeAws_restJson1GetClientCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetClientCertificatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetClientCertificatesCommandError(output, context);
   }
   const contents: GetClientCertificatesCommandOutput = {
@@ -10257,7 +10257,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeploymentCommandError(output, context);
   }
   const contents: GetDeploymentCommandOutput = {
@@ -10348,7 +10348,7 @@ export const deserializeAws_restJson1GetDeploymentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeploymentsCommandError(output, context);
   }
   const contents: GetDeploymentsCommandOutput = {
@@ -10431,7 +10431,7 @@ export const deserializeAws_restJson1GetDocumentationPartCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDocumentationPartCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDocumentationPartCommandError(output, context);
   }
   const contents: GetDocumentationPartCommandOutput = {
@@ -10510,7 +10510,7 @@ export const deserializeAws_restJson1GetDocumentationPartsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDocumentationPartsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDocumentationPartsCommandError(output, context);
   }
   const contents: GetDocumentationPartsCommandOutput = {
@@ -10593,7 +10593,7 @@ export const deserializeAws_restJson1GetDocumentationVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDocumentationVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDocumentationVersionCommandError(output, context);
   }
   const contents: GetDocumentationVersionCommandOutput = {
@@ -10672,7 +10672,7 @@ export const deserializeAws_restJson1GetDocumentationVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDocumentationVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDocumentationVersionsCommandError(output, context);
   }
   const contents: GetDocumentationVersionsCommandOutput = {
@@ -10755,7 +10755,7 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainNameCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDomainNameCommandError(output, context);
   }
   const contents: GetDomainNameCommandOutput = {
@@ -10890,7 +10890,7 @@ export const deserializeAws_restJson1GetDomainNamesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainNamesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDomainNamesCommandError(output, context);
   }
   const contents: GetDomainNamesCommandOutput = {
@@ -10965,7 +10965,7 @@ export const deserializeAws_restJson1GetExportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetExportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetExportCommandError(output, context);
   }
   const contents: GetExportCommandOutput = {
@@ -11058,7 +11058,7 @@ export const deserializeAws_restJson1GetGatewayResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGatewayResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGatewayResponseCommandError(output, context);
   }
   const contents: GetGatewayResponseCommandOutput = {
@@ -11145,7 +11145,7 @@ export const deserializeAws_restJson1GetGatewayResponsesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGatewayResponsesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGatewayResponsesCommandError(output, context);
   }
   const contents: GetGatewayResponsesCommandOutput = {
@@ -11228,7 +11228,7 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIntegrationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIntegrationCommandError(output, context);
   }
   const contents: GetIntegrationCommandOutput = {
@@ -11358,7 +11358,7 @@ export const deserializeAws_restJson1GetIntegrationResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIntegrationResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIntegrationResponseCommandError(output, context);
   }
   const contents: GetIntegrationResponseCommandOutput = {
@@ -11445,7 +11445,7 @@ export const deserializeAws_restJson1GetMethodCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMethodCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMethodCommandError(output, context);
   }
   const contents: GetMethodCommandOutput = {
@@ -11556,7 +11556,7 @@ export const deserializeAws_restJson1GetMethodResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMethodResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMethodResponseCommandError(output, context);
   }
   const contents: GetMethodResponseCommandOutput = {
@@ -11635,7 +11635,7 @@ export const deserializeAws_restJson1GetModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetModelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetModelCommandError(output, context);
   }
   const contents: GetModelCommandOutput = {
@@ -11722,7 +11722,7 @@ export const deserializeAws_restJson1GetModelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetModelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetModelsCommandError(output, context);
   }
   const contents: GetModelsCommandOutput = {
@@ -11805,7 +11805,7 @@ export const deserializeAws_restJson1GetModelTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetModelTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetModelTemplateCommandError(output, context);
   }
   const contents: GetModelTemplateCommandOutput = {
@@ -11884,7 +11884,7 @@ export const deserializeAws_restJson1GetRequestValidatorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRequestValidatorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRequestValidatorCommandError(output, context);
   }
   const contents: GetRequestValidatorCommandOutput = {
@@ -11967,7 +11967,7 @@ export const deserializeAws_restJson1GetRequestValidatorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRequestValidatorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRequestValidatorsCommandError(output, context);
   }
   const contents: GetRequestValidatorsCommandOutput = {
@@ -12050,7 +12050,7 @@ export const deserializeAws_restJson1GetResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResourceCommandError(output, context);
   }
   const contents: GetResourceCommandOutput = {
@@ -12137,7 +12137,7 @@ export const deserializeAws_restJson1GetResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResourcesCommandError(output, context);
   }
   const contents: GetResourcesCommandOutput = {
@@ -12220,7 +12220,7 @@ export const deserializeAws_restJson1GetRestApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRestApiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRestApiCommandError(output, context);
   }
   const contents: GetRestApiCommandOutput = {
@@ -12335,7 +12335,7 @@ export const deserializeAws_restJson1GetRestApisCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRestApisCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRestApisCommandError(output, context);
   }
   const contents: GetRestApisCommandOutput = {
@@ -12410,7 +12410,7 @@ export const deserializeAws_restJson1GetSdkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSdkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSdkCommandError(output, context);
   }
   const contents: GetSdkCommandOutput = {
@@ -12503,7 +12503,7 @@ export const deserializeAws_restJson1GetSdkTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSdkTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSdkTypeCommandError(output, context);
   }
   const contents: GetSdkTypeCommandOutput = {
@@ -12589,7 +12589,7 @@ export const deserializeAws_restJson1GetSdkTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSdkTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSdkTypesCommandError(output, context);
   }
   const contents: GetSdkTypesCommandOutput = {
@@ -12652,7 +12652,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetStageCommandError(output, context);
   }
   const contents: GetStageCommandOutput = {
@@ -12787,7 +12787,7 @@ export const deserializeAws_restJson1GetStagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStagesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetStagesCommandError(output, context);
   }
   const contents: GetStagesCommandOutput = {
@@ -12858,7 +12858,7 @@ export const deserializeAws_restJson1GetTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTagsCommandError(output, context);
   }
   const contents: GetTagsCommandOutput = {
@@ -12945,7 +12945,7 @@ export const deserializeAws_restJson1GetUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUsageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUsageCommandError(output, context);
   }
   const contents: GetUsageCommandOutput = {
@@ -13040,7 +13040,7 @@ export const deserializeAws_restJson1GetUsagePlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUsagePlanCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUsagePlanCommandError(output, context);
   }
   const contents: GetUsagePlanCommandOutput = {
@@ -13147,7 +13147,7 @@ export const deserializeAws_restJson1GetUsagePlanKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUsagePlanKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUsagePlanKeyCommandError(output, context);
   }
   const contents: GetUsagePlanKeyCommandOutput = {
@@ -13238,7 +13238,7 @@ export const deserializeAws_restJson1GetUsagePlanKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUsagePlanKeysCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUsagePlanKeysCommandError(output, context);
   }
   const contents: GetUsagePlanKeysCommandOutput = {
@@ -13321,7 +13321,7 @@ export const deserializeAws_restJson1GetUsagePlansCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUsagePlansCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUsagePlansCommandError(output, context);
   }
   const contents: GetUsagePlansCommandOutput = {
@@ -13412,7 +13412,7 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVpcLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVpcLinkCommandError(output, context);
   }
   const contents: GetVpcLinkCommandOutput = {
@@ -13507,7 +13507,7 @@ export const deserializeAws_restJson1GetVpcLinksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVpcLinksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVpcLinksCommandError(output, context);
   }
   const contents: GetVpcLinksCommandOutput = {
@@ -13582,7 +13582,7 @@ export const deserializeAws_restJson1ImportApiKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportApiKeysCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1ImportApiKeysCommandError(output, context);
   }
   const contents: ImportApiKeysCommandOutput = {
@@ -13681,7 +13681,7 @@ export const deserializeAws_restJson1ImportDocumentationPartsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportDocumentationPartsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ImportDocumentationPartsCommandError(output, context);
   }
   const contents: ImportDocumentationPartsCommandOutput = {
@@ -13772,7 +13772,7 @@ export const deserializeAws_restJson1ImportRestApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportRestApiCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1ImportRestApiCommandError(output, context);
   }
   const contents: ImportRestApiCommandOutput = {
@@ -13903,7 +13903,7 @@ export const deserializeAws_restJson1PutGatewayResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutGatewayResponseCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutGatewayResponseCommandError(output, context);
   }
   const contents: PutGatewayResponseCommandOutput = {
@@ -14006,7 +14006,7 @@ export const deserializeAws_restJson1PutIntegrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutIntegrationCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutIntegrationCommandError(output, context);
   }
   const contents: PutIntegrationCommandOutput = {
@@ -14152,7 +14152,7 @@ export const deserializeAws_restJson1PutIntegrationResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutIntegrationResponseCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutIntegrationResponseCommandError(output, context);
   }
   const contents: PutIntegrationResponseCommandOutput = {
@@ -14263,7 +14263,7 @@ export const deserializeAws_restJson1PutMethodCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutMethodCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutMethodCommandError(output, context);
   }
   const contents: PutMethodCommandOutput = {
@@ -14398,7 +14398,7 @@ export const deserializeAws_restJson1PutMethodResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutMethodResponseCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutMethodResponseCommandError(output, context);
   }
   const contents: PutMethodResponseCommandOutput = {
@@ -14501,7 +14501,7 @@ export const deserializeAws_restJson1PutRestApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRestApiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutRestApiCommandError(output, context);
   }
   const contents: PutRestApiCommandOutput = {
@@ -14640,7 +14640,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -14731,7 +14731,7 @@ export const deserializeAws_restJson1TestInvokeAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestInvokeAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TestInvokeAuthorizerCommandError(output, context);
   }
   const contents: TestInvokeAuthorizerCommandOutput = {
@@ -14834,7 +14834,7 @@ export const deserializeAws_restJson1TestInvokeMethodCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestInvokeMethodCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TestInvokeMethodCommandError(output, context);
   }
   const contents: TestInvokeMethodCommandOutput = {
@@ -14933,7 +14933,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -15016,7 +15016,7 @@ export const deserializeAws_restJson1UpdateAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAccountCommandError(output, context);
   }
   const contents: UpdateAccountCommandOutput = {
@@ -15107,7 +15107,7 @@ export const deserializeAws_restJson1UpdateApiKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApiKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApiKeyCommandError(output, context);
   }
   const contents: UpdateApiKeyCommandOutput = {
@@ -15230,7 +15230,7 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAuthorizerCommandError(output, context);
   }
   const contents: UpdateAuthorizerCommandOutput = {
@@ -15345,7 +15345,7 @@ export const deserializeAws_restJson1UpdateBasePathMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBasePathMappingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateBasePathMappingCommandError(output, context);
   }
   const contents: UpdateBasePathMappingCommandOutput = {
@@ -15440,7 +15440,7 @@ export const deserializeAws_restJson1UpdateClientCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateClientCertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateClientCertificateCommandError(output, context);
   }
   const contents: UpdateClientCertificateCommandOutput = {
@@ -15539,7 +15539,7 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDeploymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDeploymentCommandError(output, context);
   }
   const contents: UpdateDeploymentCommandOutput = {
@@ -15638,7 +15638,7 @@ export const deserializeAws_restJson1UpdateDocumentationPartCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDocumentationPartCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDocumentationPartCommandError(output, context);
   }
   const contents: UpdateDocumentationPartCommandOutput = {
@@ -15741,7 +15741,7 @@ export const deserializeAws_restJson1UpdateDocumentationVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDocumentationVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDocumentationVersionCommandError(output, context);
   }
   const contents: UpdateDocumentationVersionCommandOutput = {
@@ -15836,7 +15836,7 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainNameCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDomainNameCommandError(output, context);
   }
   const contents: UpdateDomainNameCommandOutput = {
@@ -15979,7 +15979,7 @@ export const deserializeAws_restJson1UpdateGatewayResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGatewayResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGatewayResponseCommandError(output, context);
   }
   const contents: UpdateGatewayResponseCommandOutput = {
@@ -16074,7 +16074,7 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIntegrationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateIntegrationCommandError(output, context);
   }
   const contents: UpdateIntegrationCommandOutput = {
@@ -16220,7 +16220,7 @@ export const deserializeAws_restJson1UpdateIntegrationResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIntegrationResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateIntegrationResponseCommandError(output, context);
   }
   const contents: UpdateIntegrationResponseCommandOutput = {
@@ -16323,7 +16323,7 @@ export const deserializeAws_restJson1UpdateMethodCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMethodCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMethodCommandError(output, context);
   }
   const contents: UpdateMethodCommandOutput = {
@@ -16450,7 +16450,7 @@ export const deserializeAws_restJson1UpdateMethodResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMethodResponseCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMethodResponseCommandError(output, context);
   }
   const contents: UpdateMethodResponseCommandOutput = {
@@ -16553,7 +16553,7 @@ export const deserializeAws_restJson1UpdateModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateModelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateModelCommandError(output, context);
   }
   const contents: UpdateModelCommandOutput = {
@@ -16656,7 +16656,7 @@ export const deserializeAws_restJson1UpdateRequestValidatorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRequestValidatorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRequestValidatorCommandError(output, context);
   }
   const contents: UpdateRequestValidatorCommandOutput = {
@@ -16747,7 +16747,7 @@ export const deserializeAws_restJson1UpdateResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateResourceCommandError(output, context);
   }
   const contents: UpdateResourceCommandOutput = {
@@ -16850,7 +16850,7 @@ export const deserializeAws_restJson1UpdateRestApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRestApiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRestApiCommandError(output, context);
   }
   const contents: UpdateRestApiCommandOutput = {
@@ -16981,7 +16981,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateStageCommandError(output, context);
   }
   const contents: UpdateStageCommandOutput = {
@@ -17132,7 +17132,7 @@ export const deserializeAws_restJson1UpdateUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUsageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUsageCommandError(output, context);
   }
   const contents: UpdateUsageCommandOutput = {
@@ -17227,7 +17227,7 @@ export const deserializeAws_restJson1UpdateUsagePlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUsagePlanCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUsagePlanCommandError(output, context);
   }
   const contents: UpdateUsagePlanCommandOutput = {
@@ -17342,7 +17342,7 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVpcLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateVpcLinkCommandError(output, context);
   }
   const contents: UpdateVpcLinkCommandOutput = {

--- a/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1.ts
@@ -117,7 +117,7 @@ export const deserializeAws_restJson1DeleteConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConnectionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteConnectionCommandError(output, context);
   }
   const contents: DeleteConnectionCommandOutput = {
@@ -184,7 +184,7 @@ export const deserializeAws_restJson1GetConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConnectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConnectionCommandError(output, context);
   }
   const contents: GetConnectionCommandOutput = {
@@ -263,7 +263,7 @@ export const deserializeAws_restJson1PostToConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PostToConnectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PostToConnectionCommandError(output, context);
   }
   const contents: PostToConnectionCommandOutput = {

--- a/clients/client-apigatewayv2/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/protocols/Aws_restJson1.ts
@@ -2995,7 +2995,7 @@ export const deserializeAws_restJson1CreateApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApiCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateApiCommandError(output, context);
   }
   const contents: CreateApiCommandOutput = {
@@ -3126,7 +3126,7 @@ export const deserializeAws_restJson1CreateApiMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApiMappingCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateApiMappingCommandError(output, context);
   }
   const contents: CreateApiMappingCommandOutput = {
@@ -3217,7 +3217,7 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAuthorizerCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAuthorizerCommandError(output, context);
   }
   const contents: CreateAuthorizerCommandOutput = {
@@ -3328,7 +3328,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeploymentCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeploymentCommandError(output, context);
   }
   const contents: CreateDeploymentCommandOutput = {
@@ -3427,7 +3427,7 @@ export const deserializeAws_restJson1CreateDomainNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDomainNameCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDomainNameCommandError(output, context);
   }
   const contents: CreateDomainNameCommandOutput = {
@@ -3529,7 +3529,7 @@ export const deserializeAws_restJson1CreateIntegrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIntegrationCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateIntegrationCommandError(output, context);
   }
   const contents: CreateIntegrationCommandOutput = {
@@ -3679,7 +3679,7 @@ export const deserializeAws_restJson1CreateIntegrationResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIntegrationResponseCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateIntegrationResponseCommandError(output, context);
   }
   const contents: CreateIntegrationResponseCommandOutput = {
@@ -3778,7 +3778,7 @@ export const deserializeAws_restJson1CreateModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateModelCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateModelCommandError(output, context);
   }
   const contents: CreateModelCommandOutput = {
@@ -3873,7 +3873,7 @@ export const deserializeAws_restJson1CreateRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRouteCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRouteCommandError(output, context);
   }
   const contents: CreateRouteCommandOutput = {
@@ -4000,7 +4000,7 @@ export const deserializeAws_restJson1CreateRouteResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRouteResponseCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRouteResponseCommandError(output, context);
   }
   const contents: CreateRouteResponseCommandOutput = {
@@ -4095,7 +4095,7 @@ export const deserializeAws_restJson1CreateStageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStageCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateStageCommandError(output, context);
   }
   const contents: CreateStageCommandOutput = {
@@ -4226,7 +4226,7 @@ export const deserializeAws_restJson1CreateVpcLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpcLinkCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateVpcLinkCommandError(output, context);
   }
   const contents: CreateVpcLinkCommandOutput = {
@@ -4321,7 +4321,7 @@ export const deserializeAws_restJson1DeleteAccessLogSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccessLogSettingsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAccessLogSettingsCommandError(output, context);
   }
   const contents: DeleteAccessLogSettingsCommandOutput = {
@@ -4380,7 +4380,7 @@ export const deserializeAws_restJson1DeleteApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApiCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApiCommandError(output, context);
   }
   const contents: DeleteApiCommandOutput = {
@@ -4439,7 +4439,7 @@ export const deserializeAws_restJson1DeleteApiMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApiMappingCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApiMappingCommandError(output, context);
   }
   const contents: DeleteApiMappingCommandOutput = {
@@ -4506,7 +4506,7 @@ export const deserializeAws_restJson1DeleteAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAuthorizerCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAuthorizerCommandError(output, context);
   }
   const contents: DeleteAuthorizerCommandOutput = {
@@ -4565,7 +4565,7 @@ export const deserializeAws_restJson1DeleteCorsConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCorsConfigurationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteCorsConfigurationCommandError(output, context);
   }
   const contents: DeleteCorsConfigurationCommandOutput = {
@@ -4624,7 +4624,7 @@ export const deserializeAws_restJson1DeleteDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeploymentCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDeploymentCommandError(output, context);
   }
   const contents: DeleteDeploymentCommandOutput = {
@@ -4683,7 +4683,7 @@ export const deserializeAws_restJson1DeleteDomainNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDomainNameCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDomainNameCommandError(output, context);
   }
   const contents: DeleteDomainNameCommandOutput = {
@@ -4742,7 +4742,7 @@ export const deserializeAws_restJson1DeleteIntegrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIntegrationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteIntegrationCommandError(output, context);
   }
   const contents: DeleteIntegrationCommandOutput = {
@@ -4801,7 +4801,7 @@ export const deserializeAws_restJson1DeleteIntegrationResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIntegrationResponseCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteIntegrationResponseCommandError(output, context);
   }
   const contents: DeleteIntegrationResponseCommandOutput = {
@@ -4860,7 +4860,7 @@ export const deserializeAws_restJson1DeleteModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteModelCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteModelCommandError(output, context);
   }
   const contents: DeleteModelCommandOutput = {
@@ -4919,7 +4919,7 @@ export const deserializeAws_restJson1DeleteRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRouteCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRouteCommandError(output, context);
   }
   const contents: DeleteRouteCommandOutput = {
@@ -4978,7 +4978,7 @@ export const deserializeAws_restJson1DeleteRouteRequestParameterCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRouteRequestParameterCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRouteRequestParameterCommandError(output, context);
   }
   const contents: DeleteRouteRequestParameterCommandOutput = {
@@ -5037,7 +5037,7 @@ export const deserializeAws_restJson1DeleteRouteResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRouteResponseCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRouteResponseCommandError(output, context);
   }
   const contents: DeleteRouteResponseCommandOutput = {
@@ -5096,7 +5096,7 @@ export const deserializeAws_restJson1DeleteRouteSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRouteSettingsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRouteSettingsCommandError(output, context);
   }
   const contents: DeleteRouteSettingsCommandOutput = {
@@ -5155,7 +5155,7 @@ export const deserializeAws_restJson1DeleteStageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStageCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteStageCommandError(output, context);
   }
   const contents: DeleteStageCommandOutput = {
@@ -5214,7 +5214,7 @@ export const deserializeAws_restJson1DeleteVpcLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpcLinkCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVpcLinkCommandError(output, context);
   }
   const contents: DeleteVpcLinkCommandOutput = {
@@ -5273,7 +5273,7 @@ export const deserializeAws_restJson1ExportApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportApiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ExportApiCommandError(output, context);
   }
   const contents: ExportApiCommandOutput = {
@@ -5342,7 +5342,7 @@ export const deserializeAws_restJson1GetApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApiCommandError(output, context);
   }
   const contents: GetApiCommandOutput = {
@@ -5457,7 +5457,7 @@ export const deserializeAws_restJson1GetApiMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApiMappingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApiMappingCommandError(output, context);
   }
   const contents: GetApiMappingCommandOutput = {
@@ -5540,7 +5540,7 @@ export const deserializeAws_restJson1GetApiMappingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApiMappingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApiMappingsCommandError(output, context);
   }
   const contents: GetApiMappingsCommandOutput = {
@@ -5615,7 +5615,7 @@ export const deserializeAws_restJson1GetApisCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApisCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApisCommandError(output, context);
   }
   const contents: GetApisCommandOutput = {
@@ -5690,7 +5690,7 @@ export const deserializeAws_restJson1GetAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAuthorizerCommandError(output, context);
   }
   const contents: GetAuthorizerCommandOutput = {
@@ -5785,7 +5785,7 @@ export const deserializeAws_restJson1GetAuthorizersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAuthorizersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAuthorizersCommandError(output, context);
   }
   const contents: GetAuthorizersCommandOutput = {
@@ -5860,7 +5860,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeploymentCommandError(output, context);
   }
   const contents: GetDeploymentCommandOutput = {
@@ -5943,7 +5943,7 @@ export const deserializeAws_restJson1GetDeploymentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeploymentsCommandError(output, context);
   }
   const contents: GetDeploymentsCommandOutput = {
@@ -6018,7 +6018,7 @@ export const deserializeAws_restJson1GetDomainNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainNameCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDomainNameCommandError(output, context);
   }
   const contents: GetDomainNameCommandOutput = {
@@ -6096,7 +6096,7 @@ export const deserializeAws_restJson1GetDomainNamesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainNamesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDomainNamesCommandError(output, context);
   }
   const contents: GetDomainNamesCommandOutput = {
@@ -6171,7 +6171,7 @@ export const deserializeAws_restJson1GetIntegrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIntegrationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIntegrationCommandError(output, context);
   }
   const contents: GetIntegrationCommandOutput = {
@@ -6305,7 +6305,7 @@ export const deserializeAws_restJson1GetIntegrationResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIntegrationResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIntegrationResponseCommandError(output, context);
   }
   const contents: GetIntegrationResponseCommandOutput = {
@@ -6388,7 +6388,7 @@ export const deserializeAws_restJson1GetIntegrationResponsesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIntegrationResponsesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIntegrationResponsesCommandError(output, context);
   }
   const contents: GetIntegrationResponsesCommandOutput = {
@@ -6463,7 +6463,7 @@ export const deserializeAws_restJson1GetIntegrationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIntegrationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIntegrationsCommandError(output, context);
   }
   const contents: GetIntegrationsCommandOutput = {
@@ -6538,7 +6538,7 @@ export const deserializeAws_restJson1GetModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetModelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetModelCommandError(output, context);
   }
   const contents: GetModelCommandOutput = {
@@ -6617,7 +6617,7 @@ export const deserializeAws_restJson1GetModelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetModelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetModelsCommandError(output, context);
   }
   const contents: GetModelsCommandOutput = {
@@ -6692,7 +6692,7 @@ export const deserializeAws_restJson1GetModelTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetModelTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetModelTemplateCommandError(output, context);
   }
   const contents: GetModelTemplateCommandOutput = {
@@ -6755,7 +6755,7 @@ export const deserializeAws_restJson1GetRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRouteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRouteCommandError(output, context);
   }
   const contents: GetRouteCommandOutput = {
@@ -6866,7 +6866,7 @@ export const deserializeAws_restJson1GetRouteResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRouteResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRouteResponseCommandError(output, context);
   }
   const contents: GetRouteResponseCommandOutput = {
@@ -6945,7 +6945,7 @@ export const deserializeAws_restJson1GetRouteResponsesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRouteResponsesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRouteResponsesCommandError(output, context);
   }
   const contents: GetRouteResponsesCommandOutput = {
@@ -7020,7 +7020,7 @@ export const deserializeAws_restJson1GetRoutesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRoutesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRoutesCommandError(output, context);
   }
   const contents: GetRoutesCommandOutput = {
@@ -7095,7 +7095,7 @@ export const deserializeAws_restJson1GetStageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetStageCommandError(output, context);
   }
   const contents: GetStageCommandOutput = {
@@ -7210,7 +7210,7 @@ export const deserializeAws_restJson1GetStagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStagesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetStagesCommandError(output, context);
   }
   const contents: GetStagesCommandOutput = {
@@ -7285,7 +7285,7 @@ export const deserializeAws_restJson1GetTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTagsCommandError(output, context);
   }
   const contents: GetTagsCommandOutput = {
@@ -7364,7 +7364,7 @@ export const deserializeAws_restJson1GetVpcLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVpcLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVpcLinkCommandError(output, context);
   }
   const contents: GetVpcLinkCommandOutput = {
@@ -7459,7 +7459,7 @@ export const deserializeAws_restJson1GetVpcLinksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVpcLinksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVpcLinksCommandError(output, context);
   }
   const contents: GetVpcLinksCommandOutput = {
@@ -7526,7 +7526,7 @@ export const deserializeAws_restJson1ImportApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportApiCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1ImportApiCommandError(output, context);
   }
   const contents: ImportApiCommandOutput = {
@@ -7657,7 +7657,7 @@ export const deserializeAws_restJson1ReimportApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReimportApiCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1ReimportApiCommandError(output, context);
   }
   const contents: ReimportApiCommandOutput = {
@@ -7788,7 +7788,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -7863,7 +7863,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -7938,7 +7938,7 @@ export const deserializeAws_restJson1UpdateApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApiCommandError(output, context);
   }
   const contents: UpdateApiCommandOutput = {
@@ -8069,7 +8069,7 @@ export const deserializeAws_restJson1UpdateApiMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApiMappingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApiMappingCommandError(output, context);
   }
   const contents: UpdateApiMappingCommandOutput = {
@@ -8160,7 +8160,7 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAuthorizerCommandError(output, context);
   }
   const contents: UpdateAuthorizerCommandOutput = {
@@ -8271,7 +8271,7 @@ export const deserializeAws_restJson1UpdateDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDeploymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDeploymentCommandError(output, context);
   }
   const contents: UpdateDeploymentCommandOutput = {
@@ -8370,7 +8370,7 @@ export const deserializeAws_restJson1UpdateDomainNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainNameCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDomainNameCommandError(output, context);
   }
   const contents: UpdateDomainNameCommandOutput = {
@@ -8464,7 +8464,7 @@ export const deserializeAws_restJson1UpdateIntegrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIntegrationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateIntegrationCommandError(output, context);
   }
   const contents: UpdateIntegrationCommandOutput = {
@@ -8614,7 +8614,7 @@ export const deserializeAws_restJson1UpdateIntegrationResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIntegrationResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateIntegrationResponseCommandError(output, context);
   }
   const contents: UpdateIntegrationResponseCommandOutput = {
@@ -8713,7 +8713,7 @@ export const deserializeAws_restJson1UpdateModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateModelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateModelCommandError(output, context);
   }
   const contents: UpdateModelCommandOutput = {
@@ -8808,7 +8808,7 @@ export const deserializeAws_restJson1UpdateRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRouteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRouteCommandError(output, context);
   }
   const contents: UpdateRouteCommandOutput = {
@@ -8935,7 +8935,7 @@ export const deserializeAws_restJson1UpdateRouteResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRouteResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRouteResponseCommandError(output, context);
   }
   const contents: UpdateRouteResponseCommandOutput = {
@@ -9030,7 +9030,7 @@ export const deserializeAws_restJson1UpdateStageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateStageCommandError(output, context);
   }
   const contents: UpdateStageCommandOutput = {
@@ -9161,7 +9161,7 @@ export const deserializeAws_restJson1UpdateVpcLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVpcLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateVpcLinkCommandError(output, context);
   }
   const contents: UpdateVpcLinkCommandOutput = {

--- a/clients/client-app-mesh/protocols/Aws_restJson1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1.ts
@@ -1803,7 +1803,7 @@ export const deserializeAws_restJson1CreateGatewayRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGatewayRouteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGatewayRouteCommandError(output, context);
   }
   const contents: CreateGatewayRouteCommandOutput = {
@@ -1912,7 +1912,7 @@ export const deserializeAws_restJson1CreateMeshCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMeshCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMeshCommandError(output, context);
   }
   const contents: CreateMeshCommandOutput = {
@@ -2021,7 +2021,7 @@ export const deserializeAws_restJson1CreateRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRouteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRouteCommandError(output, context);
   }
   const contents: CreateRouteCommandOutput = {
@@ -2130,7 +2130,7 @@ export const deserializeAws_restJson1CreateVirtualGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVirtualGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateVirtualGatewayCommandError(output, context);
   }
   const contents: CreateVirtualGatewayCommandOutput = {
@@ -2239,7 +2239,7 @@ export const deserializeAws_restJson1CreateVirtualNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVirtualNodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateVirtualNodeCommandError(output, context);
   }
   const contents: CreateVirtualNodeCommandOutput = {
@@ -2348,7 +2348,7 @@ export const deserializeAws_restJson1CreateVirtualRouterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVirtualRouterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateVirtualRouterCommandError(output, context);
   }
   const contents: CreateVirtualRouterCommandOutput = {
@@ -2457,7 +2457,7 @@ export const deserializeAws_restJson1CreateVirtualServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVirtualServiceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateVirtualServiceCommandError(output, context);
   }
   const contents: CreateVirtualServiceCommandOutput = {
@@ -2566,7 +2566,7 @@ export const deserializeAws_restJson1DeleteGatewayRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGatewayRouteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGatewayRouteCommandError(output, context);
   }
   const contents: DeleteGatewayRouteCommandOutput = {
@@ -2667,7 +2667,7 @@ export const deserializeAws_restJson1DeleteMeshCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMeshCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMeshCommandError(output, context);
   }
   const contents: DeleteMeshCommandOutput = {
@@ -2768,7 +2768,7 @@ export const deserializeAws_restJson1DeleteRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRouteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRouteCommandError(output, context);
   }
   const contents: DeleteRouteCommandOutput = {
@@ -2869,7 +2869,7 @@ export const deserializeAws_restJson1DeleteVirtualGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVirtualGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVirtualGatewayCommandError(output, context);
   }
   const contents: DeleteVirtualGatewayCommandOutput = {
@@ -2970,7 +2970,7 @@ export const deserializeAws_restJson1DeleteVirtualNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVirtualNodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVirtualNodeCommandError(output, context);
   }
   const contents: DeleteVirtualNodeCommandOutput = {
@@ -3071,7 +3071,7 @@ export const deserializeAws_restJson1DeleteVirtualRouterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVirtualRouterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVirtualRouterCommandError(output, context);
   }
   const contents: DeleteVirtualRouterCommandOutput = {
@@ -3172,7 +3172,7 @@ export const deserializeAws_restJson1DeleteVirtualServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVirtualServiceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVirtualServiceCommandError(output, context);
   }
   const contents: DeleteVirtualServiceCommandOutput = {
@@ -3273,7 +3273,7 @@ export const deserializeAws_restJson1DescribeGatewayRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGatewayRouteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeGatewayRouteCommandError(output, context);
   }
   const contents: DescribeGatewayRouteCommandOutput = {
@@ -3366,7 +3366,7 @@ export const deserializeAws_restJson1DescribeMeshCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMeshCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeMeshCommandError(output, context);
   }
   const contents: DescribeMeshCommandOutput = {
@@ -3459,7 +3459,7 @@ export const deserializeAws_restJson1DescribeRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRouteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRouteCommandError(output, context);
   }
   const contents: DescribeRouteCommandOutput = {
@@ -3552,7 +3552,7 @@ export const deserializeAws_restJson1DescribeVirtualGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVirtualGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeVirtualGatewayCommandError(output, context);
   }
   const contents: DescribeVirtualGatewayCommandOutput = {
@@ -3645,7 +3645,7 @@ export const deserializeAws_restJson1DescribeVirtualNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVirtualNodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeVirtualNodeCommandError(output, context);
   }
   const contents: DescribeVirtualNodeCommandOutput = {
@@ -3738,7 +3738,7 @@ export const deserializeAws_restJson1DescribeVirtualRouterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVirtualRouterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeVirtualRouterCommandError(output, context);
   }
   const contents: DescribeVirtualRouterCommandOutput = {
@@ -3831,7 +3831,7 @@ export const deserializeAws_restJson1DescribeVirtualServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVirtualServiceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeVirtualServiceCommandError(output, context);
   }
   const contents: DescribeVirtualServiceCommandOutput = {
@@ -3924,7 +3924,7 @@ export const deserializeAws_restJson1ListGatewayRoutesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGatewayRoutesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGatewayRoutesCommandError(output, context);
   }
   const contents: ListGatewayRoutesCommandOutput = {
@@ -4023,7 +4023,7 @@ export const deserializeAws_restJson1ListMeshesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMeshesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMeshesCommandError(output, context);
   }
   const contents: ListMeshesCommandOutput = {
@@ -4122,7 +4122,7 @@ export const deserializeAws_restJson1ListRoutesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRoutesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRoutesCommandError(output, context);
   }
   const contents: ListRoutesCommandOutput = {
@@ -4221,7 +4221,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -4320,7 +4320,7 @@ export const deserializeAws_restJson1ListVirtualGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVirtualGatewaysCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListVirtualGatewaysCommandError(output, context);
   }
   const contents: ListVirtualGatewaysCommandOutput = {
@@ -4419,7 +4419,7 @@ export const deserializeAws_restJson1ListVirtualNodesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVirtualNodesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListVirtualNodesCommandError(output, context);
   }
   const contents: ListVirtualNodesCommandOutput = {
@@ -4518,7 +4518,7 @@ export const deserializeAws_restJson1ListVirtualRoutersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVirtualRoutersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListVirtualRoutersCommandError(output, context);
   }
   const contents: ListVirtualRoutersCommandOutput = {
@@ -4617,7 +4617,7 @@ export const deserializeAws_restJson1ListVirtualServicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVirtualServicesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListVirtualServicesCommandError(output, context);
   }
   const contents: ListVirtualServicesCommandOutput = {
@@ -4716,7 +4716,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -4815,7 +4815,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -4906,7 +4906,7 @@ export const deserializeAws_restJson1UpdateGatewayRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGatewayRouteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGatewayRouteCommandError(output, context);
   }
   const contents: UpdateGatewayRouteCommandOutput = {
@@ -5015,7 +5015,7 @@ export const deserializeAws_restJson1UpdateMeshCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMeshCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMeshCommandError(output, context);
   }
   const contents: UpdateMeshCommandOutput = {
@@ -5116,7 +5116,7 @@ export const deserializeAws_restJson1UpdateRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRouteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRouteCommandError(output, context);
   }
   const contents: UpdateRouteCommandOutput = {
@@ -5225,7 +5225,7 @@ export const deserializeAws_restJson1UpdateVirtualGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVirtualGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateVirtualGatewayCommandError(output, context);
   }
   const contents: UpdateVirtualGatewayCommandOutput = {
@@ -5334,7 +5334,7 @@ export const deserializeAws_restJson1UpdateVirtualNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVirtualNodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateVirtualNodeCommandError(output, context);
   }
   const contents: UpdateVirtualNodeCommandOutput = {
@@ -5443,7 +5443,7 @@ export const deserializeAws_restJson1UpdateVirtualRouterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVirtualRouterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateVirtualRouterCommandError(output, context);
   }
   const contents: UpdateVirtualRouterCommandOutput = {
@@ -5552,7 +5552,7 @@ export const deserializeAws_restJson1UpdateVirtualServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVirtualServiceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateVirtualServiceCommandError(output, context);
   }
   const contents: UpdateVirtualServiceCommandOutput = {

--- a/clients/client-appconfig/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1.ts
@@ -1382,7 +1382,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateApplicationCommandError(output, context);
   }
   const contents: CreateApplicationCommandOutput = {
@@ -1453,7 +1453,7 @@ export const deserializeAws_restJson1CreateConfigurationProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationProfileCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConfigurationProfileCommandError(output, context);
   }
   const contents: CreateConfigurationProfileCommandOutput = {
@@ -1548,7 +1548,7 @@ export const deserializeAws_restJson1CreateDeploymentStrategyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeploymentStrategyCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeploymentStrategyCommandError(output, context);
   }
   const contents: CreateDeploymentStrategyCommandOutput = {
@@ -1639,7 +1639,7 @@ export const deserializeAws_restJson1CreateEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEnvironmentCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateEnvironmentCommandError(output, context);
   }
   const contents: CreateEnvironmentCommandOutput = {
@@ -1730,7 +1730,7 @@ export const deserializeAws_restJson1CreateHostedConfigurationVersionCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHostedConfigurationVersionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateHostedConfigurationVersionCommandError(output, context);
   }
   const contents: CreateHostedConfigurationVersionCommandOutput = {
@@ -1843,7 +1843,7 @@ export const deserializeAws_restJson1DeleteApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApplicationCommandError(output, context);
   }
   const contents: DeleteApplicationCommandOutput = {
@@ -1910,7 +1910,7 @@ export const deserializeAws_restJson1DeleteConfigurationProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationProfileCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteConfigurationProfileCommandError(output, context);
   }
   const contents: DeleteConfigurationProfileCommandOutput = {
@@ -1985,7 +1985,7 @@ export const deserializeAws_restJson1DeleteDeploymentStrategyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeploymentStrategyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDeploymentStrategyCommandError(output, context);
   }
   const contents: DeleteDeploymentStrategyCommandOutput = {
@@ -2052,7 +2052,7 @@ export const deserializeAws_restJson1DeleteEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEnvironmentCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEnvironmentCommandError(output, context);
   }
   const contents: DeleteEnvironmentCommandOutput = {
@@ -2127,7 +2127,7 @@ export const deserializeAws_restJson1DeleteHostedConfigurationVersionCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHostedConfigurationVersionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteHostedConfigurationVersionCommandError(output, context);
   }
   const contents: DeleteHostedConfigurationVersionCommandOutput = {
@@ -2194,7 +2194,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApplicationCommandError(output, context);
   }
   const contents: GetApplicationCommandOutput = {
@@ -2273,7 +2273,7 @@ export const deserializeAws_restJson1GetConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConfigurationCommandError(output, context);
   }
   const contents: GetConfigurationCommandOutput = {
@@ -2350,7 +2350,7 @@ export const deserializeAws_restJson1GetConfigurationProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConfigurationProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConfigurationProfileCommandError(output, context);
   }
   const contents: GetConfigurationProfileCommandOutput = {
@@ -2445,7 +2445,7 @@ export const deserializeAws_restJson1GetDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeploymentCommandError(output, context);
   }
   const contents: GetDeploymentCommandOutput = {
@@ -2584,7 +2584,7 @@ export const deserializeAws_restJson1GetDeploymentStrategyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentStrategyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeploymentStrategyCommandError(output, context);
   }
   const contents: GetDeploymentStrategyCommandOutput = {
@@ -2683,7 +2683,7 @@ export const deserializeAws_restJson1GetEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEnvironmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEnvironmentCommandError(output, context);
   }
   const contents: GetEnvironmentCommandOutput = {
@@ -2774,7 +2774,7 @@ export const deserializeAws_restJson1GetHostedConfigurationVersionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHostedConfigurationVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetHostedConfigurationVersionCommandError(output, context);
   }
   const contents: GetHostedConfigurationVersionCommandOutput = {
@@ -2863,7 +2863,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListApplicationsCommandError(output, context);
   }
   const contents: ListApplicationsCommandOutput = {
@@ -2930,7 +2930,7 @@ export const deserializeAws_restJson1ListConfigurationProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationProfilesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConfigurationProfilesCommandError(output, context);
   }
   const contents: ListConfigurationProfilesCommandOutput = {
@@ -3005,7 +3005,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeploymentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDeploymentsCommandError(output, context);
   }
   const contents: ListDeploymentsCommandOutput = {
@@ -3080,7 +3080,7 @@ export const deserializeAws_restJson1ListDeploymentStrategiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeploymentStrategiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDeploymentStrategiesCommandError(output, context);
   }
   const contents: ListDeploymentStrategiesCommandOutput = {
@@ -3147,7 +3147,7 @@ export const deserializeAws_restJson1ListEnvironmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEnvironmentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListEnvironmentsCommandError(output, context);
   }
   const contents: ListEnvironmentsCommandOutput = {
@@ -3222,7 +3222,7 @@ export const deserializeAws_restJson1ListHostedConfigurationVersionsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHostedConfigurationVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListHostedConfigurationVersionsCommandError(output, context);
   }
   const contents: ListHostedConfigurationVersionsCommandOutput = {
@@ -3297,7 +3297,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -3368,7 +3368,7 @@ export const deserializeAws_restJson1StartDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDeploymentCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartDeploymentCommandError(output, context);
   }
   const contents: StartDeploymentCommandOutput = {
@@ -3515,7 +3515,7 @@ export const deserializeAws_restJson1StopDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDeploymentCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopDeploymentCommandError(output, context);
   }
   const contents: StopDeploymentCommandOutput = {
@@ -3654,7 +3654,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -3721,7 +3721,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -3788,7 +3788,7 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApplicationCommandError(output, context);
   }
   const contents: UpdateApplicationCommandOutput = {
@@ -3867,7 +3867,7 @@ export const deserializeAws_restJson1UpdateConfigurationProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigurationProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateConfigurationProfileCommandError(output, context);
   }
   const contents: UpdateConfigurationProfileCommandOutput = {
@@ -3962,7 +3962,7 @@ export const deserializeAws_restJson1UpdateDeploymentStrategyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDeploymentStrategyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDeploymentStrategyCommandError(output, context);
   }
   const contents: UpdateDeploymentStrategyCommandOutput = {
@@ -4061,7 +4061,7 @@ export const deserializeAws_restJson1UpdateEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEnvironmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateEnvironmentCommandError(output, context);
   }
   const contents: UpdateEnvironmentCommandOutput = {
@@ -4152,7 +4152,7 @@ export const deserializeAws_restJson1ValidateConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ValidateConfigurationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1ValidateConfigurationCommandError(output, context);
   }
   const contents: ValidateConfigurationCommandOutput = {

--- a/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
+++ b/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
@@ -218,7 +218,7 @@ export const deserializeAws_json1_1DeleteScalingPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteScalingPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteScalingPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -297,7 +297,7 @@ export const deserializeAws_json1_1DeleteScheduledActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteScheduledActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteScheduledActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -376,7 +376,7 @@ export const deserializeAws_json1_1DeregisterScalableTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterScalableTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterScalableTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -455,7 +455,7 @@ export const deserializeAws_json1_1DescribeScalableTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScalableTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeScalableTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -534,7 +534,7 @@ export const deserializeAws_json1_1DescribeScalingActivitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScalingActivitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeScalingActivitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -613,7 +613,7 @@ export const deserializeAws_json1_1DescribeScalingPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScalingPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeScalingPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -700,7 +700,7 @@ export const deserializeAws_json1_1DescribeScheduledActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScheduledActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeScheduledActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -779,7 +779,7 @@ export const deserializeAws_json1_1PutScalingPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutScalingPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutScalingPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -874,7 +874,7 @@ export const deserializeAws_json1_1PutScheduledActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutScheduledActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutScheduledActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -961,7 +961,7 @@ export const deserializeAws_json1_1RegisterScalableTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterScalableTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterScalableTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
@@ -484,7 +484,7 @@ export const deserializeAws_json1_1AssociateConfigurationItemsToApplicationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateConfigurationItemsToApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateConfigurationItemsToApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -571,7 +571,7 @@ export const deserializeAws_json1_1BatchDeleteImportDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeleteImportDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDeleteImportDataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -658,7 +658,7 @@ export const deserializeAws_json1_1CreateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -745,7 +745,7 @@ export const deserializeAws_json1_1CreateTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -840,7 +840,7 @@ export const deserializeAws_json1_1DeleteApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -927,7 +927,7 @@ export const deserializeAws_json1_1DeleteTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1022,7 +1022,7 @@ export const deserializeAws_json1_1DescribeAgentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAgentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAgentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1109,7 +1109,7 @@ export const deserializeAws_json1_1DescribeConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1196,7 +1196,7 @@ export const deserializeAws_json1_1DescribeContinuousExportsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeContinuousExportsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeContinuousExportsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1299,7 +1299,7 @@ export const deserializeAws_json1_1DescribeExportConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeExportConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeExportConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1394,7 +1394,7 @@ export const deserializeAws_json1_1DescribeExportTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeExportTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeExportTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1481,7 +1481,7 @@ export const deserializeAws_json1_1DescribeImportTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeImportTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeImportTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1568,7 +1568,7 @@ export const deserializeAws_json1_1DescribeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1663,7 +1663,7 @@ export const deserializeAws_json1_1DisassociateConfigurationItemsFromApplication
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateConfigurationItemsFromApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateConfigurationItemsFromApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1750,7 +1750,7 @@ export const deserializeAws_json1_1ExportConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ExportConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1845,7 +1845,7 @@ export const deserializeAws_json1_1GetDiscoverySummaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDiscoverySummaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDiscoverySummaryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1932,7 +1932,7 @@ export const deserializeAws_json1_1ListConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2027,7 +2027,7 @@ export const deserializeAws_json1_1ListServerNeighborsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServerNeighborsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListServerNeighborsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2114,7 +2114,7 @@ export const deserializeAws_json1_1StartContinuousExportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartContinuousExportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartContinuousExportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2225,7 +2225,7 @@ export const deserializeAws_json1_1StartDataCollectionByAgentIdsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDataCollectionByAgentIdsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartDataCollectionByAgentIdsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2312,7 +2312,7 @@ export const deserializeAws_json1_1StartExportTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartExportTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartExportTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2407,7 +2407,7 @@ export const deserializeAws_json1_1StartImportTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartImportTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartImportTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2502,7 +2502,7 @@ export const deserializeAws_json1_1StopContinuousExportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopContinuousExportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopContinuousExportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2613,7 +2613,7 @@ export const deserializeAws_json1_1StopDataCollectionByAgentIdsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDataCollectionByAgentIdsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopDataCollectionByAgentIdsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2700,7 +2700,7 @@ export const deserializeAws_json1_1UpdateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-application-insights/protocols/Aws_json1_1.ts
+++ b/clients/client-application-insights/protocols/Aws_json1_1.ts
@@ -487,7 +487,7 @@ export const deserializeAws_json1_1CreateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -574,7 +574,7 @@ export const deserializeAws_json1_1CreateComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateComponentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateComponentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -653,7 +653,7 @@ export const deserializeAws_json1_1CreateLogPatternCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLogPatternCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLogPatternCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -732,7 +732,7 @@ export const deserializeAws_json1_1DeleteApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -811,7 +811,7 @@ export const deserializeAws_json1_1DeleteComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteComponentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteComponentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -882,7 +882,7 @@ export const deserializeAws_json1_1DeleteLogPatternCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLogPatternCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLogPatternCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -961,7 +961,7 @@ export const deserializeAws_json1_1DescribeApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1032,7 +1032,7 @@ export const deserializeAws_json1_1DescribeComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeComponentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeComponentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1103,7 +1103,7 @@ export const deserializeAws_json1_1DescribeComponentConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeComponentConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeComponentConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1174,7 +1174,7 @@ export const deserializeAws_json1_1DescribeComponentConfigurationRecommendationC
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeComponentConfigurationRecommendationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeComponentConfigurationRecommendationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1245,7 +1245,7 @@ export const deserializeAws_json1_1DescribeLogPatternCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLogPatternCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLogPatternCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1316,7 +1316,7 @@ export const deserializeAws_json1_1DescribeObservationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeObservationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeObservationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1387,7 +1387,7 @@ export const deserializeAws_json1_1DescribeProblemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProblemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProblemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1458,7 +1458,7 @@ export const deserializeAws_json1_1DescribeProblemObservationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProblemObservationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProblemObservationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1529,7 +1529,7 @@ export const deserializeAws_json1_1ListApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListApplicationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1592,7 +1592,7 @@ export const deserializeAws_json1_1ListComponentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListComponentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListComponentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1663,7 +1663,7 @@ export const deserializeAws_json1_1ListConfigurationHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListConfigurationHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1734,7 +1734,7 @@ export const deserializeAws_json1_1ListLogPatternsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLogPatternsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLogPatternsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1805,7 +1805,7 @@ export const deserializeAws_json1_1ListLogPatternSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLogPatternSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLogPatternSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1876,7 +1876,7 @@ export const deserializeAws_json1_1ListProblemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProblemsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProblemsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1947,7 +1947,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2010,7 +2010,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2081,7 +2081,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2144,7 +2144,7 @@ export const deserializeAws_json1_1UpdateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2215,7 +2215,7 @@ export const deserializeAws_json1_1UpdateComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateComponentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateComponentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2294,7 +2294,7 @@ export const deserializeAws_json1_1UpdateComponentConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateComponentConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateComponentConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2365,7 +2365,7 @@ export const deserializeAws_json1_1UpdateLogPatternCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLogPatternCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateLogPatternCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-appstream/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/protocols/Aws_json1_1.ts
@@ -863,7 +863,7 @@ export const deserializeAws_json1_1AssociateFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -958,7 +958,7 @@ export const deserializeAws_json1_1BatchAssociateUserStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchAssociateUserStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchAssociateUserStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1013,7 +1013,7 @@ export const deserializeAws_json1_1BatchDisassociateUserStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDisassociateUserStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDisassociateUserStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1060,7 +1060,7 @@ export const deserializeAws_json1_1CopyImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CopyImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1155,7 +1155,7 @@ export const deserializeAws_json1_1CreateDirectoryConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDirectoryConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDirectoryConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1226,7 +1226,7 @@ export const deserializeAws_json1_1CreateFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1353,7 +1353,7 @@ export const deserializeAws_json1_1CreateImageBuilderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateImageBuilderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateImageBuilderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1480,7 +1480,7 @@ export const deserializeAws_json1_1CreateImageBuilderStreamingURLCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateImageBuilderStreamingURLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateImageBuilderStreamingURLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1543,7 +1543,7 @@ export const deserializeAws_json1_1CreateStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1646,7 +1646,7 @@ export const deserializeAws_json1_1CreateStreamingURLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStreamingURLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateStreamingURLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1725,7 +1725,7 @@ export const deserializeAws_json1_1CreateUsageReportSubscriptionCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUsageReportSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUsageReportSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1796,7 +1796,7 @@ export const deserializeAws_json1_1CreateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1883,7 +1883,7 @@ export const deserializeAws_json1_1DeleteDirectoryConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDirectoryConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDirectoryConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1946,7 +1946,7 @@ export const deserializeAws_json1_1DeleteFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2017,7 +2017,7 @@ export const deserializeAws_json1_1DeleteImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2096,7 +2096,7 @@ export const deserializeAws_json1_1DeleteImageBuilderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteImageBuilderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteImageBuilderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2167,7 +2167,7 @@ export const deserializeAws_json1_1DeleteImagePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteImagePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteImagePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2230,7 +2230,7 @@ export const deserializeAws_json1_1DeleteStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2301,7 +2301,7 @@ export const deserializeAws_json1_1DeleteUsageReportSubscriptionCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUsageReportSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUsageReportSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2364,7 +2364,7 @@ export const deserializeAws_json1_1DeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2419,7 +2419,7 @@ export const deserializeAws_json1_1DescribeDirectoryConfigsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDirectoryConfigsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDirectoryConfigsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2474,7 +2474,7 @@ export const deserializeAws_json1_1DescribeFleetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFleetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2529,7 +2529,7 @@ export const deserializeAws_json1_1DescribeImageBuildersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeImageBuildersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeImageBuildersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2584,7 +2584,7 @@ export const deserializeAws_json1_1DescribeImagePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeImagePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeImagePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2639,7 +2639,7 @@ export const deserializeAws_json1_1DescribeImagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeImagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeImagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2702,7 +2702,7 @@ export const deserializeAws_json1_1DescribeSessionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSessionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSessionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2757,7 +2757,7 @@ export const deserializeAws_json1_1DescribeStacksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStacksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeStacksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2812,7 +2812,7 @@ export const deserializeAws_json1_1DescribeUsageReportSubscriptionsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUsageReportSubscriptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUsageReportSubscriptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2875,7 +2875,7 @@ export const deserializeAws_json1_1DescribeUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUsersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUsersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2938,7 +2938,7 @@ export const deserializeAws_json1_1DescribeUserStackAssociationsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserStackAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUserStackAssociationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2993,7 +2993,7 @@ export const deserializeAws_json1_1DisableUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3048,7 +3048,7 @@ export const deserializeAws_json1_1DisassociateFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3119,7 +3119,7 @@ export const deserializeAws_json1_1EnableUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3182,7 +3182,7 @@ export const deserializeAws_json1_1ExpireSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExpireSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ExpireSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3229,7 +3229,7 @@ export const deserializeAws_json1_1ListAssociatedFleetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssociatedFleetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssociatedFleetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3276,7 +3276,7 @@ export const deserializeAws_json1_1ListAssociatedStacksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssociatedStacksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssociatedStacksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3323,7 +3323,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3378,7 +3378,7 @@ export const deserializeAws_json1_1StartFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3481,7 +3481,7 @@ export const deserializeAws_json1_1StartImageBuilderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartImageBuilderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartImageBuilderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3568,7 +3568,7 @@ export const deserializeAws_json1_1StopFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3631,7 +3631,7 @@ export const deserializeAws_json1_1StopImageBuilderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopImageBuilderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopImageBuilderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3702,7 +3702,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3773,7 +3773,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3828,7 +3828,7 @@ export const deserializeAws_json1_1UpdateDirectoryConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDirectoryConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDirectoryConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3899,7 +3899,7 @@ export const deserializeAws_json1_1UpdateFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4026,7 +4026,7 @@ export const deserializeAws_json1_1UpdateImagePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateImagePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateImagePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4097,7 +4097,7 @@ export const deserializeAws_json1_1UpdateStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-appsync/protocols/Aws_restJson1.ts
+++ b/clients/client-appsync/protocols/Aws_restJson1.ts
@@ -1710,7 +1710,7 @@ export const deserializeAws_restJson1CreateApiCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApiCacheCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateApiCacheCommandError(output, context);
   }
   const contents: CreateApiCacheCommandOutput = {
@@ -1797,7 +1797,7 @@ export const deserializeAws_restJson1CreateApiKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApiKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateApiKeyCommandError(output, context);
   }
   const contents: CreateApiKeyCommandOutput = {
@@ -1900,7 +1900,7 @@ export const deserializeAws_restJson1CreateDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataSourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDataSourceCommandError(output, context);
   }
   const contents: CreateDataSourceCommandOutput = {
@@ -1987,7 +1987,7 @@ export const deserializeAws_restJson1CreateFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFunctionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFunctionCommandError(output, context);
   }
   const contents: CreateFunctionCommandOutput = {
@@ -2066,7 +2066,7 @@ export const deserializeAws_restJson1CreateGraphqlApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGraphqlApiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGraphqlApiCommandError(output, context);
   }
   const contents: CreateGraphqlApiCommandOutput = {
@@ -2161,7 +2161,7 @@ export const deserializeAws_restJson1CreateResolverCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResolverCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateResolverCommandError(output, context);
   }
   const contents: CreateResolverCommandOutput = {
@@ -2240,7 +2240,7 @@ export const deserializeAws_restJson1CreateTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateTypeCommandError(output, context);
   }
   const contents: CreateTypeCommandOutput = {
@@ -2327,7 +2327,7 @@ export const deserializeAws_restJson1DeleteApiCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApiCacheCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApiCacheCommandError(output, context);
   }
   const contents: DeleteApiCacheCommandOutput = {
@@ -2410,7 +2410,7 @@ export const deserializeAws_restJson1DeleteApiKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApiKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApiKeyCommandError(output, context);
   }
   const contents: DeleteApiKeyCommandOutput = {
@@ -2485,7 +2485,7 @@ export const deserializeAws_restJson1DeleteDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDataSourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDataSourceCommandError(output, context);
   }
   const contents: DeleteDataSourceCommandOutput = {
@@ -2568,7 +2568,7 @@ export const deserializeAws_restJson1DeleteFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFunctionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFunctionCommandError(output, context);
   }
   const contents: DeleteFunctionCommandOutput = {
@@ -2643,7 +2643,7 @@ export const deserializeAws_restJson1DeleteGraphqlApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGraphqlApiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGraphqlApiCommandError(output, context);
   }
   const contents: DeleteGraphqlApiCommandOutput = {
@@ -2734,7 +2734,7 @@ export const deserializeAws_restJson1DeleteResolverCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResolverCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteResolverCommandError(output, context);
   }
   const contents: DeleteResolverCommandOutput = {
@@ -2809,7 +2809,7 @@ export const deserializeAws_restJson1DeleteTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteTypeCommandError(output, context);
   }
   const contents: DeleteTypeCommandOutput = {
@@ -2892,7 +2892,7 @@ export const deserializeAws_restJson1FlushApiCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FlushApiCacheCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1FlushApiCacheCommandError(output, context);
   }
   const contents: FlushApiCacheCommandOutput = {
@@ -2975,7 +2975,7 @@ export const deserializeAws_restJson1GetApiCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApiCacheCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApiCacheCommandError(output, context);
   }
   const contents: GetApiCacheCommandOutput = {
@@ -3062,7 +3062,7 @@ export const deserializeAws_restJson1GetDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDataSourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDataSourceCommandError(output, context);
   }
   const contents: GetDataSourceCommandOutput = {
@@ -3149,7 +3149,7 @@ export const deserializeAws_restJson1GetFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFunctionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFunctionCommandError(output, context);
   }
   const contents: GetFunctionCommandOutput = {
@@ -3220,7 +3220,7 @@ export const deserializeAws_restJson1GetGraphqlApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGraphqlApiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGraphqlApiCommandError(output, context);
   }
   const contents: GetGraphqlApiCommandOutput = {
@@ -3307,7 +3307,7 @@ export const deserializeAws_restJson1GetIntrospectionSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIntrospectionSchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIntrospectionSchemaCommandError(output, context);
   }
   const contents: GetIntrospectionSchemaCommandOutput = {
@@ -3384,7 +3384,7 @@ export const deserializeAws_restJson1GetResolverCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResolverCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResolverCommandError(output, context);
   }
   const contents: GetResolverCommandOutput = {
@@ -3455,7 +3455,7 @@ export const deserializeAws_restJson1GetSchemaCreationStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSchemaCreationStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSchemaCreationStatusCommandError(output, context);
   }
   const contents: GetSchemaCreationStatusCommandOutput = {
@@ -3538,7 +3538,7 @@ export const deserializeAws_restJson1GetTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTypeCommandError(output, context);
   }
   const contents: GetTypeCommandOutput = {
@@ -3625,7 +3625,7 @@ export const deserializeAws_restJson1ListApiKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApiKeysCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListApiKeysCommandError(output, context);
   }
   const contents: ListApiKeysCommandOutput = {
@@ -3708,7 +3708,7 @@ export const deserializeAws_restJson1ListDataSourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDataSourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDataSourcesCommandError(output, context);
   }
   const contents: ListDataSourcesCommandOutput = {
@@ -3791,7 +3791,7 @@ export const deserializeAws_restJson1ListFunctionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFunctionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFunctionsCommandError(output, context);
   }
   const contents: ListFunctionsCommandOutput = {
@@ -3874,7 +3874,7 @@ export const deserializeAws_restJson1ListGraphqlApisCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGraphqlApisCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGraphqlApisCommandError(output, context);
   }
   const contents: ListGraphqlApisCommandOutput = {
@@ -3949,7 +3949,7 @@ export const deserializeAws_restJson1ListResolversCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResolversCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListResolversCommandError(output, context);
   }
   const contents: ListResolversCommandOutput = {
@@ -4032,7 +4032,7 @@ export const deserializeAws_restJson1ListResolversByFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResolversByFunctionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListResolversByFunctionCommandError(output, context);
   }
   const contents: ListResolversByFunctionCommandOutput = {
@@ -4115,7 +4115,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -4210,7 +4210,7 @@ export const deserializeAws_restJson1ListTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTypesCommandError(output, context);
   }
   const contents: ListTypesCommandOutput = {
@@ -4301,7 +4301,7 @@ export const deserializeAws_restJson1StartSchemaCreationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSchemaCreationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartSchemaCreationCommandError(output, context);
   }
   const contents: StartSchemaCreationCommandOutput = {
@@ -4388,7 +4388,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -4479,7 +4479,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -4570,7 +4570,7 @@ export const deserializeAws_restJson1UpdateApiCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApiCacheCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApiCacheCommandError(output, context);
   }
   const contents: UpdateApiCacheCommandOutput = {
@@ -4657,7 +4657,7 @@ export const deserializeAws_restJson1UpdateApiKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApiKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApiKeyCommandError(output, context);
   }
   const contents: UpdateApiKeyCommandOutput = {
@@ -4752,7 +4752,7 @@ export const deserializeAws_restJson1UpdateDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDataSourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDataSourceCommandError(output, context);
   }
   const contents: UpdateDataSourceCommandOutput = {
@@ -4839,7 +4839,7 @@ export const deserializeAws_restJson1UpdateFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFunctionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFunctionCommandError(output, context);
   }
   const contents: UpdateFunctionCommandOutput = {
@@ -4918,7 +4918,7 @@ export const deserializeAws_restJson1UpdateGraphqlApiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGraphqlApiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGraphqlApiCommandError(output, context);
   }
   const contents: UpdateGraphqlApiCommandOutput = {
@@ -5013,7 +5013,7 @@ export const deserializeAws_restJson1UpdateResolverCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateResolverCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateResolverCommandError(output, context);
   }
   const contents: UpdateResolverCommandOutput = {
@@ -5092,7 +5092,7 @@ export const deserializeAws_restJson1UpdateTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateTypeCommandError(output, context);
   }
   const contents: UpdateTypeCommandOutput = {

--- a/clients/client-athena/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/protocols/Aws_json1_1.ts
@@ -505,7 +505,7 @@ export const deserializeAws_json1_1BatchGetNamedQueryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetNamedQueryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetNamedQueryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -568,7 +568,7 @@ export const deserializeAws_json1_1BatchGetQueryExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetQueryExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetQueryExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -631,7 +631,7 @@ export const deserializeAws_json1_1CreateDataCatalogCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataCatalogCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDataCatalogCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -694,7 +694,7 @@ export const deserializeAws_json1_1CreateNamedQueryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNamedQueryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateNamedQueryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -757,7 +757,7 @@ export const deserializeAws_json1_1CreateWorkGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWorkGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWorkGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -820,7 +820,7 @@ export const deserializeAws_json1_1DeleteDataCatalogCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDataCatalogCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDataCatalogCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -883,7 +883,7 @@ export const deserializeAws_json1_1DeleteNamedQueryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNamedQueryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteNamedQueryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -946,7 +946,7 @@ export const deserializeAws_json1_1DeleteWorkGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWorkGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWorkGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1009,7 +1009,7 @@ export const deserializeAws_json1_1GetDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1080,7 +1080,7 @@ export const deserializeAws_json1_1GetDataCatalogCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDataCatalogCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDataCatalogCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1143,7 +1143,7 @@ export const deserializeAws_json1_1GetNamedQueryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetNamedQueryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetNamedQueryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1206,7 +1206,7 @@ export const deserializeAws_json1_1GetQueryExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetQueryExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetQueryExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1269,7 +1269,7 @@ export const deserializeAws_json1_1GetQueryResultsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetQueryResultsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetQueryResultsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1332,7 +1332,7 @@ export const deserializeAws_json1_1GetTableMetadataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTableMetadataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTableMetadataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1403,7 +1403,7 @@ export const deserializeAws_json1_1GetWorkGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWorkGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetWorkGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1466,7 +1466,7 @@ export const deserializeAws_json1_1ListDatabasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatabasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDatabasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1537,7 +1537,7 @@ export const deserializeAws_json1_1ListDataCatalogsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDataCatalogsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDataCatalogsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1600,7 +1600,7 @@ export const deserializeAws_json1_1ListNamedQueriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNamedQueriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListNamedQueriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1663,7 +1663,7 @@ export const deserializeAws_json1_1ListQueryExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListQueryExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListQueryExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1726,7 +1726,7 @@ export const deserializeAws_json1_1ListTableMetadataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTableMetadataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTableMetadataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1797,7 +1797,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1868,7 +1868,7 @@ export const deserializeAws_json1_1ListWorkGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWorkGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListWorkGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1931,7 +1931,7 @@ export const deserializeAws_json1_1StartQueryExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartQueryExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartQueryExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2002,7 +2002,7 @@ export const deserializeAws_json1_1StopQueryExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopQueryExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopQueryExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2065,7 +2065,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2136,7 +2136,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2207,7 +2207,7 @@ export const deserializeAws_json1_1UpdateDataCatalogCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDataCatalogCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDataCatalogCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2270,7 +2270,7 @@ export const deserializeAws_json1_1UpdateWorkGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateWorkGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateWorkGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
+++ b/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
@@ -138,7 +138,7 @@ export const deserializeAws_json1_1CreateScalingPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateScalingPlanCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateScalingPlanCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -217,7 +217,7 @@ export const deserializeAws_json1_1DeleteScalingPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteScalingPlanCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteScalingPlanCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -296,7 +296,7 @@ export const deserializeAws_json1_1DescribeScalingPlanResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScalingPlanResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeScalingPlanResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -375,7 +375,7 @@ export const deserializeAws_json1_1DescribeScalingPlansCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScalingPlansCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeScalingPlansCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -454,7 +454,7 @@ export const deserializeAws_json1_1GetScalingPlanResourceForecastDataCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetScalingPlanResourceForecastDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetScalingPlanResourceForecastDataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -517,7 +517,7 @@ export const deserializeAws_json1_1UpdateScalingPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateScalingPlanCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateScalingPlanCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-auto-scaling/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/protocols/Aws_query.ts
@@ -1233,7 +1233,7 @@ export const deserializeAws_queryAttachInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAttachInstancesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1292,7 +1292,7 @@ export const deserializeAws_queryAttachLoadBalancersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachLoadBalancersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAttachLoadBalancersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1354,7 +1354,7 @@ export const deserializeAws_queryAttachLoadBalancerTargetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachLoadBalancerTargetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAttachLoadBalancerTargetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1419,7 +1419,7 @@ export const deserializeAws_queryBatchDeleteScheduledActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeleteScheduledActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryBatchDeleteScheduledActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1473,7 +1473,7 @@ export const deserializeAws_queryBatchPutScheduledUpdateGroupActionCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchPutScheduledUpdateGroupActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryBatchPutScheduledUpdateGroupActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1546,7 +1546,7 @@ export const deserializeAws_queryCancelInstanceRefreshCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelInstanceRefreshCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCancelInstanceRefreshCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1616,7 +1616,7 @@ export const deserializeAws_queryCompleteLifecycleActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CompleteLifecycleActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCompleteLifecycleActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1670,7 +1670,7 @@ export const deserializeAws_queryCreateAutoScalingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAutoScalingGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateAutoScalingGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1745,7 +1745,7 @@ export const deserializeAws_queryCreateLaunchConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLaunchConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateLaunchConfigurationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1812,7 +1812,7 @@ export const deserializeAws_queryCreateOrUpdateTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOrUpdateTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateOrUpdateTagsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1887,7 +1887,7 @@ export const deserializeAws_queryDeleteAutoScalingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAutoScalingGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteAutoScalingGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1954,7 +1954,7 @@ export const deserializeAws_queryDeleteLaunchConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLaunchConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteLaunchConfigurationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2013,7 +2013,7 @@ export const deserializeAws_queryDeleteLifecycleHookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLifecycleHookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteLifecycleHookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2067,7 +2067,7 @@ export const deserializeAws_queryDeleteNotificationConfigurationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNotificationConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteNotificationConfigurationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2118,7 +2118,7 @@ export const deserializeAws_queryDeletePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeletePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2177,7 +2177,7 @@ export const deserializeAws_queryDeleteScheduledActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteScheduledActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteScheduledActionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2228,7 +2228,7 @@ export const deserializeAws_queryDeleteTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteTagsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2287,7 +2287,7 @@ export const deserializeAws_queryDescribeAccountLimitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountLimitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAccountLimitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2341,7 +2341,7 @@ export const deserializeAws_queryDescribeAdjustmentTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAdjustmentTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAdjustmentTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2395,7 +2395,7 @@ export const deserializeAws_queryDescribeAutoScalingGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAutoScalingGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAutoScalingGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2457,7 +2457,7 @@ export const deserializeAws_queryDescribeAutoScalingInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAutoScalingInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAutoScalingInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2519,7 +2519,7 @@ export const deserializeAws_queryDescribeAutoScalingNotificationTypesCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAutoScalingNotificationTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAutoScalingNotificationTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2576,7 +2576,7 @@ export const deserializeAws_queryDescribeInstanceRefreshesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstanceRefreshesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeInstanceRefreshesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2638,7 +2638,7 @@ export const deserializeAws_queryDescribeLaunchConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLaunchConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLaunchConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2700,7 +2700,7 @@ export const deserializeAws_queryDescribeLifecycleHooksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLifecycleHooksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLifecycleHooksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2754,7 +2754,7 @@ export const deserializeAws_queryDescribeLifecycleHookTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLifecycleHookTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLifecycleHookTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2808,7 +2808,7 @@ export const deserializeAws_queryDescribeLoadBalancersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoadBalancersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLoadBalancersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2862,7 +2862,7 @@ export const deserializeAws_queryDescribeLoadBalancerTargetGroupsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoadBalancerTargetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLoadBalancerTargetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2919,7 +2919,7 @@ export const deserializeAws_queryDescribeMetricCollectionTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMetricCollectionTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeMetricCollectionTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2973,7 +2973,7 @@ export const deserializeAws_queryDescribeNotificationConfigurationsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNotificationConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeNotificationConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3038,7 +3038,7 @@ export const deserializeAws_queryDescribePoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribePoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3108,7 +3108,7 @@ export const deserializeAws_queryDescribeScalingActivitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScalingActivitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeScalingActivitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3170,7 +3170,7 @@ export const deserializeAws_queryDescribeScalingProcessTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScalingProcessTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeScalingProcessTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3224,7 +3224,7 @@ export const deserializeAws_queryDescribeScheduledActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScheduledActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeScheduledActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3286,7 +3286,7 @@ export const deserializeAws_queryDescribeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3348,7 +3348,7 @@ export const deserializeAws_queryDescribeTerminationPolicyTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTerminationPolicyTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTerminationPolicyTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3405,7 +3405,7 @@ export const deserializeAws_queryDetachInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDetachInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3459,7 +3459,7 @@ export const deserializeAws_queryDetachLoadBalancersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachLoadBalancersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDetachLoadBalancersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3513,7 +3513,7 @@ export const deserializeAws_queryDetachLoadBalancerTargetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachLoadBalancerTargetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDetachLoadBalancerTargetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3570,7 +3570,7 @@ export const deserializeAws_queryDisableMetricsCollectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableMetricsCollectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDisableMetricsCollectionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3621,7 +3621,7 @@ export const deserializeAws_queryEnableMetricsCollectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableMetricsCollectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryEnableMetricsCollectionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3672,7 +3672,7 @@ export const deserializeAws_queryEnterStandbyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnterStandbyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryEnterStandbyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3726,7 +3726,7 @@ export const deserializeAws_queryExecutePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExecutePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryExecutePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3785,7 +3785,7 @@ export const deserializeAws_queryExitStandbyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExitStandbyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryExitStandbyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3839,7 +3839,7 @@ export const deserializeAws_queryPutLifecycleHookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLifecycleHookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutLifecycleHookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3901,7 +3901,7 @@ export const deserializeAws_queryPutNotificationConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutNotificationConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutNotificationConfigurationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3968,7 +3968,7 @@ export const deserializeAws_queryPutScalingPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutScalingPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutScalingPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4038,7 +4038,7 @@ export const deserializeAws_queryPutScheduledUpdateGroupActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutScheduledUpdateGroupActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutScheduledUpdateGroupActionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4105,7 +4105,7 @@ export const deserializeAws_queryRecordLifecycleActionHeartbeatCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RecordLifecycleActionHeartbeatCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRecordLifecycleActionHeartbeatCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4162,7 +4162,7 @@ export const deserializeAws_queryResumeProcessesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResumeProcessesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResumeProcessesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4221,7 +4221,7 @@ export const deserializeAws_querySetDesiredCapacityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetDesiredCapacityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetDesiredCapacityCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4280,7 +4280,7 @@ export const deserializeAws_querySetInstanceHealthCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetInstanceHealthCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetInstanceHealthCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4331,7 +4331,7 @@ export const deserializeAws_querySetInstanceProtectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetInstanceProtectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetInstanceProtectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4393,7 +4393,7 @@ export const deserializeAws_queryStartInstanceRefreshCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartInstanceRefreshCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStartInstanceRefreshCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4463,7 +4463,7 @@ export const deserializeAws_querySuspendProcessesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SuspendProcessesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySuspendProcessesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4522,7 +4522,7 @@ export const deserializeAws_queryTerminateInstanceInAutoScalingGroupCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateInstanceInAutoScalingGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryTerminateInstanceInAutoScalingGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4584,7 +4584,7 @@ export const deserializeAws_queryUpdateAutoScalingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAutoScalingGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateAutoScalingGroupCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-backup/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1.ts
@@ -1721,7 +1721,7 @@ export const deserializeAws_restJson1CreateBackupPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBackupPlanCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateBackupPlanCommandError(output, context);
   }
   const contents: CreateBackupPlanCommandOutput = {
@@ -1820,7 +1820,7 @@ export const deserializeAws_restJson1CreateBackupSelectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBackupSelectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateBackupSelectionCommandError(output, context);
   }
   const contents: CreateBackupSelectionCommandOutput = {
@@ -1915,7 +1915,7 @@ export const deserializeAws_restJson1CreateBackupVaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBackupVaultCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateBackupVaultCommandError(output, context);
   }
   const contents: CreateBackupVaultCommandOutput = {
@@ -2010,7 +2010,7 @@ export const deserializeAws_restJson1DeleteBackupPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBackupPlanCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBackupPlanCommandError(output, context);
   }
   const contents: DeleteBackupPlanCommandOutput = {
@@ -2109,7 +2109,7 @@ export const deserializeAws_restJson1DeleteBackupSelectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBackupSelectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBackupSelectionCommandError(output, context);
   }
   const contents: DeleteBackupSelectionCommandOutput = {
@@ -2184,7 +2184,7 @@ export const deserializeAws_restJson1DeleteBackupVaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBackupVaultCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBackupVaultCommandError(output, context);
   }
   const contents: DeleteBackupVaultCommandOutput = {
@@ -2267,7 +2267,7 @@ export const deserializeAws_restJson1DeleteBackupVaultAccessPolicyCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBackupVaultAccessPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBackupVaultAccessPolicyCommandError(output, context);
   }
   const contents: DeleteBackupVaultAccessPolicyCommandOutput = {
@@ -2342,7 +2342,7 @@ export const deserializeAws_restJson1DeleteBackupVaultNotificationsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBackupVaultNotificationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBackupVaultNotificationsCommandError(output, context);
   }
   const contents: DeleteBackupVaultNotificationsCommandOutput = {
@@ -2417,7 +2417,7 @@ export const deserializeAws_restJson1DeleteRecoveryPointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRecoveryPointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRecoveryPointCommandError(output, context);
   }
   const contents: DeleteRecoveryPointCommandOutput = {
@@ -2500,7 +2500,7 @@ export const deserializeAws_restJson1DescribeBackupJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBackupJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeBackupJobCommandError(output, context);
   }
   const contents: DescribeBackupJobCommandOutput = {
@@ -2655,7 +2655,7 @@ export const deserializeAws_restJson1DescribeBackupVaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBackupVaultCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeBackupVaultCommandError(output, context);
   }
   const contents: DescribeBackupVaultCommandOutput = {
@@ -2754,7 +2754,7 @@ export const deserializeAws_restJson1DescribeCopyJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCopyJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeCopyJobCommandError(output, context);
   }
   const contents: DescribeCopyJobCommandOutput = {
@@ -2833,7 +2833,7 @@ export const deserializeAws_restJson1DescribeProtectedResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProtectedResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeProtectedResourceCommandError(output, context);
   }
   const contents: DescribeProtectedResourceCommandOutput = {
@@ -2920,7 +2920,7 @@ export const deserializeAws_restJson1DescribeRecoveryPointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRecoveryPointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRecoveryPointCommandError(output, context);
   }
   const contents: DescribeRecoveryPointCommandOutput = {
@@ -3063,7 +3063,7 @@ export const deserializeAws_restJson1DescribeRegionSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRegionSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRegionSettingsCommandError(output, context);
   }
   const contents: DescribeRegionSettingsCommandOutput = {
@@ -3121,7 +3121,7 @@ export const deserializeAws_restJson1DescribeRestoreJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRestoreJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRestoreJobCommandError(output, context);
   }
   const contents: DescribeRestoreJobCommandOutput = {
@@ -3256,7 +3256,7 @@ export const deserializeAws_restJson1ExportBackupPlanTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportBackupPlanTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ExportBackupPlanTemplateCommandError(output, context);
   }
   const contents: ExportBackupPlanTemplateCommandOutput = {
@@ -3335,7 +3335,7 @@ export const deserializeAws_restJson1GetBackupPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBackupPlanCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBackupPlanCommandError(output, context);
   }
   const contents: GetBackupPlanCommandOutput = {
@@ -3442,7 +3442,7 @@ export const deserializeAws_restJson1GetBackupPlanFromJSONCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBackupPlanFromJSONCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBackupPlanFromJSONCommandError(output, context);
   }
   const contents: GetBackupPlanFromJSONCommandOutput = {
@@ -3529,7 +3529,7 @@ export const deserializeAws_restJson1GetBackupPlanFromTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBackupPlanFromTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBackupPlanFromTemplateCommandError(output, context);
   }
   const contents: GetBackupPlanFromTemplateCommandOutput = {
@@ -3608,7 +3608,7 @@ export const deserializeAws_restJson1GetBackupSelectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBackupSelectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBackupSelectionCommandError(output, context);
   }
   const contents: GetBackupSelectionCommandOutput = {
@@ -3703,7 +3703,7 @@ export const deserializeAws_restJson1GetBackupVaultAccessPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBackupVaultAccessPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBackupVaultAccessPolicyCommandError(output, context);
   }
   const contents: GetBackupVaultAccessPolicyCommandOutput = {
@@ -3790,7 +3790,7 @@ export const deserializeAws_restJson1GetBackupVaultNotificationsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBackupVaultNotificationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBackupVaultNotificationsCommandError(output, context);
   }
   const contents: GetBackupVaultNotificationsCommandOutput = {
@@ -3881,7 +3881,7 @@ export const deserializeAws_restJson1GetRecoveryPointRestoreMetadataCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRecoveryPointRestoreMetadataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRecoveryPointRestoreMetadataCommandError(output, context);
   }
   const contents: GetRecoveryPointRestoreMetadataCommandOutput = {
@@ -3968,7 +3968,7 @@ export const deserializeAws_restJson1GetSupportedResourceTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSupportedResourceTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSupportedResourceTypesCommandError(output, context);
   }
   const contents: GetSupportedResourceTypesCommandOutput = {
@@ -4023,7 +4023,7 @@ export const deserializeAws_restJson1ListBackupJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBackupJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBackupJobsCommandError(output, context);
   }
   const contents: ListBackupJobsCommandOutput = {
@@ -4090,7 +4090,7 @@ export const deserializeAws_restJson1ListBackupPlansCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBackupPlansCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBackupPlansCommandError(output, context);
   }
   const contents: ListBackupPlansCommandOutput = {
@@ -4173,7 +4173,7 @@ export const deserializeAws_restJson1ListBackupPlanTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBackupPlanTemplatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBackupPlanTemplatesCommandError(output, context);
   }
   const contents: ListBackupPlanTemplatesCommandOutput = {
@@ -4259,7 +4259,7 @@ export const deserializeAws_restJson1ListBackupPlanVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBackupPlanVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBackupPlanVersionsCommandError(output, context);
   }
   const contents: ListBackupPlanVersionsCommandOutput = {
@@ -4345,7 +4345,7 @@ export const deserializeAws_restJson1ListBackupSelectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBackupSelectionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBackupSelectionsCommandError(output, context);
   }
   const contents: ListBackupSelectionsCommandOutput = {
@@ -4428,7 +4428,7 @@ export const deserializeAws_restJson1ListBackupVaultsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBackupVaultsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBackupVaultsCommandError(output, context);
   }
   const contents: ListBackupVaultsCommandOutput = {
@@ -4511,7 +4511,7 @@ export const deserializeAws_restJson1ListCopyJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCopyJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListCopyJobsCommandError(output, context);
   }
   const contents: ListCopyJobsCommandOutput = {
@@ -4578,7 +4578,7 @@ export const deserializeAws_restJson1ListProtectedResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProtectedResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProtectedResourcesCommandError(output, context);
   }
   const contents: ListProtectedResourcesCommandOutput = {
@@ -4645,7 +4645,7 @@ export const deserializeAws_restJson1ListRecoveryPointsByBackupVaultCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRecoveryPointsByBackupVaultCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRecoveryPointsByBackupVaultCommandError(output, context);
   }
   const contents: ListRecoveryPointsByBackupVaultCommandOutput = {
@@ -4728,7 +4728,7 @@ export const deserializeAws_restJson1ListRecoveryPointsByResourceCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRecoveryPointsByResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRecoveryPointsByResourceCommandError(output, context);
   }
   const contents: ListRecoveryPointsByResourceCommandOutput = {
@@ -4811,7 +4811,7 @@ export const deserializeAws_restJson1ListRestoreJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRestoreJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRestoreJobsCommandError(output, context);
   }
   const contents: ListRestoreJobsCommandOutput = {
@@ -4894,7 +4894,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsCommandError(output, context);
   }
   const contents: ListTagsCommandOutput = {
@@ -4977,7 +4977,7 @@ export const deserializeAws_restJson1PutBackupVaultAccessPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBackupVaultAccessPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutBackupVaultAccessPolicyCommandError(output, context);
   }
   const contents: PutBackupVaultAccessPolicyCommandOutput = {
@@ -5052,7 +5052,7 @@ export const deserializeAws_restJson1PutBackupVaultNotificationsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBackupVaultNotificationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutBackupVaultNotificationsCommandError(output, context);
   }
   const contents: PutBackupVaultNotificationsCommandOutput = {
@@ -5127,7 +5127,7 @@ export const deserializeAws_restJson1StartBackupJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartBackupJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartBackupJobCommandError(output, context);
   }
   const contents: StartBackupJobCommandOutput = {
@@ -5222,7 +5222,7 @@ export const deserializeAws_restJson1StartCopyJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartCopyJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartCopyJobCommandError(output, context);
   }
   const contents: StartCopyJobCommandOutput = {
@@ -5313,7 +5313,7 @@ export const deserializeAws_restJson1StartRestoreJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartRestoreJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartRestoreJobCommandError(output, context);
   }
   const contents: StartRestoreJobCommandOutput = {
@@ -5392,7 +5392,7 @@ export const deserializeAws_restJson1StopBackupJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopBackupJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopBackupJobCommandError(output, context);
   }
   const contents: StopBackupJobCommandOutput = {
@@ -5475,7 +5475,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -5558,7 +5558,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -5633,7 +5633,7 @@ export const deserializeAws_restJson1UpdateBackupPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBackupPlanCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateBackupPlanCommandError(output, context);
   }
   const contents: UpdateBackupPlanCommandOutput = {
@@ -5724,7 +5724,7 @@ export const deserializeAws_restJson1UpdateRecoveryPointLifecycleCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRecoveryPointLifecycleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRecoveryPointLifecycleCommandError(output, context);
   }
   const contents: UpdateRecoveryPointLifecycleCommandOutput = {
@@ -5815,7 +5815,7 @@ export const deserializeAws_restJson1UpdateRegionSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRegionSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRegionSettingsCommandError(output, context);
   }
   const contents: UpdateRegionSettingsCommandOutput = {

--- a/clients/client-batch/protocols/Aws_restJson1.ts
+++ b/clients/client-batch/protocols/Aws_restJson1.ts
@@ -548,7 +548,7 @@ export const deserializeAws_restJson1CancelJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelJobCommandError(output, context);
   }
   const contents: CancelJobCommandOutput = {
@@ -607,7 +607,7 @@ export const deserializeAws_restJson1CreateComputeEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateComputeEnvironmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateComputeEnvironmentCommandError(output, context);
   }
   const contents: CreateComputeEnvironmentCommandOutput = {
@@ -674,7 +674,7 @@ export const deserializeAws_restJson1CreateJobQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateJobQueueCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateJobQueueCommandError(output, context);
   }
   const contents: CreateJobQueueCommandOutput = {
@@ -741,7 +741,7 @@ export const deserializeAws_restJson1DeleteComputeEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteComputeEnvironmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteComputeEnvironmentCommandError(output, context);
   }
   const contents: DeleteComputeEnvironmentCommandOutput = {
@@ -800,7 +800,7 @@ export const deserializeAws_restJson1DeleteJobQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteJobQueueCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteJobQueueCommandError(output, context);
   }
   const contents: DeleteJobQueueCommandOutput = {
@@ -859,7 +859,7 @@ export const deserializeAws_restJson1DeregisterJobDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterJobDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeregisterJobDefinitionCommandError(output, context);
   }
   const contents: DeregisterJobDefinitionCommandOutput = {
@@ -918,7 +918,7 @@ export const deserializeAws_restJson1DescribeComputeEnvironmentsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeComputeEnvironmentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeComputeEnvironmentsCommandError(output, context);
   }
   const contents: DescribeComputeEnvironmentsCommandOutput = {
@@ -988,7 +988,7 @@ export const deserializeAws_restJson1DescribeJobDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJobDefinitionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeJobDefinitionsCommandError(output, context);
   }
   const contents: DescribeJobDefinitionsCommandOutput = {
@@ -1055,7 +1055,7 @@ export const deserializeAws_restJson1DescribeJobQueuesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJobQueuesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeJobQueuesCommandError(output, context);
   }
   const contents: DescribeJobQueuesCommandOutput = {
@@ -1122,7 +1122,7 @@ export const deserializeAws_restJson1DescribeJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeJobsCommandError(output, context);
   }
   const contents: DescribeJobsCommandOutput = {
@@ -1185,7 +1185,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobsCommandError(output, context);
   }
   const contents: ListJobsCommandOutput = {
@@ -1252,7 +1252,7 @@ export const deserializeAws_restJson1RegisterJobDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterJobDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegisterJobDefinitionCommandError(output, context);
   }
   const contents: RegisterJobDefinitionCommandOutput = {
@@ -1323,7 +1323,7 @@ export const deserializeAws_restJson1SubmitJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SubmitJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SubmitJobCommandError(output, context);
   }
   const contents: SubmitJobCommandOutput = {
@@ -1390,7 +1390,7 @@ export const deserializeAws_restJson1TerminateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TerminateJobCommandError(output, context);
   }
   const contents: TerminateJobCommandOutput = {
@@ -1449,7 +1449,7 @@ export const deserializeAws_restJson1UpdateComputeEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateComputeEnvironmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateComputeEnvironmentCommandError(output, context);
   }
   const contents: UpdateComputeEnvironmentCommandOutput = {
@@ -1516,7 +1516,7 @@ export const deserializeAws_restJson1UpdateJobQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateJobQueueCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateJobQueueCommandError(output, context);
   }
   const contents: UpdateJobQueueCommandOutput = {

--- a/clients/client-braket/protocols/Aws_restJson1.ts
+++ b/clients/client-braket/protocols/Aws_restJson1.ts
@@ -217,7 +217,7 @@ export const deserializeAws_restJson1CancelQuantumTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelQuantumTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelQuantumTaskCommandError(output, context);
   }
   const contents: CancelQuantumTaskCommandOutput = {
@@ -316,7 +316,7 @@ export const deserializeAws_restJson1CreateQuantumTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateQuantumTaskCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateQuantumTaskCommandError(output, context);
   }
   const contents: CreateQuantumTaskCommandOutput = {
@@ -411,7 +411,7 @@ export const deserializeAws_restJson1GetDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeviceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeviceCommandError(output, context);
   }
   const contents: GetDeviceCommandOutput = {
@@ -518,7 +518,7 @@ export const deserializeAws_restJson1GetQuantumTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetQuantumTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetQuantumTaskCommandError(output, context);
   }
   const contents: GetQuantumTaskCommandOutput = {
@@ -641,7 +641,7 @@ export const deserializeAws_restJson1SearchDevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchDevicesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SearchDevicesCommandError(output, context);
   }
   const contents: SearchDevicesCommandOutput = {
@@ -724,7 +724,7 @@ export const deserializeAws_restJson1SearchQuantumTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchQuantumTasksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SearchQuantumTasksCommandError(output, context);
   }
   const contents: SearchQuantumTasksCommandOutput = {

--- a/clients/client-budgets/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/protocols/Aws_json1_1.ts
@@ -265,7 +265,7 @@ export const deserializeAws_json1_1CreateBudgetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBudgetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateBudgetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -352,7 +352,7 @@ export const deserializeAws_json1_1CreateNotificationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNotificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateNotificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -447,7 +447,7 @@ export const deserializeAws_json1_1CreateSubscriberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSubscriberCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSubscriberCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -542,7 +542,7 @@ export const deserializeAws_json1_1DeleteBudgetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBudgetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBudgetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -621,7 +621,7 @@ export const deserializeAws_json1_1DeleteNotificationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNotificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteNotificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -700,7 +700,7 @@ export const deserializeAws_json1_1DeleteSubscriberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSubscriberCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSubscriberCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -779,7 +779,7 @@ export const deserializeAws_json1_1DescribeBudgetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBudgetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeBudgetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -858,7 +858,7 @@ export const deserializeAws_json1_1DescribeBudgetPerformanceHistoryCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBudgetPerformanceHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeBudgetPerformanceHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -953,7 +953,7 @@ export const deserializeAws_json1_1DescribeBudgetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBudgetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeBudgetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1048,7 +1048,7 @@ export const deserializeAws_json1_1DescribeNotificationsForBudgetCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNotificationsForBudgetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeNotificationsForBudgetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1143,7 +1143,7 @@ export const deserializeAws_json1_1DescribeSubscribersForNotificationCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSubscribersForNotificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSubscribersForNotificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1238,7 +1238,7 @@ export const deserializeAws_json1_1UpdateBudgetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBudgetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateBudgetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1317,7 +1317,7 @@ export const deserializeAws_json1_1UpdateNotificationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNotificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateNotificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1404,7 +1404,7 @@ export const deserializeAws_json1_1UpdateSubscriberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSubscriberCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSubscriberCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-chime/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1.ts
@@ -4597,7 +4597,7 @@ export const deserializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociatePhoneNumbersWithVoiceConnectorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorCommandError(output, context);
   }
   const contents: AssociatePhoneNumbersWithVoiceConnectorCommandOutput = {
@@ -4708,7 +4708,7 @@ export const deserializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorGrou
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociatePhoneNumbersWithVoiceConnectorGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociatePhoneNumbersWithVoiceConnectorGroupCommandError(output, context);
   }
   const contents: AssociatePhoneNumbersWithVoiceConnectorGroupCommandOutput = {
@@ -4819,7 +4819,7 @@ export const deserializeAws_restJson1AssociatePhoneNumberWithUserCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociatePhoneNumberWithUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociatePhoneNumberWithUserCommandError(output, context);
   }
   const contents: AssociatePhoneNumberWithUserCommandOutput = {
@@ -4926,7 +4926,7 @@ export const deserializeAws_restJson1AssociateSigninDelegateGroupsWithAccountCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateSigninDelegateGroupsWithAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateSigninDelegateGroupsWithAccountCommandError(output, context);
   }
   const contents: AssociateSigninDelegateGroupsWithAccountCommandOutput = {
@@ -5025,7 +5025,7 @@ export const deserializeAws_restJson1BatchCreateAttendeeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchCreateAttendeeCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchCreateAttendeeCommandError(output, context);
   }
   const contents: BatchCreateAttendeeCommandOutput = {
@@ -5140,7 +5140,7 @@ export const deserializeAws_restJson1BatchCreateRoomMembershipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchCreateRoomMembershipCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchCreateRoomMembershipCommandError(output, context);
   }
   const contents: BatchCreateRoomMembershipCommandOutput = {
@@ -5243,7 +5243,7 @@ export const deserializeAws_restJson1BatchDeletePhoneNumberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeletePhoneNumberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchDeletePhoneNumberCommandError(output, context);
   }
   const contents: BatchDeletePhoneNumberCommandOutput = {
@@ -5346,7 +5346,7 @@ export const deserializeAws_restJson1BatchSuspendUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchSuspendUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchSuspendUserCommandError(output, context);
   }
   const contents: BatchSuspendUserCommandOutput = {
@@ -5449,7 +5449,7 @@ export const deserializeAws_restJson1BatchUnsuspendUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchUnsuspendUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchUnsuspendUserCommandError(output, context);
   }
   const contents: BatchUnsuspendUserCommandOutput = {
@@ -5552,7 +5552,7 @@ export const deserializeAws_restJson1BatchUpdatePhoneNumberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchUpdatePhoneNumberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchUpdatePhoneNumberCommandError(output, context);
   }
   const contents: BatchUpdatePhoneNumberCommandOutput = {
@@ -5655,7 +5655,7 @@ export const deserializeAws_restJson1BatchUpdateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchUpdateUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchUpdateUserCommandError(output, context);
   }
   const contents: BatchUpdateUserCommandOutput = {
@@ -5758,7 +5758,7 @@ export const deserializeAws_restJson1CreateAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAccountCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAccountCommandError(output, context);
   }
   const contents: CreateAccountCommandOutput = {
@@ -5861,7 +5861,7 @@ export const deserializeAws_restJson1CreateAttendeeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAttendeeCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAttendeeCommandError(output, context);
   }
   const contents: CreateAttendeeCommandOutput = {
@@ -5972,7 +5972,7 @@ export const deserializeAws_restJson1CreateBotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBotCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateBotCommandError(output, context);
   }
   const contents: CreateBotCommandOutput = {
@@ -6083,7 +6083,7 @@ export const deserializeAws_restJson1CreateMeetingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMeetingCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMeetingCommandError(output, context);
   }
   const contents: CreateMeetingCommandOutput = {
@@ -6186,7 +6186,7 @@ export const deserializeAws_restJson1CreateMeetingWithAttendeesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMeetingWithAttendeesCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMeetingWithAttendeesCommandError(output, context);
   }
   const contents: CreateMeetingWithAttendeesCommandOutput = {
@@ -6297,7 +6297,7 @@ export const deserializeAws_restJson1CreatePhoneNumberOrderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePhoneNumberOrderCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePhoneNumberOrderCommandError(output, context);
   }
   const contents: CreatePhoneNumberOrderCommandOutput = {
@@ -6408,7 +6408,7 @@ export const deserializeAws_restJson1CreateProxySessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProxySessionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateProxySessionCommandError(output, context);
   }
   const contents: CreateProxySessionCommandOutput = {
@@ -6511,7 +6511,7 @@ export const deserializeAws_restJson1CreateRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRoomCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRoomCommandError(output, context);
   }
   const contents: CreateRoomCommandOutput = {
@@ -6622,7 +6622,7 @@ export const deserializeAws_restJson1CreateRoomMembershipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRoomMembershipCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRoomMembershipCommandError(output, context);
   }
   const contents: CreateRoomMembershipCommandOutput = {
@@ -6741,7 +6741,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateUserCommandError(output, context);
   }
   const contents: CreateUserCommandOutput = {
@@ -6852,7 +6852,7 @@ export const deserializeAws_restJson1CreateVoiceConnectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVoiceConnectorCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateVoiceConnectorCommandError(output, context);
   }
   const contents: CreateVoiceConnectorCommandOutput = {
@@ -6963,7 +6963,7 @@ export const deserializeAws_restJson1CreateVoiceConnectorGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVoiceConnectorGroupCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateVoiceConnectorGroupCommandError(output, context);
   }
   const contents: CreateVoiceConnectorGroupCommandOutput = {
@@ -7074,7 +7074,7 @@ export const deserializeAws_restJson1DeleteAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccountCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAccountCommandError(output, context);
   }
   const contents: DeleteAccountCommandOutput = {
@@ -7181,7 +7181,7 @@ export const deserializeAws_restJson1DeleteAttendeeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAttendeeCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAttendeeCommandError(output, context);
   }
   const contents: DeleteAttendeeCommandOutput = {
@@ -7280,7 +7280,7 @@ export const deserializeAws_restJson1DeleteEventsConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventsConfigurationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEventsConfigurationCommandError(output, context);
   }
   const contents: DeleteEventsConfigurationCommandOutput = {
@@ -7371,7 +7371,7 @@ export const deserializeAws_restJson1DeleteMeetingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMeetingCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMeetingCommandError(output, context);
   }
   const contents: DeleteMeetingCommandOutput = {
@@ -7470,7 +7470,7 @@ export const deserializeAws_restJson1DeletePhoneNumberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePhoneNumberCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePhoneNumberCommandError(output, context);
   }
   const contents: DeletePhoneNumberCommandOutput = {
@@ -7569,7 +7569,7 @@ export const deserializeAws_restJson1DeleteProxySessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProxySessionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteProxySessionCommandError(output, context);
   }
   const contents: DeleteProxySessionCommandOutput = {
@@ -7668,7 +7668,7 @@ export const deserializeAws_restJson1DeleteRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRoomCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRoomCommandError(output, context);
   }
   const contents: DeleteRoomCommandOutput = {
@@ -7767,7 +7767,7 @@ export const deserializeAws_restJson1DeleteRoomMembershipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRoomMembershipCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRoomMembershipCommandError(output, context);
   }
   const contents: DeleteRoomMembershipCommandOutput = {
@@ -7866,7 +7866,7 @@ export const deserializeAws_restJson1DeleteVoiceConnectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVoiceConnectorCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVoiceConnectorCommandError(output, context);
   }
   const contents: DeleteVoiceConnectorCommandOutput = {
@@ -7973,7 +7973,7 @@ export const deserializeAws_restJson1DeleteVoiceConnectorEmergencyCallingConfigu
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVoiceConnectorEmergencyCallingConfigurationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVoiceConnectorEmergencyCallingConfigurationCommandError(output, context);
   }
   const contents: DeleteVoiceConnectorEmergencyCallingConfigurationCommandOutput = {
@@ -8072,7 +8072,7 @@ export const deserializeAws_restJson1DeleteVoiceConnectorGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVoiceConnectorGroupCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVoiceConnectorGroupCommandError(output, context);
   }
   const contents: DeleteVoiceConnectorGroupCommandOutput = {
@@ -8179,7 +8179,7 @@ export const deserializeAws_restJson1DeleteVoiceConnectorOriginationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVoiceConnectorOriginationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVoiceConnectorOriginationCommandError(output, context);
   }
   const contents: DeleteVoiceConnectorOriginationCommandOutput = {
@@ -8278,7 +8278,7 @@ export const deserializeAws_restJson1DeleteVoiceConnectorProxyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVoiceConnectorProxyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVoiceConnectorProxyCommandError(output, context);
   }
   const contents: DeleteVoiceConnectorProxyCommandOutput = {
@@ -8377,7 +8377,7 @@ export const deserializeAws_restJson1DeleteVoiceConnectorStreamingConfigurationC
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVoiceConnectorStreamingConfigurationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVoiceConnectorStreamingConfigurationCommandError(output, context);
   }
   const contents: DeleteVoiceConnectorStreamingConfigurationCommandOutput = {
@@ -8476,7 +8476,7 @@ export const deserializeAws_restJson1DeleteVoiceConnectorTerminationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVoiceConnectorTerminationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVoiceConnectorTerminationCommandError(output, context);
   }
   const contents: DeleteVoiceConnectorTerminationCommandOutput = {
@@ -8575,7 +8575,7 @@ export const deserializeAws_restJson1DeleteVoiceConnectorTerminationCredentialsC
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVoiceConnectorTerminationCredentialsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVoiceConnectorTerminationCredentialsCommandError(output, context);
   }
   const contents: DeleteVoiceConnectorTerminationCredentialsCommandOutput = {
@@ -8674,7 +8674,7 @@ export const deserializeAws_restJson1DisassociatePhoneNumberFromUserCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociatePhoneNumberFromUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociatePhoneNumberFromUserCommandError(output, context);
   }
   const contents: DisassociatePhoneNumberFromUserCommandOutput = {
@@ -8773,7 +8773,7 @@ export const deserializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorC
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociatePhoneNumbersFromVoiceConnectorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorCommandError(output, context);
   }
   const contents: DisassociatePhoneNumbersFromVoiceConnectorCommandOutput = {
@@ -8876,7 +8876,7 @@ export const deserializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorG
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociatePhoneNumbersFromVoiceConnectorGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociatePhoneNumbersFromVoiceConnectorGroupCommandError(output, context);
   }
   const contents: DisassociatePhoneNumbersFromVoiceConnectorGroupCommandOutput = {
@@ -8979,7 +8979,7 @@ export const deserializeAws_restJson1DisassociateSigninDelegateGroupsFromAccount
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateSigninDelegateGroupsFromAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateSigninDelegateGroupsFromAccountCommandError(output, context);
   }
   const contents: DisassociateSigninDelegateGroupsFromAccountCommandOutput = {
@@ -9078,7 +9078,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAccountCommandError(output, context);
   }
   const contents: GetAccountCommandOutput = {
@@ -9181,7 +9181,7 @@ export const deserializeAws_restJson1GetAccountSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAccountSettingsCommandError(output, context);
   }
   const contents: GetAccountSettingsCommandOutput = {
@@ -9284,7 +9284,7 @@ export const deserializeAws_restJson1GetAttendeeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAttendeeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAttendeeCommandError(output, context);
   }
   const contents: GetAttendeeCommandOutput = {
@@ -9387,7 +9387,7 @@ export const deserializeAws_restJson1GetBotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBotCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBotCommandError(output, context);
   }
   const contents: GetBotCommandOutput = {
@@ -9490,7 +9490,7 @@ export const deserializeAws_restJson1GetEventsConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEventsConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEventsConfigurationCommandError(output, context);
   }
   const contents: GetEventsConfigurationCommandOutput = {
@@ -9593,7 +9593,7 @@ export const deserializeAws_restJson1GetGlobalSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGlobalSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGlobalSettingsCommandError(output, context);
   }
   const contents: GetGlobalSettingsCommandOutput = {
@@ -9692,7 +9692,7 @@ export const deserializeAws_restJson1GetMeetingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMeetingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMeetingCommandError(output, context);
   }
   const contents: GetMeetingCommandOutput = {
@@ -9795,7 +9795,7 @@ export const deserializeAws_restJson1GetPhoneNumberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPhoneNumberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPhoneNumberCommandError(output, context);
   }
   const contents: GetPhoneNumberCommandOutput = {
@@ -9898,7 +9898,7 @@ export const deserializeAws_restJson1GetPhoneNumberOrderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPhoneNumberOrderCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPhoneNumberOrderCommandError(output, context);
   }
   const contents: GetPhoneNumberOrderCommandOutput = {
@@ -10001,7 +10001,7 @@ export const deserializeAws_restJson1GetPhoneNumberSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPhoneNumberSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPhoneNumberSettingsCommandError(output, context);
   }
   const contents: GetPhoneNumberSettingsCommandOutput = {
@@ -10100,7 +10100,7 @@ export const deserializeAws_restJson1GetProxySessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetProxySessionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetProxySessionCommandError(output, context);
   }
   const contents: GetProxySessionCommandOutput = {
@@ -10203,7 +10203,7 @@ export const deserializeAws_restJson1GetRetentionSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRetentionSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRetentionSettingsCommandError(output, context);
   }
   const contents: GetRetentionSettingsCommandOutput = {
@@ -10310,7 +10310,7 @@ export const deserializeAws_restJson1GetRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRoomCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRoomCommandError(output, context);
   }
   const contents: GetRoomCommandOutput = {
@@ -10413,7 +10413,7 @@ export const deserializeAws_restJson1GetUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUserCommandError(output, context);
   }
   const contents: GetUserCommandOutput = {
@@ -10516,7 +10516,7 @@ export const deserializeAws_restJson1GetUserSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUserSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUserSettingsCommandError(output, context);
   }
   const contents: GetUserSettingsCommandOutput = {
@@ -10619,7 +10619,7 @@ export const deserializeAws_restJson1GetVoiceConnectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceConnectorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceConnectorCommandError(output, context);
   }
   const contents: GetVoiceConnectorCommandOutput = {
@@ -10722,7 +10722,7 @@ export const deserializeAws_restJson1GetVoiceConnectorEmergencyCallingConfigurat
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceConnectorEmergencyCallingConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceConnectorEmergencyCallingConfigurationCommandError(output, context);
   }
   const contents: GetVoiceConnectorEmergencyCallingConfigurationCommandOutput = {
@@ -10828,7 +10828,7 @@ export const deserializeAws_restJson1GetVoiceConnectorGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceConnectorGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceConnectorGroupCommandError(output, context);
   }
   const contents: GetVoiceConnectorGroupCommandOutput = {
@@ -10931,7 +10931,7 @@ export const deserializeAws_restJson1GetVoiceConnectorLoggingConfigurationComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceConnectorLoggingConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceConnectorLoggingConfigurationCommandError(output, context);
   }
   const contents: GetVoiceConnectorLoggingConfigurationCommandOutput = {
@@ -11034,7 +11034,7 @@ export const deserializeAws_restJson1GetVoiceConnectorOriginationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceConnectorOriginationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceConnectorOriginationCommandError(output, context);
   }
   const contents: GetVoiceConnectorOriginationCommandOutput = {
@@ -11137,7 +11137,7 @@ export const deserializeAws_restJson1GetVoiceConnectorProxyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceConnectorProxyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceConnectorProxyCommandError(output, context);
   }
   const contents: GetVoiceConnectorProxyCommandOutput = {
@@ -11240,7 +11240,7 @@ export const deserializeAws_restJson1GetVoiceConnectorStreamingConfigurationComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceConnectorStreamingConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceConnectorStreamingConfigurationCommandError(output, context);
   }
   const contents: GetVoiceConnectorStreamingConfigurationCommandOutput = {
@@ -11346,7 +11346,7 @@ export const deserializeAws_restJson1GetVoiceConnectorTerminationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceConnectorTerminationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceConnectorTerminationCommandError(output, context);
   }
   const contents: GetVoiceConnectorTerminationCommandOutput = {
@@ -11449,7 +11449,7 @@ export const deserializeAws_restJson1GetVoiceConnectorTerminationHealthCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceConnectorTerminationHealthCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceConnectorTerminationHealthCommandError(output, context);
   }
   const contents: GetVoiceConnectorTerminationHealthCommandOutput = {
@@ -11552,7 +11552,7 @@ export const deserializeAws_restJson1InviteUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InviteUsersCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1InviteUsersCommandError(output, context);
   }
   const contents: InviteUsersCommandOutput = {
@@ -11655,7 +11655,7 @@ export const deserializeAws_restJson1ListAccountsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAccountsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAccountsCommandError(output, context);
   }
   const contents: ListAccountsCommandOutput = {
@@ -11762,7 +11762,7 @@ export const deserializeAws_restJson1ListAttendeesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAttendeesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAttendeesCommandError(output, context);
   }
   const contents: ListAttendeesCommandOutput = {
@@ -11869,7 +11869,7 @@ export const deserializeAws_restJson1ListAttendeeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAttendeeTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAttendeeTagsCommandError(output, context);
   }
   const contents: ListAttendeeTagsCommandOutput = {
@@ -11972,7 +11972,7 @@ export const deserializeAws_restJson1ListBotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBotsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBotsCommandError(output, context);
   }
   const contents: ListBotsCommandOutput = {
@@ -12079,7 +12079,7 @@ export const deserializeAws_restJson1ListMeetingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMeetingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMeetingsCommandError(output, context);
   }
   const contents: ListMeetingsCommandOutput = {
@@ -12178,7 +12178,7 @@ export const deserializeAws_restJson1ListMeetingTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMeetingTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMeetingTagsCommandError(output, context);
   }
   const contents: ListMeetingTagsCommandOutput = {
@@ -12281,7 +12281,7 @@ export const deserializeAws_restJson1ListPhoneNumberOrdersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPhoneNumberOrdersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPhoneNumberOrdersCommandError(output, context);
   }
   const contents: ListPhoneNumberOrdersCommandOutput = {
@@ -12380,7 +12380,7 @@ export const deserializeAws_restJson1ListPhoneNumbersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPhoneNumbersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPhoneNumbersCommandError(output, context);
   }
   const contents: ListPhoneNumbersCommandOutput = {
@@ -12479,7 +12479,7 @@ export const deserializeAws_restJson1ListProxySessionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProxySessionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProxySessionsCommandError(output, context);
   }
   const contents: ListProxySessionsCommandOutput = {
@@ -12586,7 +12586,7 @@ export const deserializeAws_restJson1ListRoomMembershipsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRoomMembershipsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRoomMembershipsCommandError(output, context);
   }
   const contents: ListRoomMembershipsCommandOutput = {
@@ -12693,7 +12693,7 @@ export const deserializeAws_restJson1ListRoomsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRoomsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRoomsCommandError(output, context);
   }
   const contents: ListRoomsCommandOutput = {
@@ -12800,7 +12800,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -12895,7 +12895,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUsersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListUsersCommandError(output, context);
   }
   const contents: ListUsersCommandOutput = {
@@ -13002,7 +13002,7 @@ export const deserializeAws_restJson1ListVoiceConnectorGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVoiceConnectorGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListVoiceConnectorGroupsCommandError(output, context);
   }
   const contents: ListVoiceConnectorGroupsCommandOutput = {
@@ -13101,7 +13101,7 @@ export const deserializeAws_restJson1ListVoiceConnectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVoiceConnectorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListVoiceConnectorsCommandError(output, context);
   }
   const contents: ListVoiceConnectorsCommandOutput = {
@@ -13200,7 +13200,7 @@ export const deserializeAws_restJson1ListVoiceConnectorTerminationCredentialsCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVoiceConnectorTerminationCredentialsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListVoiceConnectorTerminationCredentialsCommandError(output, context);
   }
   const contents: ListVoiceConnectorTerminationCredentialsCommandOutput = {
@@ -13303,7 +13303,7 @@ export const deserializeAws_restJson1LogoutUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<LogoutUserCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1LogoutUserCommandError(output, context);
   }
   const contents: LogoutUserCommandOutput = {
@@ -13402,7 +13402,7 @@ export const deserializeAws_restJson1PutEventsConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEventsConfigurationCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEventsConfigurationCommandError(output, context);
   }
   const contents: PutEventsConfigurationCommandOutput = {
@@ -13505,7 +13505,7 @@ export const deserializeAws_restJson1PutRetentionSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRetentionSettingsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutRetentionSettingsCommandError(output, context);
   }
   const contents: PutRetentionSettingsCommandOutput = {
@@ -13620,7 +13620,7 @@ export const deserializeAws_restJson1PutVoiceConnectorEmergencyCallingConfigurat
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutVoiceConnectorEmergencyCallingConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutVoiceConnectorEmergencyCallingConfigurationCommandError(output, context);
   }
   const contents: PutVoiceConnectorEmergencyCallingConfigurationCommandOutput = {
@@ -13726,7 +13726,7 @@ export const deserializeAws_restJson1PutVoiceConnectorLoggingConfigurationComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutVoiceConnectorLoggingConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutVoiceConnectorLoggingConfigurationCommandError(output, context);
   }
   const contents: PutVoiceConnectorLoggingConfigurationCommandOutput = {
@@ -13829,7 +13829,7 @@ export const deserializeAws_restJson1PutVoiceConnectorOriginationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutVoiceConnectorOriginationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutVoiceConnectorOriginationCommandError(output, context);
   }
   const contents: PutVoiceConnectorOriginationCommandOutput = {
@@ -13932,7 +13932,7 @@ export const deserializeAws_restJson1PutVoiceConnectorProxyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutVoiceConnectorProxyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutVoiceConnectorProxyCommandError(output, context);
   }
   const contents: PutVoiceConnectorProxyCommandOutput = {
@@ -14043,7 +14043,7 @@ export const deserializeAws_restJson1PutVoiceConnectorStreamingConfigurationComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutVoiceConnectorStreamingConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutVoiceConnectorStreamingConfigurationCommandError(output, context);
   }
   const contents: PutVoiceConnectorStreamingConfigurationCommandOutput = {
@@ -14149,7 +14149,7 @@ export const deserializeAws_restJson1PutVoiceConnectorTerminationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutVoiceConnectorTerminationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutVoiceConnectorTerminationCommandError(output, context);
   }
   const contents: PutVoiceConnectorTerminationCommandOutput = {
@@ -14260,7 +14260,7 @@ export const deserializeAws_restJson1PutVoiceConnectorTerminationCredentialsComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutVoiceConnectorTerminationCredentialsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutVoiceConnectorTerminationCredentialsCommandError(output, context);
   }
   const contents: PutVoiceConnectorTerminationCredentialsCommandOutput = {
@@ -14359,7 +14359,7 @@ export const deserializeAws_restJson1RedactConversationMessageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RedactConversationMessageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RedactConversationMessageCommandError(output, context);
   }
   const contents: RedactConversationMessageCommandOutput = {
@@ -14458,7 +14458,7 @@ export const deserializeAws_restJson1RedactRoomMessageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RedactRoomMessageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RedactRoomMessageCommandError(output, context);
   }
   const contents: RedactRoomMessageCommandOutput = {
@@ -14557,7 +14557,7 @@ export const deserializeAws_restJson1RegenerateSecurityTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegenerateSecurityTokenCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegenerateSecurityTokenCommandError(output, context);
   }
   const contents: RegenerateSecurityTokenCommandOutput = {
@@ -14660,7 +14660,7 @@ export const deserializeAws_restJson1ResetPersonalPINCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetPersonalPINCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ResetPersonalPINCommandError(output, context);
   }
   const contents: ResetPersonalPINCommandOutput = {
@@ -14763,7 +14763,7 @@ export const deserializeAws_restJson1RestorePhoneNumberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestorePhoneNumberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RestorePhoneNumberCommandError(output, context);
   }
   const contents: RestorePhoneNumberCommandOutput = {
@@ -14874,7 +14874,7 @@ export const deserializeAws_restJson1SearchAvailablePhoneNumbersCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchAvailablePhoneNumbersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SearchAvailablePhoneNumbersCommandError(output, context);
   }
   const contents: SearchAvailablePhoneNumbersCommandOutput = {
@@ -14977,7 +14977,7 @@ export const deserializeAws_restJson1TagAttendeeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagAttendeeCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagAttendeeCommandError(output, context);
   }
   const contents: TagAttendeeCommandOutput = {
@@ -15084,7 +15084,7 @@ export const deserializeAws_restJson1TagMeetingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagMeetingCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagMeetingCommandError(output, context);
   }
   const contents: TagMeetingCommandOutput = {
@@ -15191,7 +15191,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -15282,7 +15282,7 @@ export const deserializeAws_restJson1UntagAttendeeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagAttendeeCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagAttendeeCommandError(output, context);
   }
   const contents: UntagAttendeeCommandOutput = {
@@ -15381,7 +15381,7 @@ export const deserializeAws_restJson1UntagMeetingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagMeetingCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagMeetingCommandError(output, context);
   }
   const contents: UntagMeetingCommandOutput = {
@@ -15480,7 +15480,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -15571,7 +15571,7 @@ export const deserializeAws_restJson1UpdateAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAccountCommandError(output, context);
   }
   const contents: UpdateAccountCommandOutput = {
@@ -15674,7 +15674,7 @@ export const deserializeAws_restJson1UpdateAccountSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAccountSettingsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAccountSettingsCommandError(output, context);
   }
   const contents: UpdateAccountSettingsCommandOutput = {
@@ -15781,7 +15781,7 @@ export const deserializeAws_restJson1UpdateBotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBotCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateBotCommandError(output, context);
   }
   const contents: UpdateBotCommandOutput = {
@@ -15884,7 +15884,7 @@ export const deserializeAws_restJson1UpdateGlobalSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGlobalSettingsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGlobalSettingsCommandError(output, context);
   }
   const contents: UpdateGlobalSettingsCommandOutput = {
@@ -15975,7 +15975,7 @@ export const deserializeAws_restJson1UpdatePhoneNumberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePhoneNumberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePhoneNumberCommandError(output, context);
   }
   const contents: UpdatePhoneNumberCommandOutput = {
@@ -16078,7 +16078,7 @@ export const deserializeAws_restJson1UpdatePhoneNumberSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePhoneNumberSettingsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePhoneNumberSettingsCommandError(output, context);
   }
   const contents: UpdatePhoneNumberSettingsCommandOutput = {
@@ -16169,7 +16169,7 @@ export const deserializeAws_restJson1UpdateProxySessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProxySessionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateProxySessionCommandError(output, context);
   }
   const contents: UpdateProxySessionCommandOutput = {
@@ -16272,7 +16272,7 @@ export const deserializeAws_restJson1UpdateRoomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRoomCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRoomCommandError(output, context);
   }
   const contents: UpdateRoomCommandOutput = {
@@ -16375,7 +16375,7 @@ export const deserializeAws_restJson1UpdateRoomMembershipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRoomMembershipCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRoomMembershipCommandError(output, context);
   }
   const contents: UpdateRoomMembershipCommandOutput = {
@@ -16478,7 +16478,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUserCommandError(output, context);
   }
   const contents: UpdateUserCommandOutput = {
@@ -16581,7 +16581,7 @@ export const deserializeAws_restJson1UpdateUserSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserSettingsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUserSettingsCommandError(output, context);
   }
   const contents: UpdateUserSettingsCommandOutput = {
@@ -16680,7 +16680,7 @@ export const deserializeAws_restJson1UpdateVoiceConnectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVoiceConnectorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateVoiceConnectorCommandError(output, context);
   }
   const contents: UpdateVoiceConnectorCommandOutput = {
@@ -16783,7 +16783,7 @@ export const deserializeAws_restJson1UpdateVoiceConnectorGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVoiceConnectorGroupCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateVoiceConnectorGroupCommandError(output, context);
   }
   const contents: UpdateVoiceConnectorGroupCommandOutput = {

--- a/clients/client-cloud9/protocols/Aws_json1_1.ts
+++ b/clients/client-cloud9/protocols/Aws_json1_1.ts
@@ -258,7 +258,7 @@ export const deserializeAws_json1_1CreateEnvironmentEC2Command = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEnvironmentEC2CommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEnvironmentEC2CommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -361,7 +361,7 @@ export const deserializeAws_json1_1CreateEnvironmentMembershipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEnvironmentMembershipCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEnvironmentMembershipCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -464,7 +464,7 @@ export const deserializeAws_json1_1DeleteEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEnvironmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEnvironmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -567,7 +567,7 @@ export const deserializeAws_json1_1DeleteEnvironmentMembershipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEnvironmentMembershipCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEnvironmentMembershipCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -670,7 +670,7 @@ export const deserializeAws_json1_1DescribeEnvironmentMembershipsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEnvironmentMembershipsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEnvironmentMembershipsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -773,7 +773,7 @@ export const deserializeAws_json1_1DescribeEnvironmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEnvironmentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEnvironmentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -876,7 +876,7 @@ export const deserializeAws_json1_1DescribeEnvironmentStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEnvironmentStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEnvironmentStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -979,7 +979,7 @@ export const deserializeAws_json1_1ListEnvironmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEnvironmentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEnvironmentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1082,7 +1082,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1153,7 +1153,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1224,7 +1224,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1295,7 +1295,7 @@ export const deserializeAws_json1_1UpdateEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEnvironmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateEnvironmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1398,7 +1398,7 @@ export const deserializeAws_json1_1UpdateEnvironmentMembershipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEnvironmentMembershipCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateEnvironmentMembershipCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-clouddirectory/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/protocols/Aws_restJson1.ts
@@ -2131,7 +2131,7 @@ export const deserializeAws_restJson1AddFacetToObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddFacetToObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddFacetToObjectCommandError(output, context);
   }
   const contents: AddFacetToObjectCommandOutput = {
@@ -2246,7 +2246,7 @@ export const deserializeAws_restJson1ApplySchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ApplySchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ApplySchemaCommandError(output, context);
   }
   const contents: ApplySchemaCommandOutput = {
@@ -2369,7 +2369,7 @@ export const deserializeAws_restJson1AttachObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AttachObjectCommandError(output, context);
   }
   const contents: AttachObjectCommandOutput = {
@@ -2504,7 +2504,7 @@ export const deserializeAws_restJson1AttachPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AttachPolicyCommandError(output, context);
   }
   const contents: AttachPolicyCommandOutput = {
@@ -2619,7 +2619,7 @@ export const deserializeAws_restJson1AttachToIndexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachToIndexCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AttachToIndexCommandError(output, context);
   }
   const contents: AttachToIndexCommandOutput = {
@@ -2762,7 +2762,7 @@ export const deserializeAws_restJson1AttachTypedLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachTypedLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AttachTypedLinkCommandError(output, context);
   }
   const contents: AttachTypedLinkCommandOutput = {
@@ -2889,7 +2889,7 @@ export const deserializeAws_restJson1BatchReadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchReadCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchReadCommandError(output, context);
   }
   const contents: BatchReadCommandOutput = {
@@ -2992,7 +2992,7 @@ export const deserializeAws_restJson1BatchWriteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchWriteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchWriteCommandError(output, context);
   }
   const contents: BatchWriteCommandOutput = {
@@ -3103,7 +3103,7 @@ export const deserializeAws_restJson1CreateDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDirectoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDirectoryCommandError(output, context);
   }
   const contents: CreateDirectoryCommandOutput = {
@@ -3226,7 +3226,7 @@ export const deserializeAws_restJson1CreateFacetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFacetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFacetCommandError(output, context);
   }
   const contents: CreateFacetCommandOutput = {
@@ -3349,7 +3349,7 @@ export const deserializeAws_restJson1CreateIndexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIndexCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateIndexCommandError(output, context);
   }
   const contents: CreateIndexCommandOutput = {
@@ -3484,7 +3484,7 @@ export const deserializeAws_restJson1CreateObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateObjectCommandError(output, context);
   }
   const contents: CreateObjectCommandOutput = {
@@ -3619,7 +3619,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSchemaCommandError(output, context);
   }
   const contents: CreateSchemaCommandOutput = {
@@ -3722,7 +3722,7 @@ export const deserializeAws_restJson1CreateTypedLinkFacetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTypedLinkFacetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateTypedLinkFacetCommandError(output, context);
   }
   const contents: CreateTypedLinkFacetCommandOutput = {
@@ -3845,7 +3845,7 @@ export const deserializeAws_restJson1DeleteDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDirectoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDirectoryCommandError(output, context);
   }
   const contents: DeleteDirectoryCommandOutput = {
@@ -3964,7 +3964,7 @@ export const deserializeAws_restJson1DeleteFacetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFacetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFacetCommandError(output, context);
   }
   const contents: DeleteFacetCommandOutput = {
@@ -4079,7 +4079,7 @@ export const deserializeAws_restJson1DeleteObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteObjectCommandError(output, context);
   }
   const contents: DeleteObjectCommandOutput = {
@@ -4194,7 +4194,7 @@ export const deserializeAws_restJson1DeleteSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSchemaCommandError(output, context);
   }
   const contents: DeleteSchemaCommandOutput = {
@@ -4305,7 +4305,7 @@ export const deserializeAws_restJson1DeleteTypedLinkFacetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTypedLinkFacetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteTypedLinkFacetCommandError(output, context);
   }
   const contents: DeleteTypedLinkFacetCommandOutput = {
@@ -4412,7 +4412,7 @@ export const deserializeAws_restJson1DetachFromIndexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachFromIndexCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DetachFromIndexCommandError(output, context);
   }
   const contents: DetachFromIndexCommandOutput = {
@@ -4539,7 +4539,7 @@ export const deserializeAws_restJson1DetachObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DetachObjectCommandError(output, context);
   }
   const contents: DetachObjectCommandOutput = {
@@ -4658,7 +4658,7 @@ export const deserializeAws_restJson1DetachPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DetachPolicyCommandError(output, context);
   }
   const contents: DetachPolicyCommandOutput = {
@@ -4773,7 +4773,7 @@ export const deserializeAws_restJson1DetachTypedLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachTypedLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DetachTypedLinkCommandError(output, context);
   }
   const contents: DetachTypedLinkCommandOutput = {
@@ -4888,7 +4888,7 @@ export const deserializeAws_restJson1DisableDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableDirectoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisableDirectoryCommandError(output, context);
   }
   const contents: DisableDirectoryCommandOutput = {
@@ -4999,7 +4999,7 @@ export const deserializeAws_restJson1EnableDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableDirectoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1EnableDirectoryCommandError(output, context);
   }
   const contents: EnableDirectoryCommandOutput = {
@@ -5110,7 +5110,7 @@ export const deserializeAws_restJson1GetAppliedSchemaVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAppliedSchemaVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAppliedSchemaVersionCommandError(output, context);
   }
   const contents: GetAppliedSchemaVersionCommandOutput = {
@@ -5213,7 +5213,7 @@ export const deserializeAws_restJson1GetDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDirectoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDirectoryCommandError(output, context);
   }
   const contents: GetDirectoryCommandOutput = {
@@ -5308,7 +5308,7 @@ export const deserializeAws_restJson1GetFacetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFacetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFacetCommandError(output, context);
   }
   const contents: GetFacetCommandOutput = {
@@ -5419,7 +5419,7 @@ export const deserializeAws_restJson1GetLinkAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLinkAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLinkAttributesCommandError(output, context);
   }
   const contents: GetLinkAttributesCommandOutput = {
@@ -5538,7 +5538,7 @@ export const deserializeAws_restJson1GetObjectAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetObjectAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetObjectAttributesCommandError(output, context);
   }
   const contents: GetObjectAttributesCommandOutput = {
@@ -5657,7 +5657,7 @@ export const deserializeAws_restJson1GetObjectInformationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetObjectInformationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetObjectInformationCommandError(output, context);
   }
   const contents: GetObjectInformationCommandOutput = {
@@ -5772,7 +5772,7 @@ export const deserializeAws_restJson1GetSchemaAsJsonCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSchemaAsJsonCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSchemaAsJsonCommandError(output, context);
   }
   const contents: GetSchemaAsJsonCommandOutput = {
@@ -5879,7 +5879,7 @@ export const deserializeAws_restJson1GetTypedLinkFacetInformationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTypedLinkFacetInformationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTypedLinkFacetInformationCommandError(output, context);
   }
   const contents: GetTypedLinkFacetInformationCommandOutput = {
@@ -5998,7 +5998,7 @@ export const deserializeAws_restJson1ListAppliedSchemaArnsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAppliedSchemaArnsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAppliedSchemaArnsCommandError(output, context);
   }
   const contents: ListAppliedSchemaArnsCommandOutput = {
@@ -6113,7 +6113,7 @@ export const deserializeAws_restJson1ListAttachedIndicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAttachedIndicesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAttachedIndicesCommandError(output, context);
   }
   const contents: ListAttachedIndicesCommandOutput = {
@@ -6228,7 +6228,7 @@ export const deserializeAws_restJson1ListDevelopmentSchemaArnsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDevelopmentSchemaArnsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDevelopmentSchemaArnsCommandError(output, context);
   }
   const contents: ListDevelopmentSchemaArnsCommandOutput = {
@@ -6343,7 +6343,7 @@ export const deserializeAws_restJson1ListDirectoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDirectoriesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDirectoriesCommandError(output, context);
   }
   const contents: ListDirectoriesCommandOutput = {
@@ -6450,7 +6450,7 @@ export const deserializeAws_restJson1ListFacetAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFacetAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFacetAttributesCommandError(output, context);
   }
   const contents: ListFacetAttributesCommandOutput = {
@@ -6573,7 +6573,7 @@ export const deserializeAws_restJson1ListFacetNamesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFacetNamesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFacetNamesCommandError(output, context);
   }
   const contents: ListFacetNamesCommandOutput = {
@@ -6688,7 +6688,7 @@ export const deserializeAws_restJson1ListIncomingTypedLinksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIncomingTypedLinksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListIncomingTypedLinksCommandError(output, context);
   }
   const contents: ListIncomingTypedLinksCommandOutput = {
@@ -6819,7 +6819,7 @@ export const deserializeAws_restJson1ListIndexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIndexCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListIndexCommandError(output, context);
   }
   const contents: ListIndexCommandOutput = {
@@ -6958,7 +6958,7 @@ export const deserializeAws_restJson1ListManagedSchemaArnsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListManagedSchemaArnsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListManagedSchemaArnsCommandError(output, context);
   }
   const contents: ListManagedSchemaArnsCommandOutput = {
@@ -7057,7 +7057,7 @@ export const deserializeAws_restJson1ListObjectAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListObjectAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListObjectAttributesCommandError(output, context);
   }
   const contents: ListObjectAttributesCommandOutput = {
@@ -7188,7 +7188,7 @@ export const deserializeAws_restJson1ListObjectChildrenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListObjectChildrenCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListObjectChildrenCommandError(output, context);
   }
   const contents: ListObjectChildrenCommandOutput = {
@@ -7319,7 +7319,7 @@ export const deserializeAws_restJson1ListObjectParentPathsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListObjectParentPathsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListObjectParentPathsCommandError(output, context);
   }
   const contents: ListObjectParentPathsCommandOutput = {
@@ -7445,7 +7445,7 @@ export const deserializeAws_restJson1ListObjectParentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListObjectParentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListObjectParentsCommandError(output, context);
   }
   const contents: ListObjectParentsCommandOutput = {
@@ -7580,7 +7580,7 @@ export const deserializeAws_restJson1ListObjectPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListObjectPoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListObjectPoliciesCommandError(output, context);
   }
   const contents: ListObjectPoliciesCommandOutput = {
@@ -7703,7 +7703,7 @@ export const deserializeAws_restJson1ListOutgoingTypedLinksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOutgoingTypedLinksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListOutgoingTypedLinksCommandError(output, context);
   }
   const contents: ListOutgoingTypedLinksCommandOutput = {
@@ -7834,7 +7834,7 @@ export const deserializeAws_restJson1ListPolicyAttachmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPolicyAttachmentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPolicyAttachmentsCommandError(output, context);
   }
   const contents: ListPolicyAttachmentsCommandOutput = {
@@ -7965,7 +7965,7 @@ export const deserializeAws_restJson1ListPublishedSchemaArnsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPublishedSchemaArnsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPublishedSchemaArnsCommandError(output, context);
   }
   const contents: ListPublishedSchemaArnsCommandOutput = {
@@ -8080,7 +8080,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -8195,7 +8195,7 @@ export const deserializeAws_restJson1ListTypedLinkFacetAttributesCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTypedLinkFacetAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTypedLinkFacetAttributesCommandError(output, context);
   }
   const contents: ListTypedLinkFacetAttributesCommandOutput = {
@@ -8318,7 +8318,7 @@ export const deserializeAws_restJson1ListTypedLinkFacetNamesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTypedLinkFacetNamesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTypedLinkFacetNamesCommandError(output, context);
   }
   const contents: ListTypedLinkFacetNamesCommandOutput = {
@@ -8433,7 +8433,7 @@ export const deserializeAws_restJson1LookupPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<LookupPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1LookupPolicyCommandError(output, context);
   }
   const contents: LookupPolicyCommandOutput = {
@@ -8556,7 +8556,7 @@ export const deserializeAws_restJson1PublishSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PublishSchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PublishSchemaCommandError(output, context);
   }
   const contents: PublishSchemaCommandOutput = {
@@ -8667,7 +8667,7 @@ export const deserializeAws_restJson1PutSchemaFromJsonCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutSchemaFromJsonCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutSchemaFromJsonCommandError(output, context);
   }
   const contents: PutSchemaFromJsonCommandOutput = {
@@ -8778,7 +8778,7 @@ export const deserializeAws_restJson1RemoveFacetFromObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveFacetFromObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveFacetFromObjectCommandError(output, context);
   }
   const contents: RemoveFacetFromObjectCommandOutput = {
@@ -8893,7 +8893,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -9000,7 +9000,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -9107,7 +9107,7 @@ export const deserializeAws_restJson1UpdateFacetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFacetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFacetCommandError(output, context);
   }
   const contents: UpdateFacetCommandOutput = {
@@ -9238,7 +9238,7 @@ export const deserializeAws_restJson1UpdateLinkAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLinkAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateLinkAttributesCommandError(output, context);
   }
   const contents: UpdateLinkAttributesCommandOutput = {
@@ -9353,7 +9353,7 @@ export const deserializeAws_restJson1UpdateObjectAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateObjectAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateObjectAttributesCommandError(output, context);
   }
   const contents: UpdateObjectAttributesCommandOutput = {
@@ -9480,7 +9480,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSchemaCommandError(output, context);
   }
   const contents: UpdateSchemaCommandOutput = {
@@ -9583,7 +9583,7 @@ export const deserializeAws_restJson1UpdateTypedLinkFacetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTypedLinkFacetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateTypedLinkFacetCommandError(output, context);
   }
   const contents: UpdateTypedLinkFacetCommandOutput = {
@@ -9714,7 +9714,7 @@ export const deserializeAws_restJson1UpgradeAppliedSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpgradeAppliedSchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpgradeAppliedSchemaCommandError(output, context);
   }
   const contents: UpgradeAppliedSchemaCommandOutput = {
@@ -9837,7 +9837,7 @@ export const deserializeAws_restJson1UpgradePublishedSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpgradePublishedSchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpgradePublishedSchemaCommandError(output, context);
   }
   const contents: UpgradePublishedSchemaCommandOutput = {

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -1203,7 +1203,7 @@ export const deserializeAws_queryCancelUpdateStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelUpdateStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCancelUpdateStackCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1254,7 +1254,7 @@ export const deserializeAws_queryContinueUpdateRollbackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ContinueUpdateRollbackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryContinueUpdateRollbackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1308,7 +1308,7 @@ export const deserializeAws_queryCreateChangeSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateChangeSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateChangeSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1378,7 +1378,7 @@ export const deserializeAws_queryCreateStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1456,7 +1456,7 @@ export const deserializeAws_queryCreateStackInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStackInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateStackInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1550,7 +1550,7 @@ export const deserializeAws_queryCreateStackSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStackSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateStackSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1620,7 +1620,7 @@ export const deserializeAws_queryDeleteChangeSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteChangeSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteChangeSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1674,7 +1674,7 @@ export const deserializeAws_queryDeleteStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteStackCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1725,7 +1725,7 @@ export const deserializeAws_queryDeleteStackInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStackInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteStackInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1811,7 +1811,7 @@ export const deserializeAws_queryDeleteStackSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStackSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteStackSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1873,7 +1873,7 @@ export const deserializeAws_queryDeregisterTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeregisterTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1935,7 +1935,7 @@ export const deserializeAws_queryDescribeAccountLimitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountLimitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAccountLimitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1981,7 +1981,7 @@ export const deserializeAws_queryDescribeChangeSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeChangeSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeChangeSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2035,7 +2035,7 @@ export const deserializeAws_queryDescribeStackDriftDetectionStatusCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStackDriftDetectionStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeStackDriftDetectionStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2084,7 +2084,7 @@ export const deserializeAws_queryDescribeStackEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStackEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeStackEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2130,7 +2130,7 @@ export const deserializeAws_queryDescribeStackInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStackInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeStackInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2192,7 +2192,7 @@ export const deserializeAws_queryDescribeStackResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStackResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeStackResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2238,7 +2238,7 @@ export const deserializeAws_queryDescribeStackResourceDriftsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStackResourceDriftsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeStackResourceDriftsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2284,7 +2284,7 @@ export const deserializeAws_queryDescribeStackResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStackResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeStackResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2330,7 +2330,7 @@ export const deserializeAws_queryDescribeStacksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStacksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeStacksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2376,7 +2376,7 @@ export const deserializeAws_queryDescribeStackSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStackSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeStackSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2430,7 +2430,7 @@ export const deserializeAws_queryDescribeStackSetOperationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStackSetOperationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeStackSetOperationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2492,7 +2492,7 @@ export const deserializeAws_queryDescribeTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2554,7 +2554,7 @@ export const deserializeAws_queryDescribeTypeRegistrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTypeRegistrationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTypeRegistrationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2608,7 +2608,7 @@ export const deserializeAws_queryDetectStackDriftCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectStackDriftCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDetectStackDriftCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2654,7 +2654,7 @@ export const deserializeAws_queryDetectStackResourceDriftCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectStackResourceDriftCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDetectStackResourceDriftCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2700,7 +2700,7 @@ export const deserializeAws_queryDetectStackSetDriftCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectStackSetDriftCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDetectStackSetDriftCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2770,7 +2770,7 @@ export const deserializeAws_queryEstimateTemplateCostCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EstimateTemplateCostCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryEstimateTemplateCostCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2816,7 +2816,7 @@ export const deserializeAws_queryExecuteChangeSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExecuteChangeSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryExecuteChangeSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2894,7 +2894,7 @@ export const deserializeAws_queryGetStackPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStackPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetStackPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2940,7 +2940,7 @@ export const deserializeAws_queryGetTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2994,7 +2994,7 @@ export const deserializeAws_queryGetTemplateSummaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTemplateSummaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetTemplateSummaryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3048,7 +3048,7 @@ export const deserializeAws_queryListChangeSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListChangeSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListChangeSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3094,7 +3094,7 @@ export const deserializeAws_queryListExportsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListExportsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListExportsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3140,7 +3140,7 @@ export const deserializeAws_queryListImportsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListImportsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListImportsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3186,7 +3186,7 @@ export const deserializeAws_queryListStackInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStackInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListStackInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3240,7 +3240,7 @@ export const deserializeAws_queryListStackResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStackResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListStackResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3286,7 +3286,7 @@ export const deserializeAws_queryListStacksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStacksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListStacksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3332,7 +3332,7 @@ export const deserializeAws_queryListStackSetOperationResultsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStackSetOperationResultsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListStackSetOperationResultsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3394,7 +3394,7 @@ export const deserializeAws_queryListStackSetOperationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStackSetOperationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListStackSetOperationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3448,7 +3448,7 @@ export const deserializeAws_queryListStackSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStackSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListStackSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3494,7 +3494,7 @@ export const deserializeAws_queryListTypeRegistrationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTypeRegistrationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTypeRegistrationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3548,7 +3548,7 @@ export const deserializeAws_queryListTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3602,7 +3602,7 @@ export const deserializeAws_queryListTypeVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTypeVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTypeVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3656,7 +3656,7 @@ export const deserializeAws_queryRecordHandlerProgressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RecordHandlerProgressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRecordHandlerProgressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3718,7 +3718,7 @@ export const deserializeAws_queryRegisterTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRegisterTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3772,7 +3772,7 @@ export const deserializeAws_querySetStackPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetStackPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetStackPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3815,7 +3815,7 @@ export const deserializeAws_querySetTypeDefaultVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetTypeDefaultVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetTypeDefaultVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3877,7 +3877,7 @@ export const deserializeAws_querySignalResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SignalResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySignalResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3920,7 +3920,7 @@ export const deserializeAws_queryStopStackSetOperationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopStackSetOperationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStopStackSetOperationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3990,7 +3990,7 @@ export const deserializeAws_queryUpdateStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4052,7 +4052,7 @@ export const deserializeAws_queryUpdateStackInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStackInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateStackInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4146,7 +4146,7 @@ export const deserializeAws_queryUpdateStackSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStackSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateStackSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4240,7 +4240,7 @@ export const deserializeAws_queryUpdateTerminationProtectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTerminationProtectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateTerminationProtectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4286,7 +4286,7 @@ export const deserializeAws_queryValidateTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ValidateTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryValidateTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -2241,7 +2241,7 @@ export const deserializeAws_restXmlCreateCachePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCachePolicyCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateCachePolicyCommandError(output, context);
   }
   const contents: CreateCachePolicyCommandOutput = {
@@ -2358,7 +2358,7 @@ export const deserializeAws_restXmlCreateCloudFrontOriginAccessIdentityCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCloudFrontOriginAccessIdentityCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateCloudFrontOriginAccessIdentityCommandError(output, context);
   }
   const contents: CreateCloudFrontOriginAccessIdentityCommandOutput = {
@@ -2451,7 +2451,7 @@ export const deserializeAws_restXmlCreateDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDistributionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateDistributionCommandError(output, context);
   }
   const contents: CreateDistributionCommandOutput = {
@@ -2905,7 +2905,7 @@ export const deserializeAws_restXmlCreateDistributionWithTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDistributionWithTagsCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateDistributionWithTagsCommandError(output, context);
   }
   const contents: CreateDistributionWithTagsCommandOutput = {
@@ -3367,7 +3367,7 @@ export const deserializeAws_restXmlCreateFieldLevelEncryptionConfigCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFieldLevelEncryptionConfigCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateFieldLevelEncryptionConfigCommandError(output, context);
   }
   const contents: CreateFieldLevelEncryptionConfigCommandOutput = {
@@ -3484,7 +3484,7 @@ export const deserializeAws_restXmlCreateFieldLevelEncryptionProfileCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFieldLevelEncryptionProfileCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateFieldLevelEncryptionProfileCommandError(output, context);
   }
   const contents: CreateFieldLevelEncryptionProfileCommandOutput = {
@@ -3601,7 +3601,7 @@ export const deserializeAws_restXmlCreateInvalidationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInvalidationCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateInvalidationCommandError(output, context);
   }
   const contents: CreateInvalidationCommandOutput = {
@@ -3706,7 +3706,7 @@ export const deserializeAws_restXmlCreateOriginRequestPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOriginRequestPolicyCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateOriginRequestPolicyCommandError(output, context);
   }
   const contents: CreateOriginRequestPolicyCommandOutput = {
@@ -3823,7 +3823,7 @@ export const deserializeAws_restXmlCreatePublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePublicKeyCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreatePublicKeyCommandError(output, context);
   }
   const contents: CreatePublicKeyCommandOutput = {
@@ -3900,7 +3900,7 @@ export const deserializeAws_restXmlCreateStreamingDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStreamingDistributionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateStreamingDistributionCommandError(output, context);
   }
   const contents: CreateStreamingDistributionCommandOutput = {
@@ -4049,7 +4049,7 @@ export const deserializeAws_restXmlCreateStreamingDistributionWithTagsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStreamingDistributionWithTagsCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateStreamingDistributionWithTagsCommandError(output, context);
   }
   const contents: CreateStreamingDistributionWithTagsCommandOutput = {
@@ -4206,7 +4206,7 @@ export const deserializeAws_restXmlDeleteCachePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCachePolicyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteCachePolicyCommandError(output, context);
   }
   const contents: DeleteCachePolicyCommandOutput = {
@@ -4297,7 +4297,7 @@ export const deserializeAws_restXmlDeleteCloudFrontOriginAccessIdentityCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCloudFrontOriginAccessIdentityCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteCloudFrontOriginAccessIdentityCommandError(output, context);
   }
   const contents: DeleteCloudFrontOriginAccessIdentityCommandOutput = {
@@ -4380,7 +4380,7 @@ export const deserializeAws_restXmlDeleteDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDistributionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteDistributionCommandError(output, context);
   }
   const contents: DeleteDistributionCommandOutput = {
@@ -4463,7 +4463,7 @@ export const deserializeAws_restXmlDeleteFieldLevelEncryptionConfigCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFieldLevelEncryptionConfigCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteFieldLevelEncryptionConfigCommandError(output, context);
   }
   const contents: DeleteFieldLevelEncryptionConfigCommandOutput = {
@@ -4546,7 +4546,7 @@ export const deserializeAws_restXmlDeleteFieldLevelEncryptionProfileCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFieldLevelEncryptionProfileCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteFieldLevelEncryptionProfileCommandError(output, context);
   }
   const contents: DeleteFieldLevelEncryptionProfileCommandOutput = {
@@ -4629,7 +4629,7 @@ export const deserializeAws_restXmlDeleteOriginRequestPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOriginRequestPolicyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteOriginRequestPolicyCommandError(output, context);
   }
   const contents: DeleteOriginRequestPolicyCommandOutput = {
@@ -4720,7 +4720,7 @@ export const deserializeAws_restXmlDeletePublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePublicKeyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeletePublicKeyCommandError(output, context);
   }
   const contents: DeletePublicKeyCommandOutput = {
@@ -4803,7 +4803,7 @@ export const deserializeAws_restXmlDeleteStreamingDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStreamingDistributionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteStreamingDistributionCommandError(output, context);
   }
   const contents: DeleteStreamingDistributionCommandOutput = {
@@ -4886,7 +4886,7 @@ export const deserializeAws_restXmlGetCachePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCachePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetCachePolicyCommandError(output, context);
   }
   const contents: GetCachePolicyCommandOutput = {
@@ -4951,7 +4951,7 @@ export const deserializeAws_restXmlGetCachePolicyConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCachePolicyConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetCachePolicyConfigCommandError(output, context);
   }
   const contents: GetCachePolicyConfigCommandOutput = {
@@ -5016,7 +5016,7 @@ export const deserializeAws_restXmlGetCloudFrontOriginAccessIdentityCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCloudFrontOriginAccessIdentityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetCloudFrontOriginAccessIdentityCommandError(output, context);
   }
   const contents: GetCloudFrontOriginAccessIdentityCommandOutput = {
@@ -5081,7 +5081,7 @@ export const deserializeAws_restXmlGetCloudFrontOriginAccessIdentityConfigComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCloudFrontOriginAccessIdentityConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetCloudFrontOriginAccessIdentityConfigCommandError(output, context);
   }
   const contents: GetCloudFrontOriginAccessIdentityConfigCommandOutput = {
@@ -5149,7 +5149,7 @@ export const deserializeAws_restXmlGetDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDistributionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetDistributionCommandError(output, context);
   }
   const contents: GetDistributionCommandOutput = {
@@ -5214,7 +5214,7 @@ export const deserializeAws_restXmlGetDistributionConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDistributionConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetDistributionConfigCommandError(output, context);
   }
   const contents: GetDistributionConfigCommandOutput = {
@@ -5279,7 +5279,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFieldLevelEncryptionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetFieldLevelEncryptionCommandError(output, context);
   }
   const contents: GetFieldLevelEncryptionCommandOutput = {
@@ -5344,7 +5344,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionConfigCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFieldLevelEncryptionConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetFieldLevelEncryptionConfigCommandError(output, context);
   }
   const contents: GetFieldLevelEncryptionConfigCommandOutput = {
@@ -5409,7 +5409,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionProfileCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFieldLevelEncryptionProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetFieldLevelEncryptionProfileCommandError(output, context);
   }
   const contents: GetFieldLevelEncryptionProfileCommandOutput = {
@@ -5474,7 +5474,7 @@ export const deserializeAws_restXmlGetFieldLevelEncryptionProfileConfigCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFieldLevelEncryptionProfileConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetFieldLevelEncryptionProfileConfigCommandError(output, context);
   }
   const contents: GetFieldLevelEncryptionProfileConfigCommandOutput = {
@@ -5539,7 +5539,7 @@ export const deserializeAws_restXmlGetInvalidationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInvalidationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetInvalidationCommandError(output, context);
   }
   const contents: GetInvalidationCommandOutput = {
@@ -5608,7 +5608,7 @@ export const deserializeAws_restXmlGetOriginRequestPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOriginRequestPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetOriginRequestPolicyCommandError(output, context);
   }
   const contents: GetOriginRequestPolicyCommandOutput = {
@@ -5673,7 +5673,7 @@ export const deserializeAws_restXmlGetOriginRequestPolicyConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOriginRequestPolicyConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetOriginRequestPolicyConfigCommandError(output, context);
   }
   const contents: GetOriginRequestPolicyConfigCommandOutput = {
@@ -5738,7 +5738,7 @@ export const deserializeAws_restXmlGetPublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPublicKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetPublicKeyCommandError(output, context);
   }
   const contents: GetPublicKeyCommandOutput = {
@@ -5803,7 +5803,7 @@ export const deserializeAws_restXmlGetPublicKeyConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPublicKeyConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetPublicKeyConfigCommandError(output, context);
   }
   const contents: GetPublicKeyConfigCommandOutput = {
@@ -5868,7 +5868,7 @@ export const deserializeAws_restXmlGetStreamingDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStreamingDistributionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetStreamingDistributionCommandError(output, context);
   }
   const contents: GetStreamingDistributionCommandOutput = {
@@ -5933,7 +5933,7 @@ export const deserializeAws_restXmlGetStreamingDistributionConfigCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStreamingDistributionConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetStreamingDistributionConfigCommandError(output, context);
   }
   const contents: GetStreamingDistributionConfigCommandOutput = {
@@ -5998,7 +5998,7 @@ export const deserializeAws_restXmlListCachePoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCachePoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListCachePoliciesCommandError(output, context);
   }
   const contents: ListCachePoliciesCommandOutput = {
@@ -6067,7 +6067,7 @@ export const deserializeAws_restXmlListCloudFrontOriginAccessIdentitiesCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCloudFrontOriginAccessIdentitiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListCloudFrontOriginAccessIdentitiesCommandError(output, context);
   }
   const contents: ListCloudFrontOriginAccessIdentitiesCommandOutput = {
@@ -6120,7 +6120,7 @@ export const deserializeAws_restXmlListDistributionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDistributionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListDistributionsCommandError(output, context);
   }
   const contents: ListDistributionsCommandOutput = {
@@ -6173,7 +6173,7 @@ export const deserializeAws_restXmlListDistributionsByCachePolicyIdCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDistributionsByCachePolicyIdCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListDistributionsByCachePolicyIdCommandError(output, context);
   }
   const contents: ListDistributionsByCachePolicyIdCommandOutput = {
@@ -6242,7 +6242,7 @@ export const deserializeAws_restXmlListDistributionsByOriginRequestPolicyIdComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDistributionsByOriginRequestPolicyIdCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListDistributionsByOriginRequestPolicyIdCommandError(output, context);
   }
   const contents: ListDistributionsByOriginRequestPolicyIdCommandOutput = {
@@ -6311,7 +6311,7 @@ export const deserializeAws_restXmlListDistributionsByWebACLIdCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDistributionsByWebACLIdCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListDistributionsByWebACLIdCommandError(output, context);
   }
   const contents: ListDistributionsByWebACLIdCommandOutput = {
@@ -6372,7 +6372,7 @@ export const deserializeAws_restXmlListFieldLevelEncryptionConfigsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFieldLevelEncryptionConfigsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListFieldLevelEncryptionConfigsCommandError(output, context);
   }
   const contents: ListFieldLevelEncryptionConfigsCommandOutput = {
@@ -6425,7 +6425,7 @@ export const deserializeAws_restXmlListFieldLevelEncryptionProfilesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFieldLevelEncryptionProfilesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListFieldLevelEncryptionProfilesCommandError(output, context);
   }
   const contents: ListFieldLevelEncryptionProfilesCommandOutput = {
@@ -6478,7 +6478,7 @@ export const deserializeAws_restXmlListInvalidationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInvalidationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListInvalidationsCommandError(output, context);
   }
   const contents: ListInvalidationsCommandOutput = {
@@ -6547,7 +6547,7 @@ export const deserializeAws_restXmlListOriginRequestPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOriginRequestPoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListOriginRequestPoliciesCommandError(output, context);
   }
   const contents: ListOriginRequestPoliciesCommandOutput = {
@@ -6616,7 +6616,7 @@ export const deserializeAws_restXmlListPublicKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPublicKeysCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListPublicKeysCommandError(output, context);
   }
   const contents: ListPublicKeysCommandOutput = {
@@ -6669,7 +6669,7 @@ export const deserializeAws_restXmlListStreamingDistributionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStreamingDistributionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListStreamingDistributionsCommandError(output, context);
   }
   const contents: ListStreamingDistributionsCommandOutput = {
@@ -6722,7 +6722,7 @@ export const deserializeAws_restXmlListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -6799,7 +6799,7 @@ export const deserializeAws_restXmlTagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlTagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -6874,7 +6874,7 @@ export const deserializeAws_restXmlUntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlUntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -6949,7 +6949,7 @@ export const deserializeAws_restXmlUpdateCachePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCachePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateCachePolicyCommandError(output, context);
   }
   const contents: UpdateCachePolicyCommandOutput = {
@@ -7086,7 +7086,7 @@ export const deserializeAws_restXmlUpdateCloudFrontOriginAccessIdentityCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCloudFrontOriginAccessIdentityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateCloudFrontOriginAccessIdentityCommandError(output, context);
   }
   const contents: UpdateCloudFrontOriginAccessIdentityCommandOutput = {
@@ -7199,7 +7199,7 @@ export const deserializeAws_restXmlUpdateDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDistributionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateDistributionCommandError(output, context);
   }
   const contents: UpdateDistributionCommandOutput = {
@@ -7649,7 +7649,7 @@ export const deserializeAws_restXmlUpdateFieldLevelEncryptionConfigCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFieldLevelEncryptionConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateFieldLevelEncryptionConfigCommandError(output, context);
   }
   const contents: UpdateFieldLevelEncryptionConfigCommandOutput = {
@@ -7786,7 +7786,7 @@ export const deserializeAws_restXmlUpdateFieldLevelEncryptionProfileCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFieldLevelEncryptionProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateFieldLevelEncryptionProfileCommandError(output, context);
   }
   const contents: UpdateFieldLevelEncryptionProfileCommandOutput = {
@@ -7931,7 +7931,7 @@ export const deserializeAws_restXmlUpdateOriginRequestPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateOriginRequestPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateOriginRequestPolicyCommandError(output, context);
   }
   const contents: UpdateOriginRequestPolicyCommandOutput = {
@@ -8068,7 +8068,7 @@ export const deserializeAws_restXmlUpdatePublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePublicKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdatePublicKeyCommandError(output, context);
   }
   const contents: UpdatePublicKeyCommandOutput = {
@@ -8173,7 +8173,7 @@ export const deserializeAws_restXmlUpdateStreamingDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStreamingDistributionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateStreamingDistributionCommandError(output, context);
   }
   const contents: UpdateStreamingDistributionCommandOutput = {

--- a/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
@@ -234,7 +234,7 @@ export const deserializeAws_json1_1CopyBackupToRegionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyBackupToRegionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CopyBackupToRegionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -329,7 +329,7 @@ export const deserializeAws_json1_1CreateClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -424,7 +424,7 @@ export const deserializeAws_json1_1CreateHsmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHsmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateHsmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -511,7 +511,7 @@ export const deserializeAws_json1_1DeleteBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -598,7 +598,7 @@ export const deserializeAws_json1_1DeleteClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -693,7 +693,7 @@ export const deserializeAws_json1_1DeleteHsmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHsmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteHsmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -780,7 +780,7 @@ export const deserializeAws_json1_1DescribeBackupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBackupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeBackupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -875,7 +875,7 @@ export const deserializeAws_json1_1DescribeClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -962,7 +962,7 @@ export const deserializeAws_json1_1InitializeClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InitializeClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1InitializeClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1049,7 +1049,7 @@ export const deserializeAws_json1_1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1144,7 +1144,7 @@ export const deserializeAws_json1_1RestoreBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RestoreBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1231,7 +1231,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1326,7 +1326,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-cloudhsm/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm/protocols/Aws_json1_1.ts
@@ -344,7 +344,7 @@ export const deserializeAws_json1_1AddTagsToResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsToResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -415,7 +415,7 @@ export const deserializeAws_json1_1CreateHapgCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHapgCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateHapgCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -486,7 +486,7 @@ export const deserializeAws_json1_1CreateHsmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHsmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateHsmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -557,7 +557,7 @@ export const deserializeAws_json1_1CreateLunaClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLunaClientCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLunaClientCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -628,7 +628,7 @@ export const deserializeAws_json1_1DeleteHapgCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHapgCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteHapgCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -699,7 +699,7 @@ export const deserializeAws_json1_1DeleteHsmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHsmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteHsmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -770,7 +770,7 @@ export const deserializeAws_json1_1DeleteLunaClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLunaClientCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLunaClientCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -841,7 +841,7 @@ export const deserializeAws_json1_1DescribeHapgCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHapgCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeHapgCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -912,7 +912,7 @@ export const deserializeAws_json1_1DescribeHsmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHsmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeHsmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -983,7 +983,7 @@ export const deserializeAws_json1_1DescribeLunaClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLunaClientCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLunaClientCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1054,7 +1054,7 @@ export const deserializeAws_json1_1GetConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1125,7 +1125,7 @@ export const deserializeAws_json1_1ListAvailableZonesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAvailableZonesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAvailableZonesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1196,7 +1196,7 @@ export const deserializeAws_json1_1ListHapgsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHapgsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListHapgsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1267,7 +1267,7 @@ export const deserializeAws_json1_1ListHsmsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHsmsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListHsmsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1338,7 +1338,7 @@ export const deserializeAws_json1_1ListLunaClientsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLunaClientsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLunaClientsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1409,7 +1409,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1480,7 +1480,7 @@ export const deserializeAws_json1_1ModifyHapgCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyHapgCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyHapgCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1551,7 +1551,7 @@ export const deserializeAws_json1_1ModifyHsmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyHsmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyHsmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1622,7 +1622,7 @@ export const deserializeAws_json1_1ModifyLunaClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyLunaClientCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyLunaClientCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1677,7 +1677,7 @@ export const deserializeAws_json1_1RemoveTagsFromResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsFromResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-cloudsearch-domain/protocols/Aws_restJson1.ts
+++ b/clients/client-cloudsearch-domain/protocols/Aws_restJson1.ts
@@ -129,7 +129,7 @@ export const deserializeAws_restJson1SearchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SearchCommandError(output, context);
   }
   const contents: SearchCommandOutput = {
@@ -196,7 +196,7 @@ export const deserializeAws_restJson1SuggestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SuggestCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SuggestCommandError(output, context);
   }
   const contents: SuggestCommandOutput = {
@@ -255,7 +255,7 @@ export const deserializeAws_restJson1UploadDocumentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UploadDocumentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UploadDocumentsCommandError(output, context);
   }
   const contents: UploadDocumentsCommandOutput = {

--- a/clients/client-cloudsearch/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/protocols/Aws_query.ts
@@ -588,7 +588,7 @@ export const deserializeAws_queryBuildSuggestersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BuildSuggestersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryBuildSuggestersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -658,7 +658,7 @@ export const deserializeAws_queryCreateDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -728,7 +728,7 @@ export const deserializeAws_queryDefineAnalysisSchemeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DefineAnalysisSchemeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDefineAnalysisSchemeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -814,7 +814,7 @@ export const deserializeAws_queryDefineExpressionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DefineExpressionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDefineExpressionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -900,7 +900,7 @@ export const deserializeAws_queryDefineIndexFieldCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DefineIndexFieldCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDefineIndexFieldCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -986,7 +986,7 @@ export const deserializeAws_queryDefineSuggesterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DefineSuggesterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDefineSuggesterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1072,7 +1072,7 @@ export const deserializeAws_queryDeleteAnalysisSchemeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAnalysisSchemeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteAnalysisSchemeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1150,7 +1150,7 @@ export const deserializeAws_queryDeleteDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1212,7 +1212,7 @@ export const deserializeAws_queryDeleteExpressionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteExpressionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteExpressionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1290,7 +1290,7 @@ export const deserializeAws_queryDeleteIndexFieldCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIndexFieldCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteIndexFieldCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1368,7 +1368,7 @@ export const deserializeAws_queryDeleteSuggesterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSuggesterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteSuggesterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1446,7 +1446,7 @@ export const deserializeAws_queryDescribeAnalysisSchemesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAnalysisSchemesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAnalysisSchemesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1516,7 +1516,7 @@ export const deserializeAws_queryDescribeAvailabilityOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAvailabilityOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAvailabilityOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1610,7 +1610,7 @@ export const deserializeAws_queryDescribeDomainEndpointOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDomainEndpointOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDomainEndpointOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1699,7 +1699,7 @@ export const deserializeAws_queryDescribeDomainsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDomainsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDomainsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1761,7 +1761,7 @@ export const deserializeAws_queryDescribeExpressionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeExpressionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeExpressionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1831,7 +1831,7 @@ export const deserializeAws_queryDescribeIndexFieldsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIndexFieldsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeIndexFieldsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1901,7 +1901,7 @@ export const deserializeAws_queryDescribeScalingParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScalingParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeScalingParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1971,7 +1971,7 @@ export const deserializeAws_queryDescribeServiceAccessPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeServiceAccessPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeServiceAccessPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2044,7 +2044,7 @@ export const deserializeAws_queryDescribeSuggestersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSuggestersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeSuggestersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2114,7 +2114,7 @@ export const deserializeAws_queryIndexDocumentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IndexDocumentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryIndexDocumentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2184,7 +2184,7 @@ export const deserializeAws_queryListDomainNamesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainNamesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListDomainNamesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2238,7 +2238,7 @@ export const deserializeAws_queryUpdateAvailabilityOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAvailabilityOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateAvailabilityOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2340,7 +2340,7 @@ export const deserializeAws_queryUpdateDomainEndpointOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainEndpointOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateDomainEndpointOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2442,7 +2442,7 @@ export const deserializeAws_queryUpdateScalingParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateScalingParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateScalingParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2528,7 +2528,7 @@ export const deserializeAws_queryUpdateServiceAccessPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServiceAccessPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateServiceAccessPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-cloudtrail/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudtrail/protocols/Aws_json1_1.ts
@@ -361,7 +361,7 @@ export const deserializeAws_json1_1AddTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -480,7 +480,7 @@ export const deserializeAws_json1_1CreateTrailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTrailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -746,7 +746,7 @@ export const deserializeAws_json1_1DeleteTrailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTrailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTrailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -852,7 +852,7 @@ export const deserializeAws_json1_1DescribeTrailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTrailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -923,7 +923,7 @@ export const deserializeAws_json1_1GetEventSelectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEventSelectorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetEventSelectorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1002,7 +1002,7 @@ export const deserializeAws_json1_1GetInsightSelectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInsightSelectorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInsightSelectorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1089,7 +1089,7 @@ export const deserializeAws_json1_1GetTrailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTrailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTrailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1168,7 +1168,7 @@ export const deserializeAws_json1_1GetTrailStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTrailStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTrailStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1247,7 +1247,7 @@ export const deserializeAws_json1_1ListPublicKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPublicKeysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPublicKeysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1326,7 +1326,7 @@ export const deserializeAws_json1_1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1429,7 +1429,7 @@ export const deserializeAws_json1_1ListTrailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTrailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTrailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1492,7 +1492,7 @@ export const deserializeAws_json1_1LookupEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<LookupEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1LookupEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1595,7 +1595,7 @@ export const deserializeAws_json1_1PutEventSelectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEventSelectorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutEventSelectorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1709,7 +1709,7 @@ export const deserializeAws_json1_1PutInsightSelectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutInsightSelectorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutInsightSelectorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1828,7 +1828,7 @@ export const deserializeAws_json1_1RemoveTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1939,7 +1939,7 @@ export const deserializeAws_json1_1StartLoggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartLoggingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartLoggingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2045,7 +2045,7 @@ export const deserializeAws_json1_1StopLoggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopLoggingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopLoggingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2151,7 +2151,7 @@ export const deserializeAws_json1_1UpdateTrailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTrailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTrailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
@@ -567,7 +567,7 @@ export const deserializeAws_json1_1ActivateEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ActivateEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ActivateEventSourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -651,7 +651,7 @@ export const deserializeAws_json1_1CreateEventBusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEventBusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEventBusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -754,7 +754,7 @@ export const deserializeAws_json1_1CreatePartnerEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePartnerEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePartnerEventSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -841,7 +841,7 @@ export const deserializeAws_json1_1DeactivateEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeactivateEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeactivateEventSourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -925,7 +925,7 @@ export const deserializeAws_json1_1DeleteEventBusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventBusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEventBusCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -985,7 +985,7 @@ export const deserializeAws_json1_1DeletePartnerEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePartnerEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePartnerEventSourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1053,7 +1053,7 @@ export const deserializeAws_json1_1DeleteRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRuleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1129,7 +1129,7 @@ export const deserializeAws_json1_1DescribeEventBusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventBusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventBusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1192,7 +1192,7 @@ export const deserializeAws_json1_1DescribeEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1263,7 +1263,7 @@ export const deserializeAws_json1_1DescribePartnerEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePartnerEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePartnerEventSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1334,7 +1334,7 @@ export const deserializeAws_json1_1DescribeRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1397,7 +1397,7 @@ export const deserializeAws_json1_1DisableRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableRuleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1473,7 +1473,7 @@ export const deserializeAws_json1_1EnableRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableRuleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1549,7 +1549,7 @@ export const deserializeAws_json1_1ListEventBusesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEventBusesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEventBusesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1604,7 +1604,7 @@ export const deserializeAws_json1_1ListEventSourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEventSourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEventSourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1667,7 +1667,7 @@ export const deserializeAws_json1_1ListPartnerEventSourceAccountsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPartnerEventSourceAccountsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPartnerEventSourceAccountsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1738,7 +1738,7 @@ export const deserializeAws_json1_1ListPartnerEventSourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPartnerEventSourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPartnerEventSourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1801,7 +1801,7 @@ export const deserializeAws_json1_1ListRuleNamesByTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRuleNamesByTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRuleNamesByTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1864,7 +1864,7 @@ export const deserializeAws_json1_1ListRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1927,7 +1927,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1990,7 +1990,7 @@ export const deserializeAws_json1_1ListTargetsByRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTargetsByRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTargetsByRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2053,7 +2053,7 @@ export const deserializeAws_json1_1PutEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2108,7 +2108,7 @@ export const deserializeAws_json1_1PutPartnerEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPartnerEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutPartnerEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2171,7 +2171,7 @@ export const deserializeAws_json1_1PutPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutPermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2247,7 +2247,7 @@ export const deserializeAws_json1_1PutRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2342,7 +2342,7 @@ export const deserializeAws_json1_1PutTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2429,7 +2429,7 @@ export const deserializeAws_json1_1RemovePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemovePermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemovePermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2497,7 +2497,7 @@ export const deserializeAws_json1_1RemoveTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2576,7 +2576,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2655,7 +2655,7 @@ export const deserializeAws_json1_1TestEventPatternCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestEventPatternCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TestEventPatternCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2718,7 +2718,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
@@ -738,7 +738,7 @@ export const deserializeAws_json1_1AssociateKmsKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateKmsKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateKmsKeyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -814,7 +814,7 @@ export const deserializeAws_json1_1CancelExportTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelExportTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelExportTaskCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -890,7 +890,7 @@ export const deserializeAws_json1_1CreateExportTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateExportTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateExportTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -985,7 +985,7 @@ export const deserializeAws_json1_1CreateLogGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLogGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLogGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1069,7 +1069,7 @@ export const deserializeAws_json1_1CreateLogStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLogStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLogStreamCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1145,7 +1145,7 @@ export const deserializeAws_json1_1DeleteDestinationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDestinationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDestinationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1221,7 +1221,7 @@ export const deserializeAws_json1_1DeleteLogGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLogGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLogGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1297,7 +1297,7 @@ export const deserializeAws_json1_1DeleteLogStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLogStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLogStreamCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1373,7 +1373,7 @@ export const deserializeAws_json1_1DeleteMetricFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMetricFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMetricFilterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1449,7 +1449,7 @@ export const deserializeAws_json1_1DeleteQueryDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteQueryDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteQueryDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1520,7 +1520,7 @@ export const deserializeAws_json1_1DeleteResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResourcePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1588,7 +1588,7 @@ export const deserializeAws_json1_1DeleteRetentionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRetentionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRetentionPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1664,7 +1664,7 @@ export const deserializeAws_json1_1DeleteSubscriptionFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSubscriptionFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSubscriptionFilterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1740,7 +1740,7 @@ export const deserializeAws_json1_1DescribeDestinationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDestinationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDestinationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1803,7 +1803,7 @@ export const deserializeAws_json1_1DescribeExportTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeExportTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeExportTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1866,7 +1866,7 @@ export const deserializeAws_json1_1DescribeLogGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLogGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLogGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1929,7 +1929,7 @@ export const deserializeAws_json1_1DescribeLogStreamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLogStreamsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLogStreamsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2000,7 +2000,7 @@ export const deserializeAws_json1_1DescribeMetricFiltersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMetricFiltersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMetricFiltersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2071,7 +2071,7 @@ export const deserializeAws_json1_1DescribeQueriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeQueriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeQueriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2142,7 +2142,7 @@ export const deserializeAws_json1_1DescribeQueryDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeQueryDefinitionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeQueryDefinitionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2205,7 +2205,7 @@ export const deserializeAws_json1_1DescribeResourcePoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeResourcePoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeResourcePoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2268,7 +2268,7 @@ export const deserializeAws_json1_1DescribeSubscriptionFiltersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSubscriptionFiltersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSubscriptionFiltersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2339,7 +2339,7 @@ export const deserializeAws_json1_1DisassociateKmsKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateKmsKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateKmsKeyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2415,7 +2415,7 @@ export const deserializeAws_json1_1FilterLogEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FilterLogEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1FilterLogEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2486,7 +2486,7 @@ export const deserializeAws_json1_1GetLogEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLogEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLogEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2557,7 +2557,7 @@ export const deserializeAws_json1_1GetLogGroupFieldsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLogGroupFieldsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLogGroupFieldsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2636,7 +2636,7 @@ export const deserializeAws_json1_1GetLogRecordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLogRecordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLogRecordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2715,7 +2715,7 @@ export const deserializeAws_json1_1GetQueryResultsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetQueryResultsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetQueryResultsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2786,7 +2786,7 @@ export const deserializeAws_json1_1ListTagsLogGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsLogGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsLogGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2849,7 +2849,7 @@ export const deserializeAws_json1_1PutDestinationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDestinationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutDestinationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2920,7 +2920,7 @@ export const deserializeAws_json1_1PutDestinationPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDestinationPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutDestinationPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2988,7 +2988,7 @@ export const deserializeAws_json1_1PutLogEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLogEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutLogEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3083,7 +3083,7 @@ export const deserializeAws_json1_1PutMetricFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutMetricFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutMetricFilterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3167,7 +3167,7 @@ export const deserializeAws_json1_1PutQueryDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutQueryDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutQueryDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3238,7 +3238,7 @@ export const deserializeAws_json1_1PutResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3309,7 +3309,7 @@ export const deserializeAws_json1_1PutRetentionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRetentionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRetentionPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3385,7 +3385,7 @@ export const deserializeAws_json1_1PutSubscriptionFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutSubscriptionFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutSubscriptionFilterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3469,7 +3469,7 @@ export const deserializeAws_json1_1StartQueryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartQueryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartQueryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3556,7 +3556,7 @@ export const deserializeAws_json1_1StopQueryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopQueryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopQueryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3627,7 +3627,7 @@ export const deserializeAws_json1_1TagLogGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagLogGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagLogGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3687,7 +3687,7 @@ export const deserializeAws_json1_1TestMetricFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestMetricFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TestMetricFilterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3750,7 +3750,7 @@ export const deserializeAws_json1_1UntagLogGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagLogGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagLogGroupCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -655,7 +655,7 @@ export const deserializeAws_queryDeleteAlarmsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAlarmsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteAlarmsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -706,7 +706,7 @@ export const deserializeAws_queryDeleteAnomalyDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAnomalyDetectorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteAnomalyDetectorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -784,7 +784,7 @@ export const deserializeAws_queryDeleteDashboardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDashboardsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDashboardsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -854,7 +854,7 @@ export const deserializeAws_queryDeleteInsightRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInsightRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteInsightRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -916,7 +916,7 @@ export const deserializeAws_queryDescribeAlarmHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAlarmHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAlarmHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -970,7 +970,7 @@ export const deserializeAws_queryDescribeAlarmsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAlarmsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAlarmsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1024,7 +1024,7 @@ export const deserializeAws_queryDescribeAlarmsForMetricCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAlarmsForMetricCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAlarmsForMetricCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1070,7 +1070,7 @@ export const deserializeAws_queryDescribeAnomalyDetectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAnomalyDetectorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAnomalyDetectorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1140,7 +1140,7 @@ export const deserializeAws_queryDescribeInsightRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInsightRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeInsightRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1194,7 +1194,7 @@ export const deserializeAws_queryDisableAlarmActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableAlarmActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDisableAlarmActionsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1237,7 +1237,7 @@ export const deserializeAws_queryDisableInsightRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableInsightRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDisableInsightRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1299,7 +1299,7 @@ export const deserializeAws_queryEnableAlarmActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableAlarmActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryEnableAlarmActionsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1342,7 +1342,7 @@ export const deserializeAws_queryEnableInsightRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableInsightRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryEnableInsightRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1412,7 +1412,7 @@ export const deserializeAws_queryGetDashboardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDashboardCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetDashboardCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1482,7 +1482,7 @@ export const deserializeAws_queryGetInsightRuleReportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInsightRuleReportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetInsightRuleReportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1552,7 +1552,7 @@ export const deserializeAws_queryGetMetricDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMetricDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetMetricDataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1606,7 +1606,7 @@ export const deserializeAws_queryGetMetricStatisticsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMetricStatisticsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetMetricStatisticsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1684,7 +1684,7 @@ export const deserializeAws_queryGetMetricWidgetImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMetricWidgetImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetMetricWidgetImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1730,7 +1730,7 @@ export const deserializeAws_queryListDashboardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDashboardsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListDashboardsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1792,7 +1792,7 @@ export const deserializeAws_queryListMetricsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMetricsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListMetricsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1854,7 +1854,7 @@ export const deserializeAws_queryListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1924,7 +1924,7 @@ export const deserializeAws_queryPutAnomalyDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAnomalyDetectorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutAnomalyDetectorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2002,7 +2002,7 @@ export const deserializeAws_queryPutCompositeAlarmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutCompositeAlarmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutCompositeAlarmCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2053,7 +2053,7 @@ export const deserializeAws_queryPutDashboardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDashboardCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutDashboardCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2115,7 +2115,7 @@ export const deserializeAws_queryPutInsightRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutInsightRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutInsightRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2185,7 +2185,7 @@ export const deserializeAws_queryPutMetricAlarmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutMetricAlarmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutMetricAlarmCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2236,7 +2236,7 @@ export const deserializeAws_queryPutMetricDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutMetricDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutMetricDataCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2311,7 +2311,7 @@ export const deserializeAws_querySetAlarmStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetAlarmStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetAlarmStateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2370,7 +2370,7 @@ export const deserializeAws_queryTagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryTagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2448,7 +2448,7 @@ export const deserializeAws_queryUntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-codeartifact/protocols/Aws_restJson1.ts
+++ b/clients/client-codeartifact/protocols/Aws_restJson1.ts
@@ -1075,7 +1075,7 @@ export const deserializeAws_restJson1AssociateExternalConnectionCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateExternalConnectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateExternalConnectionCommandError(output, context);
   }
   const contents: AssociateExternalConnectionCommandOutput = {
@@ -1178,7 +1178,7 @@ export const deserializeAws_restJson1CopyPackageVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyPackageVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CopyPackageVersionsCommandError(output, context);
   }
   const contents: CopyPackageVersionsCommandOutput = {
@@ -1288,7 +1288,7 @@ export const deserializeAws_restJson1CreateDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDomainCommandError(output, context);
   }
   const contents: CreateDomainCommandOutput = {
@@ -1391,7 +1391,7 @@ export const deserializeAws_restJson1CreateRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRepositoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRepositoryCommandError(output, context);
   }
   const contents: CreateRepositoryCommandOutput = {
@@ -1494,7 +1494,7 @@ export const deserializeAws_restJson1DeleteDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDomainCommandError(output, context);
   }
   const contents: DeleteDomainCommandOutput = {
@@ -1589,7 +1589,7 @@ export const deserializeAws_restJson1DeleteDomainPermissionsPolicyCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDomainPermissionsPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDomainPermissionsPolicyCommandError(output, context);
   }
   const contents: DeleteDomainPermissionsPolicyCommandOutput = {
@@ -1684,7 +1684,7 @@ export const deserializeAws_restJson1DeletePackageVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePackageVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePackageVersionsCommandError(output, context);
   }
   const contents: DeletePackageVersionsCommandOutput = {
@@ -1786,7 +1786,7 @@ export const deserializeAws_restJson1DeleteRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRepositoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRepositoryCommandError(output, context);
   }
   const contents: DeleteRepositoryCommandOutput = {
@@ -1881,7 +1881,7 @@ export const deserializeAws_restJson1DeleteRepositoryPermissionsPolicyCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRepositoryPermissionsPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRepositoryPermissionsPolicyCommandError(output, context);
   }
   const contents: DeleteRepositoryPermissionsPolicyCommandOutput = {
@@ -1976,7 +1976,7 @@ export const deserializeAws_restJson1DescribeDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDomainCommandError(output, context);
   }
   const contents: DescribeDomainCommandOutput = {
@@ -2063,7 +2063,7 @@ export const deserializeAws_restJson1DescribePackageVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePackageVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribePackageVersionCommandError(output, context);
   }
   const contents: DescribePackageVersionCommandOutput = {
@@ -2158,7 +2158,7 @@ export const deserializeAws_restJson1DescribeRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRepositoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRepositoryCommandError(output, context);
   }
   const contents: DescribeRepositoryCommandOutput = {
@@ -2245,7 +2245,7 @@ export const deserializeAws_restJson1DisassociateExternalConnectionCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateExternalConnectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateExternalConnectionCommandError(output, context);
   }
   const contents: DisassociateExternalConnectionCommandOutput = {
@@ -2348,7 +2348,7 @@ export const deserializeAws_restJson1DisposePackageVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisposePackageVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisposePackageVersionsCommandError(output, context);
   }
   const contents: DisposePackageVersionsCommandOutput = {
@@ -2450,7 +2450,7 @@ export const deserializeAws_restJson1GetAuthorizationTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAuthorizationTokenCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAuthorizationTokenCommandError(output, context);
   }
   const contents: GetAuthorizationTokenCommandOutput = {
@@ -2541,7 +2541,7 @@ export const deserializeAws_restJson1GetDomainPermissionsPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainPermissionsPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDomainPermissionsPolicyCommandError(output, context);
   }
   const contents: GetDomainPermissionsPolicyCommandOutput = {
@@ -2628,7 +2628,7 @@ export const deserializeAws_restJson1GetPackageVersionAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPackageVersionAssetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPackageVersionAssetCommandError(output, context);
   }
   const contents: GetPackageVersionAssetCommandOutput = {
@@ -2725,7 +2725,7 @@ export const deserializeAws_restJson1GetPackageVersionReadmeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPackageVersionReadmeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPackageVersionReadmeCommandError(output, context);
   }
   const contents: GetPackageVersionReadmeCommandOutput = {
@@ -2832,7 +2832,7 @@ export const deserializeAws_restJson1GetRepositoryEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRepositoryEndpointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRepositoryEndpointCommandError(output, context);
   }
   const contents: GetRepositoryEndpointCommandOutput = {
@@ -2919,7 +2919,7 @@ export const deserializeAws_restJson1GetRepositoryPermissionsPolicyCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRepositoryPermissionsPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRepositoryPermissionsPolicyCommandError(output, context);
   }
   const contents: GetRepositoryPermissionsPolicyCommandOutput = {
@@ -3006,7 +3006,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDomainsCommandError(output, context);
   }
   const contents: ListDomainsCommandOutput = {
@@ -3089,7 +3089,7 @@ export const deserializeAws_restJson1ListPackagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPackagesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPackagesCommandError(output, context);
   }
   const contents: ListPackagesCommandOutput = {
@@ -3180,7 +3180,7 @@ export const deserializeAws_restJson1ListPackageVersionAssetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPackageVersionAssetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPackageVersionAssetsCommandError(output, context);
   }
   const contents: ListPackageVersionAssetsCommandOutput = {
@@ -3291,7 +3291,7 @@ export const deserializeAws_restJson1ListPackageVersionDependenciesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPackageVersionDependenciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPackageVersionDependenciesCommandError(output, context);
   }
   const contents: ListPackageVersionDependenciesCommandOutput = {
@@ -3402,7 +3402,7 @@ export const deserializeAws_restJson1ListPackageVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPackageVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPackageVersionsCommandError(output, context);
   }
   const contents: ListPackageVersionsCommandOutput = {
@@ -3509,7 +3509,7 @@ export const deserializeAws_restJson1ListRepositoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRepositoriesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRepositoriesCommandError(output, context);
   }
   const contents: ListRepositoriesCommandOutput = {
@@ -3592,7 +3592,7 @@ export const deserializeAws_restJson1ListRepositoriesInDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRepositoriesInDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRepositoriesInDomainCommandError(output, context);
   }
   const contents: ListRepositoriesInDomainCommandOutput = {
@@ -3683,7 +3683,7 @@ export const deserializeAws_restJson1PutDomainPermissionsPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDomainPermissionsPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutDomainPermissionsPolicyCommandError(output, context);
   }
   const contents: PutDomainPermissionsPolicyCommandOutput = {
@@ -3786,7 +3786,7 @@ export const deserializeAws_restJson1PutRepositoryPermissionsPolicyCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRepositoryPermissionsPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutRepositoryPermissionsPolicyCommandError(output, context);
   }
   const contents: PutRepositoryPermissionsPolicyCommandOutput = {
@@ -3889,7 +3889,7 @@ export const deserializeAws_restJson1UpdatePackageVersionsStatusCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePackageVersionsStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePackageVersionsStatusCommandError(output, context);
   }
   const contents: UpdatePackageVersionsStatusCommandOutput = {
@@ -3991,7 +3991,7 @@ export const deserializeAws_restJson1UpdateRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRepositoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRepositoryCommandError(output, context);
   }
   const contents: UpdateRepositoryCommandOutput = {

--- a/clients/client-codebuild/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/protocols/Aws_json1_1.ts
@@ -798,7 +798,7 @@ export const deserializeAws_json1_1BatchDeleteBuildsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeleteBuildsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDeleteBuildsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -853,7 +853,7 @@ export const deserializeAws_json1_1BatchGetBuildBatchesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetBuildBatchesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetBuildBatchesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -908,7 +908,7 @@ export const deserializeAws_json1_1BatchGetBuildsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetBuildsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetBuildsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -963,7 +963,7 @@ export const deserializeAws_json1_1BatchGetProjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetProjectsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetProjectsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1018,7 +1018,7 @@ export const deserializeAws_json1_1BatchGetReportGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetReportGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetReportGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1073,7 +1073,7 @@ export const deserializeAws_json1_1BatchGetReportsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetReportsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetReportsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1128,7 +1128,7 @@ export const deserializeAws_json1_1CreateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1199,7 +1199,7 @@ export const deserializeAws_json1_1CreateReportGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReportGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateReportGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1270,7 +1270,7 @@ export const deserializeAws_json1_1CreateWebhookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWebhookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWebhookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1349,7 +1349,7 @@ export const deserializeAws_json1_1DeleteBuildBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBuildBatchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBuildBatchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1404,7 +1404,7 @@ export const deserializeAws_json1_1DeleteProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1459,7 +1459,7 @@ export const deserializeAws_json1_1DeleteReportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteReportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1514,7 +1514,7 @@ export const deserializeAws_json1_1DeleteReportGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReportGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteReportGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1569,7 +1569,7 @@ export const deserializeAws_json1_1DeleteResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1624,7 +1624,7 @@ export const deserializeAws_json1_1DeleteSourceCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSourceCredentialsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSourceCredentialsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1687,7 +1687,7 @@ export const deserializeAws_json1_1DeleteWebhookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWebhookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWebhookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1758,7 +1758,7 @@ export const deserializeAws_json1_1DescribeCodeCoveragesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCodeCoveragesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCodeCoveragesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1813,7 +1813,7 @@ export const deserializeAws_json1_1DescribeTestCasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTestCasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTestCasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1876,7 +1876,7 @@ export const deserializeAws_json1_1GetResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1939,7 +1939,7 @@ export const deserializeAws_json1_1ImportSourceCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportSourceCredentialsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportSourceCredentialsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2010,7 +2010,7 @@ export const deserializeAws_json1_1InvalidateProjectCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InvalidateProjectCacheCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1InvalidateProjectCacheCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2073,7 +2073,7 @@ export const deserializeAws_json1_1ListBuildBatchesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBuildBatchesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBuildBatchesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2128,7 +2128,7 @@ export const deserializeAws_json1_1ListBuildBatchesForProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBuildBatchesForProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBuildBatchesForProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2191,7 +2191,7 @@ export const deserializeAws_json1_1ListBuildsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBuildsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBuildsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2246,7 +2246,7 @@ export const deserializeAws_json1_1ListBuildsForProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBuildsForProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBuildsForProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2309,7 +2309,7 @@ export const deserializeAws_json1_1ListCuratedEnvironmentImagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCuratedEnvironmentImagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCuratedEnvironmentImagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2356,7 +2356,7 @@ export const deserializeAws_json1_1ListProjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProjectsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProjectsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2411,7 +2411,7 @@ export const deserializeAws_json1_1ListReportGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListReportGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListReportGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2466,7 +2466,7 @@ export const deserializeAws_json1_1ListReportsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListReportsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListReportsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2521,7 +2521,7 @@ export const deserializeAws_json1_1ListReportsForReportGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListReportsForReportGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListReportsForReportGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2584,7 +2584,7 @@ export const deserializeAws_json1_1ListSharedProjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSharedProjectsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSharedProjectsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2639,7 +2639,7 @@ export const deserializeAws_json1_1ListSharedReportGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSharedReportGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSharedReportGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2694,7 +2694,7 @@ export const deserializeAws_json1_1ListSourceCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSourceCredentialsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSourceCredentialsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2749,7 +2749,7 @@ export const deserializeAws_json1_1PutResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2812,7 +2812,7 @@ export const deserializeAws_json1_1RetryBuildCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RetryBuildCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RetryBuildCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2883,7 +2883,7 @@ export const deserializeAws_json1_1RetryBuildBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RetryBuildBatchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RetryBuildBatchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2946,7 +2946,7 @@ export const deserializeAws_json1_1StartBuildCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartBuildCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartBuildCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3017,7 +3017,7 @@ export const deserializeAws_json1_1StartBuildBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartBuildBatchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartBuildBatchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3080,7 +3080,7 @@ export const deserializeAws_json1_1StopBuildCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopBuildCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopBuildCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3143,7 +3143,7 @@ export const deserializeAws_json1_1StopBuildBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopBuildBatchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopBuildBatchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3206,7 +3206,7 @@ export const deserializeAws_json1_1UpdateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3269,7 +3269,7 @@ export const deserializeAws_json1_1UpdateReportGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateReportGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateReportGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3332,7 +3332,7 @@ export const deserializeAws_json1_1UpdateWebhookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateWebhookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateWebhookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-codecommit/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/protocols/Aws_json1_1.ts
@@ -1625,7 +1625,7 @@ export const deserializeAws_json1_1AssociateApprovalRuleTemplateWithRepositoryCo
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateApprovalRuleTemplateWithRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateApprovalRuleTemplateWithRepositoryCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1768,7 +1768,7 @@ export const deserializeAws_json1_1BatchAssociateApprovalRuleTemplateWithReposit
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchAssociateApprovalRuleTemplateWithRepositoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchAssociateApprovalRuleTemplateWithRepositoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1895,7 +1895,7 @@ export const deserializeAws_json1_1BatchDescribeMergeConflictsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDescribeMergeConflictsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDescribeMergeConflictsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2110,7 +2110,7 @@ export const deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepo
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepositoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2237,7 +2237,7 @@ export const deserializeAws_json1_1BatchGetCommitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetCommitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetCommitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2364,7 +2364,7 @@ export const deserializeAws_json1_1BatchGetRepositoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetRepositoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetRepositoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2475,7 +2475,7 @@ export const deserializeAws_json1_1CreateApprovalRuleTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApprovalRuleTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateApprovalRuleTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2578,7 +2578,7 @@ export const deserializeAws_json1_1CreateBranchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBranchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateBranchCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2734,7 +2734,7 @@ export const deserializeAws_json1_1CreateCommitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCommitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCommitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3085,7 +3085,7 @@ export const deserializeAws_json1_1CreatePullRequestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePullRequestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePullRequestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3332,7 +3332,7 @@ export const deserializeAws_json1_1CreatePullRequestApprovalRuleCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePullRequestApprovalRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePullRequestApprovalRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3499,7 +3499,7 @@ export const deserializeAws_json1_1CreateRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRepositoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3658,7 +3658,7 @@ export const deserializeAws_json1_1CreateUnreferencedMergeCommitCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUnreferencedMergeCommitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUnreferencedMergeCommitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3996,7 +3996,7 @@ export const deserializeAws_json1_1DeleteApprovalRuleTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApprovalRuleTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApprovalRuleTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4067,7 +4067,7 @@ export const deserializeAws_json1_1DeleteBranchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBranchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBranchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4202,7 +4202,7 @@ export const deserializeAws_json1_1DeleteCommentContentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCommentContentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCommentContentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4281,7 +4281,7 @@ export const deserializeAws_json1_1DeleteFileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4504,7 +4504,7 @@ export const deserializeAws_json1_1DeletePullRequestApprovalRuleCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePullRequestApprovalRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePullRequestApprovalRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4647,7 +4647,7 @@ export const deserializeAws_json1_1DeleteRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRepositoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4750,7 +4750,7 @@ export const deserializeAws_json1_1DescribeMergeConflictsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMergeConflictsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMergeConflictsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4981,7 +4981,7 @@ export const deserializeAws_json1_1DescribePullRequestEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePullRequestEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePullRequestEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5132,7 +5132,7 @@ export const deserializeAws_json1_1DisassociateApprovalRuleTemplateFromRepositor
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateApprovalRuleTemplateFromRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateApprovalRuleTemplateFromRepositoryCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5264,7 +5264,7 @@ export const deserializeAws_json1_1EvaluatePullRequestApprovalRulesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EvaluatePullRequestApprovalRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EvaluatePullRequestApprovalRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5399,7 +5399,7 @@ export const deserializeAws_json1_1GetApprovalRuleTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApprovalRuleTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetApprovalRuleTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5470,7 +5470,7 @@ export const deserializeAws_json1_1GetBlobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBlobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetBlobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5613,7 +5613,7 @@ export const deserializeAws_json1_1GetBranchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBranchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetBranchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5748,7 +5748,7 @@ export const deserializeAws_json1_1GetCommentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCommentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCommentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5867,7 +5867,7 @@ export const deserializeAws_json1_1GetCommentReactionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCommentReactionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCommentReactionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5970,7 +5970,7 @@ export const deserializeAws_json1_1GetCommentsForComparedCommitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCommentsForComparedCommitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCommentsForComparedCommitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6121,7 +6121,7 @@ export const deserializeAws_json1_1GetCommentsForPullRequestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCommentsForPullRequestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCommentsForPullRequestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6304,7 +6304,7 @@ export const deserializeAws_json1_1GetCommitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCommitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCommitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6439,7 +6439,7 @@ export const deserializeAws_json1_1GetDifferencesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDifferencesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDifferencesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6614,7 +6614,7 @@ export const deserializeAws_json1_1GetFileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetFileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6773,7 +6773,7 @@ export const deserializeAws_json1_1GetFolderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFolderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetFolderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6924,7 +6924,7 @@ export const deserializeAws_json1_1GetMergeCommitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMergeCommitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMergeCommitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7075,7 +7075,7 @@ export const deserializeAws_json1_1GetMergeConflictsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMergeConflictsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMergeConflictsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7298,7 +7298,7 @@ export const deserializeAws_json1_1GetMergeOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMergeOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMergeOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7473,7 +7473,7 @@ export const deserializeAws_json1_1GetPullRequestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPullRequestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPullRequestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7584,7 +7584,7 @@ export const deserializeAws_json1_1GetPullRequestApprovalStatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPullRequestApprovalStatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPullRequestApprovalStatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7711,7 +7711,7 @@ export const deserializeAws_json1_1GetPullRequestOverrideStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPullRequestOverrideStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPullRequestOverrideStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7838,7 +7838,7 @@ export const deserializeAws_json1_1GetRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRepositoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7949,7 +7949,7 @@ export const deserializeAws_json1_1GetRepositoryTriggersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRepositoryTriggersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRepositoryTriggersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8060,7 +8060,7 @@ export const deserializeAws_json1_1ListApprovalRuleTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApprovalRuleTemplatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListApprovalRuleTemplatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8123,7 +8123,7 @@ export const deserializeAws_json1_1ListAssociatedApprovalRuleTemplatesForReposit
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssociatedApprovalRuleTemplatesForRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssociatedApprovalRuleTemplatesForRepositoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8250,7 +8250,7 @@ export const deserializeAws_json1_1ListBranchesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBranchesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBranchesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8369,7 +8369,7 @@ export const deserializeAws_json1_1ListPullRequestsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPullRequestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPullRequestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8520,7 +8520,7 @@ export const deserializeAws_json1_1ListRepositoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRepositoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRepositoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8591,7 +8591,7 @@ export const deserializeAws_json1_1ListRepositoriesForApprovalRuleTemplateComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRepositoriesForApprovalRuleTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRepositoriesForApprovalRuleTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8718,7 +8718,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8797,7 +8797,7 @@ export const deserializeAws_json1_1MergeBranchesByFastForwardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MergeBranchesByFastForwardCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MergeBranchesByFastForwardCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8996,7 +8996,7 @@ export const deserializeAws_json1_1MergeBranchesBySquashCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MergeBranchesBySquashCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MergeBranchesBySquashCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9358,7 +9358,7 @@ export const deserializeAws_json1_1MergeBranchesByThreeWayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MergeBranchesByThreeWayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MergeBranchesByThreeWayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9720,7 +9720,7 @@ export const deserializeAws_json1_1MergePullRequestByFastForwardCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MergePullRequestByFastForwardCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MergePullRequestByFastForwardCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9919,7 +9919,7 @@ export const deserializeAws_json1_1MergePullRequestBySquashCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MergePullRequestBySquashCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MergePullRequestBySquashCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10273,7 +10273,7 @@ export const deserializeAws_json1_1MergePullRequestByThreeWayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MergePullRequestByThreeWayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MergePullRequestByThreeWayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10627,7 +10627,7 @@ export const deserializeAws_json1_1OverridePullRequestApprovalRulesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<OverridePullRequestApprovalRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1OverridePullRequestApprovalRulesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10791,7 +10791,7 @@ export const deserializeAws_json1_1PostCommentForComparedCommitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PostCommentForComparedCommitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PostCommentForComparedCommitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11022,7 +11022,7 @@ export const deserializeAws_json1_1PostCommentForPullRequestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PostCommentForPullRequestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PostCommentForPullRequestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11285,7 +11285,7 @@ export const deserializeAws_json1_1PostCommentReplyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PostCommentReplyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PostCommentReplyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11396,7 +11396,7 @@ export const deserializeAws_json1_1PutCommentReactionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutCommentReactionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutCommentReactionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11496,7 +11496,7 @@ export const deserializeAws_json1_1PutFileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutFileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutFileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11783,7 +11783,7 @@ export const deserializeAws_json1_1PutRepositoryTriggersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRepositoryTriggersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRepositoryTriggersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12004,7 +12004,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -12120,7 +12120,7 @@ export const deserializeAws_json1_1TestRepositoryTriggersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestRepositoryTriggersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TestRepositoryTriggersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12341,7 +12341,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -12457,7 +12457,7 @@ export const deserializeAws_json1_1UpdateApprovalRuleTemplateContentCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApprovalRuleTemplateContentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateApprovalRuleTemplateContentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12552,7 +12552,7 @@ export const deserializeAws_json1_1UpdateApprovalRuleTemplateDescriptionCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApprovalRuleTemplateDescriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateApprovalRuleTemplateDescriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12631,7 +12631,7 @@ export const deserializeAws_json1_1UpdateApprovalRuleTemplateNameCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApprovalRuleTemplateNameCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateApprovalRuleTemplateNameCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12710,7 +12710,7 @@ export const deserializeAws_json1_1UpdateCommentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCommentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateCommentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12813,7 +12813,7 @@ export const deserializeAws_json1_1UpdateDefaultBranchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDefaultBranchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDefaultBranchCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -12945,7 +12945,7 @@ export const deserializeAws_json1_1UpdatePullRequestApprovalRuleContentCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePullRequestApprovalRuleContentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePullRequestApprovalRuleContentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13120,7 +13120,7 @@ export const deserializeAws_json1_1UpdatePullRequestApprovalStateCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePullRequestApprovalStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePullRequestApprovalStateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -13292,7 +13292,7 @@ export const deserializeAws_json1_1UpdatePullRequestDescriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePullRequestDescriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePullRequestDescriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13379,7 +13379,7 @@ export const deserializeAws_json1_1UpdatePullRequestStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePullRequestStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePullRequestStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13514,7 +13514,7 @@ export const deserializeAws_json1_1UpdatePullRequestTitleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePullRequestTitleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePullRequestTitleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13609,7 +13609,7 @@ export const deserializeAws_json1_1UpdateRepositoryDescriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRepositoryDescriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRepositoryDescriptionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -13725,7 +13725,7 @@ export const deserializeAws_json1_1UpdateRepositoryNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRepositoryNameCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRepositoryNameCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-codedeploy/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/protocols/Aws_json1_1.ts
@@ -1026,7 +1026,7 @@ export const deserializeAws_json1_1AddTagsToOnPremisesInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToOnPremisesInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsToOnPremisesInstancesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1126,7 +1126,7 @@ export const deserializeAws_json1_1BatchGetApplicationRevisionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetApplicationRevisionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetApplicationRevisionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1221,7 +1221,7 @@ export const deserializeAws_json1_1BatchGetApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetApplicationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetApplicationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1300,7 +1300,7 @@ export const deserializeAws_json1_1BatchGetDeploymentGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetDeploymentGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetDeploymentGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1403,7 +1403,7 @@ export const deserializeAws_json1_1BatchGetDeploymentInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetDeploymentInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetDeploymentInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1506,7 +1506,7 @@ export const deserializeAws_json1_1BatchGetDeploymentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetDeploymentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetDeploymentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1577,7 +1577,7 @@ export const deserializeAws_json1_1BatchGetDeploymentTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetDeploymentTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetDeploymentTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1696,7 +1696,7 @@ export const deserializeAws_json1_1BatchGetOnPremisesInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetOnPremisesInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetOnPremisesInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1767,7 +1767,7 @@ export const deserializeAws_json1_1ContinueDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ContinueDeploymentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ContinueDeploymentCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1875,7 +1875,7 @@ export const deserializeAws_json1_1CreateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1970,7 +1970,7 @@ export const deserializeAws_json1_1CreateDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeploymentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDeploymentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2215,7 +2215,7 @@ export const deserializeAws_json1_1CreateDeploymentConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeploymentConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDeploymentConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2318,7 +2318,7 @@ export const deserializeAws_json1_1CreateDeploymentGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeploymentGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDeploymentGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2632,7 +2632,7 @@ export const deserializeAws_json1_1DeleteApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2700,7 +2700,7 @@ export const deserializeAws_json1_1DeleteDeploymentConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeploymentConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDeploymentConfigCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2776,7 +2776,7 @@ export const deserializeAws_json1_1DeleteDeploymentGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeploymentGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDeploymentGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2863,7 +2863,7 @@ export const deserializeAws_json1_1DeleteGitHubAccountTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGitHubAccountTokenCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteGitHubAccountTokenCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2950,7 +2950,7 @@ export const deserializeAws_json1_1DeleteResourcesByExternalIdCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourcesByExternalIdCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResourcesByExternalIdCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2997,7 +2997,7 @@ export const deserializeAws_json1_1DeregisterOnPremisesInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterOnPremisesInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterOnPremisesInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3057,7 +3057,7 @@ export const deserializeAws_json1_1GetApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3128,7 +3128,7 @@ export const deserializeAws_json1_1GetApplicationRevisionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApplicationRevisionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetApplicationRevisionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3223,7 +3223,7 @@ export const deserializeAws_json1_1GetDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDeploymentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3294,7 +3294,7 @@ export const deserializeAws_json1_1GetDeploymentConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDeploymentConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3373,7 +3373,7 @@ export const deserializeAws_json1_1GetDeploymentGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDeploymentGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3476,7 +3476,7 @@ export const deserializeAws_json1_1GetDeploymentInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDeploymentInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3579,7 +3579,7 @@ export const deserializeAws_json1_1GetDeploymentTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDeploymentTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3690,7 +3690,7 @@ export const deserializeAws_json1_1GetOnPremisesInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOnPremisesInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOnPremisesInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3761,7 +3761,7 @@ export const deserializeAws_json1_1ListApplicationRevisionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationRevisionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListApplicationRevisionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3888,7 +3888,7 @@ export const deserializeAws_json1_1ListApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListApplicationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3943,7 +3943,7 @@ export const deserializeAws_json1_1ListDeploymentConfigsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeploymentConfigsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDeploymentConfigsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3998,7 +3998,7 @@ export const deserializeAws_json1_1ListDeploymentGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeploymentGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDeploymentGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4077,7 +4077,7 @@ export const deserializeAws_json1_1ListDeploymentInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeploymentInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDeploymentInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4204,7 +4204,7 @@ export const deserializeAws_json1_1ListDeploymentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeploymentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDeploymentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4339,7 +4339,7 @@ export const deserializeAws_json1_1ListDeploymentTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeploymentTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDeploymentTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4450,7 +4450,7 @@ export const deserializeAws_json1_1ListGitHubAccountTokenNamesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGitHubAccountTokenNamesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGitHubAccountTokenNamesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4521,7 +4521,7 @@ export const deserializeAws_json1_1ListOnPremisesInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOnPremisesInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListOnPremisesInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4592,7 +4592,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4663,7 +4663,7 @@ export const deserializeAws_json1_1PutLifecycleEventHookExecutionStatusCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLifecycleEventHookExecutionStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutLifecycleEventHookExecutionStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4769,7 +4769,7 @@ export const deserializeAws_json1_1RegisterApplicationRevisionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterApplicationRevisionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterApplicationRevisionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4861,7 +4861,7 @@ export const deserializeAws_json1_1RegisterOnPremisesInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterOnPremisesInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterOnPremisesInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4985,7 +4985,7 @@ export const deserializeAws_json1_1RemoveTagsFromOnPremisesInstancesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromOnPremisesInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsFromOnPremisesInstancesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5085,7 +5085,7 @@ export const deserializeAws_json1_1SkipWaitTimeForInstanceTerminationCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SkipWaitTimeForInstanceTerminationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SkipWaitTimeForInstanceTerminationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5177,7 +5177,7 @@ export const deserializeAws_json1_1StopDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDeploymentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopDeploymentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5272,7 +5272,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5383,7 +5383,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5494,7 +5494,7 @@ export const deserializeAws_json1_1UpdateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateApplicationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5570,7 +5570,7 @@ export const deserializeAws_json1_1UpdateDeploymentGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDeploymentGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDeploymentGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-codeguru-reviewer/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-reviewer/protocols/Aws_restJson1.ts
@@ -385,7 +385,7 @@ export const deserializeAws_restJson1AssociateRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateRepositoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateRepositoryCommandError(output, context);
   }
   const contents: AssociateRepositoryCommandOutput = {
@@ -472,7 +472,7 @@ export const deserializeAws_restJson1DescribeCodeReviewCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCodeReviewCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeCodeReviewCommandError(output, context);
   }
   const contents: DescribeCodeReviewCommandOutput = {
@@ -559,7 +559,7 @@ export const deserializeAws_restJson1DescribeRecommendationFeedbackCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRecommendationFeedbackCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRecommendationFeedbackCommandError(output, context);
   }
   const contents: DescribeRecommendationFeedbackCommandOutput = {
@@ -649,7 +649,7 @@ export const deserializeAws_restJson1DescribeRepositoryAssociationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRepositoryAssociationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRepositoryAssociationCommandError(output, context);
   }
   const contents: DescribeRepositoryAssociationCommandOutput = {
@@ -736,7 +736,7 @@ export const deserializeAws_restJson1DisassociateRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateRepositoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateRepositoryCommandError(output, context);
   }
   const contents: DisassociateRepositoryCommandOutput = {
@@ -831,7 +831,7 @@ export const deserializeAws_restJson1ListCodeReviewsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCodeReviewsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListCodeReviewsCommandError(output, context);
   }
   const contents: ListCodeReviewsCommandOutput = {
@@ -914,7 +914,7 @@ export const deserializeAws_restJson1ListRecommendationFeedbackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRecommendationFeedbackCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRecommendationFeedbackCommandError(output, context);
   }
   const contents: ListRecommendationFeedbackCommandOutput = {
@@ -1008,7 +1008,7 @@ export const deserializeAws_restJson1ListRecommendationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRecommendationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRecommendationsCommandError(output, context);
   }
   const contents: ListRecommendationsCommandOutput = {
@@ -1102,7 +1102,7 @@ export const deserializeAws_restJson1ListRepositoryAssociationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRepositoryAssociationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRepositoryAssociationsCommandError(output, context);
   }
   const contents: ListRepositoryAssociationsCommandOutput = {
@@ -1180,7 +1180,7 @@ export const deserializeAws_restJson1PutRecommendationFeedbackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRecommendationFeedbackCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutRecommendationFeedbackCommandError(output, context);
   }
   const contents: PutRecommendationFeedbackCommandOutput = {

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
@@ -521,7 +521,7 @@ export const deserializeAws_restJson1ConfigureAgentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfigureAgentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ConfigureAgentCommandError(output, context);
   }
   const contents: ConfigureAgentCommandOutput = {
@@ -598,7 +598,7 @@ export const deserializeAws_restJson1CreateProfilingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProfilingGroupCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateProfilingGroupCommandError(output, context);
   }
   const contents: CreateProfilingGroupCommandOutput = {
@@ -683,7 +683,7 @@ export const deserializeAws_restJson1DeleteProfilingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProfilingGroupCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteProfilingGroupCommandError(output, context);
   }
   const contents: DeleteProfilingGroupCommandOutput = {
@@ -758,7 +758,7 @@ export const deserializeAws_restJson1DescribeProfilingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProfilingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeProfilingGroupCommandError(output, context);
   }
   const contents: DescribeProfilingGroupCommandOutput = {
@@ -835,7 +835,7 @@ export const deserializeAws_restJson1ListProfilingGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProfilingGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProfilingGroupsCommandError(output, context);
   }
   const contents: ListProfilingGroupsCommandOutput = {
@@ -906,7 +906,7 @@ export const deserializeAws_restJson1UpdateProfilingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProfilingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateProfilingGroupCommandError(output, context);
   }
   const contents: UpdateProfilingGroupCommandOutput = {
@@ -991,7 +991,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPolicyCommandError(output, context);
   }
   const contents: GetPolicyCommandOutput = {
@@ -1066,7 +1066,7 @@ export const deserializeAws_restJson1PutPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPermissionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutPermissionCommandError(output, context);
   }
   const contents: PutPermissionCommandOutput = {
@@ -1157,7 +1157,7 @@ export const deserializeAws_restJson1RemovePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemovePermissionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemovePermissionCommandError(output, context);
   }
   const contents: RemovePermissionCommandOutput = {
@@ -1248,7 +1248,7 @@ export const deserializeAws_restJson1GetProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetProfileCommandError(output, context);
   }
   const contents: GetProfileCommandOutput = {
@@ -1333,7 +1333,7 @@ export const deserializeAws_restJson1ListProfileTimesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProfileTimesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProfileTimesCommandError(output, context);
   }
   const contents: ListProfileTimesCommandOutput = {
@@ -1416,7 +1416,7 @@ export const deserializeAws_restJson1PostAgentProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PostAgentProfileCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1PostAgentProfileCommandError(output, context);
   }
   const contents: PostAgentProfileCommandOutput = {
@@ -1491,7 +1491,7 @@ export const deserializeAws_restJson1RetrieveTimeSeriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RetrieveTimeSeriesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RetrieveTimeSeriesCommandError(output, context);
   }
   const contents: RetrieveTimeSeriesCommandOutput = {

--- a/clients/client-codepipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/protocols/Aws_json1_1.ts
@@ -751,7 +751,7 @@ export const deserializeAws_json1_1AcknowledgeJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcknowledgeJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AcknowledgeJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -822,7 +822,7 @@ export const deserializeAws_json1_1AcknowledgeThirdPartyJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcknowledgeThirdPartyJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AcknowledgeThirdPartyJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -901,7 +901,7 @@ export const deserializeAws_json1_1CreateCustomActionTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCustomActionTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCustomActionTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -988,7 +988,7 @@ export const deserializeAws_json1_1CreatePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePipelineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePipelineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1115,7 +1115,7 @@ export const deserializeAws_json1_1DeleteCustomActionTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCustomActionTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCustomActionTypeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1175,7 +1175,7 @@ export const deserializeAws_json1_1DeletePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePipelineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePipelineCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1235,7 +1235,7 @@ export const deserializeAws_json1_1DeleteWebhookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWebhookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWebhookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1298,7 +1298,7 @@ export const deserializeAws_json1_1DeregisterWebhookWithThirdPartyCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterWebhookWithThirdPartyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterWebhookWithThirdPartyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1361,7 +1361,7 @@ export const deserializeAws_json1_1DisableStageTransitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableStageTransitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableStageTransitionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1429,7 +1429,7 @@ export const deserializeAws_json1_1EnableStageTransitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableStageTransitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableStageTransitionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1497,7 +1497,7 @@ export const deserializeAws_json1_1GetJobDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetJobDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1560,7 +1560,7 @@ export const deserializeAws_json1_1GetPipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPipelineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPipelineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1631,7 +1631,7 @@ export const deserializeAws_json1_1GetPipelineExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPipelineExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPipelineExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1702,7 +1702,7 @@ export const deserializeAws_json1_1GetPipelineStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPipelineStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPipelineStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1765,7 +1765,7 @@ export const deserializeAws_json1_1GetThirdPartyJobDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetThirdPartyJobDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetThirdPartyJobDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1844,7 +1844,7 @@ export const deserializeAws_json1_1ListActionExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListActionExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListActionExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1923,7 +1923,7 @@ export const deserializeAws_json1_1ListActionTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListActionTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListActionTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1986,7 +1986,7 @@ export const deserializeAws_json1_1ListPipelineExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPipelineExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPipelineExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2057,7 +2057,7 @@ export const deserializeAws_json1_1ListPipelinesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPipelinesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPipelinesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2120,7 +2120,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2199,7 +2199,7 @@ export const deserializeAws_json1_1ListWebhooksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWebhooksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListWebhooksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2262,7 +2262,7 @@ export const deserializeAws_json1_1PollForJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PollForJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PollForJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2325,7 +2325,7 @@ export const deserializeAws_json1_1PollForThirdPartyJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PollForThirdPartyJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PollForThirdPartyJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2388,7 +2388,7 @@ export const deserializeAws_json1_1PutActionRevisionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutActionRevisionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutActionRevisionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2467,7 +2467,7 @@ export const deserializeAws_json1_1PutApprovalResultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutApprovalResultCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutApprovalResultCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2562,7 +2562,7 @@ export const deserializeAws_json1_1PutJobFailureResultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutJobFailureResultCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutJobFailureResultCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2630,7 +2630,7 @@ export const deserializeAws_json1_1PutJobSuccessResultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutJobSuccessResultCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutJobSuccessResultCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2706,7 +2706,7 @@ export const deserializeAws_json1_1PutThirdPartyJobFailureResultCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutThirdPartyJobFailureResultCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutThirdPartyJobFailureResultCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2782,7 +2782,7 @@ export const deserializeAws_json1_1PutThirdPartyJobSuccessResultCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutThirdPartyJobSuccessResultCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutThirdPartyJobSuccessResultCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2858,7 +2858,7 @@ export const deserializeAws_json1_1PutWebhookCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutWebhookCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutWebhookCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2969,7 +2969,7 @@ export const deserializeAws_json1_1RegisterWebhookWithThirdPartyCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterWebhookWithThirdPartyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterWebhookWithThirdPartyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3032,7 +3032,7 @@ export const deserializeAws_json1_1RetryStageExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RetryStageExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RetryStageExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3119,7 +3119,7 @@ export const deserializeAws_json1_1StartPipelineExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartPipelineExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartPipelineExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3182,7 +3182,7 @@ export const deserializeAws_json1_1StopPipelineExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopPipelineExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopPipelineExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3261,7 +3261,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3356,7 +3356,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3443,7 +3443,7 @@ export const deserializeAws_json1_1UpdatePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePipelineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePipelineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-codestar-connections/protocols/Aws_json1_0.ts
+++ b/clients/client-codestar-connections/protocols/Aws_json1_0.ts
@@ -200,7 +200,7 @@ export const deserializeAws_json1_0CreateConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CreateConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -271,7 +271,7 @@ export const deserializeAws_json1_0CreateHostCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHostCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CreateHostCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -326,7 +326,7 @@ export const deserializeAws_json1_0DeleteConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DeleteConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -381,7 +381,7 @@ export const deserializeAws_json1_0DeleteHostCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHostCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DeleteHostCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -444,7 +444,7 @@ export const deserializeAws_json1_0GetConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -507,7 +507,7 @@ export const deserializeAws_json1_0GetHostCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHostCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetHostCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -562,7 +562,7 @@ export const deserializeAws_json1_0ListConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -609,7 +609,7 @@ export const deserializeAws_json1_0ListHostsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHostsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListHostsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -656,7 +656,7 @@ export const deserializeAws_json1_0ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -711,7 +711,7 @@ export const deserializeAws_json1_0TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -774,7 +774,7 @@ export const deserializeAws_json1_0UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-codestar-notifications/protocols/Aws_restJson1.ts
+++ b/clients/client-codestar-notifications/protocols/Aws_restJson1.ts
@@ -404,7 +404,7 @@ export const deserializeAws_restJson1CreateNotificationRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNotificationRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateNotificationRuleCommandError(output, context);
   }
   const contents: CreateNotificationRuleCommandOutput = {
@@ -499,7 +499,7 @@ export const deserializeAws_restJson1DeleteNotificationRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNotificationRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteNotificationRuleCommandError(output, context);
   }
   const contents: DeleteNotificationRuleCommandOutput = {
@@ -570,7 +570,7 @@ export const deserializeAws_restJson1DeleteTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTargetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteTargetCommandError(output, context);
   }
   const contents: DeleteTargetCommandOutput = {
@@ -621,7 +621,7 @@ export const deserializeAws_restJson1DescribeNotificationRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNotificationRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeNotificationRuleCommandError(output, context);
   }
   const contents: DescribeNotificationRuleCommandOutput = {
@@ -724,7 +724,7 @@ export const deserializeAws_restJson1ListEventTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEventTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListEventTypesCommandError(output, context);
   }
   const contents: ListEventTypesCommandOutput = {
@@ -791,7 +791,7 @@ export const deserializeAws_restJson1ListNotificationRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNotificationRulesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListNotificationRulesCommandError(output, context);
   }
   const contents: ListNotificationRulesCommandOutput = {
@@ -858,7 +858,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -921,7 +921,7 @@ export const deserializeAws_restJson1ListTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTargetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTargetsCommandError(output, context);
   }
   const contents: ListTargetsCommandOutput = {
@@ -988,7 +988,7 @@ export const deserializeAws_restJson1SubscribeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SubscribeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SubscribeCommandError(output, context);
   }
   const contents: SubscribeCommandOutput = {
@@ -1051,7 +1051,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1122,7 +1122,7 @@ export const deserializeAws_restJson1UnsubscribeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnsubscribeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UnsubscribeCommandError(output, context);
   }
   const contents: UnsubscribeCommandOutput = {
@@ -1177,7 +1177,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -1244,7 +1244,7 @@ export const deserializeAws_restJson1UpdateNotificationRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNotificationRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateNotificationRuleCommandError(output, context);
   }
   const contents: UpdateNotificationRuleCommandOutput = {

--- a/clients/client-codestar/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/protocols/Aws_json1_1.ts
@@ -337,7 +337,7 @@ export const deserializeAws_json1_1AssociateTeamMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateTeamMemberCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateTeamMemberCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -440,7 +440,7 @@ export const deserializeAws_json1_1CreateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -543,7 +543,7 @@ export const deserializeAws_json1_1CreateUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -606,7 +606,7 @@ export const deserializeAws_json1_1DeleteProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -677,7 +677,7 @@ export const deserializeAws_json1_1DeleteUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -732,7 +732,7 @@ export const deserializeAws_json1_1DescribeProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -819,7 +819,7 @@ export const deserializeAws_json1_1DescribeUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUserProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -882,7 +882,7 @@ export const deserializeAws_json1_1DisassociateTeamMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateTeamMemberCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateTeamMemberCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -961,7 +961,7 @@ export const deserializeAws_json1_1ListProjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProjectsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProjectsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1024,7 +1024,7 @@ export const deserializeAws_json1_1ListResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1095,7 +1095,7 @@ export const deserializeAws_json1_1ListTagsForProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1166,7 +1166,7 @@ export const deserializeAws_json1_1ListTeamMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTeamMembersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTeamMembersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1237,7 +1237,7 @@ export const deserializeAws_json1_1ListUserProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUserProfilesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUserProfilesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1300,7 +1300,7 @@ export const deserializeAws_json1_1TagProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1379,7 +1379,7 @@ export const deserializeAws_json1_1UntagProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1458,7 +1458,7 @@ export const deserializeAws_json1_1UpdateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1521,7 +1521,7 @@ export const deserializeAws_json1_1UpdateTeamMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTeamMemberCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTeamMemberCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1624,7 +1624,7 @@ export const deserializeAws_json1_1UpdateUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateUserProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
@@ -1878,7 +1878,7 @@ export const deserializeAws_json1_1AddCustomAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddCustomAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddCustomAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1973,7 +1973,7 @@ export const deserializeAws_json1_1AdminAddUserToGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminAddUserToGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminAddUserToGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2065,7 +2065,7 @@ export const deserializeAws_json1_1AdminConfirmSignUpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminConfirmSignUpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminConfirmSignUpCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2200,7 +2200,7 @@ export const deserializeAws_json1_1AdminCreateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminCreateUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminCreateUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2375,7 +2375,7 @@ export const deserializeAws_json1_1AdminDeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminDeleteUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminDeleteUserCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2467,7 +2467,7 @@ export const deserializeAws_json1_1AdminDeleteUserAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminDeleteUserAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminDeleteUserAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2562,7 +2562,7 @@ export const deserializeAws_json1_1AdminDisableProviderForUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminDisableProviderForUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminDisableProviderForUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2665,7 +2665,7 @@ export const deserializeAws_json1_1AdminDisableUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminDisableUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminDisableUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2760,7 +2760,7 @@ export const deserializeAws_json1_1AdminEnableUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminEnableUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminEnableUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2855,7 +2855,7 @@ export const deserializeAws_json1_1AdminForgetDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminForgetDeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminForgetDeviceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2955,7 +2955,7 @@ export const deserializeAws_json1_1AdminGetDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminGetDeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminGetDeviceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3050,7 +3050,7 @@ export const deserializeAws_json1_1AdminGetUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminGetUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminGetUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3145,7 +3145,7 @@ export const deserializeAws_json1_1AdminInitiateAuthCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminInitiateAuthCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminInitiateAuthCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3312,7 +3312,7 @@ export const deserializeAws_json1_1AdminLinkProviderForUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminLinkProviderForUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminLinkProviderForUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3423,7 +3423,7 @@ export const deserializeAws_json1_1AdminListDevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminListDevicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminListDevicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3518,7 +3518,7 @@ export const deserializeAws_json1_1AdminListGroupsForUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminListGroupsForUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminListGroupsForUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3613,7 +3613,7 @@ export const deserializeAws_json1_1AdminListUserAuthEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminListUserAuthEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminListUserAuthEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3716,7 +3716,7 @@ export const deserializeAws_json1_1AdminRemoveUserFromGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminRemoveUserFromGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminRemoveUserFromGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3808,7 +3808,7 @@ export const deserializeAws_json1_1AdminResetUserPasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminResetUserPasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminResetUserPasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3959,7 +3959,7 @@ export const deserializeAws_json1_1AdminRespondToAuthChallengeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminRespondToAuthChallengeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminRespondToAuthChallengeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4166,7 +4166,7 @@ export const deserializeAws_json1_1AdminSetUserMFAPreferenceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminSetUserMFAPreferenceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminSetUserMFAPreferenceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4269,7 +4269,7 @@ export const deserializeAws_json1_1AdminSetUserPasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminSetUserPasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminSetUserPasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4372,7 +4372,7 @@ export const deserializeAws_json1_1AdminSetUserSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminSetUserSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminSetUserSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4459,7 +4459,7 @@ export const deserializeAws_json1_1AdminUpdateAuthEventFeedbackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminUpdateAuthEventFeedbackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminUpdateAuthEventFeedbackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4562,7 +4562,7 @@ export const deserializeAws_json1_1AdminUpdateDeviceStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminUpdateDeviceStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminUpdateDeviceStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4665,7 +4665,7 @@ export const deserializeAws_json1_1AdminUpdateUserAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminUpdateUserAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminUpdateUserAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4816,7 +4816,7 @@ export const deserializeAws_json1_1AdminUserGlobalSignOutCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdminUserGlobalSignOutCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdminUserGlobalSignOutCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4911,7 +4911,7 @@ export const deserializeAws_json1_1AssociateSoftwareTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateSoftwareTokenCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateSoftwareTokenCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4998,7 +4998,7 @@ export const deserializeAws_json1_1ChangePasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ChangePasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ChangePasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5125,7 +5125,7 @@ export const deserializeAws_json1_1ConfirmDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfirmDeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ConfirmDeviceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5268,7 +5268,7 @@ export const deserializeAws_json1_1ConfirmForgotPasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfirmForgotPasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ConfirmForgotPasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5435,7 +5435,7 @@ export const deserializeAws_json1_1ConfirmSignUpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfirmSignUpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ConfirmSignUpCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5594,7 +5594,7 @@ export const deserializeAws_json1_1CreateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5697,7 +5697,7 @@ export const deserializeAws_json1_1CreateIdentityProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIdentityProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateIdentityProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5800,7 +5800,7 @@ export const deserializeAws_json1_1CreateResourceServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResourceServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateResourceServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5895,7 +5895,7 @@ export const deserializeAws_json1_1CreateUserImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserImportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserImportJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5998,7 +5998,7 @@ export const deserializeAws_json1_1CreateUserPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserPoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserPoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6117,7 +6117,7 @@ export const deserializeAws_json1_1CreateUserPoolClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserPoolClientCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserPoolClientCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6228,7 +6228,7 @@ export const deserializeAws_json1_1CreateUserPoolDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserPoolDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserPoolDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6315,7 +6315,7 @@ export const deserializeAws_json1_1DeleteGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6399,7 +6399,7 @@ export const deserializeAws_json1_1DeleteIdentityProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIdentityProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteIdentityProviderCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6491,7 +6491,7 @@ export const deserializeAws_json1_1DeleteResourceServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourceServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResourceServerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6575,7 +6575,7 @@ export const deserializeAws_json1_1DeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6683,7 +6683,7 @@ export const deserializeAws_json1_1DeleteUserAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6794,7 +6794,7 @@ export const deserializeAws_json1_1DeleteUserPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserPoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserPoolCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6886,7 +6886,7 @@ export const deserializeAws_json1_1DeleteUserPoolClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserPoolClientCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserPoolClientCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6970,7 +6970,7 @@ export const deserializeAws_json1_1DeleteUserPoolDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserPoolDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserPoolDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7049,7 +7049,7 @@ export const deserializeAws_json1_1DescribeIdentityProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIdentityProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeIdentityProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7136,7 +7136,7 @@ export const deserializeAws_json1_1DescribeResourceServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeResourceServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeResourceServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7223,7 +7223,7 @@ export const deserializeAws_json1_1DescribeRiskConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRiskConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRiskConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7318,7 +7318,7 @@ export const deserializeAws_json1_1DescribeUserImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserImportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUserImportJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7405,7 +7405,7 @@ export const deserializeAws_json1_1DescribeUserPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserPoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUserPoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7500,7 +7500,7 @@ export const deserializeAws_json1_1DescribeUserPoolClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserPoolClientCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUserPoolClientCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7587,7 +7587,7 @@ export const deserializeAws_json1_1DescribeUserPoolDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserPoolDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUserPoolDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7666,7 +7666,7 @@ export const deserializeAws_json1_1ForgetDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ForgetDeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ForgetDeviceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -7782,7 +7782,7 @@ export const deserializeAws_json1_1ForgotPasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ForgotPasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ForgotPasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7949,7 +7949,7 @@ export const deserializeAws_json1_1GetCSVHeaderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCSVHeaderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCSVHeaderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8036,7 +8036,7 @@ export const deserializeAws_json1_1GetDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDeviceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8155,7 +8155,7 @@ export const deserializeAws_json1_1GetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8242,7 +8242,7 @@ export const deserializeAws_json1_1GetIdentityProviderByIdentifierCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIdentityProviderByIdentifierCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetIdentityProviderByIdentifierCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8329,7 +8329,7 @@ export const deserializeAws_json1_1GetSigningCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSigningCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSigningCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8400,7 +8400,7 @@ export const deserializeAws_json1_1GetUICustomizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUICustomizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetUICustomizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8487,7 +8487,7 @@ export const deserializeAws_json1_1GetUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8598,7 +8598,7 @@ export const deserializeAws_json1_1GetUserAttributeVerificationCodeCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUserAttributeVerificationCodeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetUserAttributeVerificationCodeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8773,7 +8773,7 @@ export const deserializeAws_json1_1GetUserPoolMfaConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUserPoolMfaConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetUserPoolMfaConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8860,7 +8860,7 @@ export const deserializeAws_json1_1GlobalSignOutCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GlobalSignOutCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GlobalSignOutCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8963,7 +8963,7 @@ export const deserializeAws_json1_1InitiateAuthCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InitiateAuthCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1InitiateAuthCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9122,7 +9122,7 @@ export const deserializeAws_json1_1ListDevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDevicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDevicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9241,7 +9241,7 @@ export const deserializeAws_json1_1ListGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9328,7 +9328,7 @@ export const deserializeAws_json1_1ListIdentityProvidersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIdentityProvidersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListIdentityProvidersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9415,7 +9415,7 @@ export const deserializeAws_json1_1ListResourceServersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceServersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourceServersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9502,7 +9502,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9589,7 +9589,7 @@ export const deserializeAws_json1_1ListUserImportJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUserImportJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUserImportJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9676,7 +9676,7 @@ export const deserializeAws_json1_1ListUserPoolClientsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUserPoolClientsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUserPoolClientsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9763,7 +9763,7 @@ export const deserializeAws_json1_1ListUserPoolsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUserPoolsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUserPoolsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9842,7 +9842,7 @@ export const deserializeAws_json1_1ListUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUsersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUsersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9929,7 +9929,7 @@ export const deserializeAws_json1_1ListUsersInGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUsersInGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUsersInGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10016,7 +10016,7 @@ export const deserializeAws_json1_1ResendConfirmationCodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResendConfirmationCodeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResendConfirmationCodeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10175,7 +10175,7 @@ export const deserializeAws_json1_1RespondToAuthChallengeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RespondToAuthChallengeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RespondToAuthChallengeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10382,7 +10382,7 @@ export const deserializeAws_json1_1SetRiskConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetRiskConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetRiskConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10493,7 +10493,7 @@ export const deserializeAws_json1_1SetUICustomizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetUICustomizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetUICustomizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10580,7 +10580,7 @@ export const deserializeAws_json1_1SetUserMFAPreferenceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetUserMFAPreferenceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetUserMFAPreferenceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10683,7 +10683,7 @@ export const deserializeAws_json1_1SetUserPoolMfaConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetUserPoolMfaConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetUserPoolMfaConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10786,7 +10786,7 @@ export const deserializeAws_json1_1SetUserSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetUserSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetUserSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10889,7 +10889,7 @@ export const deserializeAws_json1_1SignUpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SignUpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SignUpCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11048,7 +11048,7 @@ export const deserializeAws_json1_1StartUserImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartUserImportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartUserImportJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11143,7 +11143,7 @@ export const deserializeAws_json1_1StopUserImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopUserImportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopUserImportJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11238,7 +11238,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11325,7 +11325,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11412,7 +11412,7 @@ export const deserializeAws_json1_1UpdateAuthEventFeedbackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAuthEventFeedbackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAuthEventFeedbackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11515,7 +11515,7 @@ export const deserializeAws_json1_1UpdateDeviceStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDeviceStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDeviceStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11634,7 +11634,7 @@ export const deserializeAws_json1_1UpdateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11721,7 +11721,7 @@ export const deserializeAws_json1_1UpdateIdentityProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIdentityProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateIdentityProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11816,7 +11816,7 @@ export const deserializeAws_json1_1UpdateResourceServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateResourceServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateResourceServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11903,7 +11903,7 @@ export const deserializeAws_json1_1UpdateUserAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateUserAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12094,7 +12094,7 @@ export const deserializeAws_json1_1UpdateUserPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserPoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateUserPoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12229,7 +12229,7 @@ export const deserializeAws_json1_1UpdateUserPoolClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserPoolClientCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateUserPoolClientCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12340,7 +12340,7 @@ export const deserializeAws_json1_1UpdateUserPoolDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserPoolDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateUserPoolDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12427,7 +12427,7 @@ export const deserializeAws_json1_1VerifySoftwareTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<VerifySoftwareTokenCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1VerifySoftwareTokenCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12570,7 +12570,7 @@ export const deserializeAws_json1_1VerifyUserAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<VerifyUserAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1VerifyUserAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-cognito-identity/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/protocols/Aws_json1_1.ts
@@ -388,7 +388,7 @@ export const deserializeAws_json1_1CreateIdentityPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIdentityPoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateIdentityPoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -483,7 +483,7 @@ export const deserializeAws_json1_1DeleteIdentitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIdentitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteIdentitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -554,7 +554,7 @@ export const deserializeAws_json1_1DeleteIdentityPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIdentityPoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteIdentityPoolCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -638,7 +638,7 @@ export const deserializeAws_json1_1DescribeIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeIdentityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -725,7 +725,7 @@ export const deserializeAws_json1_1DescribeIdentityPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIdentityPoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeIdentityPoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -812,7 +812,7 @@ export const deserializeAws_json1_1GetCredentialsForIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCredentialsForIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCredentialsForIdentityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -923,7 +923,7 @@ export const deserializeAws_json1_1GetIdCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIdCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetIdCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1034,7 +1034,7 @@ export const deserializeAws_json1_1GetIdentityPoolRolesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIdentityPoolRolesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetIdentityPoolRolesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1129,7 +1129,7 @@ export const deserializeAws_json1_1GetOpenIdTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOpenIdTokenCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOpenIdTokenCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1232,7 +1232,7 @@ export const deserializeAws_json1_1GetOpenIdTokenForDeveloperIdentityCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOpenIdTokenForDeveloperIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOpenIdTokenForDeveloperIdentityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1335,7 +1335,7 @@ export const deserializeAws_json1_1ListIdentitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIdentitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListIdentitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1422,7 +1422,7 @@ export const deserializeAws_json1_1ListIdentityPoolsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIdentityPoolsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListIdentityPoolsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1509,7 +1509,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1596,7 +1596,7 @@ export const deserializeAws_json1_1LookupDeveloperIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<LookupDeveloperIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1LookupDeveloperIdentityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1691,7 +1691,7 @@ export const deserializeAws_json1_1MergeDeveloperIdentitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MergeDeveloperIdentitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MergeDeveloperIdentitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1786,7 +1786,7 @@ export const deserializeAws_json1_1SetIdentityPoolRolesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetIdentityPoolRolesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetIdentityPoolRolesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1886,7 +1886,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1973,7 +1973,7 @@ export const deserializeAws_json1_1UnlinkDeveloperIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnlinkDeveloperIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UnlinkDeveloperIdentityCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2065,7 +2065,7 @@ export const deserializeAws_json1_1UnlinkIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnlinkIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UnlinkIdentityCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2165,7 +2165,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2252,7 +2252,7 @@ export const deserializeAws_json1_1UpdateIdentityPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIdentityPoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateIdentityPoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-cognito-sync/protocols/Aws_restJson1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1.ts
@@ -769,7 +769,7 @@ export const deserializeAws_restJson1BulkPublishCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BulkPublishCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BulkPublishCommandError(output, context);
   }
   const contents: BulkPublishCommandOutput = {
@@ -864,7 +864,7 @@ export const deserializeAws_restJson1DeleteDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDatasetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDatasetCommandError(output, context);
   }
   const contents: DeleteDatasetCommandOutput = {
@@ -959,7 +959,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDatasetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDatasetCommandError(output, context);
   }
   const contents: DescribeDatasetCommandOutput = {
@@ -1046,7 +1046,7 @@ export const deserializeAws_restJson1DescribeIdentityPoolUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIdentityPoolUsageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeIdentityPoolUsageCommandError(output, context);
   }
   const contents: DescribeIdentityPoolUsageCommandOutput = {
@@ -1133,7 +1133,7 @@ export const deserializeAws_restJson1DescribeIdentityUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIdentityUsageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeIdentityUsageCommandError(output, context);
   }
   const contents: DescribeIdentityUsageCommandOutput = {
@@ -1220,7 +1220,7 @@ export const deserializeAws_restJson1GetBulkPublishDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBulkPublishDetailsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBulkPublishDetailsCommandError(output, context);
   }
   const contents: GetBulkPublishDetailsCommandOutput = {
@@ -1315,7 +1315,7 @@ export const deserializeAws_restJson1GetCognitoEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCognitoEventsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCognitoEventsCommandError(output, context);
   }
   const contents: GetCognitoEventsCommandOutput = {
@@ -1402,7 +1402,7 @@ export const deserializeAws_restJson1GetIdentityPoolConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIdentityPoolConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIdentityPoolConfigurationCommandError(output, context);
   }
   const contents: GetIdentityPoolConfigurationCommandOutput = {
@@ -1497,7 +1497,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatasetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDatasetsCommandError(output, context);
   }
   const contents: ListDatasetsCommandOutput = {
@@ -1584,7 +1584,7 @@ export const deserializeAws_restJson1ListIdentityPoolUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIdentityPoolUsageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListIdentityPoolUsageCommandError(output, context);
   }
   const contents: ListIdentityPoolUsageCommandOutput = {
@@ -1675,7 +1675,7 @@ export const deserializeAws_restJson1ListRecordsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRecordsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRecordsCommandError(output, context);
   }
   const contents: ListRecordsCommandOutput = {
@@ -1786,7 +1786,7 @@ export const deserializeAws_restJson1RegisterDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterDeviceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegisterDeviceCommandError(output, context);
   }
   const contents: RegisterDeviceCommandOutput = {
@@ -1881,7 +1881,7 @@ export const deserializeAws_restJson1SetCognitoEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetCognitoEventsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SetCognitoEventsCommandError(output, context);
   }
   const contents: SetCognitoEventsCommandOutput = {
@@ -1964,7 +1964,7 @@ export const deserializeAws_restJson1SetIdentityPoolConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetIdentityPoolConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SetIdentityPoolConfigurationCommandError(output, context);
   }
   const contents: SetIdentityPoolConfigurationCommandOutput = {
@@ -2067,7 +2067,7 @@ export const deserializeAws_restJson1SubscribeToDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SubscribeToDatasetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SubscribeToDatasetCommandError(output, context);
   }
   const contents: SubscribeToDatasetCommandOutput = {
@@ -2158,7 +2158,7 @@ export const deserializeAws_restJson1UnsubscribeFromDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnsubscribeFromDatasetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UnsubscribeFromDatasetCommandError(output, context);
   }
   const contents: UnsubscribeFromDatasetCommandOutput = {
@@ -2249,7 +2249,7 @@ export const deserializeAws_restJson1UpdateRecordsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRecordsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRecordsCommandError(output, context);
   }
   const contents: UpdateRecordsCommandOutput = {

--- a/clients/client-comprehend/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/protocols/Aws_json1_1.ts
@@ -1010,7 +1010,7 @@ export const deserializeAws_json1_1BatchDetectDominantLanguageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDetectDominantLanguageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDetectDominantLanguageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1089,7 +1089,7 @@ export const deserializeAws_json1_1BatchDetectEntitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDetectEntitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDetectEntitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1176,7 +1176,7 @@ export const deserializeAws_json1_1BatchDetectKeyPhrasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDetectKeyPhrasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDetectKeyPhrasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1263,7 +1263,7 @@ export const deserializeAws_json1_1BatchDetectSentimentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDetectSentimentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDetectSentimentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1350,7 +1350,7 @@ export const deserializeAws_json1_1BatchDetectSyntaxCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDetectSyntaxCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDetectSyntaxCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1437,7 +1437,7 @@ export const deserializeAws_json1_1ClassifyDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ClassifyDocumentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ClassifyDocumentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1516,7 +1516,7 @@ export const deserializeAws_json1_1CreateDocumentClassifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDocumentClassifierCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDocumentClassifierCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1627,7 +1627,7 @@ export const deserializeAws_json1_1CreateEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1738,7 +1738,7 @@ export const deserializeAws_json1_1CreateEntityRecognizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEntityRecognizerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEntityRecognizerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1849,7 +1849,7 @@ export const deserializeAws_json1_1DeleteDocumentClassifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDocumentClassifierCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDocumentClassifierCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1944,7 +1944,7 @@ export const deserializeAws_json1_1DeleteEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2031,7 +2031,7 @@ export const deserializeAws_json1_1DeleteEntityRecognizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEntityRecognizerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEntityRecognizerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2126,7 +2126,7 @@ export const deserializeAws_json1_1DescribeDocumentClassificationJobCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDocumentClassificationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDocumentClassificationJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2205,7 +2205,7 @@ export const deserializeAws_json1_1DescribeDocumentClassifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDocumentClassifierCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDocumentClassifierCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2284,7 +2284,7 @@ export const deserializeAws_json1_1DescribeDominantLanguageDetectionJobCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDominantLanguageDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDominantLanguageDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2363,7 +2363,7 @@ export const deserializeAws_json1_1DescribeEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2442,7 +2442,7 @@ export const deserializeAws_json1_1DescribeEntitiesDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEntitiesDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEntitiesDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2521,7 +2521,7 @@ export const deserializeAws_json1_1DescribeEntityRecognizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEntityRecognizerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEntityRecognizerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2600,7 +2600,7 @@ export const deserializeAws_json1_1DescribeKeyPhrasesDetectionJobCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeKeyPhrasesDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeKeyPhrasesDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2679,7 +2679,7 @@ export const deserializeAws_json1_1DescribeSentimentDetectionJobCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSentimentDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSentimentDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2758,7 +2758,7 @@ export const deserializeAws_json1_1DescribeTopicsDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTopicsDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTopicsDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2837,7 +2837,7 @@ export const deserializeAws_json1_1DetectDominantLanguageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectDominantLanguageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectDominantLanguageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2908,7 +2908,7 @@ export const deserializeAws_json1_1DetectEntitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectEntitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectEntitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2995,7 +2995,7 @@ export const deserializeAws_json1_1DetectKeyPhrasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectKeyPhrasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectKeyPhrasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3074,7 +3074,7 @@ export const deserializeAws_json1_1DetectSentimentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectSentimentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectSentimentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3153,7 +3153,7 @@ export const deserializeAws_json1_1DetectSyntaxCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectSyntaxCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectSyntaxCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3232,7 +3232,7 @@ export const deserializeAws_json1_1ListDocumentClassificationJobsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDocumentClassificationJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDocumentClassificationJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3311,7 +3311,7 @@ export const deserializeAws_json1_1ListDocumentClassifiersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDocumentClassifiersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDocumentClassifiersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3390,7 +3390,7 @@ export const deserializeAws_json1_1ListDominantLanguageDetectionJobsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDominantLanguageDetectionJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDominantLanguageDetectionJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3469,7 +3469,7 @@ export const deserializeAws_json1_1ListEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3540,7 +3540,7 @@ export const deserializeAws_json1_1ListEntitiesDetectionJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEntitiesDetectionJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEntitiesDetectionJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3619,7 +3619,7 @@ export const deserializeAws_json1_1ListEntityRecognizersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEntityRecognizersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEntityRecognizersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3698,7 +3698,7 @@ export const deserializeAws_json1_1ListKeyPhrasesDetectionJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListKeyPhrasesDetectionJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListKeyPhrasesDetectionJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3777,7 +3777,7 @@ export const deserializeAws_json1_1ListSentimentDetectionJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSentimentDetectionJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSentimentDetectionJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3856,7 +3856,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3927,7 +3927,7 @@ export const deserializeAws_json1_1ListTopicsDetectionJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTopicsDetectionJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTopicsDetectionJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4006,7 +4006,7 @@ export const deserializeAws_json1_1StartDocumentClassificationJobCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDocumentClassificationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartDocumentClassificationJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4101,7 +4101,7 @@ export const deserializeAws_json1_1StartDominantLanguageDetectionJobCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDominantLanguageDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartDominantLanguageDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4180,7 +4180,7 @@ export const deserializeAws_json1_1StartEntitiesDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartEntitiesDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartEntitiesDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4275,7 +4275,7 @@ export const deserializeAws_json1_1StartKeyPhrasesDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartKeyPhrasesDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartKeyPhrasesDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4354,7 +4354,7 @@ export const deserializeAws_json1_1StartSentimentDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSentimentDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartSentimentDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4433,7 +4433,7 @@ export const deserializeAws_json1_1StartTopicsDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartTopicsDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartTopicsDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4512,7 +4512,7 @@ export const deserializeAws_json1_1StopDominantLanguageDetectionJobCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDominantLanguageDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopDominantLanguageDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4583,7 +4583,7 @@ export const deserializeAws_json1_1StopEntitiesDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopEntitiesDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopEntitiesDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4654,7 +4654,7 @@ export const deserializeAws_json1_1StopKeyPhrasesDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopKeyPhrasesDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopKeyPhrasesDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4725,7 +4725,7 @@ export const deserializeAws_json1_1StopSentimentDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopSentimentDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopSentimentDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4796,7 +4796,7 @@ export const deserializeAws_json1_1StopTrainingDocumentClassifierCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopTrainingDocumentClassifierCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopTrainingDocumentClassifierCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4875,7 +4875,7 @@ export const deserializeAws_json1_1StopTrainingEntityRecognizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopTrainingEntityRecognizerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopTrainingEntityRecognizerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4954,7 +4954,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5041,7 +5041,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5128,7 +5128,7 @@ export const deserializeAws_json1_1UpdateEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
@@ -423,7 +423,7 @@ export const deserializeAws_json1_1DescribeEntitiesDetectionV2JobCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEntitiesDetectionV2JobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEntitiesDetectionV2JobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -502,7 +502,7 @@ export const deserializeAws_json1_1DescribeICD10CMInferenceJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeICD10CMInferenceJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeICD10CMInferenceJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -581,7 +581,7 @@ export const deserializeAws_json1_1DescribePHIDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePHIDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePHIDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -660,7 +660,7 @@ export const deserializeAws_json1_1DescribeRxNormInferenceJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRxNormInferenceJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRxNormInferenceJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -739,7 +739,7 @@ export const deserializeAws_json1_1DetectEntitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectEntitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectEntitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -834,7 +834,7 @@ export const deserializeAws_json1_1DetectEntitiesV2Command = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectEntitiesV2CommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectEntitiesV2CommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -929,7 +929,7 @@ export const deserializeAws_json1_1DetectPHICommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectPHICommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectPHICommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1024,7 +1024,7 @@ export const deserializeAws_json1_1InferICD10CMCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InferICD10CMCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1InferICD10CMCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1119,7 +1119,7 @@ export const deserializeAws_json1_1InferRxNormCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InferRxNormCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1InferRxNormCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1214,7 +1214,7 @@ export const deserializeAws_json1_1ListEntitiesDetectionV2JobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEntitiesDetectionV2JobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEntitiesDetectionV2JobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1293,7 +1293,7 @@ export const deserializeAws_json1_1ListICD10CMInferenceJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListICD10CMInferenceJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListICD10CMInferenceJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1372,7 +1372,7 @@ export const deserializeAws_json1_1ListPHIDetectionJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPHIDetectionJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPHIDetectionJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1451,7 +1451,7 @@ export const deserializeAws_json1_1ListRxNormInferenceJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRxNormInferenceJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRxNormInferenceJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1530,7 +1530,7 @@ export const deserializeAws_json1_1StartEntitiesDetectionV2JobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartEntitiesDetectionV2JobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartEntitiesDetectionV2JobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1609,7 +1609,7 @@ export const deserializeAws_json1_1StartICD10CMInferenceJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartICD10CMInferenceJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartICD10CMInferenceJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1688,7 +1688,7 @@ export const deserializeAws_json1_1StartPHIDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartPHIDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartPHIDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1767,7 +1767,7 @@ export const deserializeAws_json1_1StartRxNormInferenceJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartRxNormInferenceJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartRxNormInferenceJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1846,7 +1846,7 @@ export const deserializeAws_json1_1StopEntitiesDetectionV2JobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopEntitiesDetectionV2JobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopEntitiesDetectionV2JobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1917,7 +1917,7 @@ export const deserializeAws_json1_1StopICD10CMInferenceJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopICD10CMInferenceJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopICD10CMInferenceJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1988,7 +1988,7 @@ export const deserializeAws_json1_1StopPHIDetectionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopPHIDetectionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopPHIDetectionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2059,7 +2059,7 @@ export const deserializeAws_json1_1StopRxNormInferenceJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopRxNormInferenceJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopRxNormInferenceJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
+++ b/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
@@ -214,7 +214,7 @@ export const deserializeAws_json1_0DescribeRecommendationExportJobsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRecommendationExportJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeRecommendationExportJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -325,7 +325,7 @@ export const deserializeAws_json1_0ExportAutoScalingGroupRecommendationsCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportAutoScalingGroupRecommendationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ExportAutoScalingGroupRecommendationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -436,7 +436,7 @@ export const deserializeAws_json1_0ExportEC2InstanceRecommendationsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportEC2InstanceRecommendationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ExportEC2InstanceRecommendationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -547,7 +547,7 @@ export const deserializeAws_json1_0GetAutoScalingGroupRecommendationsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAutoScalingGroupRecommendationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetAutoScalingGroupRecommendationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -658,7 +658,7 @@ export const deserializeAws_json1_0GetEC2InstanceRecommendationsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEC2InstanceRecommendationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetEC2InstanceRecommendationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -769,7 +769,7 @@ export const deserializeAws_json1_0GetEC2RecommendationProjectedMetricsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEC2RecommendationProjectedMetricsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetEC2RecommendationProjectedMetricsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -880,7 +880,7 @@ export const deserializeAws_json1_0GetEnrollmentStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEnrollmentStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetEnrollmentStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -975,7 +975,7 @@ export const deserializeAws_json1_0GetRecommendationSummariesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRecommendationSummariesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetRecommendationSummariesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1078,7 +1078,7 @@ export const deserializeAws_json1_0UpdateEnrollmentStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEnrollmentStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UpdateEnrollmentStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-config-service/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/protocols/Aws_json1_1.ts
@@ -1603,7 +1603,7 @@ export const deserializeAws_json1_1BatchGetAggregateResourceConfigCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetAggregateResourceConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetAggregateResourceConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1666,7 +1666,7 @@ export const deserializeAws_json1_1BatchGetResourceConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetResourceConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetResourceConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1729,7 +1729,7 @@ export const deserializeAws_json1_1DeleteAggregationAuthorizationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAggregationAuthorizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAggregationAuthorizationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1781,7 +1781,7 @@ export const deserializeAws_json1_1DeleteConfigRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteConfigRuleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1841,7 +1841,7 @@ export const deserializeAws_json1_1DeleteConfigurationAggregatorCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationAggregatorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteConfigurationAggregatorCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1893,7 +1893,7 @@ export const deserializeAws_json1_1DeleteConfigurationRecorderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationRecorderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteConfigurationRecorderCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1945,7 +1945,7 @@ export const deserializeAws_json1_1DeleteConformancePackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConformancePackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteConformancePackCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2005,7 +2005,7 @@ export const deserializeAws_json1_1DeleteDeliveryChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeliveryChannelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDeliveryChannelCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2065,7 +2065,7 @@ export const deserializeAws_json1_1DeleteEvaluationResultsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEvaluationResultsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEvaluationResultsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2128,7 +2128,7 @@ export const deserializeAws_json1_1DeleteOrganizationConfigRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOrganizationConfigRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteOrganizationConfigRuleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2196,7 +2196,7 @@ export const deserializeAws_json1_1DeleteOrganizationConformancePackCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOrganizationConformancePackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteOrganizationConformancePackCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2264,7 +2264,7 @@ export const deserializeAws_json1_1DeletePendingAggregationRequestCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePendingAggregationRequestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePendingAggregationRequestCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2316,7 +2316,7 @@ export const deserializeAws_json1_1DeleteRemediationConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRemediationConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRemediationConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2387,7 +2387,7 @@ export const deserializeAws_json1_1DeleteRemediationExceptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRemediationExceptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRemediationExceptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2442,7 +2442,7 @@ export const deserializeAws_json1_1DeleteResourceConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourceConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResourceConfigCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2502,7 +2502,7 @@ export const deserializeAws_json1_1DeleteRetentionConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRetentionConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRetentionConfigurationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2562,7 +2562,7 @@ export const deserializeAws_json1_1DeliverConfigSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeliverConfigSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeliverConfigSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2633,7 +2633,7 @@ export const deserializeAws_json1_1DescribeAggregateComplianceByConfigRulesComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAggregateComplianceByConfigRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAggregateComplianceByConfigRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2712,7 +2712,7 @@ export const deserializeAws_json1_1DescribeAggregationAuthorizationsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAggregationAuthorizationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAggregationAuthorizationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2783,7 +2783,7 @@ export const deserializeAws_json1_1DescribeComplianceByConfigRuleCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeComplianceByConfigRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeComplianceByConfigRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2854,7 +2854,7 @@ export const deserializeAws_json1_1DescribeComplianceByResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeComplianceByResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeComplianceByResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2917,7 +2917,7 @@ export const deserializeAws_json1_1DescribeConfigRuleEvaluationStatusCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigRuleEvaluationStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConfigRuleEvaluationStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2988,7 +2988,7 @@ export const deserializeAws_json1_1DescribeConfigRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConfigRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3051,7 +3051,7 @@ export const deserializeAws_json1_1DescribeConfigurationAggregatorsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationAggregatorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConfigurationAggregatorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3130,7 +3130,7 @@ export const deserializeAws_json1_1DescribeConfigurationAggregatorSourcesStatusC
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationAggregatorSourcesStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConfigurationAggregatorSourcesStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3209,7 +3209,7 @@ export const deserializeAws_json1_1DescribeConfigurationRecordersCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationRecordersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConfigurationRecordersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3264,7 +3264,7 @@ export const deserializeAws_json1_1DescribeConfigurationRecorderStatusCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationRecorderStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConfigurationRecorderStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3319,7 +3319,7 @@ export const deserializeAws_json1_1DescribeConformancePackComplianceCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConformancePackComplianceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConformancePackComplianceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3406,7 +3406,7 @@ export const deserializeAws_json1_1DescribeConformancePacksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConformancePacksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConformancePacksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3485,7 +3485,7 @@ export const deserializeAws_json1_1DescribeConformancePackStatusCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConformancePackStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConformancePackStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3556,7 +3556,7 @@ export const deserializeAws_json1_1DescribeDeliveryChannelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDeliveryChannelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDeliveryChannelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3611,7 +3611,7 @@ export const deserializeAws_json1_1DescribeDeliveryChannelStatusCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDeliveryChannelStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDeliveryChannelStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3666,7 +3666,7 @@ export const deserializeAws_json1_1DescribeOrganizationConfigRulesCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrganizationConfigRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeOrganizationConfigRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3745,7 +3745,7 @@ export const deserializeAws_json1_1DescribeOrganizationConfigRuleStatusesCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrganizationConfigRuleStatusesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeOrganizationConfigRuleStatusesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3824,7 +3824,7 @@ export const deserializeAws_json1_1DescribeOrganizationConformancePacksCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrganizationConformancePacksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeOrganizationConformancePacksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3903,7 +3903,7 @@ export const deserializeAws_json1_1DescribeOrganizationConformancePackStatusesCo
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrganizationConformancePackStatusesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeOrganizationConformancePackStatusesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3982,7 +3982,7 @@ export const deserializeAws_json1_1DescribePendingAggregationRequestsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePendingAggregationRequestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePendingAggregationRequestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4053,7 +4053,7 @@ export const deserializeAws_json1_1DescribeRemediationConfigurationsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRemediationConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRemediationConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4100,7 +4100,7 @@ export const deserializeAws_json1_1DescribeRemediationExceptionsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRemediationExceptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRemediationExceptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4163,7 +4163,7 @@ export const deserializeAws_json1_1DescribeRemediationExecutionStatusCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRemediationExecutionStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRemediationExecutionStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4226,7 +4226,7 @@ export const deserializeAws_json1_1DescribeRetentionConfigurationsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRetentionConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRetentionConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4297,7 +4297,7 @@ export const deserializeAws_json1_1GetAggregateComplianceDetailsByConfigRuleComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAggregateComplianceDetailsByConfigRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAggregateComplianceDetailsByConfigRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4376,7 +4376,7 @@ export const deserializeAws_json1_1GetAggregateConfigRuleComplianceSummaryComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAggregateConfigRuleComplianceSummaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAggregateConfigRuleComplianceSummaryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4455,7 +4455,7 @@ export const deserializeAws_json1_1GetAggregateDiscoveredResourceCountsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAggregateDiscoveredResourceCountsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAggregateDiscoveredResourceCountsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4534,7 +4534,7 @@ export const deserializeAws_json1_1GetAggregateResourceConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAggregateResourceConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAggregateResourceConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4613,7 +4613,7 @@ export const deserializeAws_json1_1GetComplianceDetailsByConfigRuleCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetComplianceDetailsByConfigRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetComplianceDetailsByConfigRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4684,7 +4684,7 @@ export const deserializeAws_json1_1GetComplianceDetailsByResourceCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetComplianceDetailsByResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetComplianceDetailsByResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4739,7 +4739,7 @@ export const deserializeAws_json1_1GetComplianceSummaryByConfigRuleCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetComplianceSummaryByConfigRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetComplianceSummaryByConfigRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4786,7 +4786,7 @@ export const deserializeAws_json1_1GetComplianceSummaryByResourceTypeCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetComplianceSummaryByResourceTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetComplianceSummaryByResourceTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4841,7 +4841,7 @@ export const deserializeAws_json1_1GetConformancePackComplianceDetailsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConformancePackComplianceDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetConformancePackComplianceDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4928,7 +4928,7 @@ export const deserializeAws_json1_1GetConformancePackComplianceSummaryCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConformancePackComplianceSummaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetConformancePackComplianceSummaryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4999,7 +4999,7 @@ export const deserializeAws_json1_1GetDiscoveredResourceCountsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDiscoveredResourceCountsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDiscoveredResourceCountsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5070,7 +5070,7 @@ export const deserializeAws_json1_1GetOrganizationConfigRuleDetailedStatusComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOrganizationConfigRuleDetailedStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOrganizationConfigRuleDetailedStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5149,7 +5149,7 @@ export const deserializeAws_json1_1GetOrganizationConformancePackDetailedStatusC
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOrganizationConformancePackDetailedStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOrganizationConformancePackDetailedStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5228,7 +5228,7 @@ export const deserializeAws_json1_1GetResourceConfigHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourceConfigHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResourceConfigHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5323,7 +5323,7 @@ export const deserializeAws_json1_1ListAggregateDiscoveredResourcesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAggregateDiscoveredResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAggregateDiscoveredResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5402,7 +5402,7 @@ export const deserializeAws_json1_1ListDiscoveredResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDiscoveredResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDiscoveredResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5481,7 +5481,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5560,7 +5560,7 @@ export const deserializeAws_json1_1PutAggregationAuthorizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAggregationAuthorizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutAggregationAuthorizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5615,7 +5615,7 @@ export const deserializeAws_json1_1PutConfigRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutConfigRuleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5699,7 +5699,7 @@ export const deserializeAws_json1_1PutConfigurationAggregatorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationAggregatorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutConfigurationAggregatorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5794,7 +5794,7 @@ export const deserializeAws_json1_1PutConfigurationRecorderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationRecorderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutConfigurationRecorderCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5873,7 +5873,7 @@ export const deserializeAws_json1_1PutConformancePackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConformancePackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutConformancePackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5960,7 +5960,7 @@ export const deserializeAws_json1_1PutDeliveryChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDeliveryChannelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutDeliveryChannelCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6060,7 +6060,7 @@ export const deserializeAws_json1_1PutEvaluationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEvaluationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutEvaluationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6131,7 +6131,7 @@ export const deserializeAws_json1_1PutOrganizationConfigRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutOrganizationConfigRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutOrganizationConfigRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6245,7 +6245,7 @@ export const deserializeAws_json1_1PutOrganizationConformancePackCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutOrganizationConformancePackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutOrganizationConformancePackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6362,7 +6362,7 @@ export const deserializeAws_json1_1PutRemediationConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRemediationConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRemediationConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6425,7 +6425,7 @@ export const deserializeAws_json1_1PutRemediationExceptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRemediationExceptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRemediationExceptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6488,7 +6488,7 @@ export const deserializeAws_json1_1PutResourceConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutResourceConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutResourceConfigCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6564,7 +6564,7 @@ export const deserializeAws_json1_1PutRetentionConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRetentionConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRetentionConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6630,7 +6630,7 @@ export const deserializeAws_json1_1SelectAggregateResourceConfigCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SelectAggregateResourceConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SelectAggregateResourceConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6709,7 +6709,7 @@ export const deserializeAws_json1_1SelectResourceConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SelectResourceConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SelectResourceConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6780,7 +6780,7 @@ export const deserializeAws_json1_1StartConfigRulesEvaluationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartConfigRulesEvaluationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartConfigRulesEvaluationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6859,7 +6859,7 @@ export const deserializeAws_json1_1StartConfigurationRecorderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartConfigurationRecorderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartConfigurationRecorderCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6919,7 +6919,7 @@ export const deserializeAws_json1_1StartRemediationExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartRemediationExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartRemediationExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6990,7 +6990,7 @@ export const deserializeAws_json1_1StopConfigurationRecorderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopConfigurationRecorderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopConfigurationRecorderCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -7042,7 +7042,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -7110,7 +7110,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-connect/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1.ts
@@ -1322,7 +1322,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateUserCommandError(output, context);
   }
   const contents: CreateUserCommandOutput = {
@@ -1429,7 +1429,7 @@ export const deserializeAws_restJson1DeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteUserCommandError(output, context);
   }
   const contents: DeleteUserCommandOutput = {
@@ -1512,7 +1512,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeUserCommandError(output, context);
   }
   const contents: DescribeUserCommandOutput = {
@@ -1599,7 +1599,7 @@ export const deserializeAws_restJson1DescribeUserHierarchyGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserHierarchyGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeUserHierarchyGroupCommandError(output, context);
   }
   const contents: DescribeUserHierarchyGroupCommandOutput = {
@@ -1686,7 +1686,7 @@ export const deserializeAws_restJson1DescribeUserHierarchyStructureCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserHierarchyStructureCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeUserHierarchyStructureCommandError(output, context);
   }
   const contents: DescribeUserHierarchyStructureCommandOutput = {
@@ -1773,7 +1773,7 @@ export const deserializeAws_restJson1GetContactAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetContactAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetContactAttributesCommandError(output, context);
   }
   const contents: GetContactAttributesCommandOutput = {
@@ -1844,7 +1844,7 @@ export const deserializeAws_restJson1GetCurrentMetricDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCurrentMetricDataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCurrentMetricDataCommandError(output, context);
   }
   const contents: GetCurrentMetricDataCommandOutput = {
@@ -1939,7 +1939,7 @@ export const deserializeAws_restJson1GetFederationTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFederationTokenCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFederationTokenCommandError(output, context);
   }
   const contents: GetFederationTokenCommandOutput = {
@@ -2034,7 +2034,7 @@ export const deserializeAws_restJson1GetMetricDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMetricDataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMetricDataCommandError(output, context);
   }
   const contents: GetMetricDataCommandOutput = {
@@ -2125,7 +2125,7 @@ export const deserializeAws_restJson1ListContactFlowsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListContactFlowsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListContactFlowsCommandError(output, context);
   }
   const contents: ListContactFlowsCommandOutput = {
@@ -2219,7 +2219,7 @@ export const deserializeAws_restJson1ListHoursOfOperationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHoursOfOperationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListHoursOfOperationsCommandError(output, context);
   }
   const contents: ListHoursOfOperationsCommandOutput = {
@@ -2313,7 +2313,7 @@ export const deserializeAws_restJson1ListPhoneNumbersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPhoneNumbersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPhoneNumbersCommandError(output, context);
   }
   const contents: ListPhoneNumbersCommandOutput = {
@@ -2407,7 +2407,7 @@ export const deserializeAws_restJson1ListQueuesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListQueuesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListQueuesCommandError(output, context);
   }
   const contents: ListQueuesCommandOutput = {
@@ -2498,7 +2498,7 @@ export const deserializeAws_restJson1ListRoutingProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRoutingProfilesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRoutingProfilesCommandError(output, context);
   }
   const contents: ListRoutingProfilesCommandOutput = {
@@ -2592,7 +2592,7 @@ export const deserializeAws_restJson1ListSecurityProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSecurityProfilesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSecurityProfilesCommandError(output, context);
   }
   const contents: ListSecurityProfilesCommandOutput = {
@@ -2686,7 +2686,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -2773,7 +2773,7 @@ export const deserializeAws_restJson1ListUserHierarchyGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUserHierarchyGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListUserHierarchyGroupsCommandError(output, context);
   }
   const contents: ListUserHierarchyGroupsCommandOutput = {
@@ -2867,7 +2867,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUsersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListUsersCommandError(output, context);
   }
   const contents: ListUsersCommandOutput = {
@@ -2958,7 +2958,7 @@ export const deserializeAws_restJson1ResumeContactRecordingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResumeContactRecordingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ResumeContactRecordingCommandError(output, context);
   }
   const contents: ResumeContactRecordingCommandOutput = {
@@ -3025,7 +3025,7 @@ export const deserializeAws_restJson1StartChatContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartChatContactCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartChatContactCommandError(output, context);
   }
   const contents: StartChatContactCommandOutput = {
@@ -3120,7 +3120,7 @@ export const deserializeAws_restJson1StartContactRecordingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartContactRecordingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartContactRecordingCommandError(output, context);
   }
   const contents: StartContactRecordingCommandOutput = {
@@ -3195,7 +3195,7 @@ export const deserializeAws_restJson1StartOutboundVoiceContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartOutboundVoiceContactCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartOutboundVoiceContactCommandError(output, context);
   }
   const contents: StartOutboundVoiceContactCommandOutput = {
@@ -3298,7 +3298,7 @@ export const deserializeAws_restJson1StopContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopContactCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopContactCommandError(output, context);
   }
   const contents: StopContactCommandOutput = {
@@ -3381,7 +3381,7 @@ export const deserializeAws_restJson1StopContactRecordingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopContactRecordingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopContactRecordingCommandError(output, context);
   }
   const contents: StopContactRecordingCommandOutput = {
@@ -3448,7 +3448,7 @@ export const deserializeAws_restJson1SuspendContactRecordingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SuspendContactRecordingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SuspendContactRecordingCommandError(output, context);
   }
   const contents: SuspendContactRecordingCommandOutput = {
@@ -3515,7 +3515,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -3598,7 +3598,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -3681,7 +3681,7 @@ export const deserializeAws_restJson1UpdateContactAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateContactAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateContactAttributesCommandError(output, context);
   }
   const contents: UpdateContactAttributesCommandOutput = {
@@ -3756,7 +3756,7 @@ export const deserializeAws_restJson1UpdateUserHierarchyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserHierarchyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUserHierarchyCommandError(output, context);
   }
   const contents: UpdateUserHierarchyCommandOutput = {
@@ -3839,7 +3839,7 @@ export const deserializeAws_restJson1UpdateUserIdentityInfoCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserIdentityInfoCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUserIdentityInfoCommandError(output, context);
   }
   const contents: UpdateUserIdentityInfoCommandOutput = {
@@ -3922,7 +3922,7 @@ export const deserializeAws_restJson1UpdateUserPhoneConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserPhoneConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUserPhoneConfigCommandError(output, context);
   }
   const contents: UpdateUserPhoneConfigCommandOutput = {
@@ -4005,7 +4005,7 @@ export const deserializeAws_restJson1UpdateUserRoutingProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserRoutingProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUserRoutingProfileCommandError(output, context);
   }
   const contents: UpdateUserRoutingProfileCommandOutput = {
@@ -4088,7 +4088,7 @@ export const deserializeAws_restJson1UpdateUserSecurityProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserSecurityProfilesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUserSecurityProfilesCommandError(output, context);
   }
   const contents: UpdateUserSecurityProfilesCommandOutput = {

--- a/clients/client-connectparticipant/protocols/Aws_restJson1.ts
+++ b/clients/client-connectparticipant/protocols/Aws_restJson1.ts
@@ -170,7 +170,7 @@ export const deserializeAws_restJson1CreateParticipantConnectionCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateParticipantConnectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateParticipantConnectionCommandError(output, context);
   }
   const contents: CreateParticipantConnectionCommandOutput = {
@@ -253,7 +253,7 @@ export const deserializeAws_restJson1DisconnectParticipantCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisconnectParticipantCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisconnectParticipantCommandError(output, context);
   }
   const contents: DisconnectParticipantCommandOutput = {
@@ -328,7 +328,7 @@ export const deserializeAws_restJson1GetTranscriptCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTranscriptCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTranscriptCommandError(output, context);
   }
   const contents: GetTranscriptCommandOutput = {
@@ -415,7 +415,7 @@ export const deserializeAws_restJson1SendEventCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendEventCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SendEventCommandError(output, context);
   }
   const contents: SendEventCommandOutput = {
@@ -498,7 +498,7 @@ export const deserializeAws_restJson1SendMessageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendMessageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SendMessageCommandError(output, context);
   }
   const contents: SendMessageCommandOutput = {

--- a/clients/client-cost-and-usage-report-service/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-and-usage-report-service/protocols/Aws_json1_1.ts
@@ -97,7 +97,7 @@ export const deserializeAws_json1_1DeleteReportDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReportDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteReportDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -160,7 +160,7 @@ export const deserializeAws_json1_1DescribeReportDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReportDefinitionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeReportDefinitionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -215,7 +215,7 @@ export const deserializeAws_json1_1ModifyReportDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyReportDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyReportDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -278,7 +278,7 @@ export const deserializeAws_json1_1PutReportDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutReportDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutReportDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-cost-explorer/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-explorer/protocols/Aws_json1_1.ts
@@ -429,7 +429,7 @@ export const deserializeAws_json1_1CreateCostCategoryDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCostCategoryDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCostCategoryDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -492,7 +492,7 @@ export const deserializeAws_json1_1DeleteCostCategoryDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCostCategoryDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCostCategoryDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -555,7 +555,7 @@ export const deserializeAws_json1_1DescribeCostCategoryDefinitionCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCostCategoryDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCostCategoryDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -618,7 +618,7 @@ export const deserializeAws_json1_1GetCostAndUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCostAndUsageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCostAndUsageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -705,7 +705,7 @@ export const deserializeAws_json1_1GetCostAndUsageWithResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCostAndUsageWithResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCostAndUsageWithResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -792,7 +792,7 @@ export const deserializeAws_json1_1GetCostForecastCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCostForecastCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCostForecastCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -855,7 +855,7 @@ export const deserializeAws_json1_1GetDimensionValuesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDimensionValuesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDimensionValuesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -942,7 +942,7 @@ export const deserializeAws_json1_1GetReservationCoverageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetReservationCoverageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetReservationCoverageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1013,7 +1013,7 @@ export const deserializeAws_json1_1GetReservationPurchaseRecommendationCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetReservationPurchaseRecommendationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetReservationPurchaseRecommendationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1084,7 +1084,7 @@ export const deserializeAws_json1_1GetReservationUtilizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetReservationUtilizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetReservationUtilizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1155,7 +1155,7 @@ export const deserializeAws_json1_1GetRightsizingRecommendationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRightsizingRecommendationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRightsizingRecommendationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1218,7 +1218,7 @@ export const deserializeAws_json1_1GetSavingsPlansCoverageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSavingsPlansCoverageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSavingsPlansCoverageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1289,7 +1289,7 @@ export const deserializeAws_json1_1GetSavingsPlansPurchaseRecommendationCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSavingsPlansPurchaseRecommendationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSavingsPlansPurchaseRecommendationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1352,7 +1352,7 @@ export const deserializeAws_json1_1GetSavingsPlansUtilizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSavingsPlansUtilizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSavingsPlansUtilizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1415,7 +1415,7 @@ export const deserializeAws_json1_1GetSavingsPlansUtilizationDetailsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSavingsPlansUtilizationDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSavingsPlansUtilizationDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1486,7 +1486,7 @@ export const deserializeAws_json1_1GetTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1573,7 +1573,7 @@ export const deserializeAws_json1_1GetUsageForecastCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUsageForecastCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetUsageForecastCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1644,7 +1644,7 @@ export const deserializeAws_json1_1ListCostCategoryDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCostCategoryDefinitionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCostCategoryDefinitionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1699,7 +1699,7 @@ export const deserializeAws_json1_1UpdateCostCategoryDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCostCategoryDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateCostCategoryDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-data-pipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-data-pipeline/protocols/Aws_json1_1.ts
@@ -348,7 +348,7 @@ export const deserializeAws_json1_1ActivatePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ActivatePipelineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ActivatePipelineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -427,7 +427,7 @@ export const deserializeAws_json1_1AddTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -506,7 +506,7 @@ export const deserializeAws_json1_1CreatePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePipelineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePipelineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -569,7 +569,7 @@ export const deserializeAws_json1_1DeactivatePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeactivatePipelineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeactivatePipelineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -648,7 +648,7 @@ export const deserializeAws_json1_1DeletePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePipelineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePipelineCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -716,7 +716,7 @@ export const deserializeAws_json1_1DescribeObjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeObjectsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeObjectsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -795,7 +795,7 @@ export const deserializeAws_json1_1DescribePipelinesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePipelinesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePipelinesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -874,7 +874,7 @@ export const deserializeAws_json1_1EvaluateExpressionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EvaluateExpressionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EvaluateExpressionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -961,7 +961,7 @@ export const deserializeAws_json1_1GetPipelineDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPipelineDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPipelineDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1040,7 +1040,7 @@ export const deserializeAws_json1_1ListPipelinesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPipelinesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPipelinesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1103,7 +1103,7 @@ export const deserializeAws_json1_1PollForTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PollForTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PollForTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1174,7 +1174,7 @@ export const deserializeAws_json1_1PutPipelineDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPipelineDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutPipelineDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1253,7 +1253,7 @@ export const deserializeAws_json1_1QueryObjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryObjectsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1QueryObjectsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1332,7 +1332,7 @@ export const deserializeAws_json1_1RemoveTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1411,7 +1411,7 @@ export const deserializeAws_json1_1ReportTaskProgressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReportTaskProgressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ReportTaskProgressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1498,7 +1498,7 @@ export const deserializeAws_json1_1ReportTaskRunnerHeartbeatCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReportTaskRunnerHeartbeatCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ReportTaskRunnerHeartbeatCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1561,7 +1561,7 @@ export const deserializeAws_json1_1SetStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetStatusCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1637,7 +1637,7 @@ export const deserializeAws_json1_1SetTaskStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetTaskStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetTaskStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1724,7 +1724,7 @@ export const deserializeAws_json1_1ValidatePipelineDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ValidatePipelineDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ValidatePipelineDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-database-migration-service/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/protocols/Aws_json1_1.ts
@@ -1049,7 +1049,7 @@ export const deserializeAws_json1_1AddTagsToResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsToResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1104,7 +1104,7 @@ export const deserializeAws_json1_1ApplyPendingMaintenanceActionCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ApplyPendingMaintenanceActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ApplyPendingMaintenanceActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1159,7 +1159,7 @@ export const deserializeAws_json1_1CancelReplicationTaskAssessmentRunCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelReplicationTaskAssessmentRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelReplicationTaskAssessmentRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1230,7 +1230,7 @@ export const deserializeAws_json1_1CreateEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1325,7 +1325,7 @@ export const deserializeAws_json1_1CreateEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1452,7 +1452,7 @@ export const deserializeAws_json1_1CreateReplicationInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReplicationInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateReplicationInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1579,7 +1579,7 @@ export const deserializeAws_json1_1CreateReplicationSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReplicationSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateReplicationSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1674,7 +1674,7 @@ export const deserializeAws_json1_1CreateReplicationTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReplicationTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateReplicationTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1769,7 +1769,7 @@ export const deserializeAws_json1_1DeleteCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1832,7 +1832,7 @@ export const deserializeAws_json1_1DeleteConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1903,7 +1903,7 @@ export const deserializeAws_json1_1DeleteEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1966,7 +1966,7 @@ export const deserializeAws_json1_1DeleteEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2029,7 +2029,7 @@ export const deserializeAws_json1_1DeleteReplicationInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReplicationInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteReplicationInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2092,7 +2092,7 @@ export const deserializeAws_json1_1DeleteReplicationSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReplicationSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteReplicationSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2155,7 +2155,7 @@ export const deserializeAws_json1_1DeleteReplicationTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReplicationTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteReplicationTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2218,7 +2218,7 @@ export const deserializeAws_json1_1DeleteReplicationTaskAssessmentRunCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReplicationTaskAssessmentRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteReplicationTaskAssessmentRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2289,7 +2289,7 @@ export const deserializeAws_json1_1DescribeAccountAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAccountAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2336,7 +2336,7 @@ export const deserializeAws_json1_1DescribeApplicableIndividualAssessmentsComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeApplicableIndividualAssessmentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeApplicableIndividualAssessmentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2407,7 +2407,7 @@ export const deserializeAws_json1_1DescribeCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2462,7 +2462,7 @@ export const deserializeAws_json1_1DescribeConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2517,7 +2517,7 @@ export const deserializeAws_json1_1DescribeEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2572,7 +2572,7 @@ export const deserializeAws_json1_1DescribeEndpointTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEndpointTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEndpointTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2619,7 +2619,7 @@ export const deserializeAws_json1_1DescribeEventCategoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventCategoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventCategoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2666,7 +2666,7 @@ export const deserializeAws_json1_1DescribeEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2713,7 +2713,7 @@ export const deserializeAws_json1_1DescribeEventSubscriptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventSubscriptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventSubscriptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2768,7 +2768,7 @@ export const deserializeAws_json1_1DescribeOrderableReplicationInstancesCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrderableReplicationInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeOrderableReplicationInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2815,7 +2815,7 @@ export const deserializeAws_json1_1DescribePendingMaintenanceActionsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePendingMaintenanceActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePendingMaintenanceActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2870,7 +2870,7 @@ export const deserializeAws_json1_1DescribeRefreshSchemasStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRefreshSchemasStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRefreshSchemasStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2933,7 +2933,7 @@ export const deserializeAws_json1_1DescribeReplicationInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReplicationInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeReplicationInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2988,7 +2988,7 @@ export const deserializeAws_json1_1DescribeReplicationInstanceTaskLogsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReplicationInstanceTaskLogsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeReplicationInstanceTaskLogsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3051,7 +3051,7 @@ export const deserializeAws_json1_1DescribeReplicationSubnetGroupsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReplicationSubnetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeReplicationSubnetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3106,7 +3106,7 @@ export const deserializeAws_json1_1DescribeReplicationTaskAssessmentResultsComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReplicationTaskAssessmentResultsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeReplicationTaskAssessmentResultsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3161,7 +3161,7 @@ export const deserializeAws_json1_1DescribeReplicationTaskAssessmentRunsCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReplicationTaskAssessmentRunsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeReplicationTaskAssessmentRunsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3216,7 +3216,7 @@ export const deserializeAws_json1_1DescribeReplicationTaskIndividualAssessmentsC
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReplicationTaskIndividualAssessmentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeReplicationTaskIndividualAssessmentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3271,7 +3271,7 @@ export const deserializeAws_json1_1DescribeReplicationTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReplicationTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeReplicationTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3326,7 +3326,7 @@ export const deserializeAws_json1_1DescribeSchemasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSchemasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSchemasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3389,7 +3389,7 @@ export const deserializeAws_json1_1DescribeTableStatisticsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTableStatisticsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTableStatisticsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3452,7 +3452,7 @@ export const deserializeAws_json1_1ImportCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3523,7 +3523,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3578,7 +3578,7 @@ export const deserializeAws_json1_1ModifyEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3665,7 +3665,7 @@ export const deserializeAws_json1_1ModifyEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3784,7 +3784,7 @@ export const deserializeAws_json1_1ModifyReplicationInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyReplicationInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyReplicationInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3887,7 +3887,7 @@ export const deserializeAws_json1_1ModifyReplicationSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyReplicationSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyReplicationSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3982,7 +3982,7 @@ export const deserializeAws_json1_1ModifyReplicationTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyReplicationTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyReplicationTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4061,7 +4061,7 @@ export const deserializeAws_json1_1RebootReplicationInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootReplicationInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RebootReplicationInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4124,7 +4124,7 @@ export const deserializeAws_json1_1RefreshSchemasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RefreshSchemasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RefreshSchemasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4203,7 +4203,7 @@ export const deserializeAws_json1_1ReloadTablesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReloadTablesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ReloadTablesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4266,7 +4266,7 @@ export const deserializeAws_json1_1RemoveTagsFromResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsFromResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4321,7 +4321,7 @@ export const deserializeAws_json1_1StartReplicationTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartReplicationTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartReplicationTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4392,7 +4392,7 @@ export const deserializeAws_json1_1StartReplicationTaskAssessmentCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartReplicationTaskAssessmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartReplicationTaskAssessmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4455,7 +4455,7 @@ export const deserializeAws_json1_1StartReplicationTaskAssessmentRunCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartReplicationTaskAssessmentRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartReplicationTaskAssessmentRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4598,7 +4598,7 @@ export const deserializeAws_json1_1StopReplicationTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopReplicationTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopReplicationTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4661,7 +4661,7 @@ export const deserializeAws_json1_1TestConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TestConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-dataexchange/protocols/Aws_restJson1.ts
+++ b/clients/client-dataexchange/protocols/Aws_restJson1.ts
@@ -843,7 +843,7 @@ export const deserializeAws_restJson1CancelJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelJobCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelJobCommandError(output, context);
   }
   const contents: CancelJobCommandOutput = {
@@ -926,7 +926,7 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataSetCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDataSetCommandError(output, context);
   }
   const contents: CreateDataSetCommandOutput = {
@@ -1053,7 +1053,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateJobCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateJobCommandError(output, context);
   }
   const contents: CreateJobCommandOutput = {
@@ -1168,7 +1168,7 @@ export const deserializeAws_restJson1CreateRevisionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRevisionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRevisionCommandError(output, context);
   }
   const contents: CreateRevisionCommandOutput = {
@@ -1287,7 +1287,7 @@ export const deserializeAws_restJson1DeleteAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAssetCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAssetCommandError(output, context);
   }
   const contents: DeleteAssetCommandOutput = {
@@ -1378,7 +1378,7 @@ export const deserializeAws_restJson1DeleteDataSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDataSetCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDataSetCommandError(output, context);
   }
   const contents: DeleteDataSetCommandOutput = {
@@ -1469,7 +1469,7 @@ export const deserializeAws_restJson1DeleteRevisionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRevisionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRevisionCommandError(output, context);
   }
   const contents: DeleteRevisionCommandOutput = {
@@ -1560,7 +1560,7 @@ export const deserializeAws_restJson1GetAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAssetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAssetCommandError(output, context);
   }
   const contents: GetAssetCommandOutput = {
@@ -1675,7 +1675,7 @@ export const deserializeAws_restJson1GetDataSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDataSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDataSetCommandError(output, context);
   }
   const contents: GetDataSetCommandOutput = {
@@ -1794,7 +1794,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJobCommandError(output, context);
   }
   const contents: GetJobCommandOutput = {
@@ -1901,7 +1901,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRevisionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRevisionCommandError(output, context);
   }
   const contents: GetRevisionCommandOutput = {
@@ -2012,7 +2012,7 @@ export const deserializeAws_restJson1ListDataSetRevisionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDataSetRevisionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDataSetRevisionsCommandError(output, context);
   }
   const contents: ListDataSetRevisionsCommandOutput = {
@@ -2095,7 +2095,7 @@ export const deserializeAws_restJson1ListDataSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDataSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDataSetsCommandError(output, context);
   }
   const contents: ListDataSetsCommandOutput = {
@@ -2178,7 +2178,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobsCommandError(output, context);
   }
   const contents: ListJobsCommandOutput = {
@@ -2261,7 +2261,7 @@ export const deserializeAws_restJson1ListRevisionAssetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRevisionAssetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRevisionAssetsCommandError(output, context);
   }
   const contents: ListRevisionAssetsCommandOutput = {
@@ -2344,7 +2344,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -2391,7 +2391,7 @@ export const deserializeAws_restJson1StartJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartJobCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartJobCommandError(output, context);
   }
   const contents: StartJobCommandOutput = {
@@ -2482,7 +2482,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -2525,7 +2525,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -2568,7 +2568,7 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAssetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAssetCommandError(output, context);
   }
   const contents: UpdateAssetCommandOutput = {
@@ -2699,7 +2699,7 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDataSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDataSetCommandError(output, context);
   }
   const contents: UpdateDataSetCommandOutput = {
@@ -2822,7 +2822,7 @@ export const deserializeAws_restJson1UpdateRevisionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRevisionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRevisionCommandError(output, context);
   }
   const contents: UpdateRevisionCommandOutput = {

--- a/clients/client-datasync/protocols/Aws_json1_1.ts
+++ b/clients/client-datasync/protocols/Aws_json1_1.ts
@@ -557,7 +557,7 @@ export const deserializeAws_json1_1CancelTaskExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelTaskExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelTaskExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -620,7 +620,7 @@ export const deserializeAws_json1_1CreateAgentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAgentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAgentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -683,7 +683,7 @@ export const deserializeAws_json1_1CreateLocationEfsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLocationEfsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLocationEfsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -746,7 +746,7 @@ export const deserializeAws_json1_1CreateLocationFsxWindowsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLocationFsxWindowsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLocationFsxWindowsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -809,7 +809,7 @@ export const deserializeAws_json1_1CreateLocationNfsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLocationNfsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLocationNfsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -872,7 +872,7 @@ export const deserializeAws_json1_1CreateLocationObjectStorageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLocationObjectStorageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLocationObjectStorageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -935,7 +935,7 @@ export const deserializeAws_json1_1CreateLocationS3Command = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLocationS3CommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLocationS3CommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -998,7 +998,7 @@ export const deserializeAws_json1_1CreateLocationSmbCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLocationSmbCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLocationSmbCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1061,7 +1061,7 @@ export const deserializeAws_json1_1CreateTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1124,7 +1124,7 @@ export const deserializeAws_json1_1DeleteAgentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAgentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAgentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1187,7 +1187,7 @@ export const deserializeAws_json1_1DeleteLocationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLocationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLocationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1250,7 +1250,7 @@ export const deserializeAws_json1_1DeleteTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1313,7 +1313,7 @@ export const deserializeAws_json1_1DescribeAgentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAgentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAgentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1376,7 +1376,7 @@ export const deserializeAws_json1_1DescribeLocationEfsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocationEfsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLocationEfsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1439,7 +1439,7 @@ export const deserializeAws_json1_1DescribeLocationFsxWindowsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocationFsxWindowsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLocationFsxWindowsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1502,7 +1502,7 @@ export const deserializeAws_json1_1DescribeLocationNfsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocationNfsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLocationNfsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1565,7 +1565,7 @@ export const deserializeAws_json1_1DescribeLocationObjectStorageCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocationObjectStorageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLocationObjectStorageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1628,7 +1628,7 @@ export const deserializeAws_json1_1DescribeLocationS3Command = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocationS3CommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLocationS3CommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1691,7 +1691,7 @@ export const deserializeAws_json1_1DescribeLocationSmbCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocationSmbCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLocationSmbCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1754,7 +1754,7 @@ export const deserializeAws_json1_1DescribeTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1817,7 +1817,7 @@ export const deserializeAws_json1_1DescribeTaskExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTaskExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTaskExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1880,7 +1880,7 @@ export const deserializeAws_json1_1ListAgentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAgentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAgentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1943,7 +1943,7 @@ export const deserializeAws_json1_1ListLocationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLocationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLocationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2006,7 +2006,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2069,7 +2069,7 @@ export const deserializeAws_json1_1ListTaskExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTaskExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTaskExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2132,7 +2132,7 @@ export const deserializeAws_json1_1ListTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2195,7 +2195,7 @@ export const deserializeAws_json1_1StartTaskExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartTaskExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartTaskExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2258,7 +2258,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2321,7 +2321,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2384,7 +2384,7 @@ export const deserializeAws_json1_1UpdateAgentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAgentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAgentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2447,7 +2447,7 @@ export const deserializeAws_json1_1UpdateTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-dax/protocols/Aws_json1_1.ts
+++ b/clients/client-dax/protocols/Aws_json1_1.ts
@@ -416,7 +416,7 @@ export const deserializeAws_json1_1CreateClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -575,7 +575,7 @@ export const deserializeAws_json1_1CreateParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -670,7 +670,7 @@ export const deserializeAws_json1_1CreateSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -757,7 +757,7 @@ export const deserializeAws_json1_1DecreaseReplicationFactorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DecreaseReplicationFactorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DecreaseReplicationFactorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -852,7 +852,7 @@ export const deserializeAws_json1_1DeleteClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -939,7 +939,7 @@ export const deserializeAws_json1_1DeleteParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1026,7 +1026,7 @@ export const deserializeAws_json1_1DeleteSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1097,7 +1097,7 @@ export const deserializeAws_json1_1DescribeClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1176,7 +1176,7 @@ export const deserializeAws_json1_1DescribeDefaultParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDefaultParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDefaultParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1247,7 +1247,7 @@ export const deserializeAws_json1_1DescribeEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1318,7 +1318,7 @@ export const deserializeAws_json1_1DescribeParameterGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeParameterGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeParameterGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1397,7 +1397,7 @@ export const deserializeAws_json1_1DescribeParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1476,7 +1476,7 @@ export const deserializeAws_json1_1DescribeSubnetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSubnetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSubnetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1539,7 +1539,7 @@ export const deserializeAws_json1_1IncreaseReplicationFactorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IncreaseReplicationFactorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1IncreaseReplicationFactorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1658,7 +1658,7 @@ export const deserializeAws_json1_1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1753,7 +1753,7 @@ export const deserializeAws_json1_1RebootNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootNodeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RebootNodeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1848,7 +1848,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1951,7 +1951,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2054,7 +2054,7 @@ export const deserializeAws_json1_1UpdateClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2157,7 +2157,7 @@ export const deserializeAws_json1_1UpdateParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2244,7 +2244,7 @@ export const deserializeAws_json1_1UpdateSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-detective/protocols/Aws_restJson1.ts
+++ b/clients/client-detective/protocols/Aws_restJson1.ts
@@ -339,7 +339,7 @@ export const deserializeAws_restJson1AcceptInvitationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptInvitationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AcceptInvitationCommandError(output, context);
   }
   const contents: AcceptInvitationCommandOutput = {
@@ -414,7 +414,7 @@ export const deserializeAws_restJson1CreateGraphCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGraphCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGraphCommandError(output, context);
   }
   const contents: CreateGraphCommandOutput = {
@@ -485,7 +485,7 @@ export const deserializeAws_restJson1CreateMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMembersCommandError(output, context);
   }
   const contents: CreateMembersCommandOutput = {
@@ -568,7 +568,7 @@ export const deserializeAws_restJson1DeleteGraphCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGraphCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGraphCommandError(output, context);
   }
   const contents: DeleteGraphCommandOutput = {
@@ -635,7 +635,7 @@ export const deserializeAws_restJson1DeleteMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMembersCommandError(output, context);
   }
   const contents: DeleteMembersCommandOutput = {
@@ -718,7 +718,7 @@ export const deserializeAws_restJson1DisassociateMembershipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateMembershipCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateMembershipCommandError(output, context);
   }
   const contents: DisassociateMembershipCommandOutput = {
@@ -793,7 +793,7 @@ export const deserializeAws_restJson1GetMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMembersCommandError(output, context);
   }
   const contents: GetMembersCommandOutput = {
@@ -868,7 +868,7 @@ export const deserializeAws_restJson1ListGraphsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGraphsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGraphsCommandError(output, context);
   }
   const contents: ListGraphsCommandOutput = {
@@ -935,7 +935,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListInvitationsCommandError(output, context);
   }
   const contents: ListInvitationsCommandOutput = {
@@ -1002,7 +1002,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMembersCommandError(output, context);
   }
   const contents: ListMembersCommandOutput = {
@@ -1077,7 +1077,7 @@ export const deserializeAws_restJson1RejectInvitationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectInvitationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RejectInvitationCommandError(output, context);
   }
   const contents: RejectInvitationCommandOutput = {
@@ -1152,7 +1152,7 @@ export const deserializeAws_restJson1StartMonitoringMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMonitoringMemberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartMonitoringMemberCommandError(output, context);
   }
   const contents: StartMonitoringMemberCommandOutput = {

--- a/clients/client-device-farm/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/protocols/Aws_json1_1.ts
@@ -1404,7 +1404,7 @@ export const deserializeAws_json1_1CreateDevicePoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDevicePoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDevicePoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1483,7 +1483,7 @@ export const deserializeAws_json1_1CreateInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateInstanceProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1562,7 +1562,7 @@ export const deserializeAws_json1_1CreateNetworkProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNetworkProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateNetworkProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1641,7 +1641,7 @@ export const deserializeAws_json1_1CreateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1728,7 +1728,7 @@ export const deserializeAws_json1_1CreateRemoteAccessSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRemoteAccessSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRemoteAccessSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1807,7 +1807,7 @@ export const deserializeAws_json1_1CreateTestGridProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTestGridProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTestGridProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1862,7 +1862,7 @@ export const deserializeAws_json1_1CreateTestGridUrlCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTestGridUrlCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTestGridUrlCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1933,7 +1933,7 @@ export const deserializeAws_json1_1CreateUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUploadCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUploadCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2012,7 +2012,7 @@ export const deserializeAws_json1_1CreateVPCEConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVPCEConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateVPCEConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2083,7 +2083,7 @@ export const deserializeAws_json1_1DeleteDevicePoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDevicePoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDevicePoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2162,7 +2162,7 @@ export const deserializeAws_json1_1DeleteInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteInstanceProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2241,7 +2241,7 @@ export const deserializeAws_json1_1DeleteNetworkProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNetworkProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteNetworkProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2320,7 +2320,7 @@ export const deserializeAws_json1_1DeleteProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2399,7 +2399,7 @@ export const deserializeAws_json1_1DeleteRemoteAccessSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRemoteAccessSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRemoteAccessSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2478,7 +2478,7 @@ export const deserializeAws_json1_1DeleteRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2557,7 +2557,7 @@ export const deserializeAws_json1_1DeleteTestGridProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTestGridProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTestGridProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2636,7 +2636,7 @@ export const deserializeAws_json1_1DeleteUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUploadCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUploadCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2715,7 +2715,7 @@ export const deserializeAws_json1_1DeleteVPCEConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVPCEConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteVPCEConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2794,7 +2794,7 @@ export const deserializeAws_json1_1GetAccountSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAccountSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2873,7 +2873,7 @@ export const deserializeAws_json1_1GetDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDeviceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2952,7 +2952,7 @@ export const deserializeAws_json1_1GetDeviceInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeviceInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDeviceInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3031,7 +3031,7 @@ export const deserializeAws_json1_1GetDevicePoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDevicePoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDevicePoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3110,7 +3110,7 @@ export const deserializeAws_json1_1GetDevicePoolCompatibilityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDevicePoolCompatibilityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDevicePoolCompatibilityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3189,7 +3189,7 @@ export const deserializeAws_json1_1GetInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstanceProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3268,7 +3268,7 @@ export const deserializeAws_json1_1GetJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3347,7 +3347,7 @@ export const deserializeAws_json1_1GetNetworkProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetNetworkProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetNetworkProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3426,7 +3426,7 @@ export const deserializeAws_json1_1GetOfferingStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOfferingStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOfferingStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3513,7 +3513,7 @@ export const deserializeAws_json1_1GetProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3592,7 +3592,7 @@ export const deserializeAws_json1_1GetRemoteAccessSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRemoteAccessSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRemoteAccessSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3671,7 +3671,7 @@ export const deserializeAws_json1_1GetRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3750,7 +3750,7 @@ export const deserializeAws_json1_1GetSuiteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSuiteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSuiteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3829,7 +3829,7 @@ export const deserializeAws_json1_1GetTestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3908,7 +3908,7 @@ export const deserializeAws_json1_1GetTestGridProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTestGridProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTestGridProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3979,7 +3979,7 @@ export const deserializeAws_json1_1GetTestGridSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTestGridSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTestGridSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4050,7 +4050,7 @@ export const deserializeAws_json1_1GetUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUploadCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetUploadCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4129,7 +4129,7 @@ export const deserializeAws_json1_1GetVPCEConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVPCEConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetVPCEConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4200,7 +4200,7 @@ export const deserializeAws_json1_1InstallToRemoteAccessSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InstallToRemoteAccessSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1InstallToRemoteAccessSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4279,7 +4279,7 @@ export const deserializeAws_json1_1ListArtifactsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListArtifactsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListArtifactsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4358,7 +4358,7 @@ export const deserializeAws_json1_1ListDeviceInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeviceInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDeviceInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4437,7 +4437,7 @@ export const deserializeAws_json1_1ListDevicePoolsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDevicePoolsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDevicePoolsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4516,7 +4516,7 @@ export const deserializeAws_json1_1ListDevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDevicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDevicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4595,7 +4595,7 @@ export const deserializeAws_json1_1ListInstanceProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInstanceProfilesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListInstanceProfilesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4674,7 +4674,7 @@ export const deserializeAws_json1_1ListJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4753,7 +4753,7 @@ export const deserializeAws_json1_1ListNetworkProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNetworkProfilesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListNetworkProfilesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4832,7 +4832,7 @@ export const deserializeAws_json1_1ListOfferingPromotionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOfferingPromotionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListOfferingPromotionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4919,7 +4919,7 @@ export const deserializeAws_json1_1ListOfferingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOfferingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListOfferingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5006,7 +5006,7 @@ export const deserializeAws_json1_1ListOfferingTransactionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOfferingTransactionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListOfferingTransactionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5093,7 +5093,7 @@ export const deserializeAws_json1_1ListProjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProjectsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProjectsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5172,7 +5172,7 @@ export const deserializeAws_json1_1ListRemoteAccessSessionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRemoteAccessSessionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRemoteAccessSessionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5251,7 +5251,7 @@ export const deserializeAws_json1_1ListRunsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRunsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRunsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5330,7 +5330,7 @@ export const deserializeAws_json1_1ListSamplesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSamplesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSamplesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5409,7 +5409,7 @@ export const deserializeAws_json1_1ListSuitesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSuitesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSuitesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5488,7 +5488,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5559,7 +5559,7 @@ export const deserializeAws_json1_1ListTestGridProjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTestGridProjectsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTestGridProjectsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5622,7 +5622,7 @@ export const deserializeAws_json1_1ListTestGridSessionActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTestGridSessionActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTestGridSessionActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5693,7 +5693,7 @@ export const deserializeAws_json1_1ListTestGridSessionArtifactsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTestGridSessionArtifactsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTestGridSessionArtifactsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5764,7 +5764,7 @@ export const deserializeAws_json1_1ListTestGridSessionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTestGridSessionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTestGridSessionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5835,7 +5835,7 @@ export const deserializeAws_json1_1ListTestsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5914,7 +5914,7 @@ export const deserializeAws_json1_1ListUniqueProblemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUniqueProblemsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUniqueProblemsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5993,7 +5993,7 @@ export const deserializeAws_json1_1ListUploadsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUploadsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUploadsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6072,7 +6072,7 @@ export const deserializeAws_json1_1ListVPCEConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVPCEConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListVPCEConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6135,7 +6135,7 @@ export const deserializeAws_json1_1PurchaseOfferingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurchaseOfferingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PurchaseOfferingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6222,7 +6222,7 @@ export const deserializeAws_json1_1RenewOfferingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RenewOfferingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RenewOfferingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6309,7 +6309,7 @@ export const deserializeAws_json1_1ScheduleRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ScheduleRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ScheduleRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6396,7 +6396,7 @@ export const deserializeAws_json1_1StopJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6475,7 +6475,7 @@ export const deserializeAws_json1_1StopRemoteAccessSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopRemoteAccessSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopRemoteAccessSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6554,7 +6554,7 @@ export const deserializeAws_json1_1StopRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6633,7 +6633,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6720,7 +6720,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6791,7 +6791,7 @@ export const deserializeAws_json1_1UpdateDeviceInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDeviceInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDeviceInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6870,7 +6870,7 @@ export const deserializeAws_json1_1UpdateDevicePoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDevicePoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDevicePoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6949,7 +6949,7 @@ export const deserializeAws_json1_1UpdateInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateInstanceProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7028,7 +7028,7 @@ export const deserializeAws_json1_1UpdateNetworkProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNetworkProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateNetworkProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7107,7 +7107,7 @@ export const deserializeAws_json1_1UpdateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7186,7 +7186,7 @@ export const deserializeAws_json1_1UpdateTestGridProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTestGridProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTestGridProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7257,7 +7257,7 @@ export const deserializeAws_json1_1UpdateUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUploadCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateUploadCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7336,7 +7336,7 @@ export const deserializeAws_json1_1UpdateVPCEConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVPCEConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateVPCEConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-direct-connect/protocols/Aws_json1_1.ts
+++ b/clients/client-direct-connect/protocols/Aws_json1_1.ts
@@ -1032,7 +1032,7 @@ export const deserializeAws_json1_1AcceptDirectConnectGatewayAssociationProposal
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptDirectConnectGatewayAssociationProposalCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AcceptDirectConnectGatewayAssociationProposalCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1095,7 +1095,7 @@ export const deserializeAws_json1_1AllocateConnectionOnInterconnectCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AllocateConnectionOnInterconnectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AllocateConnectionOnInterconnectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1158,7 +1158,7 @@ export const deserializeAws_json1_1AllocateHostedConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AllocateHostedConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AllocateHostedConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1237,7 +1237,7 @@ export const deserializeAws_json1_1AllocatePrivateVirtualInterfaceCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AllocatePrivateVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AllocatePrivateVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1316,7 +1316,7 @@ export const deserializeAws_json1_1AllocatePublicVirtualInterfaceCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AllocatePublicVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AllocatePublicVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1395,7 +1395,7 @@ export const deserializeAws_json1_1AllocateTransitVirtualInterfaceCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AllocateTransitVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AllocateTransitVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1474,7 +1474,7 @@ export const deserializeAws_json1_1AssociateConnectionWithLagCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateConnectionWithLagCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateConnectionWithLagCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1537,7 +1537,7 @@ export const deserializeAws_json1_1AssociateHostedConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateHostedConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateHostedConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1600,7 +1600,7 @@ export const deserializeAws_json1_1AssociateVirtualInterfaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1663,7 +1663,7 @@ export const deserializeAws_json1_1ConfirmConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfirmConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ConfirmConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1726,7 +1726,7 @@ export const deserializeAws_json1_1ConfirmPrivateVirtualInterfaceCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfirmPrivateVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ConfirmPrivateVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1789,7 +1789,7 @@ export const deserializeAws_json1_1ConfirmPublicVirtualInterfaceCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfirmPublicVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ConfirmPublicVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1852,7 +1852,7 @@ export const deserializeAws_json1_1ConfirmTransitVirtualInterfaceCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfirmTransitVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ConfirmTransitVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1915,7 +1915,7 @@ export const deserializeAws_json1_1CreateBGPPeerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBGPPeerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateBGPPeerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1978,7 +1978,7 @@ export const deserializeAws_json1_1CreateConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2057,7 +2057,7 @@ export const deserializeAws_json1_1CreateDirectConnectGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDirectConnectGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDirectConnectGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2120,7 +2120,7 @@ export const deserializeAws_json1_1CreateDirectConnectGatewayAssociationCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDirectConnectGatewayAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDirectConnectGatewayAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2183,7 +2183,7 @@ export const deserializeAws_json1_1CreateDirectConnectGatewayAssociationProposal
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDirectConnectGatewayAssociationProposalCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDirectConnectGatewayAssociationProposalCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2246,7 +2246,7 @@ export const deserializeAws_json1_1CreateInterconnectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInterconnectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateInterconnectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2325,7 +2325,7 @@ export const deserializeAws_json1_1CreateLagCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLagCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLagCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2404,7 +2404,7 @@ export const deserializeAws_json1_1CreatePrivateVirtualInterfaceCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePrivateVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePrivateVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2483,7 +2483,7 @@ export const deserializeAws_json1_1CreatePublicVirtualInterfaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePublicVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePublicVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2562,7 +2562,7 @@ export const deserializeAws_json1_1CreateTransitVirtualInterfaceCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTransitVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTransitVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2641,7 +2641,7 @@ export const deserializeAws_json1_1DeleteBGPPeerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBGPPeerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBGPPeerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2704,7 +2704,7 @@ export const deserializeAws_json1_1DeleteConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2767,7 +2767,7 @@ export const deserializeAws_json1_1DeleteDirectConnectGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDirectConnectGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDirectConnectGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2830,7 +2830,7 @@ export const deserializeAws_json1_1DeleteDirectConnectGatewayAssociationCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDirectConnectGatewayAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDirectConnectGatewayAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2893,7 +2893,7 @@ export const deserializeAws_json1_1DeleteDirectConnectGatewayAssociationProposal
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDirectConnectGatewayAssociationProposalCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDirectConnectGatewayAssociationProposalCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2956,7 +2956,7 @@ export const deserializeAws_json1_1DeleteInterconnectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInterconnectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteInterconnectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3019,7 +3019,7 @@ export const deserializeAws_json1_1DeleteLagCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLagCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLagCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3082,7 +3082,7 @@ export const deserializeAws_json1_1DeleteVirtualInterfaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVirtualInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteVirtualInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3145,7 +3145,7 @@ export const deserializeAws_json1_1DescribeConnectionLoaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConnectionLoaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConnectionLoaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3208,7 +3208,7 @@ export const deserializeAws_json1_1DescribeConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3271,7 +3271,7 @@ export const deserializeAws_json1_1DescribeConnectionsOnInterconnectCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConnectionsOnInterconnectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConnectionsOnInterconnectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3334,7 +3334,7 @@ export const deserializeAws_json1_1DescribeDirectConnectGatewayAssociationPropos
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDirectConnectGatewayAssociationProposalsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDirectConnectGatewayAssociationProposalsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3397,7 +3397,7 @@ export const deserializeAws_json1_1DescribeDirectConnectGatewayAssociationsComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDirectConnectGatewayAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDirectConnectGatewayAssociationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3460,7 +3460,7 @@ export const deserializeAws_json1_1DescribeDirectConnectGatewayAttachmentsComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDirectConnectGatewayAttachmentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDirectConnectGatewayAttachmentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3523,7 +3523,7 @@ export const deserializeAws_json1_1DescribeDirectConnectGatewaysCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDirectConnectGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDirectConnectGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3586,7 +3586,7 @@ export const deserializeAws_json1_1DescribeHostedConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHostedConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeHostedConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3649,7 +3649,7 @@ export const deserializeAws_json1_1DescribeInterconnectLoaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInterconnectLoaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeInterconnectLoaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3712,7 +3712,7 @@ export const deserializeAws_json1_1DescribeInterconnectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInterconnectsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeInterconnectsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3775,7 +3775,7 @@ export const deserializeAws_json1_1DescribeLagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3838,7 +3838,7 @@ export const deserializeAws_json1_1DescribeLoaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLoaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3901,7 +3901,7 @@ export const deserializeAws_json1_1DescribeLocationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLocationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3964,7 +3964,7 @@ export const deserializeAws_json1_1DescribeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4027,7 +4027,7 @@ export const deserializeAws_json1_1DescribeVirtualGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVirtualGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeVirtualGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4090,7 +4090,7 @@ export const deserializeAws_json1_1DescribeVirtualInterfacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVirtualInterfacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeVirtualInterfacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4153,7 +4153,7 @@ export const deserializeAws_json1_1DisassociateConnectionFromLagCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateConnectionFromLagCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateConnectionFromLagCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4216,7 +4216,7 @@ export const deserializeAws_json1_1ListVirtualInterfaceTestHistoryCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVirtualInterfaceTestHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListVirtualInterfaceTestHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4279,7 +4279,7 @@ export const deserializeAws_json1_1StartBgpFailoverTestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartBgpFailoverTestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartBgpFailoverTestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4342,7 +4342,7 @@ export const deserializeAws_json1_1StopBgpFailoverTestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopBgpFailoverTestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopBgpFailoverTestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4405,7 +4405,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4484,7 +4484,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4547,7 +4547,7 @@ export const deserializeAws_json1_1UpdateDirectConnectGatewayAssociationCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDirectConnectGatewayAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDirectConnectGatewayAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4610,7 +4610,7 @@ export const deserializeAws_json1_1UpdateLagCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLagCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateLagCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4673,7 +4673,7 @@ export const deserializeAws_json1_1UpdateVirtualInterfaceAttributesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVirtualInterfaceAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateVirtualInterfaceAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-directory-service/protocols/Aws_json1_1.ts
+++ b/clients/client-directory-service/protocols/Aws_json1_1.ts
@@ -1059,7 +1059,7 @@ export const deserializeAws_json1_1AcceptSharedDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptSharedDirectoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AcceptSharedDirectoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1146,7 +1146,7 @@ export const deserializeAws_json1_1AddIpRoutesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddIpRoutesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddIpRoutesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1249,7 +1249,7 @@ export const deserializeAws_json1_1AddTagsToResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsToResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1336,7 +1336,7 @@ export const deserializeAws_json1_1CancelSchemaExtensionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelSchemaExtensionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelSchemaExtensionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1407,7 +1407,7 @@ export const deserializeAws_json1_1ConnectDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConnectDirectoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ConnectDirectoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1486,7 +1486,7 @@ export const deserializeAws_json1_1CreateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAliasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1573,7 +1573,7 @@ export const deserializeAws_json1_1CreateComputerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateComputerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateComputerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1684,7 +1684,7 @@ export const deserializeAws_json1_1CreateConditionalForwarderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConditionalForwarderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateConditionalForwarderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1787,7 +1787,7 @@ export const deserializeAws_json1_1CreateDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDirectoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDirectoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1866,7 +1866,7 @@ export const deserializeAws_json1_1CreateLogSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLogSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLogSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1961,7 +1961,7 @@ export const deserializeAws_json1_1CreateMicrosoftADCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMicrosoftADCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateMicrosoftADCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2048,7 +2048,7 @@ export const deserializeAws_json1_1CreateSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2135,7 +2135,7 @@ export const deserializeAws_json1_1CreateTrustCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrustCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTrustCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2230,7 +2230,7 @@ export const deserializeAws_json1_1DeleteConditionalForwarderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConditionalForwarderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteConditionalForwarderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2325,7 +2325,7 @@ export const deserializeAws_json1_1DeleteDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDirectoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDirectoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2396,7 +2396,7 @@ export const deserializeAws_json1_1DeleteLogSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLogSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLogSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2475,7 +2475,7 @@ export const deserializeAws_json1_1DeleteSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2554,7 +2554,7 @@ export const deserializeAws_json1_1DeleteTrustCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTrustCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTrustCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2641,7 +2641,7 @@ export const deserializeAws_json1_1DeregisterCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2752,7 +2752,7 @@ export const deserializeAws_json1_1DeregisterEventTopicCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterEventTopicCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterEventTopicCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2831,7 +2831,7 @@ export const deserializeAws_json1_1DescribeCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2926,7 +2926,7 @@ export const deserializeAws_json1_1DescribeConditionalForwardersCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConditionalForwardersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConditionalForwardersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3021,7 +3021,7 @@ export const deserializeAws_json1_1DescribeDirectoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDirectoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDirectoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3108,7 +3108,7 @@ export const deserializeAws_json1_1DescribeDomainControllersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDomainControllersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDomainControllersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3203,7 +3203,7 @@ export const deserializeAws_json1_1DescribeEventTopicsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventTopicsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventTopicsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3282,7 +3282,7 @@ export const deserializeAws_json1_1DescribeLDAPSSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLDAPSSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLDAPSSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3377,7 +3377,7 @@ export const deserializeAws_json1_1DescribeSharedDirectoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSharedDirectoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSharedDirectoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3472,7 +3472,7 @@ export const deserializeAws_json1_1DescribeSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3559,7 +3559,7 @@ export const deserializeAws_json1_1DescribeTrustsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrustsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTrustsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3654,7 +3654,7 @@ export const deserializeAws_json1_1DisableLDAPSCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableLDAPSCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableLDAPSCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3757,7 +3757,7 @@ export const deserializeAws_json1_1DisableRadiusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableRadiusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableRadiusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3828,7 +3828,7 @@ export const deserializeAws_json1_1DisableSsoCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableSsoCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableSsoCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3915,7 +3915,7 @@ export const deserializeAws_json1_1EnableLDAPSCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableLDAPSCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableLDAPSCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4026,7 +4026,7 @@ export const deserializeAws_json1_1EnableRadiusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableRadiusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableRadiusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4113,7 +4113,7 @@ export const deserializeAws_json1_1EnableSsoCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableSsoCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableSsoCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4200,7 +4200,7 @@ export const deserializeAws_json1_1GetDirectoryLimitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDirectoryLimitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDirectoryLimitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4271,7 +4271,7 @@ export const deserializeAws_json1_1GetSnapshotLimitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSnapshotLimitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSnapshotLimitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4342,7 +4342,7 @@ export const deserializeAws_json1_1ListCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4437,7 +4437,7 @@ export const deserializeAws_json1_1ListIpRoutesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIpRoutesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListIpRoutesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4524,7 +4524,7 @@ export const deserializeAws_json1_1ListLogSubscriptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLogSubscriptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLogSubscriptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4603,7 +4603,7 @@ export const deserializeAws_json1_1ListSchemaExtensionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSchemaExtensionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSchemaExtensionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4682,7 +4682,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4769,7 +4769,7 @@ export const deserializeAws_json1_1RegisterCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4888,7 +4888,7 @@ export const deserializeAws_json1_1RegisterEventTopicCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterEventTopicCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterEventTopicCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4967,7 +4967,7 @@ export const deserializeAws_json1_1RejectSharedDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectSharedDirectoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RejectSharedDirectoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5054,7 +5054,7 @@ export const deserializeAws_json1_1RemoveIpRoutesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveIpRoutesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveIpRoutesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5141,7 +5141,7 @@ export const deserializeAws_json1_1RemoveTagsFromResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsFromResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5220,7 +5220,7 @@ export const deserializeAws_json1_1ResetUserPasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetUserPasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResetUserPasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5323,7 +5323,7 @@ export const deserializeAws_json1_1RestoreFromSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreFromSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RestoreFromSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5402,7 +5402,7 @@ export const deserializeAws_json1_1ShareDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ShareDirectoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ShareDirectoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5529,7 +5529,7 @@ export const deserializeAws_json1_1StartSchemaExtensionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSchemaExtensionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartSchemaExtensionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5624,7 +5624,7 @@ export const deserializeAws_json1_1UnshareDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnshareDirectoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UnshareDirectoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5711,7 +5711,7 @@ export const deserializeAws_json1_1UpdateConditionalForwarderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConditionalForwarderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateConditionalForwarderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5806,7 +5806,7 @@ export const deserializeAws_json1_1UpdateNumberOfDomainControllersCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNumberOfDomainControllersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateNumberOfDomainControllersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5909,7 +5909,7 @@ export const deserializeAws_json1_1UpdateRadiusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRadiusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRadiusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5988,7 +5988,7 @@ export const deserializeAws_json1_1UpdateTrustCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTrustCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTrustCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6067,7 +6067,7 @@ export const deserializeAws_json1_1VerifyTrustCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<VerifyTrustCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1VerifyTrustCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-dlm/protocols/Aws_restJson1.ts
+++ b/clients/client-dlm/protocols/Aws_restJson1.ts
@@ -309,7 +309,7 @@ export const deserializeAws_restJson1CreateLifecyclePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLifecyclePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateLifecyclePolicyCommandError(output, context);
   }
   const contents: CreateLifecyclePolicyCommandOutput = {
@@ -380,7 +380,7 @@ export const deserializeAws_restJson1DeleteLifecyclePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLifecyclePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteLifecyclePolicyCommandError(output, context);
   }
   const contents: DeleteLifecyclePolicyCommandOutput = {
@@ -447,7 +447,7 @@ export const deserializeAws_restJson1GetLifecyclePoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLifecyclePoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLifecyclePoliciesCommandError(output, context);
   }
   const contents: GetLifecyclePoliciesCommandOutput = {
@@ -526,7 +526,7 @@ export const deserializeAws_restJson1GetLifecyclePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLifecyclePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLifecyclePolicyCommandError(output, context);
   }
   const contents: GetLifecyclePolicyCommandOutput = {
@@ -597,7 +597,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -668,7 +668,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -735,7 +735,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -802,7 +802,7 @@ export const deserializeAws_restJson1UpdateLifecyclePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLifecyclePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateLifecyclePolicyCommandError(output, context);
   }
   const contents: UpdateLifecyclePolicyCommandOutput = {

--- a/clients/client-docdb/protocols/Aws_query.ts
+++ b/clients/client-docdb/protocols/Aws_query.ts
@@ -973,7 +973,7 @@ export const deserializeAws_queryAddTagsToResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddTagsToResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1040,7 +1040,7 @@ export const deserializeAws_queryApplyPendingMaintenanceActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ApplyPendingMaintenanceActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryApplyPendingMaintenanceActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1110,7 +1110,7 @@ export const deserializeAws_queryCopyDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1180,7 +1180,7 @@ export const deserializeAws_queryCopyDBClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyDBClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyDBClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1274,7 +1274,7 @@ export const deserializeAws_queryCreateDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1440,7 +1440,7 @@ export const deserializeAws_queryCreateDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1502,7 +1502,7 @@ export const deserializeAws_queryCreateDBClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1588,7 +1588,7 @@ export const deserializeAws_queryCreateDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1754,7 +1754,7 @@ export const deserializeAws_queryCreateDBSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1840,7 +1840,7 @@ export const deserializeAws_queryDeleteDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1926,7 +1926,7 @@ export const deserializeAws_queryDeleteDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBClusterParameterGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1985,7 +1985,7 @@ export const deserializeAws_queryDeleteDBClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2047,7 +2047,7 @@ export const deserializeAws_queryDeleteDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2133,7 +2133,7 @@ export const deserializeAws_queryDeleteDBSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBSubnetGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2200,7 +2200,7 @@ export const deserializeAws_queryDescribeCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2254,7 +2254,7 @@ export const deserializeAws_queryDescribeDBClusterParameterGroupsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterParameterGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterParameterGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2308,7 +2308,7 @@ export const deserializeAws_queryDescribeDBClusterParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2362,7 +2362,7 @@ export const deserializeAws_queryDescribeDBClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2416,7 +2416,7 @@ export const deserializeAws_queryDescribeDBClusterSnapshotAttributesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterSnapshotAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterSnapshotAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2473,7 +2473,7 @@ export const deserializeAws_queryDescribeDBClusterSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2527,7 +2527,7 @@ export const deserializeAws_queryDescribeDBEngineVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBEngineVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBEngineVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2573,7 +2573,7 @@ export const deserializeAws_queryDescribeDBInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2627,7 +2627,7 @@ export const deserializeAws_queryDescribeDBSubnetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBSubnetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBSubnetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2681,7 +2681,7 @@ export const deserializeAws_queryDescribeEngineDefaultClusterParametersCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEngineDefaultClusterParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEngineDefaultClusterParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2730,7 +2730,7 @@ export const deserializeAws_queryDescribeEventCategoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventCategoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventCategoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2776,7 +2776,7 @@ export const deserializeAws_queryDescribeEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2822,7 +2822,7 @@ export const deserializeAws_queryDescribeOrderableDBInstanceOptionsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrderableDBInstanceOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeOrderableDBInstanceOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2871,7 +2871,7 @@ export const deserializeAws_queryDescribePendingMaintenanceActionsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePendingMaintenanceActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribePendingMaintenanceActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2928,7 +2928,7 @@ export const deserializeAws_queryFailoverDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FailoverDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryFailoverDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2998,7 +2998,7 @@ export const deserializeAws_queryListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3068,7 +3068,7 @@ export const deserializeAws_queryModifyDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3202,7 +3202,7 @@ export const deserializeAws_queryModifyDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3264,7 +3264,7 @@ export const deserializeAws_queryModifyDBClusterSnapshotAttributeCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBClusterSnapshotAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBClusterSnapshotAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3337,7 +3337,7 @@ export const deserializeAws_queryModifyDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3487,7 +3487,7 @@ export const deserializeAws_queryModifyDBSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3573,7 +3573,7 @@ export const deserializeAws_queryRebootDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRebootDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3635,7 +3635,7 @@ export const deserializeAws_queryRemoveTagsFromResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveTagsFromResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3702,7 +3702,7 @@ export const deserializeAws_queryResetDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResetDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3764,7 +3764,7 @@ export const deserializeAws_queryRestoreDBClusterFromSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDBClusterFromSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreDBClusterFromSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3922,7 +3922,7 @@ export const deserializeAws_queryRestoreDBClusterToPointInTimeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDBClusterToPointInTimeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreDBClusterToPointInTimeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4088,7 +4088,7 @@ export const deserializeAws_queryStartDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStartDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4158,7 +4158,7 @@ export const deserializeAws_queryStopDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStopDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
@@ -92,7 +92,7 @@ export const deserializeAws_json1_0DescribeStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -155,7 +155,7 @@ export const deserializeAws_json1_0GetRecordsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRecordsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetRecordsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -242,7 +242,7 @@ export const deserializeAws_json1_0GetShardIteratorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetShardIteratorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetShardIteratorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -313,7 +313,7 @@ export const deserializeAws_json1_0ListStreamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStreamsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListStreamsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-dynamodb/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/protocols/Aws_json1_0.ts
@@ -818,7 +818,7 @@ export const deserializeAws_json1_0BatchGetItemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetItemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0BatchGetItemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -905,7 +905,7 @@ export const deserializeAws_json1_0BatchWriteItemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchWriteItemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0BatchWriteItemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1000,7 +1000,7 @@ export const deserializeAws_json1_0CreateBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CreateBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1103,7 +1103,7 @@ export const deserializeAws_json1_0CreateGlobalTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGlobalTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CreateGlobalTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1190,7 +1190,7 @@ export const deserializeAws_json1_0CreateTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CreateTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1269,7 +1269,7 @@ export const deserializeAws_json1_0DeleteBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DeleteBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1356,7 +1356,7 @@ export const deserializeAws_json1_0DeleteItemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteItemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DeleteItemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1467,7 +1467,7 @@ export const deserializeAws_json1_0DeleteTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DeleteTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1554,7 +1554,7 @@ export const deserializeAws_json1_0DescribeBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1625,7 +1625,7 @@ export const deserializeAws_json1_0DescribeContinuousBackupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeContinuousBackupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeContinuousBackupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1696,7 +1696,7 @@ export const deserializeAws_json1_0DescribeContributorInsightsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeContributorInsightsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeContributorInsightsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1759,7 +1759,7 @@ export const deserializeAws_json1_0DescribeEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1806,7 +1806,7 @@ export const deserializeAws_json1_0DescribeGlobalTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGlobalTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeGlobalTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1877,7 +1877,7 @@ export const deserializeAws_json1_0DescribeGlobalTableSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGlobalTableSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeGlobalTableSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1948,7 +1948,7 @@ export const deserializeAws_json1_0DescribeLimitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLimitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeLimitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2011,7 +2011,7 @@ export const deserializeAws_json1_0DescribeTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2082,7 +2082,7 @@ export const deserializeAws_json1_0DescribeTableReplicaAutoScalingCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTableReplicaAutoScalingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeTableReplicaAutoScalingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2145,7 +2145,7 @@ export const deserializeAws_json1_0DescribeTimeToLiveCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTimeToLiveCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeTimeToLiveCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2216,7 +2216,7 @@ export const deserializeAws_json1_0GetItemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetItemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetItemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2303,7 +2303,7 @@ export const deserializeAws_json1_0ListBackupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBackupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListBackupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2366,7 +2366,7 @@ export const deserializeAws_json1_0ListContributorInsightsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListContributorInsightsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListContributorInsightsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2429,7 +2429,7 @@ export const deserializeAws_json1_0ListGlobalTablesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGlobalTablesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListGlobalTablesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2492,7 +2492,7 @@ export const deserializeAws_json1_0ListTablesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTablesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListTablesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2555,7 +2555,7 @@ export const deserializeAws_json1_0ListTagsOfResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsOfResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListTagsOfResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2626,7 +2626,7 @@ export const deserializeAws_json1_0PutItemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutItemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0PutItemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2737,7 +2737,7 @@ export const deserializeAws_json1_0QueryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0QueryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2824,7 +2824,7 @@ export const deserializeAws_json1_0RestoreTableFromBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreTableFromBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RestoreTableFromBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2927,7 +2927,7 @@ export const deserializeAws_json1_0RestoreTableToPointInTimeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreTableToPointInTimeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RestoreTableToPointInTimeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3038,7 +3038,7 @@ export const deserializeAws_json1_0ScanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ScanCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ScanCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3125,7 +3125,7 @@ export const deserializeAws_json1_0TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0TagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3209,7 +3209,7 @@ export const deserializeAws_json1_0TransactGetItemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TransactGetItemsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0TransactGetItemsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3304,7 +3304,7 @@ export const deserializeAws_json1_0TransactWriteItemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TransactWriteItemsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0TransactWriteItemsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3415,7 +3415,7 @@ export const deserializeAws_json1_0UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UntagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3499,7 +3499,7 @@ export const deserializeAws_json1_0UpdateContinuousBackupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateContinuousBackupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UpdateContinuousBackupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3578,7 +3578,7 @@ export const deserializeAws_json1_0UpdateContributorInsightsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateContributorInsightsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UpdateContributorInsightsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3641,7 +3641,7 @@ export const deserializeAws_json1_0UpdateGlobalTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGlobalTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UpdateGlobalTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3736,7 +3736,7 @@ export const deserializeAws_json1_0UpdateGlobalTableSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGlobalTableSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UpdateGlobalTableSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3839,7 +3839,7 @@ export const deserializeAws_json1_0UpdateItemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateItemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UpdateItemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3950,7 +3950,7 @@ export const deserializeAws_json1_0UpdateTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UpdateTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4037,7 +4037,7 @@ export const deserializeAws_json1_0UpdateTableReplicaAutoScalingCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTableReplicaAutoScalingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UpdateTableReplicaAutoScalingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4116,7 +4116,7 @@ export const deserializeAws_json1_0UpdateTimeToLiveCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTimeToLiveCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UpdateTimeToLiveCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-ebs/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/protocols/Aws_restJson1.ts
@@ -266,7 +266,7 @@ export const deserializeAws_restJson1CompleteSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CompleteSnapshotCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1CompleteSnapshotCommandError(output, context);
   }
   const contents: CompleteSnapshotCommandOutput = {
@@ -361,7 +361,7 @@ export const deserializeAws_restJson1GetSnapshotBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSnapshotBlockCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSnapshotBlockCommandError(output, context);
   }
   const contents: GetSnapshotBlockCommandOutput = {
@@ -466,7 +466,7 @@ export const deserializeAws_restJson1ListChangedBlocksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListChangedBlocksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListChangedBlocksCommandError(output, context);
   }
   const contents: ListChangedBlocksCommandOutput = {
@@ -577,7 +577,7 @@ export const deserializeAws_restJson1ListSnapshotBlocksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSnapshotBlocksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSnapshotBlocksCommandError(output, context);
   }
   const contents: ListSnapshotBlocksCommandOutput = {
@@ -688,7 +688,7 @@ export const deserializeAws_restJson1PutSnapshotBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutSnapshotBlockCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutSnapshotBlockCommandError(output, context);
   }
   const contents: PutSnapshotBlockCommandOutput = {
@@ -787,7 +787,7 @@ export const deserializeAws_restJson1StartSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSnapshotCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartSnapshotCommandError(output, context);
   }
   const contents: StartSnapshotCommandOutput = {

--- a/clients/client-ec2-instance-connect/protocols/Aws_json1_1.ts
+++ b/clients/client-ec2-instance-connect/protocols/Aws_json1_1.ts
@@ -35,7 +35,7 @@ export const deserializeAws_json1_1SendSSHPublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendSSHPublicKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SendSSHPublicKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -9197,7 +9197,7 @@ export const deserializeAws_ec2AcceptReservedInstancesExchangeQuoteCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptReservedInstancesExchangeQuoteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AcceptReservedInstancesExchangeQuoteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9243,7 +9243,7 @@ export const deserializeAws_ec2AcceptTransitGatewayPeeringAttachmentCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptTransitGatewayPeeringAttachmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AcceptTransitGatewayPeeringAttachmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9289,7 +9289,7 @@ export const deserializeAws_ec2AcceptTransitGatewayVpcAttachmentCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptTransitGatewayVpcAttachmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AcceptTransitGatewayVpcAttachmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9335,7 +9335,7 @@ export const deserializeAws_ec2AcceptVpcEndpointConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptVpcEndpointConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AcceptVpcEndpointConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9381,7 +9381,7 @@ export const deserializeAws_ec2AcceptVpcPeeringConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptVpcPeeringConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AcceptVpcPeeringConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9427,7 +9427,7 @@ export const deserializeAws_ec2AdvertiseByoipCidrCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdvertiseByoipCidrCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AdvertiseByoipCidrCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9473,7 +9473,7 @@ export const deserializeAws_ec2AllocateAddressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AllocateAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AllocateAddressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9519,7 +9519,7 @@ export const deserializeAws_ec2AllocateHostsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AllocateHostsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AllocateHostsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9565,7 +9565,7 @@ export const deserializeAws_ec2ApplySecurityGroupsToClientVpnTargetNetworkComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ApplySecurityGroupsToClientVpnTargetNetworkCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ApplySecurityGroupsToClientVpnTargetNetworkCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9611,7 +9611,7 @@ export const deserializeAws_ec2AssignIpv6AddressesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssignIpv6AddressesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssignIpv6AddressesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9657,7 +9657,7 @@ export const deserializeAws_ec2AssignPrivateIpAddressesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssignPrivateIpAddressesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssignPrivateIpAddressesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9703,7 +9703,7 @@ export const deserializeAws_ec2AssociateAddressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssociateAddressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9749,7 +9749,7 @@ export const deserializeAws_ec2AssociateClientVpnTargetNetworkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateClientVpnTargetNetworkCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssociateClientVpnTargetNetworkCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9795,7 +9795,7 @@ export const deserializeAws_ec2AssociateDhcpOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateDhcpOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssociateDhcpOptionsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -9838,7 +9838,7 @@ export const deserializeAws_ec2AssociateIamInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateIamInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssociateIamInstanceProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9884,7 +9884,7 @@ export const deserializeAws_ec2AssociateRouteTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateRouteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssociateRouteTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9930,7 +9930,7 @@ export const deserializeAws_ec2AssociateSubnetCidrBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateSubnetCidrBlockCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssociateSubnetCidrBlockCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9976,7 +9976,7 @@ export const deserializeAws_ec2AssociateTransitGatewayMulticastDomainCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateTransitGatewayMulticastDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssociateTransitGatewayMulticastDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10022,7 +10022,7 @@ export const deserializeAws_ec2AssociateTransitGatewayRouteTableCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateTransitGatewayRouteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssociateTransitGatewayRouteTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10068,7 +10068,7 @@ export const deserializeAws_ec2AssociateVpcCidrBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateVpcCidrBlockCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AssociateVpcCidrBlockCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10114,7 +10114,7 @@ export const deserializeAws_ec2AttachClassicLinkVpcCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachClassicLinkVpcCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AttachClassicLinkVpcCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10160,7 +10160,7 @@ export const deserializeAws_ec2AttachInternetGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachInternetGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AttachInternetGatewayCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10203,7 +10203,7 @@ export const deserializeAws_ec2AttachNetworkInterfaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachNetworkInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AttachNetworkInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10249,7 +10249,7 @@ export const deserializeAws_ec2AttachVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AttachVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10295,7 +10295,7 @@ export const deserializeAws_ec2AttachVpnGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachVpnGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AttachVpnGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10341,7 +10341,7 @@ export const deserializeAws_ec2AuthorizeClientVpnIngressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AuthorizeClientVpnIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AuthorizeClientVpnIngressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10387,7 +10387,7 @@ export const deserializeAws_ec2AuthorizeSecurityGroupEgressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AuthorizeSecurityGroupEgressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AuthorizeSecurityGroupEgressCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10430,7 +10430,7 @@ export const deserializeAws_ec2AuthorizeSecurityGroupIngressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AuthorizeSecurityGroupIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2AuthorizeSecurityGroupIngressCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10473,7 +10473,7 @@ export const deserializeAws_ec2BundleInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BundleInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2BundleInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10519,7 +10519,7 @@ export const deserializeAws_ec2CancelBundleTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelBundleTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CancelBundleTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10565,7 +10565,7 @@ export const deserializeAws_ec2CancelCapacityReservationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelCapacityReservationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CancelCapacityReservationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10611,7 +10611,7 @@ export const deserializeAws_ec2CancelConversionTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelConversionTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CancelConversionTaskCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10654,7 +10654,7 @@ export const deserializeAws_ec2CancelExportTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelExportTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CancelExportTaskCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10697,7 +10697,7 @@ export const deserializeAws_ec2CancelImportTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelImportTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CancelImportTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10743,7 +10743,7 @@ export const deserializeAws_ec2CancelReservedInstancesListingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelReservedInstancesListingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CancelReservedInstancesListingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10789,7 +10789,7 @@ export const deserializeAws_ec2CancelSpotFleetRequestsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelSpotFleetRequestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CancelSpotFleetRequestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10835,7 +10835,7 @@ export const deserializeAws_ec2CancelSpotInstanceRequestsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelSpotInstanceRequestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CancelSpotInstanceRequestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10881,7 +10881,7 @@ export const deserializeAws_ec2ConfirmProductInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfirmProductInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ConfirmProductInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10927,7 +10927,7 @@ export const deserializeAws_ec2CopyFpgaImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyFpgaImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CopyFpgaImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10973,7 +10973,7 @@ export const deserializeAws_ec2CopyImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CopyImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11019,7 +11019,7 @@ export const deserializeAws_ec2CopySnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopySnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CopySnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11065,7 +11065,7 @@ export const deserializeAws_ec2CreateCapacityReservationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCapacityReservationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateCapacityReservationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11111,7 +11111,7 @@ export const deserializeAws_ec2CreateClientVpnEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClientVpnEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateClientVpnEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11157,7 +11157,7 @@ export const deserializeAws_ec2CreateClientVpnRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClientVpnRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateClientVpnRouteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11203,7 +11203,7 @@ export const deserializeAws_ec2CreateCustomerGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCustomerGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateCustomerGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11249,7 +11249,7 @@ export const deserializeAws_ec2CreateDefaultSubnetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDefaultSubnetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateDefaultSubnetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11295,7 +11295,7 @@ export const deserializeAws_ec2CreateDefaultVpcCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDefaultVpcCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateDefaultVpcCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11341,7 +11341,7 @@ export const deserializeAws_ec2CreateDhcpOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDhcpOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateDhcpOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11387,7 +11387,7 @@ export const deserializeAws_ec2CreateEgressOnlyInternetGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEgressOnlyInternetGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateEgressOnlyInternetGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11433,7 +11433,7 @@ export const deserializeAws_ec2CreateFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11479,7 +11479,7 @@ export const deserializeAws_ec2CreateFlowLogsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFlowLogsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateFlowLogsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11525,7 +11525,7 @@ export const deserializeAws_ec2CreateFpgaImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFpgaImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateFpgaImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11571,7 +11571,7 @@ export const deserializeAws_ec2CreateImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11617,7 +11617,7 @@ export const deserializeAws_ec2CreateInstanceExportTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInstanceExportTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateInstanceExportTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11663,7 +11663,7 @@ export const deserializeAws_ec2CreateInternetGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInternetGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateInternetGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11709,7 +11709,7 @@ export const deserializeAws_ec2CreateKeyPairCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateKeyPairCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateKeyPairCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11755,7 +11755,7 @@ export const deserializeAws_ec2CreateLaunchTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLaunchTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateLaunchTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11801,7 +11801,7 @@ export const deserializeAws_ec2CreateLaunchTemplateVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLaunchTemplateVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateLaunchTemplateVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11847,7 +11847,7 @@ export const deserializeAws_ec2CreateLocalGatewayRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLocalGatewayRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateLocalGatewayRouteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11893,7 +11893,7 @@ export const deserializeAws_ec2CreateLocalGatewayRouteTableVpcAssociationCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLocalGatewayRouteTableVpcAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateLocalGatewayRouteTableVpcAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11939,7 +11939,7 @@ export const deserializeAws_ec2CreateManagedPrefixListCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateManagedPrefixListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateManagedPrefixListCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11985,7 +11985,7 @@ export const deserializeAws_ec2CreateNatGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNatGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateNatGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12031,7 +12031,7 @@ export const deserializeAws_ec2CreateNetworkAclCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNetworkAclCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateNetworkAclCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12077,7 +12077,7 @@ export const deserializeAws_ec2CreateNetworkAclEntryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNetworkAclEntryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateNetworkAclEntryCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -12120,7 +12120,7 @@ export const deserializeAws_ec2CreateNetworkInterfaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNetworkInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateNetworkInterfaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12166,7 +12166,7 @@ export const deserializeAws_ec2CreateNetworkInterfacePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNetworkInterfacePermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateNetworkInterfacePermissionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12212,7 +12212,7 @@ export const deserializeAws_ec2CreatePlacementGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePlacementGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreatePlacementGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12258,7 +12258,7 @@ export const deserializeAws_ec2CreateReservedInstancesListingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReservedInstancesListingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateReservedInstancesListingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12304,7 +12304,7 @@ export const deserializeAws_ec2CreateRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateRouteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12350,7 +12350,7 @@ export const deserializeAws_ec2CreateRouteTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRouteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateRouteTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12396,7 +12396,7 @@ export const deserializeAws_ec2CreateSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSecurityGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateSecurityGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12442,7 +12442,7 @@ export const deserializeAws_ec2CreateSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12488,7 +12488,7 @@ export const deserializeAws_ec2CreateSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12534,7 +12534,7 @@ export const deserializeAws_ec2CreateSpotDatafeedSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSpotDatafeedSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateSpotDatafeedSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12580,7 +12580,7 @@ export const deserializeAws_ec2CreateSubnetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSubnetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateSubnetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12626,7 +12626,7 @@ export const deserializeAws_ec2CreateTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTagsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -12669,7 +12669,7 @@ export const deserializeAws_ec2CreateTrafficMirrorFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrafficMirrorFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTrafficMirrorFilterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12715,7 +12715,7 @@ export const deserializeAws_ec2CreateTrafficMirrorFilterRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrafficMirrorFilterRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTrafficMirrorFilterRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12761,7 +12761,7 @@ export const deserializeAws_ec2CreateTrafficMirrorSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrafficMirrorSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTrafficMirrorSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12807,7 +12807,7 @@ export const deserializeAws_ec2CreateTrafficMirrorTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrafficMirrorTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTrafficMirrorTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12853,7 +12853,7 @@ export const deserializeAws_ec2CreateTransitGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTransitGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTransitGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12899,7 +12899,7 @@ export const deserializeAws_ec2CreateTransitGatewayMulticastDomainCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTransitGatewayMulticastDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTransitGatewayMulticastDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12945,7 +12945,7 @@ export const deserializeAws_ec2CreateTransitGatewayPeeringAttachmentCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTransitGatewayPeeringAttachmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTransitGatewayPeeringAttachmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12991,7 +12991,7 @@ export const deserializeAws_ec2CreateTransitGatewayRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTransitGatewayRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTransitGatewayRouteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13037,7 +13037,7 @@ export const deserializeAws_ec2CreateTransitGatewayRouteTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTransitGatewayRouteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTransitGatewayRouteTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13083,7 +13083,7 @@ export const deserializeAws_ec2CreateTransitGatewayVpcAttachmentCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTransitGatewayVpcAttachmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateTransitGatewayVpcAttachmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13129,7 +13129,7 @@ export const deserializeAws_ec2CreateVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13175,7 +13175,7 @@ export const deserializeAws_ec2CreateVpcCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpcCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateVpcCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13221,7 +13221,7 @@ export const deserializeAws_ec2CreateVpcEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpcEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateVpcEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13267,7 +13267,7 @@ export const deserializeAws_ec2CreateVpcEndpointConnectionNotificationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpcEndpointConnectionNotificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateVpcEndpointConnectionNotificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13313,7 +13313,7 @@ export const deserializeAws_ec2CreateVpcEndpointServiceConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpcEndpointServiceConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateVpcEndpointServiceConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13359,7 +13359,7 @@ export const deserializeAws_ec2CreateVpcPeeringConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpcPeeringConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateVpcPeeringConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13405,7 +13405,7 @@ export const deserializeAws_ec2CreateVpnConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpnConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateVpnConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13451,7 +13451,7 @@ export const deserializeAws_ec2CreateVpnConnectionRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpnConnectionRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateVpnConnectionRouteCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -13494,7 +13494,7 @@ export const deserializeAws_ec2CreateVpnGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpnGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2CreateVpnGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13540,7 +13540,7 @@ export const deserializeAws_ec2DeleteClientVpnEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClientVpnEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteClientVpnEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13586,7 +13586,7 @@ export const deserializeAws_ec2DeleteClientVpnRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClientVpnRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteClientVpnRouteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13632,7 +13632,7 @@ export const deserializeAws_ec2DeleteCustomerGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCustomerGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteCustomerGatewayCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -13675,7 +13675,7 @@ export const deserializeAws_ec2DeleteDhcpOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDhcpOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteDhcpOptionsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -13718,7 +13718,7 @@ export const deserializeAws_ec2DeleteEgressOnlyInternetGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEgressOnlyInternetGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteEgressOnlyInternetGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13764,7 +13764,7 @@ export const deserializeAws_ec2DeleteFleetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFleetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteFleetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13810,7 +13810,7 @@ export const deserializeAws_ec2DeleteFlowLogsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFlowLogsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteFlowLogsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13856,7 +13856,7 @@ export const deserializeAws_ec2DeleteFpgaImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFpgaImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteFpgaImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13902,7 +13902,7 @@ export const deserializeAws_ec2DeleteInternetGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInternetGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteInternetGatewayCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -13945,7 +13945,7 @@ export const deserializeAws_ec2DeleteKeyPairCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteKeyPairCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteKeyPairCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -13988,7 +13988,7 @@ export const deserializeAws_ec2DeleteLaunchTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLaunchTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteLaunchTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14034,7 +14034,7 @@ export const deserializeAws_ec2DeleteLaunchTemplateVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLaunchTemplateVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteLaunchTemplateVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14080,7 +14080,7 @@ export const deserializeAws_ec2DeleteLocalGatewayRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLocalGatewayRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteLocalGatewayRouteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14126,7 +14126,7 @@ export const deserializeAws_ec2DeleteLocalGatewayRouteTableVpcAssociationCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLocalGatewayRouteTableVpcAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteLocalGatewayRouteTableVpcAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14172,7 +14172,7 @@ export const deserializeAws_ec2DeleteManagedPrefixListCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteManagedPrefixListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteManagedPrefixListCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14218,7 +14218,7 @@ export const deserializeAws_ec2DeleteNatGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNatGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteNatGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14264,7 +14264,7 @@ export const deserializeAws_ec2DeleteNetworkAclCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNetworkAclCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteNetworkAclCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14307,7 +14307,7 @@ export const deserializeAws_ec2DeleteNetworkAclEntryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNetworkAclEntryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteNetworkAclEntryCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14350,7 +14350,7 @@ export const deserializeAws_ec2DeleteNetworkInterfaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNetworkInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteNetworkInterfaceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14393,7 +14393,7 @@ export const deserializeAws_ec2DeleteNetworkInterfacePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNetworkInterfacePermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteNetworkInterfacePermissionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14439,7 +14439,7 @@ export const deserializeAws_ec2DeletePlacementGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePlacementGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeletePlacementGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14482,7 +14482,7 @@ export const deserializeAws_ec2DeleteQueuedReservedInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteQueuedReservedInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteQueuedReservedInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14528,7 +14528,7 @@ export const deserializeAws_ec2DeleteRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteRouteCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14571,7 +14571,7 @@ export const deserializeAws_ec2DeleteRouteTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRouteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteRouteTableCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14614,7 +14614,7 @@ export const deserializeAws_ec2DeleteSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSecurityGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteSecurityGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14657,7 +14657,7 @@ export const deserializeAws_ec2DeleteSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteSnapshotCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14700,7 +14700,7 @@ export const deserializeAws_ec2DeleteSpotDatafeedSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSpotDatafeedSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteSpotDatafeedSubscriptionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14743,7 +14743,7 @@ export const deserializeAws_ec2DeleteSubnetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSubnetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteSubnetCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14786,7 +14786,7 @@ export const deserializeAws_ec2DeleteTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTagsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -14829,7 +14829,7 @@ export const deserializeAws_ec2DeleteTrafficMirrorFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTrafficMirrorFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTrafficMirrorFilterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14875,7 +14875,7 @@ export const deserializeAws_ec2DeleteTrafficMirrorFilterRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTrafficMirrorFilterRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTrafficMirrorFilterRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14921,7 +14921,7 @@ export const deserializeAws_ec2DeleteTrafficMirrorSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTrafficMirrorSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTrafficMirrorSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14967,7 +14967,7 @@ export const deserializeAws_ec2DeleteTrafficMirrorTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTrafficMirrorTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTrafficMirrorTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15013,7 +15013,7 @@ export const deserializeAws_ec2DeleteTransitGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTransitGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTransitGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15059,7 +15059,7 @@ export const deserializeAws_ec2DeleteTransitGatewayMulticastDomainCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTransitGatewayMulticastDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTransitGatewayMulticastDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15105,7 +15105,7 @@ export const deserializeAws_ec2DeleteTransitGatewayPeeringAttachmentCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTransitGatewayPeeringAttachmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTransitGatewayPeeringAttachmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15151,7 +15151,7 @@ export const deserializeAws_ec2DeleteTransitGatewayRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTransitGatewayRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTransitGatewayRouteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15197,7 +15197,7 @@ export const deserializeAws_ec2DeleteTransitGatewayRouteTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTransitGatewayRouteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTransitGatewayRouteTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15243,7 +15243,7 @@ export const deserializeAws_ec2DeleteTransitGatewayVpcAttachmentCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTransitGatewayVpcAttachmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteTransitGatewayVpcAttachmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15289,7 +15289,7 @@ export const deserializeAws_ec2DeleteVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteVolumeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -15332,7 +15332,7 @@ export const deserializeAws_ec2DeleteVpcCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpcCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteVpcCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -15375,7 +15375,7 @@ export const deserializeAws_ec2DeleteVpcEndpointConnectionNotificationsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpcEndpointConnectionNotificationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteVpcEndpointConnectionNotificationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15421,7 +15421,7 @@ export const deserializeAws_ec2DeleteVpcEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpcEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteVpcEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15467,7 +15467,7 @@ export const deserializeAws_ec2DeleteVpcEndpointServiceConfigurationsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpcEndpointServiceConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteVpcEndpointServiceConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15513,7 +15513,7 @@ export const deserializeAws_ec2DeleteVpcPeeringConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpcPeeringConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteVpcPeeringConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15559,7 +15559,7 @@ export const deserializeAws_ec2DeleteVpnConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpnConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteVpnConnectionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -15602,7 +15602,7 @@ export const deserializeAws_ec2DeleteVpnConnectionRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpnConnectionRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteVpnConnectionRouteCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -15645,7 +15645,7 @@ export const deserializeAws_ec2DeleteVpnGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpnGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeleteVpnGatewayCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -15688,7 +15688,7 @@ export const deserializeAws_ec2DeprovisionByoipCidrCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeprovisionByoipCidrCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeprovisionByoipCidrCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15734,7 +15734,7 @@ export const deserializeAws_ec2DeregisterImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeregisterImageCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -15777,7 +15777,7 @@ export const deserializeAws_ec2DeregisterInstanceEventNotificationAttributesComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterInstanceEventNotificationAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeregisterInstanceEventNotificationAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15823,7 +15823,7 @@ export const deserializeAws_ec2DeregisterTransitGatewayMulticastGroupMembersComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterTransitGatewayMulticastGroupMembersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeregisterTransitGatewayMulticastGroupMembersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15869,7 +15869,7 @@ export const deserializeAws_ec2DeregisterTransitGatewayMulticastGroupSourcesComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterTransitGatewayMulticastGroupSourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DeregisterTransitGatewayMulticastGroupSourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15915,7 +15915,7 @@ export const deserializeAws_ec2DescribeAccountAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeAccountAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15961,7 +15961,7 @@ export const deserializeAws_ec2DescribeAddressesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAddressesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeAddressesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16007,7 +16007,7 @@ export const deserializeAws_ec2DescribeAggregateIdFormatCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAggregateIdFormatCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeAggregateIdFormatCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16053,7 +16053,7 @@ export const deserializeAws_ec2DescribeAvailabilityZonesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAvailabilityZonesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeAvailabilityZonesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16099,7 +16099,7 @@ export const deserializeAws_ec2DescribeBundleTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBundleTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeBundleTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16145,7 +16145,7 @@ export const deserializeAws_ec2DescribeByoipCidrsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeByoipCidrsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeByoipCidrsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16191,7 +16191,7 @@ export const deserializeAws_ec2DescribeCapacityReservationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCapacityReservationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeCapacityReservationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16237,7 +16237,7 @@ export const deserializeAws_ec2DescribeClassicLinkInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClassicLinkInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeClassicLinkInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16283,7 +16283,7 @@ export const deserializeAws_ec2DescribeClientVpnAuthorizationRulesCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClientVpnAuthorizationRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeClientVpnAuthorizationRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16329,7 +16329,7 @@ export const deserializeAws_ec2DescribeClientVpnConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClientVpnConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeClientVpnConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16375,7 +16375,7 @@ export const deserializeAws_ec2DescribeClientVpnEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClientVpnEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeClientVpnEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16421,7 +16421,7 @@ export const deserializeAws_ec2DescribeClientVpnRoutesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClientVpnRoutesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeClientVpnRoutesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16467,7 +16467,7 @@ export const deserializeAws_ec2DescribeClientVpnTargetNetworksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClientVpnTargetNetworksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeClientVpnTargetNetworksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16513,7 +16513,7 @@ export const deserializeAws_ec2DescribeCoipPoolsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCoipPoolsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeCoipPoolsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16559,7 +16559,7 @@ export const deserializeAws_ec2DescribeConversionTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConversionTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeConversionTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16605,7 +16605,7 @@ export const deserializeAws_ec2DescribeCustomerGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCustomerGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeCustomerGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16651,7 +16651,7 @@ export const deserializeAws_ec2DescribeDhcpOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDhcpOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeDhcpOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16697,7 +16697,7 @@ export const deserializeAws_ec2DescribeEgressOnlyInternetGatewaysCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEgressOnlyInternetGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeEgressOnlyInternetGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16743,7 +16743,7 @@ export const deserializeAws_ec2DescribeElasticGpusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeElasticGpusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeElasticGpusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16789,7 +16789,7 @@ export const deserializeAws_ec2DescribeExportImageTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeExportImageTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeExportImageTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16835,7 +16835,7 @@ export const deserializeAws_ec2DescribeExportTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeExportTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeExportTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16881,7 +16881,7 @@ export const deserializeAws_ec2DescribeFastSnapshotRestoresCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFastSnapshotRestoresCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeFastSnapshotRestoresCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16927,7 +16927,7 @@ export const deserializeAws_ec2DescribeFleetHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeFleetHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -16973,7 +16973,7 @@ export const deserializeAws_ec2DescribeFleetInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeFleetInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17019,7 +17019,7 @@ export const deserializeAws_ec2DescribeFleetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeFleetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17065,7 +17065,7 @@ export const deserializeAws_ec2DescribeFlowLogsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFlowLogsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeFlowLogsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17111,7 +17111,7 @@ export const deserializeAws_ec2DescribeFpgaImageAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFpgaImageAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeFpgaImageAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17157,7 +17157,7 @@ export const deserializeAws_ec2DescribeFpgaImagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFpgaImagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeFpgaImagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17203,7 +17203,7 @@ export const deserializeAws_ec2DescribeHostReservationOfferingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHostReservationOfferingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeHostReservationOfferingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17249,7 +17249,7 @@ export const deserializeAws_ec2DescribeHostReservationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHostReservationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeHostReservationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17295,7 +17295,7 @@ export const deserializeAws_ec2DescribeHostsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHostsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeHostsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17341,7 +17341,7 @@ export const deserializeAws_ec2DescribeIamInstanceProfileAssociationsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIamInstanceProfileAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeIamInstanceProfileAssociationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17387,7 +17387,7 @@ export const deserializeAws_ec2DescribeIdentityIdFormatCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIdentityIdFormatCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeIdentityIdFormatCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17433,7 +17433,7 @@ export const deserializeAws_ec2DescribeIdFormatCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIdFormatCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeIdFormatCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17479,7 +17479,7 @@ export const deserializeAws_ec2DescribeImageAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeImageAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeImageAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17525,7 +17525,7 @@ export const deserializeAws_ec2DescribeImagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeImagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeImagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17571,7 +17571,7 @@ export const deserializeAws_ec2DescribeImportImageTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeImportImageTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeImportImageTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17617,7 +17617,7 @@ export const deserializeAws_ec2DescribeImportSnapshotTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeImportSnapshotTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeImportSnapshotTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17663,7 +17663,7 @@ export const deserializeAws_ec2DescribeInstanceAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstanceAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeInstanceAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17709,7 +17709,7 @@ export const deserializeAws_ec2DescribeInstanceCreditSpecificationsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstanceCreditSpecificationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeInstanceCreditSpecificationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17755,7 +17755,7 @@ export const deserializeAws_ec2DescribeInstanceEventNotificationAttributesComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstanceEventNotificationAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeInstanceEventNotificationAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17801,7 +17801,7 @@ export const deserializeAws_ec2DescribeInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17847,7 +17847,7 @@ export const deserializeAws_ec2DescribeInstanceStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstanceStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeInstanceStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17893,7 +17893,7 @@ export const deserializeAws_ec2DescribeInstanceTypeOfferingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstanceTypeOfferingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeInstanceTypeOfferingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17939,7 +17939,7 @@ export const deserializeAws_ec2DescribeInstanceTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstanceTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeInstanceTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -17985,7 +17985,7 @@ export const deserializeAws_ec2DescribeInternetGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInternetGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeInternetGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18031,7 +18031,7 @@ export const deserializeAws_ec2DescribeIpv6PoolsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIpv6PoolsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeIpv6PoolsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18077,7 +18077,7 @@ export const deserializeAws_ec2DescribeKeyPairsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeKeyPairsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeKeyPairsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18123,7 +18123,7 @@ export const deserializeAws_ec2DescribeLaunchTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLaunchTemplatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeLaunchTemplatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18169,7 +18169,7 @@ export const deserializeAws_ec2DescribeLaunchTemplateVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLaunchTemplateVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeLaunchTemplateVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18215,7 +18215,7 @@ export const deserializeAws_ec2DescribeLocalGatewayRouteTablesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocalGatewayRouteTablesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeLocalGatewayRouteTablesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18261,7 +18261,7 @@ export const deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGro
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociationsCommandError(
       output,
       context
@@ -18310,7 +18310,7 @@ export const deserializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocalGatewayRouteTableVpcAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeLocalGatewayRouteTableVpcAssociationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18356,7 +18356,7 @@ export const deserializeAws_ec2DescribeLocalGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocalGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeLocalGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18402,7 +18402,7 @@ export const deserializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocalGatewayVirtualInterfaceGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeLocalGatewayVirtualInterfaceGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18448,7 +18448,7 @@ export const deserializeAws_ec2DescribeLocalGatewayVirtualInterfacesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLocalGatewayVirtualInterfacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeLocalGatewayVirtualInterfacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18494,7 +18494,7 @@ export const deserializeAws_ec2DescribeManagedPrefixListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeManagedPrefixListsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeManagedPrefixListsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18540,7 +18540,7 @@ export const deserializeAws_ec2DescribeMovingAddressesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMovingAddressesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeMovingAddressesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18586,7 +18586,7 @@ export const deserializeAws_ec2DescribeNatGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNatGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeNatGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18632,7 +18632,7 @@ export const deserializeAws_ec2DescribeNetworkAclsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNetworkAclsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeNetworkAclsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18678,7 +18678,7 @@ export const deserializeAws_ec2DescribeNetworkInterfaceAttributeCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNetworkInterfaceAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeNetworkInterfaceAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18724,7 +18724,7 @@ export const deserializeAws_ec2DescribeNetworkInterfacePermissionsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNetworkInterfacePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeNetworkInterfacePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18770,7 +18770,7 @@ export const deserializeAws_ec2DescribeNetworkInterfacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNetworkInterfacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeNetworkInterfacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18816,7 +18816,7 @@ export const deserializeAws_ec2DescribePlacementGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePlacementGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribePlacementGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18862,7 +18862,7 @@ export const deserializeAws_ec2DescribePrefixListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePrefixListsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribePrefixListsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18908,7 +18908,7 @@ export const deserializeAws_ec2DescribePrincipalIdFormatCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePrincipalIdFormatCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribePrincipalIdFormatCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -18954,7 +18954,7 @@ export const deserializeAws_ec2DescribePublicIpv4PoolsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePublicIpv4PoolsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribePublicIpv4PoolsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19000,7 +19000,7 @@ export const deserializeAws_ec2DescribeRegionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRegionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeRegionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19046,7 +19046,7 @@ export const deserializeAws_ec2DescribeReservedInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeReservedInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19092,7 +19092,7 @@ export const deserializeAws_ec2DescribeReservedInstancesListingsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedInstancesListingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeReservedInstancesListingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19138,7 +19138,7 @@ export const deserializeAws_ec2DescribeReservedInstancesModificationsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedInstancesModificationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeReservedInstancesModificationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19184,7 +19184,7 @@ export const deserializeAws_ec2DescribeReservedInstancesOfferingsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedInstancesOfferingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeReservedInstancesOfferingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19230,7 +19230,7 @@ export const deserializeAws_ec2DescribeRouteTablesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRouteTablesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeRouteTablesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19276,7 +19276,7 @@ export const deserializeAws_ec2DescribeScheduledInstanceAvailabilityCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScheduledInstanceAvailabilityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeScheduledInstanceAvailabilityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19322,7 +19322,7 @@ export const deserializeAws_ec2DescribeScheduledInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScheduledInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeScheduledInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19368,7 +19368,7 @@ export const deserializeAws_ec2DescribeSecurityGroupReferencesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSecurityGroupReferencesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSecurityGroupReferencesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19414,7 +19414,7 @@ export const deserializeAws_ec2DescribeSecurityGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSecurityGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSecurityGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19460,7 +19460,7 @@ export const deserializeAws_ec2DescribeSnapshotAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSnapshotAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSnapshotAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19506,7 +19506,7 @@ export const deserializeAws_ec2DescribeSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19552,7 +19552,7 @@ export const deserializeAws_ec2DescribeSpotDatafeedSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSpotDatafeedSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSpotDatafeedSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19598,7 +19598,7 @@ export const deserializeAws_ec2DescribeSpotFleetInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSpotFleetInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSpotFleetInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19644,7 +19644,7 @@ export const deserializeAws_ec2DescribeSpotFleetRequestHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSpotFleetRequestHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSpotFleetRequestHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19690,7 +19690,7 @@ export const deserializeAws_ec2DescribeSpotFleetRequestsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSpotFleetRequestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSpotFleetRequestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19736,7 +19736,7 @@ export const deserializeAws_ec2DescribeSpotInstanceRequestsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSpotInstanceRequestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSpotInstanceRequestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19782,7 +19782,7 @@ export const deserializeAws_ec2DescribeSpotPriceHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSpotPriceHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSpotPriceHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19828,7 +19828,7 @@ export const deserializeAws_ec2DescribeStaleSecurityGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStaleSecurityGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeStaleSecurityGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19874,7 +19874,7 @@ export const deserializeAws_ec2DescribeSubnetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSubnetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeSubnetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19920,7 +19920,7 @@ export const deserializeAws_ec2DescribeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -19966,7 +19966,7 @@ export const deserializeAws_ec2DescribeTrafficMirrorFiltersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrafficMirrorFiltersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeTrafficMirrorFiltersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20012,7 +20012,7 @@ export const deserializeAws_ec2DescribeTrafficMirrorSessionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrafficMirrorSessionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeTrafficMirrorSessionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20058,7 +20058,7 @@ export const deserializeAws_ec2DescribeTrafficMirrorTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrafficMirrorTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeTrafficMirrorTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20104,7 +20104,7 @@ export const deserializeAws_ec2DescribeTransitGatewayAttachmentsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTransitGatewayAttachmentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeTransitGatewayAttachmentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20150,7 +20150,7 @@ export const deserializeAws_ec2DescribeTransitGatewayMulticastDomainsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTransitGatewayMulticastDomainsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeTransitGatewayMulticastDomainsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20196,7 +20196,7 @@ export const deserializeAws_ec2DescribeTransitGatewayPeeringAttachmentsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTransitGatewayPeeringAttachmentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeTransitGatewayPeeringAttachmentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20242,7 +20242,7 @@ export const deserializeAws_ec2DescribeTransitGatewayRouteTablesCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTransitGatewayRouteTablesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeTransitGatewayRouteTablesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20288,7 +20288,7 @@ export const deserializeAws_ec2DescribeTransitGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTransitGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeTransitGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20334,7 +20334,7 @@ export const deserializeAws_ec2DescribeTransitGatewayVpcAttachmentsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTransitGatewayVpcAttachmentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeTransitGatewayVpcAttachmentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20380,7 +20380,7 @@ export const deserializeAws_ec2DescribeVolumeAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVolumeAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVolumeAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20426,7 +20426,7 @@ export const deserializeAws_ec2DescribeVolumesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVolumesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVolumesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20472,7 +20472,7 @@ export const deserializeAws_ec2DescribeVolumesModificationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVolumesModificationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVolumesModificationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20518,7 +20518,7 @@ export const deserializeAws_ec2DescribeVolumeStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVolumeStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVolumeStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20564,7 +20564,7 @@ export const deserializeAws_ec2DescribeVpcAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20610,7 +20610,7 @@ export const deserializeAws_ec2DescribeVpcClassicLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcClassicLinkCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcClassicLinkCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20656,7 +20656,7 @@ export const deserializeAws_ec2DescribeVpcClassicLinkDnsSupportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcClassicLinkDnsSupportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcClassicLinkDnsSupportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20702,7 +20702,7 @@ export const deserializeAws_ec2DescribeVpcEndpointConnectionNotificationsCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcEndpointConnectionNotificationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcEndpointConnectionNotificationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20748,7 +20748,7 @@ export const deserializeAws_ec2DescribeVpcEndpointConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcEndpointConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcEndpointConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20794,7 +20794,7 @@ export const deserializeAws_ec2DescribeVpcEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20840,7 +20840,7 @@ export const deserializeAws_ec2DescribeVpcEndpointServiceConfigurationsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcEndpointServiceConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcEndpointServiceConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20886,7 +20886,7 @@ export const deserializeAws_ec2DescribeVpcEndpointServicePermissionsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcEndpointServicePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcEndpointServicePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20932,7 +20932,7 @@ export const deserializeAws_ec2DescribeVpcEndpointServicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcEndpointServicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcEndpointServicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -20978,7 +20978,7 @@ export const deserializeAws_ec2DescribeVpcPeeringConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcPeeringConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcPeeringConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21024,7 +21024,7 @@ export const deserializeAws_ec2DescribeVpcsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpcsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21070,7 +21070,7 @@ export const deserializeAws_ec2DescribeVpnConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpnConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpnConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21116,7 +21116,7 @@ export const deserializeAws_ec2DescribeVpnGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpnGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DescribeVpnGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21162,7 +21162,7 @@ export const deserializeAws_ec2DetachClassicLinkVpcCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachClassicLinkVpcCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DetachClassicLinkVpcCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21208,7 +21208,7 @@ export const deserializeAws_ec2DetachInternetGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachInternetGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DetachInternetGatewayCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -21251,7 +21251,7 @@ export const deserializeAws_ec2DetachNetworkInterfaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachNetworkInterfaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DetachNetworkInterfaceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -21294,7 +21294,7 @@ export const deserializeAws_ec2DetachVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DetachVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21340,7 +21340,7 @@ export const deserializeAws_ec2DetachVpnGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachVpnGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DetachVpnGatewayCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -21383,7 +21383,7 @@ export const deserializeAws_ec2DisableEbsEncryptionByDefaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableEbsEncryptionByDefaultCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisableEbsEncryptionByDefaultCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21429,7 +21429,7 @@ export const deserializeAws_ec2DisableFastSnapshotRestoresCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableFastSnapshotRestoresCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisableFastSnapshotRestoresCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21475,7 +21475,7 @@ export const deserializeAws_ec2DisableTransitGatewayRouteTablePropagationCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableTransitGatewayRouteTablePropagationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisableTransitGatewayRouteTablePropagationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21521,7 +21521,7 @@ export const deserializeAws_ec2DisableVgwRoutePropagationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableVgwRoutePropagationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisableVgwRoutePropagationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -21564,7 +21564,7 @@ export const deserializeAws_ec2DisableVpcClassicLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableVpcClassicLinkCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisableVpcClassicLinkCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21610,7 +21610,7 @@ export const deserializeAws_ec2DisableVpcClassicLinkDnsSupportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableVpcClassicLinkDnsSupportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisableVpcClassicLinkDnsSupportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21656,7 +21656,7 @@ export const deserializeAws_ec2DisassociateAddressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisassociateAddressCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -21699,7 +21699,7 @@ export const deserializeAws_ec2DisassociateClientVpnTargetNetworkCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateClientVpnTargetNetworkCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisassociateClientVpnTargetNetworkCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21745,7 +21745,7 @@ export const deserializeAws_ec2DisassociateIamInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateIamInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisassociateIamInstanceProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21791,7 +21791,7 @@ export const deserializeAws_ec2DisassociateRouteTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateRouteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisassociateRouteTableCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -21834,7 +21834,7 @@ export const deserializeAws_ec2DisassociateSubnetCidrBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateSubnetCidrBlockCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisassociateSubnetCidrBlockCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21880,7 +21880,7 @@ export const deserializeAws_ec2DisassociateTransitGatewayMulticastDomainCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateTransitGatewayMulticastDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisassociateTransitGatewayMulticastDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21926,7 +21926,7 @@ export const deserializeAws_ec2DisassociateTransitGatewayRouteTableCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateTransitGatewayRouteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisassociateTransitGatewayRouteTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -21972,7 +21972,7 @@ export const deserializeAws_ec2DisassociateVpcCidrBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateVpcCidrBlockCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2DisassociateVpcCidrBlockCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22018,7 +22018,7 @@ export const deserializeAws_ec2EnableEbsEncryptionByDefaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableEbsEncryptionByDefaultCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2EnableEbsEncryptionByDefaultCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22064,7 +22064,7 @@ export const deserializeAws_ec2EnableFastSnapshotRestoresCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableFastSnapshotRestoresCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2EnableFastSnapshotRestoresCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22110,7 +22110,7 @@ export const deserializeAws_ec2EnableTransitGatewayRouteTablePropagationCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableTransitGatewayRouteTablePropagationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2EnableTransitGatewayRouteTablePropagationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22156,7 +22156,7 @@ export const deserializeAws_ec2EnableVgwRoutePropagationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableVgwRoutePropagationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2EnableVgwRoutePropagationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -22199,7 +22199,7 @@ export const deserializeAws_ec2EnableVolumeIOCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableVolumeIOCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2EnableVolumeIOCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -22242,7 +22242,7 @@ export const deserializeAws_ec2EnableVpcClassicLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableVpcClassicLinkCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2EnableVpcClassicLinkCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22288,7 +22288,7 @@ export const deserializeAws_ec2EnableVpcClassicLinkDnsSupportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableVpcClassicLinkDnsSupportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2EnableVpcClassicLinkDnsSupportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22334,7 +22334,7 @@ export const deserializeAws_ec2ExportClientVpnClientCertificateRevocationListCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportClientVpnClientCertificateRevocationListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ExportClientVpnClientCertificateRevocationListCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22380,7 +22380,7 @@ export const deserializeAws_ec2ExportClientVpnClientConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportClientVpnClientConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ExportClientVpnClientConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22426,7 +22426,7 @@ export const deserializeAws_ec2ExportImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ExportImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22472,7 +22472,7 @@ export const deserializeAws_ec2ExportTransitGatewayRoutesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportTransitGatewayRoutesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ExportTransitGatewayRoutesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22518,7 +22518,7 @@ export const deserializeAws_ec2GetAssociatedIpv6PoolCidrsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAssociatedIpv6PoolCidrsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetAssociatedIpv6PoolCidrsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22564,7 +22564,7 @@ export const deserializeAws_ec2GetCapacityReservationUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCapacityReservationUsageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetCapacityReservationUsageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22610,7 +22610,7 @@ export const deserializeAws_ec2GetCoipPoolUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCoipPoolUsageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetCoipPoolUsageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22656,7 +22656,7 @@ export const deserializeAws_ec2GetConsoleOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConsoleOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetConsoleOutputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22702,7 +22702,7 @@ export const deserializeAws_ec2GetConsoleScreenshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConsoleScreenshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetConsoleScreenshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22748,7 +22748,7 @@ export const deserializeAws_ec2GetDefaultCreditSpecificationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDefaultCreditSpecificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetDefaultCreditSpecificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22794,7 +22794,7 @@ export const deserializeAws_ec2GetEbsDefaultKmsKeyIdCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEbsDefaultKmsKeyIdCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetEbsDefaultKmsKeyIdCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22840,7 +22840,7 @@ export const deserializeAws_ec2GetEbsEncryptionByDefaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEbsEncryptionByDefaultCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetEbsEncryptionByDefaultCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22886,7 +22886,7 @@ export const deserializeAws_ec2GetGroupsForCapacityReservationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupsForCapacityReservationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetGroupsForCapacityReservationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22932,7 +22932,7 @@ export const deserializeAws_ec2GetHostReservationPurchasePreviewCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHostReservationPurchasePreviewCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetHostReservationPurchasePreviewCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -22978,7 +22978,7 @@ export const deserializeAws_ec2GetLaunchTemplateDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLaunchTemplateDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetLaunchTemplateDataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23024,7 +23024,7 @@ export const deserializeAws_ec2GetManagedPrefixListAssociationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetManagedPrefixListAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetManagedPrefixListAssociationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23070,7 +23070,7 @@ export const deserializeAws_ec2GetManagedPrefixListEntriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetManagedPrefixListEntriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetManagedPrefixListEntriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23116,7 +23116,7 @@ export const deserializeAws_ec2GetPasswordDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPasswordDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetPasswordDataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23162,7 +23162,7 @@ export const deserializeAws_ec2GetReservedInstancesExchangeQuoteCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetReservedInstancesExchangeQuoteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetReservedInstancesExchangeQuoteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23208,7 +23208,7 @@ export const deserializeAws_ec2GetTransitGatewayAttachmentPropagationsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTransitGatewayAttachmentPropagationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetTransitGatewayAttachmentPropagationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23254,7 +23254,7 @@ export const deserializeAws_ec2GetTransitGatewayMulticastDomainAssociationsComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTransitGatewayMulticastDomainAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetTransitGatewayMulticastDomainAssociationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23300,7 +23300,7 @@ export const deserializeAws_ec2GetTransitGatewayRouteTableAssociationsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTransitGatewayRouteTableAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetTransitGatewayRouteTableAssociationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23346,7 +23346,7 @@ export const deserializeAws_ec2GetTransitGatewayRouteTablePropagationsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTransitGatewayRouteTablePropagationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GetTransitGatewayRouteTablePropagationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23392,7 +23392,7 @@ export const deserializeAws_ec2ImportClientVpnClientCertificateRevocationListCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportClientVpnClientCertificateRevocationListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ImportClientVpnClientCertificateRevocationListCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23438,7 +23438,7 @@ export const deserializeAws_ec2ImportImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ImportImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23484,7 +23484,7 @@ export const deserializeAws_ec2ImportInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ImportInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23530,7 +23530,7 @@ export const deserializeAws_ec2ImportKeyPairCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportKeyPairCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ImportKeyPairCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23576,7 +23576,7 @@ export const deserializeAws_ec2ImportSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ImportSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23622,7 +23622,7 @@ export const deserializeAws_ec2ImportVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ImportVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23668,7 +23668,7 @@ export const deserializeAws_ec2ModifyAvailabilityZoneGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyAvailabilityZoneGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyAvailabilityZoneGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23714,7 +23714,7 @@ export const deserializeAws_ec2ModifyCapacityReservationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyCapacityReservationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyCapacityReservationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23760,7 +23760,7 @@ export const deserializeAws_ec2ModifyClientVpnEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClientVpnEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyClientVpnEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23806,7 +23806,7 @@ export const deserializeAws_ec2ModifyDefaultCreditSpecificationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDefaultCreditSpecificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyDefaultCreditSpecificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23852,7 +23852,7 @@ export const deserializeAws_ec2ModifyEbsDefaultKmsKeyIdCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyEbsDefaultKmsKeyIdCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyEbsDefaultKmsKeyIdCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23898,7 +23898,7 @@ export const deserializeAws_ec2ModifyFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23944,7 +23944,7 @@ export const deserializeAws_ec2ModifyFpgaImageAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyFpgaImageAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyFpgaImageAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -23990,7 +23990,7 @@ export const deserializeAws_ec2ModifyHostsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyHostsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyHostsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24036,7 +24036,7 @@ export const deserializeAws_ec2ModifyIdentityIdFormatCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyIdentityIdFormatCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyIdentityIdFormatCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -24079,7 +24079,7 @@ export const deserializeAws_ec2ModifyIdFormatCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyIdFormatCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyIdFormatCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -24122,7 +24122,7 @@ export const deserializeAws_ec2ModifyImageAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyImageAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyImageAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -24165,7 +24165,7 @@ export const deserializeAws_ec2ModifyInstanceAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyInstanceAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyInstanceAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -24208,7 +24208,7 @@ export const deserializeAws_ec2ModifyInstanceCapacityReservationAttributesComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyInstanceCapacityReservationAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyInstanceCapacityReservationAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24254,7 +24254,7 @@ export const deserializeAws_ec2ModifyInstanceCreditSpecificationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyInstanceCreditSpecificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyInstanceCreditSpecificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24300,7 +24300,7 @@ export const deserializeAws_ec2ModifyInstanceEventStartTimeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyInstanceEventStartTimeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyInstanceEventStartTimeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24346,7 +24346,7 @@ export const deserializeAws_ec2ModifyInstanceMetadataOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyInstanceMetadataOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyInstanceMetadataOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24392,7 +24392,7 @@ export const deserializeAws_ec2ModifyInstancePlacementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyInstancePlacementCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyInstancePlacementCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24438,7 +24438,7 @@ export const deserializeAws_ec2ModifyLaunchTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyLaunchTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyLaunchTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24484,7 +24484,7 @@ export const deserializeAws_ec2ModifyManagedPrefixListCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyManagedPrefixListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyManagedPrefixListCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24530,7 +24530,7 @@ export const deserializeAws_ec2ModifyNetworkInterfaceAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyNetworkInterfaceAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyNetworkInterfaceAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -24573,7 +24573,7 @@ export const deserializeAws_ec2ModifyReservedInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyReservedInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyReservedInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24619,7 +24619,7 @@ export const deserializeAws_ec2ModifySnapshotAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifySnapshotAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifySnapshotAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -24662,7 +24662,7 @@ export const deserializeAws_ec2ModifySpotFleetRequestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifySpotFleetRequestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifySpotFleetRequestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24708,7 +24708,7 @@ export const deserializeAws_ec2ModifySubnetAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifySubnetAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifySubnetAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -24751,7 +24751,7 @@ export const deserializeAws_ec2ModifyTrafficMirrorFilterNetworkServicesCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyTrafficMirrorFilterNetworkServicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyTrafficMirrorFilterNetworkServicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24797,7 +24797,7 @@ export const deserializeAws_ec2ModifyTrafficMirrorFilterRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyTrafficMirrorFilterRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyTrafficMirrorFilterRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24843,7 +24843,7 @@ export const deserializeAws_ec2ModifyTrafficMirrorSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyTrafficMirrorSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyTrafficMirrorSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24889,7 +24889,7 @@ export const deserializeAws_ec2ModifyTransitGatewayVpcAttachmentCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyTransitGatewayVpcAttachmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyTransitGatewayVpcAttachmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24935,7 +24935,7 @@ export const deserializeAws_ec2ModifyVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -24981,7 +24981,7 @@ export const deserializeAws_ec2ModifyVolumeAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVolumeAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVolumeAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -25024,7 +25024,7 @@ export const deserializeAws_ec2ModifyVpcAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVpcAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVpcAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -25067,7 +25067,7 @@ export const deserializeAws_ec2ModifyVpcEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVpcEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVpcEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25113,7 +25113,7 @@ export const deserializeAws_ec2ModifyVpcEndpointConnectionNotificationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVpcEndpointConnectionNotificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVpcEndpointConnectionNotificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25159,7 +25159,7 @@ export const deserializeAws_ec2ModifyVpcEndpointServiceConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVpcEndpointServiceConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVpcEndpointServiceConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25205,7 +25205,7 @@ export const deserializeAws_ec2ModifyVpcEndpointServicePermissionsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVpcEndpointServicePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVpcEndpointServicePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25251,7 +25251,7 @@ export const deserializeAws_ec2ModifyVpcPeeringConnectionOptionsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVpcPeeringConnectionOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVpcPeeringConnectionOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25297,7 +25297,7 @@ export const deserializeAws_ec2ModifyVpcTenancyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVpcTenancyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVpcTenancyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25343,7 +25343,7 @@ export const deserializeAws_ec2ModifyVpnConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVpnConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVpnConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25389,7 +25389,7 @@ export const deserializeAws_ec2ModifyVpnTunnelCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVpnTunnelCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVpnTunnelCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25435,7 +25435,7 @@ export const deserializeAws_ec2ModifyVpnTunnelOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyVpnTunnelOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ModifyVpnTunnelOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25481,7 +25481,7 @@ export const deserializeAws_ec2MonitorInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MonitorInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2MonitorInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25527,7 +25527,7 @@ export const deserializeAws_ec2MoveAddressToVpcCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MoveAddressToVpcCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2MoveAddressToVpcCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25573,7 +25573,7 @@ export const deserializeAws_ec2ProvisionByoipCidrCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ProvisionByoipCidrCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ProvisionByoipCidrCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25619,7 +25619,7 @@ export const deserializeAws_ec2PurchaseHostReservationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurchaseHostReservationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2PurchaseHostReservationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25665,7 +25665,7 @@ export const deserializeAws_ec2PurchaseReservedInstancesOfferingCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurchaseReservedInstancesOfferingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2PurchaseReservedInstancesOfferingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25711,7 +25711,7 @@ export const deserializeAws_ec2PurchaseScheduledInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurchaseScheduledInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2PurchaseScheduledInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25757,7 +25757,7 @@ export const deserializeAws_ec2RebootInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RebootInstancesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -25800,7 +25800,7 @@ export const deserializeAws_ec2RegisterImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RegisterImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25846,7 +25846,7 @@ export const deserializeAws_ec2RegisterInstanceEventNotificationAttributesComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterInstanceEventNotificationAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RegisterInstanceEventNotificationAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25892,7 +25892,7 @@ export const deserializeAws_ec2RegisterTransitGatewayMulticastGroupMembersComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterTransitGatewayMulticastGroupMembersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RegisterTransitGatewayMulticastGroupMembersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25938,7 +25938,7 @@ export const deserializeAws_ec2RegisterTransitGatewayMulticastGroupSourcesComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterTransitGatewayMulticastGroupSourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RegisterTransitGatewayMulticastGroupSourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -25984,7 +25984,7 @@ export const deserializeAws_ec2RejectTransitGatewayPeeringAttachmentCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectTransitGatewayPeeringAttachmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RejectTransitGatewayPeeringAttachmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26030,7 +26030,7 @@ export const deserializeAws_ec2RejectTransitGatewayVpcAttachmentCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectTransitGatewayVpcAttachmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RejectTransitGatewayVpcAttachmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26076,7 +26076,7 @@ export const deserializeAws_ec2RejectVpcEndpointConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectVpcEndpointConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RejectVpcEndpointConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26122,7 +26122,7 @@ export const deserializeAws_ec2RejectVpcPeeringConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectVpcPeeringConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RejectVpcPeeringConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26168,7 +26168,7 @@ export const deserializeAws_ec2ReleaseAddressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReleaseAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ReleaseAddressCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -26211,7 +26211,7 @@ export const deserializeAws_ec2ReleaseHostsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReleaseHostsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ReleaseHostsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26257,7 +26257,7 @@ export const deserializeAws_ec2ReplaceIamInstanceProfileAssociationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReplaceIamInstanceProfileAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ReplaceIamInstanceProfileAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26303,7 +26303,7 @@ export const deserializeAws_ec2ReplaceNetworkAclAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReplaceNetworkAclAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ReplaceNetworkAclAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26349,7 +26349,7 @@ export const deserializeAws_ec2ReplaceNetworkAclEntryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReplaceNetworkAclEntryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ReplaceNetworkAclEntryCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -26392,7 +26392,7 @@ export const deserializeAws_ec2ReplaceRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReplaceRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ReplaceRouteCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -26435,7 +26435,7 @@ export const deserializeAws_ec2ReplaceRouteTableAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReplaceRouteTableAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ReplaceRouteTableAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26481,7 +26481,7 @@ export const deserializeAws_ec2ReplaceTransitGatewayRouteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReplaceTransitGatewayRouteCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ReplaceTransitGatewayRouteCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26527,7 +26527,7 @@ export const deserializeAws_ec2ReportInstanceStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReportInstanceStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ReportInstanceStatusCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -26570,7 +26570,7 @@ export const deserializeAws_ec2RequestSpotFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RequestSpotFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RequestSpotFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26616,7 +26616,7 @@ export const deserializeAws_ec2RequestSpotInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RequestSpotInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RequestSpotInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26662,7 +26662,7 @@ export const deserializeAws_ec2ResetEbsDefaultKmsKeyIdCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetEbsDefaultKmsKeyIdCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ResetEbsDefaultKmsKeyIdCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26708,7 +26708,7 @@ export const deserializeAws_ec2ResetFpgaImageAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetFpgaImageAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ResetFpgaImageAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26754,7 +26754,7 @@ export const deserializeAws_ec2ResetImageAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetImageAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ResetImageAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -26797,7 +26797,7 @@ export const deserializeAws_ec2ResetInstanceAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetInstanceAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ResetInstanceAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -26840,7 +26840,7 @@ export const deserializeAws_ec2ResetNetworkInterfaceAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetNetworkInterfaceAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ResetNetworkInterfaceAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -26883,7 +26883,7 @@ export const deserializeAws_ec2ResetSnapshotAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetSnapshotAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2ResetSnapshotAttributeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -26926,7 +26926,7 @@ export const deserializeAws_ec2RestoreAddressToClassicCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreAddressToClassicCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RestoreAddressToClassicCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -26972,7 +26972,7 @@ export const deserializeAws_ec2RestoreManagedPrefixListVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreManagedPrefixListVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RestoreManagedPrefixListVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27018,7 +27018,7 @@ export const deserializeAws_ec2RevokeClientVpnIngressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeClientVpnIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RevokeClientVpnIngressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27064,7 +27064,7 @@ export const deserializeAws_ec2RevokeSecurityGroupEgressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeSecurityGroupEgressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RevokeSecurityGroupEgressCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -27107,7 +27107,7 @@ export const deserializeAws_ec2RevokeSecurityGroupIngressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeSecurityGroupIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RevokeSecurityGroupIngressCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -27150,7 +27150,7 @@ export const deserializeAws_ec2RunInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RunInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RunInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27196,7 +27196,7 @@ export const deserializeAws_ec2RunScheduledInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RunScheduledInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RunScheduledInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27242,7 +27242,7 @@ export const deserializeAws_ec2SearchLocalGatewayRoutesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchLocalGatewayRoutesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2SearchLocalGatewayRoutesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27288,7 +27288,7 @@ export const deserializeAws_ec2SearchTransitGatewayMulticastGroupsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchTransitGatewayMulticastGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2SearchTransitGatewayMulticastGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27334,7 +27334,7 @@ export const deserializeAws_ec2SearchTransitGatewayRoutesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchTransitGatewayRoutesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2SearchTransitGatewayRoutesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27380,7 +27380,7 @@ export const deserializeAws_ec2SendDiagnosticInterruptCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendDiagnosticInterruptCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2SendDiagnosticInterruptCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -27423,7 +27423,7 @@ export const deserializeAws_ec2StartInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2StartInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27469,7 +27469,7 @@ export const deserializeAws_ec2StartVpcEndpointServicePrivateDnsVerificationComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartVpcEndpointServicePrivateDnsVerificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2StartVpcEndpointServicePrivateDnsVerificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27515,7 +27515,7 @@ export const deserializeAws_ec2StopInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2StopInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27561,7 +27561,7 @@ export const deserializeAws_ec2TerminateClientVpnConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateClientVpnConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2TerminateClientVpnConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27607,7 +27607,7 @@ export const deserializeAws_ec2TerminateInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2TerminateInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27653,7 +27653,7 @@ export const deserializeAws_ec2UnassignIpv6AddressesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnassignIpv6AddressesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2UnassignIpv6AddressesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27699,7 +27699,7 @@ export const deserializeAws_ec2UnassignPrivateIpAddressesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnassignPrivateIpAddressesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2UnassignPrivateIpAddressesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -27742,7 +27742,7 @@ export const deserializeAws_ec2UnmonitorInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnmonitorInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2UnmonitorInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27788,7 +27788,7 @@ export const deserializeAws_ec2UpdateSecurityGroupRuleDescriptionsEgressCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSecurityGroupRuleDescriptionsEgressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2UpdateSecurityGroupRuleDescriptionsEgressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27834,7 +27834,7 @@ export const deserializeAws_ec2UpdateSecurityGroupRuleDescriptionsIngressCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSecurityGroupRuleDescriptionsIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2UpdateSecurityGroupRuleDescriptionsIngressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -27880,7 +27880,7 @@ export const deserializeAws_ec2WithdrawByoipCidrCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<WithdrawByoipCidrCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2WithdrawByoipCidrCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-ecr/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr/protocols/Aws_json1_1.ts
@@ -577,7 +577,7 @@ export const deserializeAws_json1_1BatchCheckLayerAvailabilityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchCheckLayerAvailabilityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchCheckLayerAvailabilityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -648,7 +648,7 @@ export const deserializeAws_json1_1BatchDeleteImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeleteImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDeleteImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -719,7 +719,7 @@ export const deserializeAws_json1_1BatchGetImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -790,7 +790,7 @@ export const deserializeAws_json1_1CompleteLayerUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CompleteLayerUploadCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CompleteLayerUploadCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -909,7 +909,7 @@ export const deserializeAws_json1_1CreateRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRepositoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1012,7 +1012,7 @@ export const deserializeAws_json1_1DeleteLifecyclePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLifecyclePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLifecyclePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1091,7 +1091,7 @@ export const deserializeAws_json1_1DeleteRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRepositoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1178,7 +1178,7 @@ export const deserializeAws_json1_1DeleteRepositoryPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRepositoryPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRepositoryPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1257,7 +1257,7 @@ export const deserializeAws_json1_1DescribeImagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeImagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeImagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1336,7 +1336,7 @@ export const deserializeAws_json1_1DescribeImageScanFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeImageScanFindingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeImageScanFindingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1423,7 +1423,7 @@ export const deserializeAws_json1_1DescribeRepositoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRepositoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRepositoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1494,7 +1494,7 @@ export const deserializeAws_json1_1GetAuthorizationTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAuthorizationTokenCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAuthorizationTokenCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1557,7 +1557,7 @@ export const deserializeAws_json1_1GetDownloadUrlForLayerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDownloadUrlForLayerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDownloadUrlForLayerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1644,7 +1644,7 @@ export const deserializeAws_json1_1GetLifecyclePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLifecyclePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLifecyclePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1723,7 +1723,7 @@ export const deserializeAws_json1_1GetLifecyclePolicyPreviewCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLifecyclePolicyPreviewCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLifecyclePolicyPreviewCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1802,7 +1802,7 @@ export const deserializeAws_json1_1GetRepositoryPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRepositoryPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRepositoryPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1881,7 +1881,7 @@ export const deserializeAws_json1_1InitiateLayerUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InitiateLayerUploadCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1InitiateLayerUploadCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1960,7 +1960,7 @@ export const deserializeAws_json1_1ListImagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListImagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListImagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2031,7 +2031,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2102,7 +2102,7 @@ export const deserializeAws_json1_1PutImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2229,7 +2229,7 @@ export const deserializeAws_json1_1PutImageScanningConfigurationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutImageScanningConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutImageScanningConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2300,7 +2300,7 @@ export const deserializeAws_json1_1PutImageTagMutabilityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutImageTagMutabilityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutImageTagMutabilityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2371,7 +2371,7 @@ export const deserializeAws_json1_1PutLifecyclePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLifecyclePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutLifecyclePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2442,7 +2442,7 @@ export const deserializeAws_json1_1SetRepositoryPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetRepositoryPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetRepositoryPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2513,7 +2513,7 @@ export const deserializeAws_json1_1StartImageScanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartImageScanCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartImageScanCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2608,7 +2608,7 @@ export const deserializeAws_json1_1StartLifecyclePolicyPreviewCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartLifecyclePolicyPreviewCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartLifecyclePolicyPreviewCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2695,7 +2695,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2782,7 +2782,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2869,7 +2869,7 @@ export const deserializeAws_json1_1UploadLayerPartCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UploadLayerPartCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UploadLayerPartCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-ecs/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/protocols/Aws_json1_1.ts
@@ -971,7 +971,7 @@ export const deserializeAws_json1_1CreateCapacityProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCapacityProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCapacityProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1058,7 +1058,7 @@ export const deserializeAws_json1_1CreateClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1129,7 +1129,7 @@ export const deserializeAws_json1_1CreateServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateServiceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateServiceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1240,7 +1240,7 @@ export const deserializeAws_json1_1CreateTaskSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTaskSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTaskSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1367,7 +1367,7 @@ export const deserializeAws_json1_1DeleteAccountSettingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccountSettingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAccountSettingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1438,7 +1438,7 @@ export const deserializeAws_json1_1DeleteAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1509,7 +1509,7 @@ export const deserializeAws_json1_1DeleteCapacityProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCapacityProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCapacityProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1580,7 +1580,7 @@ export const deserializeAws_json1_1DeleteClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1691,7 +1691,7 @@ export const deserializeAws_json1_1DeleteServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteServiceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteServiceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1778,7 +1778,7 @@ export const deserializeAws_json1_1DeleteTaskSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTaskSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTaskSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1897,7 +1897,7 @@ export const deserializeAws_json1_1DeregisterContainerInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterContainerInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterContainerInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1976,7 +1976,7 @@ export const deserializeAws_json1_1DeregisterTaskDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterTaskDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterTaskDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2047,7 +2047,7 @@ export const deserializeAws_json1_1DescribeCapacityProvidersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCapacityProvidersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCapacityProvidersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2118,7 +2118,7 @@ export const deserializeAws_json1_1DescribeClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2189,7 +2189,7 @@ export const deserializeAws_json1_1DescribeContainerInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeContainerInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeContainerInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2268,7 +2268,7 @@ export const deserializeAws_json1_1DescribeServicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeServicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeServicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2347,7 +2347,7 @@ export const deserializeAws_json1_1DescribeTaskDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTaskDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTaskDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2418,7 +2418,7 @@ export const deserializeAws_json1_1DescribeTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2497,7 +2497,7 @@ export const deserializeAws_json1_1DescribeTaskSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTaskSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTaskSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2608,7 +2608,7 @@ export const deserializeAws_json1_1DiscoverPollEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DiscoverPollEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DiscoverPollEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2671,7 +2671,7 @@ export const deserializeAws_json1_1ListAccountSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAccountSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAccountSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2742,7 +2742,7 @@ export const deserializeAws_json1_1ListAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2805,7 +2805,7 @@ export const deserializeAws_json1_1ListClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2876,7 +2876,7 @@ export const deserializeAws_json1_1ListContainerInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListContainerInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListContainerInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2955,7 +2955,7 @@ export const deserializeAws_json1_1ListServicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListServicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3034,7 +3034,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3113,7 +3113,7 @@ export const deserializeAws_json1_1ListTaskDefinitionFamiliesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTaskDefinitionFamiliesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTaskDefinitionFamiliesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3184,7 +3184,7 @@ export const deserializeAws_json1_1ListTaskDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTaskDefinitionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTaskDefinitionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3255,7 +3255,7 @@ export const deserializeAws_json1_1ListTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3342,7 +3342,7 @@ export const deserializeAws_json1_1PutAccountSettingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAccountSettingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutAccountSettingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3413,7 +3413,7 @@ export const deserializeAws_json1_1PutAccountSettingDefaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAccountSettingDefaultCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutAccountSettingDefaultCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3484,7 +3484,7 @@ export const deserializeAws_json1_1PutAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3563,7 +3563,7 @@ export const deserializeAws_json1_1PutClusterCapacityProvidersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutClusterCapacityProvidersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutClusterCapacityProvidersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3658,7 +3658,7 @@ export const deserializeAws_json1_1RegisterContainerInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterContainerInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterContainerInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3729,7 +3729,7 @@ export const deserializeAws_json1_1RegisterTaskDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterTaskDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterTaskDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3800,7 +3800,7 @@ export const deserializeAws_json1_1RunTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RunTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RunTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3919,7 +3919,7 @@ export const deserializeAws_json1_1StartTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3998,7 +3998,7 @@ export const deserializeAws_json1_1StopTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4077,7 +4077,7 @@ export const deserializeAws_json1_1SubmitAttachmentStateChangesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SubmitAttachmentStateChangesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SubmitAttachmentStateChangesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4156,7 +4156,7 @@ export const deserializeAws_json1_1SubmitContainerStateChangeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SubmitContainerStateChangeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SubmitContainerStateChangeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4227,7 +4227,7 @@ export const deserializeAws_json1_1SubmitTaskStateChangeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SubmitTaskStateChangeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SubmitTaskStateChangeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4306,7 +4306,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4393,7 +4393,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4480,7 +4480,7 @@ export const deserializeAws_json1_1UpdateClusterSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateClusterSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateClusterSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4559,7 +4559,7 @@ export const deserializeAws_json1_1UpdateContainerAgentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateContainerAgentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateContainerAgentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4662,7 +4662,7 @@ export const deserializeAws_json1_1UpdateContainerInstancesStateCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateContainerInstancesStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateContainerInstancesStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4741,7 +4741,7 @@ export const deserializeAws_json1_1UpdateServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServiceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateServiceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4860,7 +4860,7 @@ export const deserializeAws_json1_1UpdateServicePrimaryTaskSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServicePrimaryTaskSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateServicePrimaryTaskSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4979,7 +4979,7 @@ export const deserializeAws_json1_1UpdateTaskSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTaskSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTaskSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-efs/protocols/Aws_restJson1.ts
+++ b/clients/client-efs/protocols/Aws_restJson1.ts
@@ -911,7 +911,7 @@ export const deserializeAws_restJson1CreateAccessPointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAccessPointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAccessPointCommandError(output, context);
   }
   const contents: CreateAccessPointCommandOutput = {
@@ -1042,7 +1042,7 @@ export const deserializeAws_restJson1CreateFileSystemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFileSystemCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFileSystemCommandError(output, context);
   }
   const contents: CreateFileSystemCommandOutput = {
@@ -1193,7 +1193,7 @@ export const deserializeAws_restJson1CreateMountTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMountTargetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMountTargetCommandError(output, context);
   }
   const contents: CreateMountTargetCommandOutput = {
@@ -1372,7 +1372,7 @@ export const deserializeAws_restJson1CreateTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTagsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateTagsCommandError(output, context);
   }
   const contents: CreateTagsCommandOutput = {
@@ -1439,7 +1439,7 @@ export const deserializeAws_restJson1DeleteAccessPointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccessPointCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAccessPointCommandError(output, context);
   }
   const contents: DeleteAccessPointCommandOutput = {
@@ -1506,7 +1506,7 @@ export const deserializeAws_restJson1DeleteFileSystemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFileSystemCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFileSystemCommandError(output, context);
   }
   const contents: DeleteFileSystemCommandOutput = {
@@ -1581,7 +1581,7 @@ export const deserializeAws_restJson1DeleteFileSystemPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFileSystemPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFileSystemPolicyCommandError(output, context);
   }
   const contents: DeleteFileSystemPolicyCommandOutput = {
@@ -1648,7 +1648,7 @@ export const deserializeAws_restJson1DeleteMountTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMountTargetCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMountTargetCommandError(output, context);
   }
   const contents: DeleteMountTargetCommandOutput = {
@@ -1723,7 +1723,7 @@ export const deserializeAws_restJson1DeleteTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteTagsCommandError(output, context);
   }
   const contents: DeleteTagsCommandOutput = {
@@ -1790,7 +1790,7 @@ export const deserializeAws_restJson1DescribeAccessPointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccessPointsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAccessPointsCommandError(output, context);
   }
   const contents: DescribeAccessPointsCommandOutput = {
@@ -1873,7 +1873,7 @@ export const deserializeAws_restJson1DescribeBackupPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBackupPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeBackupPolicyCommandError(output, context);
   }
   const contents: DescribeBackupPolicyCommandOutput = {
@@ -1960,7 +1960,7 @@ export const deserializeAws_restJson1DescribeFileSystemPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFileSystemPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeFileSystemPolicyCommandError(output, context);
   }
   const contents: DescribeFileSystemPolicyCommandOutput = {
@@ -2035,7 +2035,7 @@ export const deserializeAws_restJson1DescribeFileSystemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFileSystemsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeFileSystemsCommandError(output, context);
   }
   const contents: DescribeFileSystemsCommandOutput = {
@@ -2114,7 +2114,7 @@ export const deserializeAws_restJson1DescribeLifecycleConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLifecycleConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeLifecycleConfigurationCommandError(output, context);
   }
   const contents: DescribeLifecycleConfigurationCommandOutput = {
@@ -2185,7 +2185,7 @@ export const deserializeAws_restJson1DescribeMountTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMountTargetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeMountTargetsCommandError(output, context);
   }
   const contents: DescribeMountTargetsCommandOutput = {
@@ -2280,7 +2280,7 @@ export const deserializeAws_restJson1DescribeMountTargetSecurityGroupsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMountTargetSecurityGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeMountTargetSecurityGroupsCommandError(output, context);
   }
   const contents: DescribeMountTargetSecurityGroupsCommandOutput = {
@@ -2359,7 +2359,7 @@ export const deserializeAws_restJson1DescribeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeTagsCommandError(output, context);
   }
   const contents: DescribeTagsCommandOutput = {
@@ -2438,7 +2438,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -2521,7 +2521,7 @@ export const deserializeAws_restJson1ModifyMountTargetSecurityGroupsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyMountTargetSecurityGroupsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1ModifyMountTargetSecurityGroupsCommandError(output, context);
   }
   const contents: ModifyMountTargetSecurityGroupsCommandOutput = {
@@ -2612,7 +2612,7 @@ export const deserializeAws_restJson1PutBackupPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBackupPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutBackupPolicyCommandError(output, context);
   }
   const contents: PutBackupPolicyCommandOutput = {
@@ -2699,7 +2699,7 @@ export const deserializeAws_restJson1PutFileSystemPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutFileSystemPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutFileSystemPolicyCommandError(output, context);
   }
   const contents: PutFileSystemPolicyCommandOutput = {
@@ -2782,7 +2782,7 @@ export const deserializeAws_restJson1PutLifecycleConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLifecycleConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutLifecycleConfigurationCommandError(output, context);
   }
   const contents: PutLifecycleConfigurationCommandOutput = {
@@ -2861,7 +2861,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -2936,7 +2936,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -3011,7 +3011,7 @@ export const deserializeAws_restJson1UpdateFileSystemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFileSystemCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFileSystemCommandError(output, context);
   }
   const contents: UpdateFileSystemCommandOutput = {

--- a/clients/client-eks/protocols/Aws_restJson1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1.ts
@@ -876,7 +876,7 @@ export const deserializeAws_restJson1CreateClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateClusterCommandError(output, context);
   }
   const contents: CreateClusterCommandOutput = {
@@ -979,7 +979,7 @@ export const deserializeAws_restJson1CreateFargateProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFargateProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFargateProfileCommandError(output, context);
   }
   const contents: CreateFargateProfileCommandOutput = {
@@ -1074,7 +1074,7 @@ export const deserializeAws_restJson1CreateNodegroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNodegroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateNodegroupCommandError(output, context);
   }
   const contents: CreateNodegroupCommandOutput = {
@@ -1177,7 +1177,7 @@ export const deserializeAws_restJson1DeleteClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClusterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteClusterCommandError(output, context);
   }
   const contents: DeleteClusterCommandOutput = {
@@ -1264,7 +1264,7 @@ export const deserializeAws_restJson1DeleteFargateProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFargateProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFargateProfileCommandError(output, context);
   }
   const contents: DeleteFargateProfileCommandOutput = {
@@ -1343,7 +1343,7 @@ export const deserializeAws_restJson1DeleteNodegroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNodegroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteNodegroupCommandError(output, context);
   }
   const contents: DeleteNodegroupCommandOutput = {
@@ -1438,7 +1438,7 @@ export const deserializeAws_restJson1DescribeClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeClusterCommandError(output, context);
   }
   const contents: DescribeClusterCommandOutput = {
@@ -1517,7 +1517,7 @@ export const deserializeAws_restJson1DescribeFargateProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFargateProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeFargateProfileCommandError(output, context);
   }
   const contents: DescribeFargateProfileCommandOutput = {
@@ -1596,7 +1596,7 @@ export const deserializeAws_restJson1DescribeNodegroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNodegroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeNodegroupCommandError(output, context);
   }
   const contents: DescribeNodegroupCommandOutput = {
@@ -1683,7 +1683,7 @@ export const deserializeAws_restJson1DescribeUpdateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUpdateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeUpdateCommandError(output, context);
   }
   const contents: DescribeUpdateCommandOutput = {
@@ -1762,7 +1762,7 @@ export const deserializeAws_restJson1ListClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListClustersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListClustersCommandError(output, context);
   }
   const contents: ListClustersCommandOutput = {
@@ -1845,7 +1845,7 @@ export const deserializeAws_restJson1ListFargateProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFargateProfilesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFargateProfilesCommandError(output, context);
   }
   const contents: ListFargateProfilesCommandOutput = {
@@ -1928,7 +1928,7 @@ export const deserializeAws_restJson1ListNodegroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNodegroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListNodegroupsCommandError(output, context);
   }
   const contents: ListNodegroupsCommandOutput = {
@@ -2019,7 +2019,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -2082,7 +2082,7 @@ export const deserializeAws_restJson1ListUpdatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUpdatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListUpdatesCommandError(output, context);
   }
   const contents: ListUpdatesCommandOutput = {
@@ -2165,7 +2165,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -2224,7 +2224,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -2283,7 +2283,7 @@ export const deserializeAws_restJson1UpdateClusterConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateClusterConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateClusterConfigCommandError(output, context);
   }
   const contents: UpdateClusterConfigCommandOutput = {
@@ -2378,7 +2378,7 @@ export const deserializeAws_restJson1UpdateClusterVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateClusterVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateClusterVersionCommandError(output, context);
   }
   const contents: UpdateClusterVersionCommandOutput = {
@@ -2473,7 +2473,7 @@ export const deserializeAws_restJson1UpdateNodegroupConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNodegroupConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateNodegroupConfigCommandError(output, context);
   }
   const contents: UpdateNodegroupConfigCommandOutput = {
@@ -2568,7 +2568,7 @@ export const deserializeAws_restJson1UpdateNodegroupVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNodegroupVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateNodegroupVersionCommandError(output, context);
   }
   const contents: UpdateNodegroupVersionCommandOutput = {

--- a/clients/client-elastic-beanstalk/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/protocols/Aws_query.ts
@@ -1077,7 +1077,7 @@ export const deserializeAws_queryAbortEnvironmentUpdateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AbortEnvironmentUpdateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAbortEnvironmentUpdateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1128,7 +1128,7 @@ export const deserializeAws_queryApplyEnvironmentManagedActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ApplyEnvironmentManagedActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryApplyEnvironmentManagedActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1190,7 +1190,7 @@ export const deserializeAws_queryAssociateEnvironmentOperationsRoleCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateEnvironmentOperationsRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAssociateEnvironmentOperationsRoleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1241,7 +1241,7 @@ export const deserializeAws_queryCheckDNSAvailabilityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CheckDNSAvailabilityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCheckDNSAvailabilityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1287,7 +1287,7 @@ export const deserializeAws_queryComposeEnvironmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ComposeEnvironmentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryComposeEnvironmentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1349,7 +1349,7 @@ export const deserializeAws_queryCreateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1403,7 +1403,7 @@ export const deserializeAws_queryCreateApplicationVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateApplicationVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1489,7 +1489,7 @@ export const deserializeAws_queryCreateConfigurationTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateConfigurationTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1559,7 +1559,7 @@ export const deserializeAws_queryCreateEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEnvironmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateEnvironmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1621,7 +1621,7 @@ export const deserializeAws_queryCreatePlatformVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePlatformVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreatePlatformVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1691,7 +1691,7 @@ export const deserializeAws_queryCreateStorageLocationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStorageLocationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateStorageLocationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1761,7 +1761,7 @@ export const deserializeAws_queryDeleteApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteApplicationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1812,7 +1812,7 @@ export const deserializeAws_queryDeleteApplicationVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteApplicationVersionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1887,7 +1887,7 @@ export const deserializeAws_queryDeleteConfigurationTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteConfigurationTemplateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1938,7 +1938,7 @@ export const deserializeAws_queryDeleteEnvironmentConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEnvironmentConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteEnvironmentConfigurationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1981,7 +1981,7 @@ export const deserializeAws_queryDeletePlatformVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePlatformVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeletePlatformVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2059,7 +2059,7 @@ export const deserializeAws_queryDescribeAccountAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAccountAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2113,7 +2113,7 @@ export const deserializeAws_queryDescribeApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeApplicationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeApplicationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2159,7 +2159,7 @@ export const deserializeAws_queryDescribeApplicationVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeApplicationVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeApplicationVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2205,7 +2205,7 @@ export const deserializeAws_queryDescribeConfigurationOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeConfigurationOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2259,7 +2259,7 @@ export const deserializeAws_queryDescribeConfigurationSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeConfigurationSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2313,7 +2313,7 @@ export const deserializeAws_queryDescribeEnvironmentHealthCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEnvironmentHealthCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEnvironmentHealthCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2375,7 +2375,7 @@ export const deserializeAws_queryDescribeEnvironmentManagedActionHistoryCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEnvironmentManagedActionHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEnvironmentManagedActionHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2432,7 +2432,7 @@ export const deserializeAws_queryDescribeEnvironmentManagedActionsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEnvironmentManagedActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEnvironmentManagedActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2489,7 +2489,7 @@ export const deserializeAws_queryDescribeEnvironmentResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEnvironmentResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEnvironmentResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2546,7 +2546,7 @@ export const deserializeAws_queryDescribeEnvironmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEnvironmentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEnvironmentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2592,7 +2592,7 @@ export const deserializeAws_queryDescribeEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2638,7 +2638,7 @@ export const deserializeAws_queryDescribeInstancesHealthCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstancesHealthCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeInstancesHealthCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2700,7 +2700,7 @@ export const deserializeAws_queryDescribePlatformVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePlatformVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribePlatformVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2762,7 +2762,7 @@ export const deserializeAws_queryDisassociateEnvironmentOperationsRoleCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateEnvironmentOperationsRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDisassociateEnvironmentOperationsRoleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2813,7 +2813,7 @@ export const deserializeAws_queryListAvailableSolutionStacksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAvailableSolutionStacksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListAvailableSolutionStacksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2862,7 +2862,7 @@ export const deserializeAws_queryListPlatformBranchesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPlatformBranchesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListPlatformBranchesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2908,7 +2908,7 @@ export const deserializeAws_queryListPlatformVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPlatformVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListPlatformVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2970,7 +2970,7 @@ export const deserializeAws_queryListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3040,7 +3040,7 @@ export const deserializeAws_queryRebuildEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebuildEnvironmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRebuildEnvironmentCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3091,7 +3091,7 @@ export const deserializeAws_queryRequestEnvironmentInfoCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RequestEnvironmentInfoCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRequestEnvironmentInfoCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3134,7 +3134,7 @@ export const deserializeAws_queryRestartAppServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestartAppServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestartAppServerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3177,7 +3177,7 @@ export const deserializeAws_queryRetrieveEnvironmentInfoCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RetrieveEnvironmentInfoCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRetrieveEnvironmentInfoCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3223,7 +3223,7 @@ export const deserializeAws_querySwapEnvironmentCNAMEsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SwapEnvironmentCNAMEsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySwapEnvironmentCNAMEsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3266,7 +3266,7 @@ export const deserializeAws_queryTerminateEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateEnvironmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryTerminateEnvironmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3320,7 +3320,7 @@ export const deserializeAws_queryUpdateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3366,7 +3366,7 @@ export const deserializeAws_queryUpdateApplicationResourceLifecycleCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationResourceLifecycleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateApplicationResourceLifecycleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3423,7 +3423,7 @@ export const deserializeAws_queryUpdateApplicationVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateApplicationVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3469,7 +3469,7 @@ export const deserializeAws_queryUpdateConfigurationTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigurationTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateConfigurationTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3531,7 +3531,7 @@ export const deserializeAws_queryUpdateEnvironmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEnvironmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateEnvironmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3593,7 +3593,7 @@ export const deserializeAws_queryUpdateTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateTagsForResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3676,7 +3676,7 @@ export const deserializeAws_queryValidateConfigurationSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ValidateConfigurationSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryValidateConfigurationSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-elastic-inference/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-inference/protocols/Aws_restJson1.ts
@@ -219,7 +219,7 @@ export const deserializeAws_restJson1DescribeAcceleratorOfferingsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAcceleratorOfferingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAcceleratorOfferingsCommandError(output, context);
   }
   const contents: DescribeAcceleratorOfferingsCommandOutput = {
@@ -293,7 +293,7 @@ export const deserializeAws_restJson1DescribeAcceleratorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAcceleratorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAcceleratorsCommandError(output, context);
   }
   const contents: DescribeAcceleratorsCommandOutput = {
@@ -368,7 +368,7 @@ export const deserializeAws_restJson1DescribeAcceleratorTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAcceleratorTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAcceleratorTypesCommandError(output, context);
   }
   const contents: DescribeAcceleratorTypesCommandOutput = {
@@ -423,7 +423,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -494,7 +494,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -561,7 +561,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {

--- a/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
@@ -776,7 +776,7 @@ export const deserializeAws_queryAddListenerCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddListenerCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddListenerCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -846,7 +846,7 @@ export const deserializeAws_queryAddTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -924,7 +924,7 @@ export const deserializeAws_queryCreateListenerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateListenerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateListenerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1106,7 +1106,7 @@ export const deserializeAws_queryCreateLoadBalancerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1256,7 +1256,7 @@ export const deserializeAws_queryCreateRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1414,7 +1414,7 @@ export const deserializeAws_queryCreateTargetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTargetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateTargetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1484,7 +1484,7 @@ export const deserializeAws_queryDeleteListenerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteListenerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteListenerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1538,7 +1538,7 @@ export const deserializeAws_queryDeleteLoadBalancerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1608,7 +1608,7 @@ export const deserializeAws_queryDeleteRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1670,7 +1670,7 @@ export const deserializeAws_queryDeleteTargetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTargetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteTargetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1724,7 +1724,7 @@ export const deserializeAws_queryDeregisterTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeregisterTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1786,7 +1786,7 @@ export const deserializeAws_queryDescribeAccountLimitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountLimitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAccountLimitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1832,7 +1832,7 @@ export const deserializeAws_queryDescribeListenerCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeListenerCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeListenerCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1886,7 +1886,7 @@ export const deserializeAws_queryDescribeListenersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeListenersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeListenersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1956,7 +1956,7 @@ export const deserializeAws_queryDescribeLoadBalancerAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoadBalancerAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLoadBalancerAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2013,7 +2013,7 @@ export const deserializeAws_queryDescribeLoadBalancersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoadBalancersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLoadBalancersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2067,7 +2067,7 @@ export const deserializeAws_queryDescribeRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2137,7 +2137,7 @@ export const deserializeAws_queryDescribeSSLPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSSLPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeSSLPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2191,7 +2191,7 @@ export const deserializeAws_queryDescribeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2269,7 +2269,7 @@ export const deserializeAws_queryDescribeTargetGroupAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTargetGroupAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTargetGroupAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2323,7 +2323,7 @@ export const deserializeAws_queryDescribeTargetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTargetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTargetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2385,7 +2385,7 @@ export const deserializeAws_queryDescribeTargetHealthCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTargetHealthCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTargetHealthCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2455,7 +2455,7 @@ export const deserializeAws_queryModifyListenerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyListenerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyListenerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2637,7 +2637,7 @@ export const deserializeAws_queryModifyLoadBalancerAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyLoadBalancerAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyLoadBalancerAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2699,7 +2699,7 @@ export const deserializeAws_queryModifyRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2833,7 +2833,7 @@ export const deserializeAws_queryModifyTargetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyTargetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyTargetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2895,7 +2895,7 @@ export const deserializeAws_queryModifyTargetGroupAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyTargetGroupAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyTargetGroupAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2957,7 +2957,7 @@ export const deserializeAws_queryRegisterTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRegisterTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3035,7 +3035,7 @@ export const deserializeAws_queryRemoveListenerCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveListenerCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveListenerCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3097,7 +3097,7 @@ export const deserializeAws_queryRemoveTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3183,7 +3183,7 @@ export const deserializeAws_querySetIpAddressTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetIpAddressTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetIpAddressTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3253,7 +3253,7 @@ export const deserializeAws_querySetRulePrioritiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetRulePrioritiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetRulePrioritiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3323,7 +3323,7 @@ export const deserializeAws_querySetSecurityGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetSecurityGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetSecurityGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3393,7 +3393,7 @@ export const deserializeAws_querySetSubnetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetSubnetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetSubnetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-elastic-load-balancing/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/protocols/Aws_query.ts
@@ -691,7 +691,7 @@ export const deserializeAws_queryAddTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -761,7 +761,7 @@ export const deserializeAws_queryApplySecurityGroupsToLoadBalancerCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ApplySecurityGroupsToLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryApplySecurityGroupsToLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -834,7 +834,7 @@ export const deserializeAws_queryAttachLoadBalancerToSubnetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachLoadBalancerToSubnetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAttachLoadBalancerToSubnetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -912,7 +912,7 @@ export const deserializeAws_queryConfigureHealthCheckCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfigureHealthCheckCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryConfigureHealthCheckCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -966,7 +966,7 @@ export const deserializeAws_queryCreateAppCookieStickinessPolicyCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAppCookieStickinessPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateAppCookieStickinessPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1047,7 +1047,7 @@ export const deserializeAws_queryCreateLBCookieStickinessPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLBCookieStickinessPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateLBCookieStickinessPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1128,7 +1128,7 @@ export const deserializeAws_queryCreateLoadBalancerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1270,7 +1270,7 @@ export const deserializeAws_queryCreateLoadBalancerListenersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLoadBalancerListenersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateLoadBalancerListenersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1356,7 +1356,7 @@ export const deserializeAws_queryCreateLoadBalancerPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLoadBalancerPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateLoadBalancerPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1442,7 +1442,7 @@ export const deserializeAws_queryDeleteLoadBalancerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1488,7 +1488,7 @@ export const deserializeAws_queryDeleteLoadBalancerListenersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoadBalancerListenersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteLoadBalancerListenersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1542,7 +1542,7 @@ export const deserializeAws_queryDeleteLoadBalancerPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoadBalancerPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteLoadBalancerPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1604,7 +1604,7 @@ export const deserializeAws_queryDeregisterInstancesFromLoadBalancerCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterInstancesFromLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeregisterInstancesFromLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1666,7 +1666,7 @@ export const deserializeAws_queryDescribeAccountLimitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountLimitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAccountLimitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1712,7 +1712,7 @@ export const deserializeAws_queryDescribeInstanceHealthCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstanceHealthCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeInstanceHealthCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1774,7 +1774,7 @@ export const deserializeAws_queryDescribeLoadBalancerAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoadBalancerAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLoadBalancerAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1839,7 +1839,7 @@ export const deserializeAws_queryDescribeLoadBalancerPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoadBalancerPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLoadBalancerPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1901,7 +1901,7 @@ export const deserializeAws_queryDescribeLoadBalancerPolicyTypesCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoadBalancerPolicyTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLoadBalancerPolicyTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1958,7 +1958,7 @@ export const deserializeAws_queryDescribeLoadBalancersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoadBalancersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLoadBalancersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2020,7 +2020,7 @@ export const deserializeAws_queryDescribeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2074,7 +2074,7 @@ export const deserializeAws_queryDetachLoadBalancerFromSubnetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachLoadBalancerFromSubnetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDetachLoadBalancerFromSubnetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2136,7 +2136,7 @@ export const deserializeAws_queryDisableAvailabilityZonesForLoadBalancerCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableAvailabilityZonesForLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDisableAvailabilityZonesForLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2201,7 +2201,7 @@ export const deserializeAws_queryEnableAvailabilityZonesForLoadBalancerCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableAvailabilityZonesForLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryEnableAvailabilityZonesForLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2255,7 +2255,7 @@ export const deserializeAws_queryModifyLoadBalancerAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyLoadBalancerAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyLoadBalancerAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2325,7 +2325,7 @@ export const deserializeAws_queryRegisterInstancesWithLoadBalancerCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterInstancesWithLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRegisterInstancesWithLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2387,7 +2387,7 @@ export const deserializeAws_queryRemoveTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2441,7 +2441,7 @@ export const deserializeAws_querySetLoadBalancerListenerSSLCertificateCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetLoadBalancerListenerSSLCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetLoadBalancerListenerSSLCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2530,7 +2530,7 @@ export const deserializeAws_querySetLoadBalancerPoliciesForBackendServerCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetLoadBalancerPoliciesForBackendServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetLoadBalancerPoliciesForBackendServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2603,7 +2603,7 @@ export const deserializeAws_querySetLoadBalancerPoliciesOfListenerCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetLoadBalancerPoliciesOfListenerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetLoadBalancerPoliciesOfListenerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-elastic-transcoder/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-transcoder/protocols/Aws_restJson1.ts
@@ -620,7 +620,7 @@ export const deserializeAws_restJson1CancelJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelJobCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelJobCommandError(output, context);
   }
   const contents: CancelJobCommandOutput = {
@@ -711,7 +711,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateJobCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateJobCommandError(output, context);
   }
   const contents: CreateJobCommandOutput = {
@@ -806,7 +806,7 @@ export const deserializeAws_restJson1CreatePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePipelineCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePipelineCommandError(output, context);
   }
   const contents: CreatePipelineCommandOutput = {
@@ -905,7 +905,7 @@ export const deserializeAws_restJson1CreatePresetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePresetCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePresetCommandError(output, context);
   }
   const contents: CreatePresetCommandOutput = {
@@ -996,7 +996,7 @@ export const deserializeAws_restJson1DeletePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePipelineCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePipelineCommandError(output, context);
   }
   const contents: DeletePipelineCommandOutput = {
@@ -1087,7 +1087,7 @@ export const deserializeAws_restJson1DeletePresetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePresetCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePresetCommandError(output, context);
   }
   const contents: DeletePresetCommandOutput = {
@@ -1170,7 +1170,7 @@ export const deserializeAws_restJson1ListJobsByPipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsByPipelineCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobsByPipelineCommandError(output, context);
   }
   const contents: ListJobsByPipelineCommandOutput = {
@@ -1261,7 +1261,7 @@ export const deserializeAws_restJson1ListJobsByStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsByStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobsByStatusCommandError(output, context);
   }
   const contents: ListJobsByStatusCommandOutput = {
@@ -1352,7 +1352,7 @@ export const deserializeAws_restJson1ListPipelinesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPipelinesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPipelinesCommandError(output, context);
   }
   const contents: ListPipelinesCommandOutput = {
@@ -1435,7 +1435,7 @@ export const deserializeAws_restJson1ListPresetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPresetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPresetsCommandError(output, context);
   }
   const contents: ListPresetsCommandOutput = {
@@ -1518,7 +1518,7 @@ export const deserializeAws_restJson1ReadJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReadJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ReadJobCommandError(output, context);
   }
   const contents: ReadJobCommandOutput = {
@@ -1605,7 +1605,7 @@ export const deserializeAws_restJson1ReadPipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReadPipelineCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ReadPipelineCommandError(output, context);
   }
   const contents: ReadPipelineCommandOutput = {
@@ -1696,7 +1696,7 @@ export const deserializeAws_restJson1ReadPresetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReadPresetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ReadPresetCommandError(output, context);
   }
   const contents: ReadPresetCommandOutput = {
@@ -1783,7 +1783,7 @@ export const deserializeAws_restJson1TestRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestRoleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TestRoleCommandError(output, context);
   }
   const contents: TestRoleCommandOutput = {
@@ -1874,7 +1874,7 @@ export const deserializeAws_restJson1UpdatePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePipelineCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePipelineCommandError(output, context);
   }
   const contents: UpdatePipelineCommandOutput = {
@@ -1973,7 +1973,7 @@ export const deserializeAws_restJson1UpdatePipelineNotificationsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePipelineNotificationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePipelineNotificationsCommandError(output, context);
   }
   const contents: UpdatePipelineNotificationsCommandOutput = {
@@ -2068,7 +2068,7 @@ export const deserializeAws_restJson1UpdatePipelineStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePipelineStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePipelineStatusCommandError(output, context);
   }
   const contents: UpdatePipelineStatusCommandOutput = {

--- a/clients/client-elasticache/protocols/Aws_query.ts
+++ b/clients/client-elasticache/protocols/Aws_query.ts
@@ -1335,7 +1335,7 @@ export const deserializeAws_queryAddTagsToResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddTagsToResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1413,7 +1413,7 @@ export const deserializeAws_queryAuthorizeCacheSecurityGroupIngressCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AuthorizeCacheSecurityGroupIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAuthorizeCacheSecurityGroupIngressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1502,7 +1502,7 @@ export const deserializeAws_queryBatchApplyUpdateActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchApplyUpdateActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryBatchApplyUpdateActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1564,7 +1564,7 @@ export const deserializeAws_queryBatchStopUpdateActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchStopUpdateActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryBatchStopUpdateActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1626,7 +1626,7 @@ export const deserializeAws_queryCompleteMigrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CompleteMigrationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCompleteMigrationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1696,7 +1696,7 @@ export const deserializeAws_queryCopySnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopySnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopySnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1790,7 +1790,7 @@ export const deserializeAws_queryCreateCacheClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCacheClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateCacheClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1948,7 +1948,7 @@ export const deserializeAws_queryCreateCacheParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCacheParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateCacheParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2034,7 +2034,7 @@ export const deserializeAws_queryCreateCacheSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCacheSecurityGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateCacheSecurityGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2112,7 +2112,7 @@ export const deserializeAws_queryCreateCacheSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCacheSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateCacheSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2190,7 +2190,7 @@ export const deserializeAws_queryCreateGlobalReplicationGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGlobalReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateGlobalReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2276,7 +2276,7 @@ export const deserializeAws_queryCreateReplicationGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2458,7 +2458,7 @@ export const deserializeAws_queryCreateSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2576,7 +2576,7 @@ export const deserializeAws_queryDecreaseNodeGroupsInGlobalReplicationGroupComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DecreaseNodeGroupsInGlobalReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDecreaseNodeGroupsInGlobalReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2657,7 +2657,7 @@ export const deserializeAws_queryDecreaseReplicaCountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DecreaseReplicaCountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDecreaseReplicaCountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2799,7 +2799,7 @@ export const deserializeAws_queryDeleteCacheClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCacheClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteCacheClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2901,7 +2901,7 @@ export const deserializeAws_queryDeleteCacheParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCacheParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteCacheParameterGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2976,7 +2976,7 @@ export const deserializeAws_queryDeleteCacheSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCacheSecurityGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteCacheSecurityGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3051,7 +3051,7 @@ export const deserializeAws_queryDeleteCacheSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCacheSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteCacheSubnetGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3110,7 +3110,7 @@ export const deserializeAws_queryDeleteGlobalReplicationGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGlobalReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteGlobalReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3180,7 +3180,7 @@ export const deserializeAws_queryDeleteReplicationGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3282,7 +3282,7 @@ export const deserializeAws_queryDeleteSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3360,7 +3360,7 @@ export const deserializeAws_queryDescribeCacheClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCacheClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeCacheClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3430,7 +3430,7 @@ export const deserializeAws_queryDescribeCacheEngineVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCacheEngineVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeCacheEngineVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3476,7 +3476,7 @@ export const deserializeAws_queryDescribeCacheParameterGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCacheParameterGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeCacheParameterGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3546,7 +3546,7 @@ export const deserializeAws_queryDescribeCacheParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCacheParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeCacheParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3616,7 +3616,7 @@ export const deserializeAws_queryDescribeCacheSecurityGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCacheSecurityGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeCacheSecurityGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3686,7 +3686,7 @@ export const deserializeAws_queryDescribeCacheSubnetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCacheSubnetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeCacheSubnetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3740,7 +3740,7 @@ export const deserializeAws_queryDescribeEngineDefaultParametersCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEngineDefaultParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEngineDefaultParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3805,7 +3805,7 @@ export const deserializeAws_queryDescribeEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3867,7 +3867,7 @@ export const deserializeAws_queryDescribeGlobalReplicationGroupsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGlobalReplicationGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeGlobalReplicationGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3940,7 +3940,7 @@ export const deserializeAws_queryDescribeReplicationGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReplicationGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeReplicationGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4010,7 +4010,7 @@ export const deserializeAws_queryDescribeReservedCacheNodesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedCacheNodesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeReservedCacheNodesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4080,7 +4080,7 @@ export const deserializeAws_queryDescribeReservedCacheNodesOfferingsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedCacheNodesOfferingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeReservedCacheNodesOfferingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4153,7 +4153,7 @@ export const deserializeAws_queryDescribeServiceUpdatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeServiceUpdatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeServiceUpdatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4223,7 +4223,7 @@ export const deserializeAws_queryDescribeSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4301,7 +4301,7 @@ export const deserializeAws_queryDescribeUpdateActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUpdateActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeUpdateActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4363,7 +4363,7 @@ export const deserializeAws_queryDisassociateGlobalReplicationGroupCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateGlobalReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDisassociateGlobalReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4444,7 +4444,7 @@ export const deserializeAws_queryFailoverGlobalReplicationGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FailoverGlobalReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryFailoverGlobalReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4525,7 +4525,7 @@ export const deserializeAws_queryIncreaseNodeGroupsInGlobalReplicationGroupComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IncreaseNodeGroupsInGlobalReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryIncreaseNodeGroupsInGlobalReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4598,7 +4598,7 @@ export const deserializeAws_queryIncreaseReplicaCountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IncreaseReplicaCountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryIncreaseReplicaCountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4740,7 +4740,7 @@ export const deserializeAws_queryListAllowedNodeTypeModificationsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAllowedNodeTypeModificationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListAllowedNodeTypeModificationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4821,7 +4821,7 @@ export const deserializeAws_queryListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4891,7 +4891,7 @@ export const deserializeAws_queryModifyCacheClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyCacheClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyCacheClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5025,7 +5025,7 @@ export const deserializeAws_queryModifyCacheParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyCacheParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyCacheParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5111,7 +5111,7 @@ export const deserializeAws_queryModifyCacheSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyCacheSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyCacheSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5189,7 +5189,7 @@ export const deserializeAws_queryModifyGlobalReplicationGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyGlobalReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyGlobalReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5259,7 +5259,7 @@ export const deserializeAws_queryModifyReplicationGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5417,7 +5417,7 @@ export const deserializeAws_queryModifyReplicationGroupShardConfigurationCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyReplicationGroupShardConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyReplicationGroupShardConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5546,7 +5546,7 @@ export const deserializeAws_queryPurchaseReservedCacheNodesOfferingCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurchaseReservedCacheNodesOfferingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPurchaseReservedCacheNodesOfferingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5635,7 +5635,7 @@ export const deserializeAws_queryRebalanceSlotsInGlobalReplicationGroupCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebalanceSlotsInGlobalReplicationGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRebalanceSlotsInGlobalReplicationGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5708,7 +5708,7 @@ export const deserializeAws_queryRebootCacheClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootCacheClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRebootCacheClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5770,7 +5770,7 @@ export const deserializeAws_queryRemoveTagsFromResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveTagsFromResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5848,7 +5848,7 @@ export const deserializeAws_queryResetCacheParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetCacheParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResetCacheParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5934,7 +5934,7 @@ export const deserializeAws_queryRevokeCacheSecurityGroupIngressCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeCacheSecurityGroupIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRevokeCacheSecurityGroupIngressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6023,7 +6023,7 @@ export const deserializeAws_queryStartMigrationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMigrationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStartMigrationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6101,7 +6101,7 @@ export const deserializeAws_queryTestFailoverCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestFailoverCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryTestFailoverCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
@@ -1353,7 +1353,7 @@ export const deserializeAws_restJson1AcceptInboundCrossClusterSearchConnectionCo
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptInboundCrossClusterSearchConnectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AcceptInboundCrossClusterSearchConnectionCommandError(output, context);
   }
   const contents: AcceptInboundCrossClusterSearchConnectionCommandOutput = {
@@ -1427,7 +1427,7 @@ export const deserializeAws_restJson1AddTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddTagsCommandError(output, context);
   }
   const contents: AddTagsCommandOutput = {
@@ -1502,7 +1502,7 @@ export const deserializeAws_restJson1AssociatePackageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociatePackageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociatePackageCommandError(output, context);
   }
   const contents: AssociatePackageCommandOutput = {
@@ -1597,7 +1597,7 @@ export const deserializeAws_restJson1CancelElasticsearchServiceSoftwareUpdateCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelElasticsearchServiceSoftwareUpdateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelElasticsearchServiceSoftwareUpdateCommandError(output, context);
   }
   const contents: CancelElasticsearchServiceSoftwareUpdateCommandOutput = {
@@ -1679,7 +1679,7 @@ export const deserializeAws_restJson1CreateElasticsearchDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateElasticsearchDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateElasticsearchDomainCommandError(output, context);
   }
   const contents: CreateElasticsearchDomainCommandOutput = {
@@ -1782,7 +1782,7 @@ export const deserializeAws_restJson1CreateOutboundCrossClusterSearchConnectionC
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOutboundCrossClusterSearchConnectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateOutboundCrossClusterSearchConnectionCommandError(output, context);
   }
   const contents: CreateOutboundCrossClusterSearchConnectionCommandOutput = {
@@ -1880,7 +1880,7 @@ export const deserializeAws_restJson1CreatePackageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePackageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePackageCommandError(output, context);
   }
   const contents: CreatePackageCommandOutput = {
@@ -1983,7 +1983,7 @@ export const deserializeAws_restJson1DeleteElasticsearchDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteElasticsearchDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteElasticsearchDomainCommandError(output, context);
   }
   const contents: DeleteElasticsearchDomainCommandOutput = {
@@ -2062,7 +2062,7 @@ export const deserializeAws_restJson1DeleteElasticsearchServiceRoleCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteElasticsearchServiceRoleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteElasticsearchServiceRoleCommandError(output, context);
   }
   const contents: DeleteElasticsearchServiceRoleCommandOutput = {
@@ -2129,7 +2129,7 @@ export const deserializeAws_restJson1DeleteInboundCrossClusterSearchConnectionCo
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInboundCrossClusterSearchConnectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteInboundCrossClusterSearchConnectionCommandError(output, context);
   }
   const contents: DeleteInboundCrossClusterSearchConnectionCommandOutput = {
@@ -2195,7 +2195,7 @@ export const deserializeAws_restJson1DeleteOutboundCrossClusterSearchConnectionC
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOutboundCrossClusterSearchConnectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteOutboundCrossClusterSearchConnectionCommandError(output, context);
   }
   const contents: DeleteOutboundCrossClusterSearchConnectionCommandOutput = {
@@ -2261,7 +2261,7 @@ export const deserializeAws_restJson1DeletePackageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePackageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePackageCommandError(output, context);
   }
   const contents: DeletePackageCommandOutput = {
@@ -2356,7 +2356,7 @@ export const deserializeAws_restJson1DescribeElasticsearchDomainCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeElasticsearchDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeElasticsearchDomainCommandError(output, context);
   }
   const contents: DescribeElasticsearchDomainCommandOutput = {
@@ -2435,7 +2435,7 @@ export const deserializeAws_restJson1DescribeElasticsearchDomainConfigCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeElasticsearchDomainConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeElasticsearchDomainConfigCommandError(output, context);
   }
   const contents: DescribeElasticsearchDomainConfigCommandOutput = {
@@ -2514,7 +2514,7 @@ export const deserializeAws_restJson1DescribeElasticsearchDomainsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeElasticsearchDomainsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeElasticsearchDomainsCommandError(output, context);
   }
   const contents: DescribeElasticsearchDomainsCommandOutput = {
@@ -2585,7 +2585,7 @@ export const deserializeAws_restJson1DescribeElasticsearchInstanceTypeLimitsComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeElasticsearchInstanceTypeLimitsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeElasticsearchInstanceTypeLimitsCommandError(output, context);
   }
   const contents: DescribeElasticsearchInstanceTypeLimitsCommandOutput = {
@@ -2680,7 +2680,7 @@ export const deserializeAws_restJson1DescribeInboundCrossClusterSearchConnection
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInboundCrossClusterSearchConnectionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeInboundCrossClusterSearchConnectionsCommandError(output, context);
   }
   const contents: DescribeInboundCrossClusterSearchConnectionsCommandOutput = {
@@ -2750,7 +2750,7 @@ export const deserializeAws_restJson1DescribeOutboundCrossClusterSearchConnectio
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOutboundCrossClusterSearchConnectionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeOutboundCrossClusterSearchConnectionsCommandError(output, context);
   }
   const contents: DescribeOutboundCrossClusterSearchConnectionsCommandOutput = {
@@ -2820,7 +2820,7 @@ export const deserializeAws_restJson1DescribePackagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePackagesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribePackagesCommandError(output, context);
   }
   const contents: DescribePackagesCommandOutput = {
@@ -2911,7 +2911,7 @@ export const deserializeAws_restJson1DescribeReservedElasticsearchInstanceOfferi
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedElasticsearchInstanceOfferingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeReservedElasticsearchInstanceOfferingsCommandError(output, context);
   }
   const contents: DescribeReservedElasticsearchInstanceOfferingsCommandOutput = {
@@ -3000,7 +3000,7 @@ export const deserializeAws_restJson1DescribeReservedElasticsearchInstancesComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedElasticsearchInstancesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeReservedElasticsearchInstancesCommandError(output, context);
   }
   const contents: DescribeReservedElasticsearchInstancesCommandOutput = {
@@ -3086,7 +3086,7 @@ export const deserializeAws_restJson1DissociatePackageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DissociatePackageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DissociatePackageCommandError(output, context);
   }
   const contents: DissociatePackageCommandOutput = {
@@ -3181,7 +3181,7 @@ export const deserializeAws_restJson1GetCompatibleElasticsearchVersionsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCompatibleElasticsearchVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCompatibleElasticsearchVersionsCommandError(output, context);
   }
   const contents: GetCompatibleElasticsearchVersionsCommandOutput = {
@@ -3271,7 +3271,7 @@ export const deserializeAws_restJson1GetUpgradeHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUpgradeHistoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUpgradeHistoryCommandError(output, context);
   }
   const contents: GetUpgradeHistoryCommandOutput = {
@@ -3362,7 +3362,7 @@ export const deserializeAws_restJson1GetUpgradeStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUpgradeStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUpgradeStatusCommandError(output, context);
   }
   const contents: GetUpgradeStatusCommandOutput = {
@@ -3457,7 +3457,7 @@ export const deserializeAws_restJson1ListDomainNamesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainNamesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDomainNamesCommandError(output, context);
   }
   const contents: ListDomainNamesCommandOutput = {
@@ -3520,7 +3520,7 @@ export const deserializeAws_restJson1ListDomainsForPackageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainsForPackageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDomainsForPackageCommandError(output, context);
   }
   const contents: ListDomainsForPackageCommandOutput = {
@@ -3614,7 +3614,7 @@ export const deserializeAws_restJson1ListElasticsearchInstanceTypesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListElasticsearchInstanceTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListElasticsearchInstanceTypesCommandError(output, context);
   }
   const contents: ListElasticsearchInstanceTypesCommandOutput = {
@@ -3700,7 +3700,7 @@ export const deserializeAws_restJson1ListElasticsearchVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListElasticsearchVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListElasticsearchVersionsCommandError(output, context);
   }
   const contents: ListElasticsearchVersionsCommandOutput = {
@@ -3786,7 +3786,7 @@ export const deserializeAws_restJson1ListPackagesForDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPackagesForDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPackagesForDomainCommandError(output, context);
   }
   const contents: ListPackagesForDomainCommandOutput = {
@@ -3880,7 +3880,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsCommandError(output, context);
   }
   const contents: ListTagsCommandOutput = {
@@ -3959,7 +3959,7 @@ export const deserializeAws_restJson1PurchaseReservedElasticsearchInstanceOfferi
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurchaseReservedElasticsearchInstanceOfferingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PurchaseReservedElasticsearchInstanceOfferingCommandError(output, context);
   }
   const contents: PurchaseReservedElasticsearchInstanceOfferingCommandOutput = {
@@ -4058,7 +4058,7 @@ export const deserializeAws_restJson1RejectInboundCrossClusterSearchConnectionCo
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectInboundCrossClusterSearchConnectionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RejectInboundCrossClusterSearchConnectionCommandError(output, context);
   }
   const contents: RejectInboundCrossClusterSearchConnectionCommandOutput = {
@@ -4124,7 +4124,7 @@ export const deserializeAws_restJson1RemoveTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveTagsCommandError(output, context);
   }
   const contents: RemoveTagsCommandOutput = {
@@ -4191,7 +4191,7 @@ export const deserializeAws_restJson1StartElasticsearchServiceSoftwareUpdateComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartElasticsearchServiceSoftwareUpdateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartElasticsearchServiceSoftwareUpdateCommandError(output, context);
   }
   const contents: StartElasticsearchServiceSoftwareUpdateCommandOutput = {
@@ -4273,7 +4273,7 @@ export const deserializeAws_restJson1UpdateElasticsearchDomainConfigCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateElasticsearchDomainConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateElasticsearchDomainConfigCommandError(output, context);
   }
   const contents: UpdateElasticsearchDomainConfigCommandOutput = {
@@ -4368,7 +4368,7 @@ export const deserializeAws_restJson1UpgradeElasticsearchDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpgradeElasticsearchDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpgradeElasticsearchDomainCommandError(output, context);
   }
   const contents: UpgradeElasticsearchDomainCommandOutput = {

--- a/clients/client-emr/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/protocols/Aws_json1_1.ts
@@ -672,7 +672,7 @@ export const deserializeAws_json1_1AddInstanceFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddInstanceFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddInstanceFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -735,7 +735,7 @@ export const deserializeAws_json1_1AddInstanceGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddInstanceGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddInstanceGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -790,7 +790,7 @@ export const deserializeAws_json1_1AddJobFlowStepsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddJobFlowStepsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddJobFlowStepsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -845,7 +845,7 @@ export const deserializeAws_json1_1AddTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -908,7 +908,7 @@ export const deserializeAws_json1_1CancelStepsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelStepsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelStepsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -971,7 +971,7 @@ export const deserializeAws_json1_1CreateSecurityConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSecurityConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSecurityConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1034,7 +1034,7 @@ export const deserializeAws_json1_1DeleteSecurityConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSecurityConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSecurityConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1097,7 +1097,7 @@ export const deserializeAws_json1_1DescribeClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1160,7 +1160,7 @@ export const deserializeAws_json1_1DescribeJobFlowsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJobFlowsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeJobFlowsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1215,7 +1215,7 @@ export const deserializeAws_json1_1DescribeSecurityConfigurationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSecurityConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSecurityConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1278,7 +1278,7 @@ export const deserializeAws_json1_1DescribeStepCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStepCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeStepCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1341,7 +1341,7 @@ export const deserializeAws_json1_1GetBlockPublicAccessConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBlockPublicAccessConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetBlockPublicAccessConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1404,7 +1404,7 @@ export const deserializeAws_json1_1GetManagedScalingPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetManagedScalingPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetManagedScalingPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1451,7 +1451,7 @@ export const deserializeAws_json1_1ListBootstrapActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBootstrapActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBootstrapActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1514,7 +1514,7 @@ export const deserializeAws_json1_1ListClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1577,7 +1577,7 @@ export const deserializeAws_json1_1ListInstanceFleetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInstanceFleetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListInstanceFleetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1640,7 +1640,7 @@ export const deserializeAws_json1_1ListInstanceGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInstanceGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListInstanceGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1703,7 +1703,7 @@ export const deserializeAws_json1_1ListInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1766,7 +1766,7 @@ export const deserializeAws_json1_1ListSecurityConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSecurityConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSecurityConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1829,7 +1829,7 @@ export const deserializeAws_json1_1ListStepsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStepsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListStepsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1892,7 +1892,7 @@ export const deserializeAws_json1_1ModifyClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1955,7 +1955,7 @@ export const deserializeAws_json1_1ModifyInstanceFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyInstanceFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyInstanceFleetCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2015,7 +2015,7 @@ export const deserializeAws_json1_1ModifyInstanceGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyInstanceGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyInstanceGroupsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2067,7 +2067,7 @@ export const deserializeAws_json1_1PutAutoScalingPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAutoScalingPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutAutoScalingPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2114,7 +2114,7 @@ export const deserializeAws_json1_1PutBlockPublicAccessConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBlockPublicAccessConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutBlockPublicAccessConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2177,7 +2177,7 @@ export const deserializeAws_json1_1PutManagedScalingPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutManagedScalingPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutManagedScalingPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2224,7 +2224,7 @@ export const deserializeAws_json1_1RemoveAutoScalingPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveAutoScalingPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveAutoScalingPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2271,7 +2271,7 @@ export const deserializeAws_json1_1RemoveManagedScalingPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveManagedScalingPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveManagedScalingPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2318,7 +2318,7 @@ export const deserializeAws_json1_1RemoveTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2381,7 +2381,7 @@ export const deserializeAws_json1_1RunJobFlowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RunJobFlowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RunJobFlowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2436,7 +2436,7 @@ export const deserializeAws_json1_1SetTerminationProtectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetTerminationProtectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetTerminationProtectionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2488,7 +2488,7 @@ export const deserializeAws_json1_1SetVisibleToAllUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetVisibleToAllUsersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetVisibleToAllUsersCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2540,7 +2540,7 @@ export const deserializeAws_json1_1TerminateJobFlowsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateJobFlowsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TerminateJobFlowsCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-eventbridge/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/protocols/Aws_json1_1.ts
@@ -567,7 +567,7 @@ export const deserializeAws_json1_1ActivateEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ActivateEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ActivateEventSourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -651,7 +651,7 @@ export const deserializeAws_json1_1CreateEventBusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEventBusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEventBusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -754,7 +754,7 @@ export const deserializeAws_json1_1CreatePartnerEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePartnerEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePartnerEventSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -841,7 +841,7 @@ export const deserializeAws_json1_1DeactivateEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeactivateEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeactivateEventSourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -925,7 +925,7 @@ export const deserializeAws_json1_1DeleteEventBusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventBusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEventBusCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -985,7 +985,7 @@ export const deserializeAws_json1_1DeletePartnerEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePartnerEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePartnerEventSourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1053,7 +1053,7 @@ export const deserializeAws_json1_1DeleteRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRuleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1129,7 +1129,7 @@ export const deserializeAws_json1_1DescribeEventBusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventBusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventBusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1192,7 +1192,7 @@ export const deserializeAws_json1_1DescribeEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1263,7 +1263,7 @@ export const deserializeAws_json1_1DescribePartnerEventSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePartnerEventSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePartnerEventSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1334,7 +1334,7 @@ export const deserializeAws_json1_1DescribeRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1397,7 +1397,7 @@ export const deserializeAws_json1_1DisableRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableRuleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1473,7 +1473,7 @@ export const deserializeAws_json1_1EnableRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableRuleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1549,7 +1549,7 @@ export const deserializeAws_json1_1ListEventBusesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEventBusesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEventBusesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1604,7 +1604,7 @@ export const deserializeAws_json1_1ListEventSourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEventSourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEventSourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1667,7 +1667,7 @@ export const deserializeAws_json1_1ListPartnerEventSourceAccountsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPartnerEventSourceAccountsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPartnerEventSourceAccountsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1738,7 +1738,7 @@ export const deserializeAws_json1_1ListPartnerEventSourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPartnerEventSourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPartnerEventSourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1801,7 +1801,7 @@ export const deserializeAws_json1_1ListRuleNamesByTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRuleNamesByTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRuleNamesByTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1864,7 +1864,7 @@ export const deserializeAws_json1_1ListRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1927,7 +1927,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1990,7 +1990,7 @@ export const deserializeAws_json1_1ListTargetsByRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTargetsByRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTargetsByRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2053,7 +2053,7 @@ export const deserializeAws_json1_1PutEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2108,7 +2108,7 @@ export const deserializeAws_json1_1PutPartnerEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPartnerEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutPartnerEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2171,7 +2171,7 @@ export const deserializeAws_json1_1PutPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutPermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2247,7 +2247,7 @@ export const deserializeAws_json1_1PutRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2342,7 +2342,7 @@ export const deserializeAws_json1_1PutTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2429,7 +2429,7 @@ export const deserializeAws_json1_1RemovePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemovePermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemovePermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2497,7 +2497,7 @@ export const deserializeAws_json1_1RemoveTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2576,7 +2576,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2655,7 +2655,7 @@ export const deserializeAws_json1_1TestEventPatternCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestEventPatternCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TestEventPatternCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2718,7 +2718,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-firehose/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/protocols/Aws_json1_1.ts
@@ -296,7 +296,7 @@ export const deserializeAws_json1_1CreateDeliveryStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeliveryStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDeliveryStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -375,7 +375,7 @@ export const deserializeAws_json1_1DeleteDeliveryStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeliveryStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDeliveryStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -438,7 +438,7 @@ export const deserializeAws_json1_1DescribeDeliveryStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDeliveryStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDeliveryStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -493,7 +493,7 @@ export const deserializeAws_json1_1ListDeliveryStreamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeliveryStreamsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDeliveryStreamsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -540,7 +540,7 @@ export const deserializeAws_json1_1ListTagsForDeliveryStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForDeliveryStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForDeliveryStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -611,7 +611,7 @@ export const deserializeAws_json1_1PutRecordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRecordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRecordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -690,7 +690,7 @@ export const deserializeAws_json1_1PutRecordBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRecordBatchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRecordBatchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -769,7 +769,7 @@ export const deserializeAws_json1_1StartDeliveryStreamEncryptionCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDeliveryStreamEncryptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartDeliveryStreamEncryptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -856,7 +856,7 @@ export const deserializeAws_json1_1StopDeliveryStreamEncryptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDeliveryStreamEncryptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopDeliveryStreamEncryptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -935,7 +935,7 @@ export const deserializeAws_json1_1TagDeliveryStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagDeliveryStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagDeliveryStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1014,7 +1014,7 @@ export const deserializeAws_json1_1UntagDeliveryStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagDeliveryStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagDeliveryStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1093,7 +1093,7 @@ export const deserializeAws_json1_1UpdateDestinationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDestinationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDestinationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-fms/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/protocols/Aws_json1_1.ts
@@ -486,7 +486,7 @@ export const deserializeAws_json1_1AssociateAdminAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateAdminAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateAdminAccountCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -562,7 +562,7 @@ export const deserializeAws_json1_1DeleteAppsListCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAppsListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAppsListCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -630,7 +630,7 @@ export const deserializeAws_json1_1DeleteNotificationChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNotificationChannelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteNotificationChannelCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -698,7 +698,7 @@ export const deserializeAws_json1_1DeletePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -766,7 +766,7 @@ export const deserializeAws_json1_1DeleteProtocolsListCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProtocolsListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProtocolsListCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -834,7 +834,7 @@ export const deserializeAws_json1_1DisassociateAdminAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateAdminAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateAdminAccountCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -902,7 +902,7 @@ export const deserializeAws_json1_1GetAdminAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAdminAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAdminAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -973,7 +973,7 @@ export const deserializeAws_json1_1GetAppsListCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAppsListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAppsListCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1044,7 +1044,7 @@ export const deserializeAws_json1_1GetComplianceDetailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetComplianceDetailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetComplianceDetailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1123,7 +1123,7 @@ export const deserializeAws_json1_1GetNotificationChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetNotificationChannelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetNotificationChannelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1194,7 +1194,7 @@ export const deserializeAws_json1_1GetPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1273,7 +1273,7 @@ export const deserializeAws_json1_1GetProtectionStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetProtectionStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetProtectionStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1344,7 +1344,7 @@ export const deserializeAws_json1_1GetProtocolsListCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetProtocolsListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetProtocolsListCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1415,7 +1415,7 @@ export const deserializeAws_json1_1GetViolationDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetViolationDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetViolationDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1486,7 +1486,7 @@ export const deserializeAws_json1_1ListAppsListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAppsListsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAppsListsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1565,7 +1565,7 @@ export const deserializeAws_json1_1ListComplianceStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListComplianceStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListComplianceStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1628,7 +1628,7 @@ export const deserializeAws_json1_1ListMemberAccountsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMemberAccountsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListMemberAccountsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1691,7 +1691,7 @@ export const deserializeAws_json1_1ListPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1770,7 +1770,7 @@ export const deserializeAws_json1_1ListProtocolsListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProtocolsListsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProtocolsListsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1841,7 +1841,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1920,7 +1920,7 @@ export const deserializeAws_json1_1PutAppsListCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAppsListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutAppsListCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2007,7 +2007,7 @@ export const deserializeAws_json1_1PutNotificationChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutNotificationChannelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutNotificationChannelCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2075,7 +2075,7 @@ export const deserializeAws_json1_1PutPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2170,7 +2170,7 @@ export const deserializeAws_json1_1PutProtocolsListCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutProtocolsListCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutProtocolsListCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2257,7 +2257,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2344,7 +2344,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-forecast/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/protocols/Aws_json1_1.ts
@@ -541,7 +541,7 @@ export const deserializeAws_json1_1CreateDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDatasetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDatasetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -612,7 +612,7 @@ export const deserializeAws_json1_1CreateDatasetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDatasetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDatasetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -699,7 +699,7 @@ export const deserializeAws_json1_1CreateDatasetImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDatasetImportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDatasetImportJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -786,7 +786,7 @@ export const deserializeAws_json1_1CreateForecastCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateForecastCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateForecastCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -873,7 +873,7 @@ export const deserializeAws_json1_1CreateForecastExportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateForecastExportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateForecastExportJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -960,7 +960,7 @@ export const deserializeAws_json1_1CreatePredictorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePredictorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePredictorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1047,7 +1047,7 @@ export const deserializeAws_json1_1DeleteDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDatasetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDatasetCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1115,7 +1115,7 @@ export const deserializeAws_json1_1DeleteDatasetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDatasetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDatasetGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1183,7 +1183,7 @@ export const deserializeAws_json1_1DeleteDatasetImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDatasetImportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDatasetImportJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1251,7 +1251,7 @@ export const deserializeAws_json1_1DeleteForecastCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteForecastCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteForecastCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1319,7 +1319,7 @@ export const deserializeAws_json1_1DeleteForecastExportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteForecastExportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteForecastExportJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1387,7 +1387,7 @@ export const deserializeAws_json1_1DeletePredictorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePredictorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePredictorCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1455,7 +1455,7 @@ export const deserializeAws_json1_1DescribeDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDatasetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDatasetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1518,7 +1518,7 @@ export const deserializeAws_json1_1DescribeDatasetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDatasetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDatasetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1581,7 +1581,7 @@ export const deserializeAws_json1_1DescribeDatasetImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDatasetImportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDatasetImportJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1644,7 +1644,7 @@ export const deserializeAws_json1_1DescribeForecastCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeForecastCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeForecastCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1707,7 +1707,7 @@ export const deserializeAws_json1_1DescribeForecastExportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeForecastExportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeForecastExportJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1770,7 +1770,7 @@ export const deserializeAws_json1_1DescribePredictorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePredictorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePredictorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1833,7 +1833,7 @@ export const deserializeAws_json1_1GetAccuracyMetricsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccuracyMetricsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAccuracyMetricsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1904,7 +1904,7 @@ export const deserializeAws_json1_1ListDatasetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatasetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDatasetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1959,7 +1959,7 @@ export const deserializeAws_json1_1ListDatasetImportJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatasetImportJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDatasetImportJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2022,7 +2022,7 @@ export const deserializeAws_json1_1ListDatasetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatasetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDatasetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2077,7 +2077,7 @@ export const deserializeAws_json1_1ListForecastExportJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListForecastExportJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListForecastExportJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2140,7 +2140,7 @@ export const deserializeAws_json1_1ListForecastsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListForecastsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListForecastsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2203,7 +2203,7 @@ export const deserializeAws_json1_1ListPredictorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPredictorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPredictorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2266,7 +2266,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2329,7 +2329,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2400,7 +2400,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2463,7 +2463,7 @@ export const deserializeAws_json1_1UpdateDatasetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDatasetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDatasetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-forecastquery/protocols/Aws_json1_1.ts
+++ b/clients/client-forecastquery/protocols/Aws_json1_1.ts
@@ -37,7 +37,7 @@ export const deserializeAws_json1_1QueryForecastCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryForecastCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1QueryForecastCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-frauddetector/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/protocols/Aws_json1_1.ts
@@ -803,7 +803,7 @@ export const deserializeAws_json1_1BatchCreateVariableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchCreateVariableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchCreateVariableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -882,7 +882,7 @@ export const deserializeAws_json1_1BatchGetVariableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetVariableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetVariableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -961,7 +961,7 @@ export const deserializeAws_json1_1CreateDetectorVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDetectorVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDetectorVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1048,7 +1048,7 @@ export const deserializeAws_json1_1CreateModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateModelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateModelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1119,7 +1119,7 @@ export const deserializeAws_json1_1CreateModelVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateModelVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateModelVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1198,7 +1198,7 @@ export const deserializeAws_json1_1CreateRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1277,7 +1277,7 @@ export const deserializeAws_json1_1CreateVariableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVariableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateVariableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1356,7 +1356,7 @@ export const deserializeAws_json1_1DeleteDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDetectorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDetectorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1443,7 +1443,7 @@ export const deserializeAws_json1_1DeleteDetectorVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDetectorVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDetectorVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1538,7 +1538,7 @@ export const deserializeAws_json1_1DeleteEventCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEventCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1609,7 +1609,7 @@ export const deserializeAws_json1_1DeleteRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1696,7 +1696,7 @@ export const deserializeAws_json1_1DescribeDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDetectorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDetectorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1783,7 +1783,7 @@ export const deserializeAws_json1_1DescribeModelVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeModelVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeModelVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1862,7 +1862,7 @@ export const deserializeAws_json1_1GetDetectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDetectorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDetectorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1949,7 +1949,7 @@ export const deserializeAws_json1_1GetDetectorVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDetectorVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDetectorVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2036,7 +2036,7 @@ export const deserializeAws_json1_1GetEntityTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEntityTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetEntityTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2115,7 +2115,7 @@ export const deserializeAws_json1_1GetEventPredictionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEventPredictionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetEventPredictionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2202,7 +2202,7 @@ export const deserializeAws_json1_1GetEventTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEventTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetEventTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2281,7 +2281,7 @@ export const deserializeAws_json1_1GetExternalModelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetExternalModelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetExternalModelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2368,7 +2368,7 @@ export const deserializeAws_json1_1GetKMSEncryptionKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetKMSEncryptionKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetKMSEncryptionKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2439,7 +2439,7 @@ export const deserializeAws_json1_1GetLabelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLabelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLabelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2518,7 +2518,7 @@ export const deserializeAws_json1_1GetModelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetModelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetModelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2597,7 +2597,7 @@ export const deserializeAws_json1_1GetModelVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetModelVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetModelVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2676,7 +2676,7 @@ export const deserializeAws_json1_1GetOutcomesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOutcomesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOutcomesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2763,7 +2763,7 @@ export const deserializeAws_json1_1GetRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2850,7 +2850,7 @@ export const deserializeAws_json1_1GetVariablesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVariablesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetVariablesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2937,7 +2937,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3008,7 +3008,7 @@ export const deserializeAws_json1_1PutDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDetectorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutDetectorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3087,7 +3087,7 @@ export const deserializeAws_json1_1PutEntityTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEntityTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutEntityTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3158,7 +3158,7 @@ export const deserializeAws_json1_1PutEventTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEventTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutEventTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3229,7 +3229,7 @@ export const deserializeAws_json1_1PutExternalModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutExternalModelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutExternalModelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3308,7 +3308,7 @@ export const deserializeAws_json1_1PutKMSEncryptionKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutKMSEncryptionKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutKMSEncryptionKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3387,7 +3387,7 @@ export const deserializeAws_json1_1PutLabelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLabelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutLabelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3458,7 +3458,7 @@ export const deserializeAws_json1_1PutOutcomeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutOutcomeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutOutcomeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3537,7 +3537,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3608,7 +3608,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3679,7 +3679,7 @@ export const deserializeAws_json1_1UpdateDetectorVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDetectorVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDetectorVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3766,7 +3766,7 @@ export const deserializeAws_json1_1UpdateDetectorVersionMetadataCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDetectorVersionMetadataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDetectorVersionMetadataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3845,7 +3845,7 @@ export const deserializeAws_json1_1UpdateDetectorVersionStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDetectorVersionStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDetectorVersionStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3932,7 +3932,7 @@ export const deserializeAws_json1_1UpdateModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateModelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateModelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4011,7 +4011,7 @@ export const deserializeAws_json1_1UpdateModelVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateModelVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateModelVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4090,7 +4090,7 @@ export const deserializeAws_json1_1UpdateModelVersionStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateModelVersionStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateModelVersionStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4169,7 +4169,7 @@ export const deserializeAws_json1_1UpdateRuleMetadataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRuleMetadataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRuleMetadataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4256,7 +4256,7 @@ export const deserializeAws_json1_1UpdateRuleVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRuleVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRuleVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4343,7 +4343,7 @@ export const deserializeAws_json1_1UpdateVariableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVariableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateVariableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-fsx/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/protocols/Aws_json1_1.ts
@@ -308,7 +308,7 @@ export const deserializeAws_json1_1CancelDataRepositoryTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelDataRepositoryTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelDataRepositoryTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -395,7 +395,7 @@ export const deserializeAws_json1_1CreateBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -498,7 +498,7 @@ export const deserializeAws_json1_1CreateDataRepositoryTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataRepositoryTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDataRepositoryTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -601,7 +601,7 @@ export const deserializeAws_json1_1CreateFileSystemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFileSystemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateFileSystemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -728,7 +728,7 @@ export const deserializeAws_json1_1CreateFileSystemFromBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFileSystemFromBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateFileSystemFromBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -847,7 +847,7 @@ export const deserializeAws_json1_1DeleteBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -942,7 +942,7 @@ export const deserializeAws_json1_1DeleteFileSystemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFileSystemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFileSystemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1029,7 +1029,7 @@ export const deserializeAws_json1_1DescribeBackupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBackupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeBackupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1108,7 +1108,7 @@ export const deserializeAws_json1_1DescribeDataRepositoryTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDataRepositoryTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDataRepositoryTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1187,7 +1187,7 @@ export const deserializeAws_json1_1DescribeFileSystemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFileSystemsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFileSystemsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1258,7 +1258,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1345,7 +1345,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1432,7 +1432,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1519,7 +1519,7 @@ export const deserializeAws_json1_1UpdateFileSystemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFileSystemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateFileSystemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-gamelift/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/protocols/Aws_json1_1.ts
@@ -1652,7 +1652,7 @@ export const deserializeAws_json1_1AcceptMatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptMatchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AcceptMatchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1731,7 +1731,7 @@ export const deserializeAws_json1_1ClaimGameServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ClaimGameServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ClaimGameServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1826,7 +1826,7 @@ export const deserializeAws_json1_1CreateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAliasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1921,7 +1921,7 @@ export const deserializeAws_json1_1CreateBuildCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBuildCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateBuildCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2008,7 +2008,7 @@ export const deserializeAws_json1_1CreateFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateFleetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2111,7 +2111,7 @@ export const deserializeAws_json1_1CreateGameServerGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGameServerGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateGameServerGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2198,7 +2198,7 @@ export const deserializeAws_json1_1CreateGameSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGameSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateGameSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2325,7 +2325,7 @@ export const deserializeAws_json1_1CreateGameSessionQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGameSessionQueueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateGameSessionQueueCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2412,7 +2412,7 @@ export const deserializeAws_json1_1CreateMatchmakingConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMatchmakingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateMatchmakingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2507,7 +2507,7 @@ export const deserializeAws_json1_1CreateMatchmakingRuleSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMatchmakingRuleSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateMatchmakingRuleSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2586,7 +2586,7 @@ export const deserializeAws_json1_1CreatePlayerSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePlayerSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePlayerSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2689,7 +2689,7 @@ export const deserializeAws_json1_1CreatePlayerSessionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePlayerSessionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePlayerSessionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2792,7 +2792,7 @@ export const deserializeAws_json1_1CreateScriptCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateScriptCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateScriptCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2879,7 +2879,7 @@ export const deserializeAws_json1_1CreateVpcPeeringAuthorizationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpcPeeringAuthorizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateVpcPeeringAuthorizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2958,7 +2958,7 @@ export const deserializeAws_json1_1CreateVpcPeeringConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVpcPeeringConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateVpcPeeringConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3037,7 +3037,7 @@ export const deserializeAws_json1_1DeleteAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAliasCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3121,7 +3121,7 @@ export const deserializeAws_json1_1DeleteBuildCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBuildCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBuildCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3205,7 +3205,7 @@ export const deserializeAws_json1_1DeleteFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFleetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFleetCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3297,7 +3297,7 @@ export const deserializeAws_json1_1DeleteGameServerGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGameServerGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteGameServerGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3376,7 +3376,7 @@ export const deserializeAws_json1_1DeleteGameSessionQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGameSessionQueueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteGameSessionQueueCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3463,7 +3463,7 @@ export const deserializeAws_json1_1DeleteMatchmakingConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMatchmakingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMatchmakingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3550,7 +3550,7 @@ export const deserializeAws_json1_1DeleteMatchmakingRuleSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMatchmakingRuleSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMatchmakingRuleSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3637,7 +3637,7 @@ export const deserializeAws_json1_1DeleteScalingPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteScalingPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteScalingPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3713,7 +3713,7 @@ export const deserializeAws_json1_1DeleteScriptCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteScriptCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteScriptCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3797,7 +3797,7 @@ export const deserializeAws_json1_1DeleteVpcPeeringAuthorizationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpcPeeringAuthorizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteVpcPeeringAuthorizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3876,7 +3876,7 @@ export const deserializeAws_json1_1DeleteVpcPeeringConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVpcPeeringConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteVpcPeeringConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3955,7 +3955,7 @@ export const deserializeAws_json1_1DeregisterGameServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterGameServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterGameServerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4031,7 +4031,7 @@ export const deserializeAws_json1_1DescribeAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAliasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4110,7 +4110,7 @@ export const deserializeAws_json1_1DescribeBuildCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBuildCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeBuildCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4189,7 +4189,7 @@ export const deserializeAws_json1_1DescribeEC2InstanceLimitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEC2InstanceLimitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEC2InstanceLimitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4260,7 +4260,7 @@ export const deserializeAws_json1_1DescribeFleetAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFleetAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4339,7 +4339,7 @@ export const deserializeAws_json1_1DescribeFleetCapacityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetCapacityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFleetCapacityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4418,7 +4418,7 @@ export const deserializeAws_json1_1DescribeFleetEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFleetEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4497,7 +4497,7 @@ export const deserializeAws_json1_1DescribeFleetPortSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetPortSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFleetPortSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4576,7 +4576,7 @@ export const deserializeAws_json1_1DescribeFleetUtilizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetUtilizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFleetUtilizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4655,7 +4655,7 @@ export const deserializeAws_json1_1DescribeGameServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGameServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeGameServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4734,7 +4734,7 @@ export const deserializeAws_json1_1DescribeGameServerGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGameServerGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeGameServerGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4813,7 +4813,7 @@ export const deserializeAws_json1_1DescribeGameSessionDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGameSessionDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeGameSessionDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4900,7 +4900,7 @@ export const deserializeAws_json1_1DescribeGameSessionPlacementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGameSessionPlacementCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeGameSessionPlacementCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4979,7 +4979,7 @@ export const deserializeAws_json1_1DescribeGameSessionQueuesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGameSessionQueuesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeGameSessionQueuesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5058,7 +5058,7 @@ export const deserializeAws_json1_1DescribeGameSessionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGameSessionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeGameSessionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5145,7 +5145,7 @@ export const deserializeAws_json1_1DescribeInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5224,7 +5224,7 @@ export const deserializeAws_json1_1DescribeMatchmakingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMatchmakingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMatchmakingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5295,7 +5295,7 @@ export const deserializeAws_json1_1DescribeMatchmakingConfigurationsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMatchmakingConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMatchmakingConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5366,7 +5366,7 @@ export const deserializeAws_json1_1DescribeMatchmakingRuleSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMatchmakingRuleSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMatchmakingRuleSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5445,7 +5445,7 @@ export const deserializeAws_json1_1DescribePlayerSessionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePlayerSessionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePlayerSessionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5524,7 +5524,7 @@ export const deserializeAws_json1_1DescribeRuntimeConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRuntimeConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRuntimeConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5603,7 +5603,7 @@ export const deserializeAws_json1_1DescribeScalingPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScalingPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeScalingPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5682,7 +5682,7 @@ export const deserializeAws_json1_1DescribeScriptCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScriptCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeScriptCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5761,7 +5761,7 @@ export const deserializeAws_json1_1DescribeVpcPeeringAuthorizationsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcPeeringAuthorizationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeVpcPeeringAuthorizationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5832,7 +5832,7 @@ export const deserializeAws_json1_1DescribeVpcPeeringConnectionsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVpcPeeringConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeVpcPeeringConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5911,7 +5911,7 @@ export const deserializeAws_json1_1GetGameSessionLogUrlCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGameSessionLogUrlCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetGameSessionLogUrlCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5990,7 +5990,7 @@ export const deserializeAws_json1_1GetInstanceAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstanceAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstanceAccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6069,7 +6069,7 @@ export const deserializeAws_json1_1ListAliasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAliasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAliasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6140,7 +6140,7 @@ export const deserializeAws_json1_1ListBuildsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBuildsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBuildsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6211,7 +6211,7 @@ export const deserializeAws_json1_1ListFleetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFleetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListFleetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6290,7 +6290,7 @@ export const deserializeAws_json1_1ListGameServerGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGameServerGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGameServerGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6361,7 +6361,7 @@ export const deserializeAws_json1_1ListGameServersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGameServersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGameServersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6432,7 +6432,7 @@ export const deserializeAws_json1_1ListScriptsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListScriptsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListScriptsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6503,7 +6503,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6582,7 +6582,7 @@ export const deserializeAws_json1_1PutScalingPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutScalingPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutScalingPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6661,7 +6661,7 @@ export const deserializeAws_json1_1RegisterGameServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterGameServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterGameServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6748,7 +6748,7 @@ export const deserializeAws_json1_1RequestUploadCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RequestUploadCredentialsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RequestUploadCredentialsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6827,7 +6827,7 @@ export const deserializeAws_json1_1ResolveAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResolveAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResolveAliasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6914,7 +6914,7 @@ export const deserializeAws_json1_1ResumeGameServerGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResumeGameServerGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResumeGameServerGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6993,7 +6993,7 @@ export const deserializeAws_json1_1SearchGameSessionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchGameSessionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchGameSessionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7080,7 +7080,7 @@ export const deserializeAws_json1_1StartFleetActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartFleetActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartFleetActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7159,7 +7159,7 @@ export const deserializeAws_json1_1StartGameSessionPlacementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartGameSessionPlacementCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartGameSessionPlacementCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7238,7 +7238,7 @@ export const deserializeAws_json1_1StartMatchBackfillCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMatchBackfillCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartMatchBackfillCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7317,7 +7317,7 @@ export const deserializeAws_json1_1StartMatchmakingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMatchmakingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartMatchmakingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7396,7 +7396,7 @@ export const deserializeAws_json1_1StopFleetActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopFleetActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopFleetActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7475,7 +7475,7 @@ export const deserializeAws_json1_1StopGameSessionPlacementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopGameSessionPlacementCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopGameSessionPlacementCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7554,7 +7554,7 @@ export const deserializeAws_json1_1StopMatchmakingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopMatchmakingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopMatchmakingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7633,7 +7633,7 @@ export const deserializeAws_json1_1SuspendGameServerGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SuspendGameServerGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SuspendGameServerGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7712,7 +7712,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7791,7 +7791,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7870,7 +7870,7 @@ export const deserializeAws_json1_1UpdateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAliasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7949,7 +7949,7 @@ export const deserializeAws_json1_1UpdateBuildCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBuildCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateBuildCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8028,7 +8028,7 @@ export const deserializeAws_json1_1UpdateFleetAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFleetAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateFleetAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8131,7 +8131,7 @@ export const deserializeAws_json1_1UpdateFleetCapacityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFleetCapacityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateFleetCapacityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8234,7 +8234,7 @@ export const deserializeAws_json1_1UpdateFleetPortSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFleetPortSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateFleetPortSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8337,7 +8337,7 @@ export const deserializeAws_json1_1UpdateGameServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGameServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGameServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8416,7 +8416,7 @@ export const deserializeAws_json1_1UpdateGameServerGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGameServerGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGameServerGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8495,7 +8495,7 @@ export const deserializeAws_json1_1UpdateGameSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGameSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGameSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8590,7 +8590,7 @@ export const deserializeAws_json1_1UpdateGameSessionQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGameSessionQueueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGameSessionQueueCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8669,7 +8669,7 @@ export const deserializeAws_json1_1UpdateMatchmakingConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMatchmakingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMatchmakingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8748,7 +8748,7 @@ export const deserializeAws_json1_1UpdateRuntimeConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRuntimeConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRuntimeConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8835,7 +8835,7 @@ export const deserializeAws_json1_1UpdateScriptCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateScriptCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateScriptCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8914,7 +8914,7 @@ export const deserializeAws_json1_1ValidateMatchmakingRuleSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ValidateMatchmakingRuleSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ValidateMatchmakingRuleSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-glacier/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1.ts
@@ -1528,7 +1528,7 @@ export const deserializeAws_restJson1AbortMultipartUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AbortMultipartUploadCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1AbortMultipartUploadCommandError(output, context);
   }
   const contents: AbortMultipartUploadCommandOutput = {
@@ -1603,7 +1603,7 @@ export const deserializeAws_restJson1AbortVaultLockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AbortVaultLockCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1AbortVaultLockCommandError(output, context);
   }
   const contents: AbortVaultLockCommandOutput = {
@@ -1678,7 +1678,7 @@ export const deserializeAws_restJson1AddTagsToVaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToVaultCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddTagsToVaultCommandError(output, context);
   }
   const contents: AddTagsToVaultCommandOutput = {
@@ -1761,7 +1761,7 @@ export const deserializeAws_restJson1CompleteMultipartUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CompleteMultipartUploadCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CompleteMultipartUploadCommandError(output, context);
   }
   const contents: CompleteMultipartUploadCommandOutput = {
@@ -1848,7 +1848,7 @@ export const deserializeAws_restJson1CompleteVaultLockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CompleteVaultLockCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1CompleteVaultLockCommandError(output, context);
   }
   const contents: CompleteVaultLockCommandOutput = {
@@ -1923,7 +1923,7 @@ export const deserializeAws_restJson1CreateVaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVaultCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateVaultCommandError(output, context);
   }
   const contents: CreateVaultCommandOutput = {
@@ -2002,7 +2002,7 @@ export const deserializeAws_restJson1DeleteArchiveCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteArchiveCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteArchiveCommandError(output, context);
   }
   const contents: DeleteArchiveCommandOutput = {
@@ -2077,7 +2077,7 @@ export const deserializeAws_restJson1DeleteVaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVaultCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVaultCommandError(output, context);
   }
   const contents: DeleteVaultCommandOutput = {
@@ -2152,7 +2152,7 @@ export const deserializeAws_restJson1DeleteVaultAccessPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVaultAccessPolicyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVaultAccessPolicyCommandError(output, context);
   }
   const contents: DeleteVaultAccessPolicyCommandOutput = {
@@ -2227,7 +2227,7 @@ export const deserializeAws_restJson1DeleteVaultNotificationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVaultNotificationsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVaultNotificationsCommandError(output, context);
   }
   const contents: DeleteVaultNotificationsCommandOutput = {
@@ -2302,7 +2302,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeJobCommandError(output, context);
   }
   const contents: DescribeJobCommandOutput = {
@@ -2464,7 +2464,7 @@ export const deserializeAws_restJson1DescribeVaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVaultCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeVaultCommandError(output, context);
   }
   const contents: DescribeVaultCommandOutput = {
@@ -2563,7 +2563,7 @@ export const deserializeAws_restJson1GetDataRetrievalPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDataRetrievalPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDataRetrievalPolicyCommandError(output, context);
   }
   const contents: GetDataRetrievalPolicyCommandOutput = {
@@ -2634,7 +2634,7 @@ export const deserializeAws_restJson1GetJobOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobOutputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJobOutputCommandError(output, context);
   }
   const contents: GetJobOutputCommandOutput = {
@@ -2731,7 +2731,7 @@ export const deserializeAws_restJson1GetVaultAccessPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVaultAccessPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVaultAccessPolicyCommandError(output, context);
   }
   const contents: GetVaultAccessPolicyCommandOutput = {
@@ -2808,7 +2808,7 @@ export const deserializeAws_restJson1GetVaultLockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVaultLockCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVaultLockCommandError(output, context);
   }
   const contents: GetVaultLockCommandOutput = {
@@ -2899,7 +2899,7 @@ export const deserializeAws_restJson1GetVaultNotificationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVaultNotificationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVaultNotificationsCommandError(output, context);
   }
   const contents: GetVaultNotificationsCommandOutput = {
@@ -2976,7 +2976,7 @@ export const deserializeAws_restJson1InitiateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InitiateJobCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1InitiateJobCommandError(output, context);
   }
   const contents: InitiateJobCommandOutput = {
@@ -3079,7 +3079,7 @@ export const deserializeAws_restJson1InitiateMultipartUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InitiateMultipartUploadCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1InitiateMultipartUploadCommandError(output, context);
   }
   const contents: InitiateMultipartUploadCommandOutput = {
@@ -3162,7 +3162,7 @@ export const deserializeAws_restJson1InitiateVaultLockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InitiateVaultLockCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1InitiateVaultLockCommandError(output, context);
   }
   const contents: InitiateVaultLockCommandOutput = {
@@ -3241,7 +3241,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobsCommandError(output, context);
   }
   const contents: ListJobsCommandOutput = {
@@ -3324,7 +3324,7 @@ export const deserializeAws_restJson1ListMultipartUploadsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMultipartUploadsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMultipartUploadsCommandError(output, context);
   }
   const contents: ListMultipartUploadsCommandOutput = {
@@ -3407,7 +3407,7 @@ export const deserializeAws_restJson1ListPartsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPartsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPartsCommandError(output, context);
   }
   const contents: ListPartsCommandOutput = {
@@ -3510,7 +3510,7 @@ export const deserializeAws_restJson1ListProvisionedCapacityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProvisionedCapacityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProvisionedCapacityCommandError(output, context);
   }
   const contents: ListProvisionedCapacityCommandOutput = {
@@ -3584,7 +3584,7 @@ export const deserializeAws_restJson1ListTagsForVaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForVaultCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForVaultCommandError(output, context);
   }
   const contents: ListTagsForVaultCommandOutput = {
@@ -3663,7 +3663,7 @@ export const deserializeAws_restJson1ListVaultsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVaultsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListVaultsCommandError(output, context);
   }
   const contents: ListVaultsCommandOutput = {
@@ -3746,7 +3746,7 @@ export const deserializeAws_restJson1PurchaseProvisionedCapacityCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurchaseProvisionedCapacityCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PurchaseProvisionedCapacityCommandError(output, context);
   }
   const contents: PurchaseProvisionedCapacityCommandOutput = {
@@ -3825,7 +3825,7 @@ export const deserializeAws_restJson1RemoveTagsFromVaultCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromVaultCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveTagsFromVaultCommandError(output, context);
   }
   const contents: RemoveTagsFromVaultCommandOutput = {
@@ -3900,7 +3900,7 @@ export const deserializeAws_restJson1SetDataRetrievalPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetDataRetrievalPolicyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1SetDataRetrievalPolicyCommandError(output, context);
   }
   const contents: SetDataRetrievalPolicyCommandOutput = {
@@ -3967,7 +3967,7 @@ export const deserializeAws_restJson1SetVaultAccessPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetVaultAccessPolicyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1SetVaultAccessPolicyCommandError(output, context);
   }
   const contents: SetVaultAccessPolicyCommandOutput = {
@@ -4042,7 +4042,7 @@ export const deserializeAws_restJson1SetVaultNotificationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetVaultNotificationsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1SetVaultNotificationsCommandError(output, context);
   }
   const contents: SetVaultNotificationsCommandOutput = {
@@ -4117,7 +4117,7 @@ export const deserializeAws_restJson1UploadArchiveCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UploadArchiveCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1UploadArchiveCommandError(output, context);
   }
   const contents: UploadArchiveCommandOutput = {
@@ -4212,7 +4212,7 @@ export const deserializeAws_restJson1UploadMultipartPartCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UploadMultipartPartCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UploadMultipartPartCommandError(output, context);
   }
   const contents: UploadMultipartPartCommandOutput = {

--- a/clients/client-global-accelerator/protocols/Aws_json1_1.ts
+++ b/clients/client-global-accelerator/protocols/Aws_json1_1.ts
@@ -466,7 +466,7 @@ export const deserializeAws_json1_1AdvertiseByoipCidrCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AdvertiseByoipCidrCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AdvertiseByoipCidrCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -553,7 +553,7 @@ export const deserializeAws_json1_1CreateAcceleratorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAcceleratorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAcceleratorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -624,7 +624,7 @@ export const deserializeAws_json1_1CreateEndpointGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEndpointGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEndpointGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -727,7 +727,7 @@ export const deserializeAws_json1_1CreateListenerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateListenerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateListenerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -814,7 +814,7 @@ export const deserializeAws_json1_1DeleteAcceleratorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAcceleratorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAcceleratorCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -898,7 +898,7 @@ export const deserializeAws_json1_1DeleteEndpointGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEndpointGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEndpointGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -966,7 +966,7 @@ export const deserializeAws_json1_1DeleteListenerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteListenerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteListenerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1042,7 +1042,7 @@ export const deserializeAws_json1_1DeprovisionByoipCidrCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeprovisionByoipCidrCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeprovisionByoipCidrCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1129,7 +1129,7 @@ export const deserializeAws_json1_1DescribeAcceleratorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAcceleratorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAcceleratorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1200,7 +1200,7 @@ export const deserializeAws_json1_1DescribeAcceleratorAttributesCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAcceleratorAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAcceleratorAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1271,7 +1271,7 @@ export const deserializeAws_json1_1DescribeEndpointGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEndpointGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEndpointGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1342,7 +1342,7 @@ export const deserializeAws_json1_1DescribeListenerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeListenerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeListenerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1413,7 +1413,7 @@ export const deserializeAws_json1_1ListAcceleratorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAcceleratorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAcceleratorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1484,7 +1484,7 @@ export const deserializeAws_json1_1ListByoipCidrsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListByoipCidrsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListByoipCidrsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1563,7 +1563,7 @@ export const deserializeAws_json1_1ListEndpointGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEndpointGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEndpointGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1642,7 +1642,7 @@ export const deserializeAws_json1_1ListListenersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListListenersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListListenersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1721,7 +1721,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1792,7 +1792,7 @@ export const deserializeAws_json1_1ProvisionByoipCidrCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ProvisionByoipCidrCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ProvisionByoipCidrCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1879,7 +1879,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1950,7 +1950,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2021,7 +2021,7 @@ export const deserializeAws_json1_1UpdateAcceleratorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAcceleratorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAcceleratorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2092,7 +2092,7 @@ export const deserializeAws_json1_1UpdateAcceleratorAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAcceleratorAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAcceleratorAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2171,7 +2171,7 @@ export const deserializeAws_json1_1UpdateEndpointGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEndpointGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateEndpointGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2258,7 +2258,7 @@ export const deserializeAws_json1_1UpdateListenerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateListenerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateListenerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2345,7 +2345,7 @@ export const deserializeAws_json1_1WithdrawByoipCidrCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<WithdrawByoipCidrCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1WithdrawByoipCidrCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-glue/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/protocols/Aws_json1_1.ts
@@ -2402,7 +2402,7 @@ export const deserializeAws_json1_1BatchCreatePartitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchCreatePartitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchCreatePartitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2505,7 +2505,7 @@ export const deserializeAws_json1_1BatchDeleteConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeleteConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDeleteConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2568,7 +2568,7 @@ export const deserializeAws_json1_1BatchDeletePartitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeletePartitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDeletePartitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2647,7 +2647,7 @@ export const deserializeAws_json1_1BatchDeleteTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeleteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDeleteTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2726,7 +2726,7 @@ export const deserializeAws_json1_1BatchDeleteTableVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeleteTableVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDeleteTableVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2805,7 +2805,7 @@ export const deserializeAws_json1_1BatchGetCrawlersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetCrawlersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetCrawlersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2868,7 +2868,7 @@ export const deserializeAws_json1_1BatchGetDevEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetDevEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetDevEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2947,7 +2947,7 @@ export const deserializeAws_json1_1BatchGetJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3018,7 +3018,7 @@ export const deserializeAws_json1_1BatchGetPartitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetPartitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetPartitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3105,7 +3105,7 @@ export const deserializeAws_json1_1BatchGetTriggersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetTriggersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetTriggersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3176,7 +3176,7 @@ export const deserializeAws_json1_1BatchGetWorkflowsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetWorkflowsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGetWorkflowsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3247,7 +3247,7 @@ export const deserializeAws_json1_1BatchStopJobRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchStopJobRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchStopJobRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3318,7 +3318,7 @@ export const deserializeAws_json1_1CancelMLTaskRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelMLTaskRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelMLTaskRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3397,7 +3397,7 @@ export const deserializeAws_json1_1CreateClassifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClassifierCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateClassifierCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3468,7 +3468,7 @@ export const deserializeAws_json1_1CreateConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3555,7 +3555,7 @@ export const deserializeAws_json1_1CreateCrawlerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCrawlerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCrawlerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3634,7 +3634,7 @@ export const deserializeAws_json1_1CreateDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3729,7 +3729,7 @@ export const deserializeAws_json1_1CreateDevEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDevEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDevEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3840,7 +3840,7 @@ export const deserializeAws_json1_1CreateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3943,7 +3943,7 @@ export const deserializeAws_json1_1CreateMLTransformCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMLTransformCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateMLTransformCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4046,7 +4046,7 @@ export const deserializeAws_json1_1CreatePartitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePartitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePartitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4149,7 +4149,7 @@ export const deserializeAws_json1_1CreateScriptCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateScriptCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateScriptCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4220,7 +4220,7 @@ export const deserializeAws_json1_1CreateSecurityConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSecurityConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSecurityConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4307,7 +4307,7 @@ export const deserializeAws_json1_1CreateTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4410,7 +4410,7 @@ export const deserializeAws_json1_1CreateTriggerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTriggerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTriggerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4521,7 +4521,7 @@ export const deserializeAws_json1_1CreateUserDefinedFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserDefinedFunctionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserDefinedFunctionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4624,7 +4624,7 @@ export const deserializeAws_json1_1CreateWorkflowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWorkflowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWorkflowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4719,7 +4719,7 @@ export const deserializeAws_json1_1DeleteClassifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClassifierCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteClassifierCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4782,7 +4782,7 @@ export const deserializeAws_json1_1DeleteColumnStatisticsForPartitionCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteColumnStatisticsForPartitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteColumnStatisticsForPartitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4869,7 +4869,7 @@ export const deserializeAws_json1_1DeleteColumnStatisticsForTableCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteColumnStatisticsForTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteColumnStatisticsForTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4956,7 +4956,7 @@ export const deserializeAws_json1_1DeleteConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5019,7 +5019,7 @@ export const deserializeAws_json1_1DeleteCrawlerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCrawlerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCrawlerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5098,7 +5098,7 @@ export const deserializeAws_json1_1DeleteDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5177,7 +5177,7 @@ export const deserializeAws_json1_1DeleteDevEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDevEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDevEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5256,7 +5256,7 @@ export const deserializeAws_json1_1DeleteJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5327,7 +5327,7 @@ export const deserializeAws_json1_1DeleteMLTransformCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMLTransformCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMLTransformCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5406,7 +5406,7 @@ export const deserializeAws_json1_1DeletePartitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePartitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePartitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5485,7 +5485,7 @@ export const deserializeAws_json1_1DeleteResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5572,7 +5572,7 @@ export const deserializeAws_json1_1DeleteSecurityConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSecurityConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSecurityConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5651,7 +5651,7 @@ export const deserializeAws_json1_1DeleteTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5730,7 +5730,7 @@ export const deserializeAws_json1_1DeleteTableVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTableVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTableVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5809,7 +5809,7 @@ export const deserializeAws_json1_1DeleteTriggerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTriggerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTriggerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5888,7 +5888,7 @@ export const deserializeAws_json1_1DeleteUserDefinedFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserDefinedFunctionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserDefinedFunctionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5967,7 +5967,7 @@ export const deserializeAws_json1_1DeleteWorkflowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWorkflowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWorkflowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6046,7 +6046,7 @@ export const deserializeAws_json1_1GetCatalogImportStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCatalogImportStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCatalogImportStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6109,7 +6109,7 @@ export const deserializeAws_json1_1GetClassifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetClassifierCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetClassifierCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6172,7 +6172,7 @@ export const deserializeAws_json1_1GetClassifiersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetClassifiersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetClassifiersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6227,7 +6227,7 @@ export const deserializeAws_json1_1GetColumnStatisticsForPartitionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetColumnStatisticsForPartitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetColumnStatisticsForPartitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6314,7 +6314,7 @@ export const deserializeAws_json1_1GetColumnStatisticsForTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetColumnStatisticsForTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetColumnStatisticsForTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6401,7 +6401,7 @@ export const deserializeAws_json1_1GetConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6480,7 +6480,7 @@ export const deserializeAws_json1_1GetConnectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConnectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetConnectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6559,7 +6559,7 @@ export const deserializeAws_json1_1GetCrawlerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCrawlerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCrawlerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6622,7 +6622,7 @@ export const deserializeAws_json1_1GetCrawlerMetricsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCrawlerMetricsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCrawlerMetricsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6677,7 +6677,7 @@ export const deserializeAws_json1_1GetCrawlersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCrawlersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCrawlersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6732,7 +6732,7 @@ export const deserializeAws_json1_1GetDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6819,7 +6819,7 @@ export const deserializeAws_json1_1GetDatabasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDatabasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDatabasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6898,7 +6898,7 @@ export const deserializeAws_json1_1GetDataCatalogEncryptionSettingsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDataCatalogEncryptionSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDataCatalogEncryptionSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6969,7 +6969,7 @@ export const deserializeAws_json1_1GetDataflowGraphCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDataflowGraphCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDataflowGraphCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7040,7 +7040,7 @@ export const deserializeAws_json1_1GetDevEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDevEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDevEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7119,7 +7119,7 @@ export const deserializeAws_json1_1GetDevEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDevEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDevEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7198,7 +7198,7 @@ export const deserializeAws_json1_1GetJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7277,7 +7277,7 @@ export const deserializeAws_json1_1GetJobBookmarkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobBookmarkCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetJobBookmarkCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7364,7 +7364,7 @@ export const deserializeAws_json1_1GetJobRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetJobRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7443,7 +7443,7 @@ export const deserializeAws_json1_1GetJobRunsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobRunsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetJobRunsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7522,7 +7522,7 @@ export const deserializeAws_json1_1GetJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7601,7 +7601,7 @@ export const deserializeAws_json1_1GetMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMappingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMappingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7680,7 +7680,7 @@ export const deserializeAws_json1_1GetMLTaskRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMLTaskRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMLTaskRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7759,7 +7759,7 @@ export const deserializeAws_json1_1GetMLTaskRunsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMLTaskRunsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMLTaskRunsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7838,7 +7838,7 @@ export const deserializeAws_json1_1GetMLTransformCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMLTransformCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMLTransformCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7917,7 +7917,7 @@ export const deserializeAws_json1_1GetMLTransformsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMLTransformsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMLTransformsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7996,7 +7996,7 @@ export const deserializeAws_json1_1GetPartitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPartitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPartitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8083,7 +8083,7 @@ export const deserializeAws_json1_1GetPartitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPartitionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPartitionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8170,7 +8170,7 @@ export const deserializeAws_json1_1GetPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPlanCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPlanCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8241,7 +8241,7 @@ export const deserializeAws_json1_1GetResourcePoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourcePoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResourcePoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8320,7 +8320,7 @@ export const deserializeAws_json1_1GetResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8399,7 +8399,7 @@ export const deserializeAws_json1_1GetSecurityConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSecurityConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSecurityConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8478,7 +8478,7 @@ export const deserializeAws_json1_1GetSecurityConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSecurityConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSecurityConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8557,7 +8557,7 @@ export const deserializeAws_json1_1GetTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8644,7 +8644,7 @@ export const deserializeAws_json1_1GetTablesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTablesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTablesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8731,7 +8731,7 @@ export const deserializeAws_json1_1GetTableVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTableVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTableVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8818,7 +8818,7 @@ export const deserializeAws_json1_1GetTableVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTableVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTableVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8905,7 +8905,7 @@ export const deserializeAws_json1_1GetTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8984,7 +8984,7 @@ export const deserializeAws_json1_1GetTriggerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTriggerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTriggerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9063,7 +9063,7 @@ export const deserializeAws_json1_1GetTriggersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTriggersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTriggersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9142,7 +9142,7 @@ export const deserializeAws_json1_1GetUserDefinedFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUserDefinedFunctionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetUserDefinedFunctionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9229,7 +9229,7 @@ export const deserializeAws_json1_1GetUserDefinedFunctionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUserDefinedFunctionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetUserDefinedFunctionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9316,7 +9316,7 @@ export const deserializeAws_json1_1GetWorkflowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWorkflowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetWorkflowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9395,7 +9395,7 @@ export const deserializeAws_json1_1GetWorkflowRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWorkflowRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetWorkflowRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9474,7 +9474,7 @@ export const deserializeAws_json1_1GetWorkflowRunPropertiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWorkflowRunPropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetWorkflowRunPropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9553,7 +9553,7 @@ export const deserializeAws_json1_1GetWorkflowRunsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWorkflowRunsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetWorkflowRunsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9632,7 +9632,7 @@ export const deserializeAws_json1_1ImportCatalogToGlueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportCatalogToGlueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportCatalogToGlueCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9695,7 +9695,7 @@ export const deserializeAws_json1_1ListCrawlersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCrawlersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCrawlersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9750,7 +9750,7 @@ export const deserializeAws_json1_1ListDevEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDevEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDevEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9829,7 +9829,7 @@ export const deserializeAws_json1_1ListJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9908,7 +9908,7 @@ export const deserializeAws_json1_1ListMLTransformsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMLTransformsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListMLTransformsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9987,7 +9987,7 @@ export const deserializeAws_json1_1ListTriggersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTriggersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTriggersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10066,7 +10066,7 @@ export const deserializeAws_json1_1ListWorkflowsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWorkflowsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListWorkflowsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10137,7 +10137,7 @@ export const deserializeAws_json1_1PutDataCatalogEncryptionSettingsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDataCatalogEncryptionSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutDataCatalogEncryptionSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10208,7 +10208,7 @@ export const deserializeAws_json1_1PutResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10295,7 +10295,7 @@ export const deserializeAws_json1_1PutWorkflowRunPropertiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutWorkflowRunPropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutWorkflowRunPropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10398,7 +10398,7 @@ export const deserializeAws_json1_1ResetJobBookmarkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetJobBookmarkCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResetJobBookmarkCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10477,7 +10477,7 @@ export const deserializeAws_json1_1ResumeWorkflowRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResumeWorkflowRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResumeWorkflowRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10572,7 +10572,7 @@ export const deserializeAws_json1_1SearchTablesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchTablesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchTablesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10643,7 +10643,7 @@ export const deserializeAws_json1_1StartCrawlerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartCrawlerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartCrawlerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10714,7 +10714,7 @@ export const deserializeAws_json1_1StartCrawlerScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartCrawlerScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartCrawlerScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10801,7 +10801,7 @@ export const deserializeAws_json1_1StartExportLabelsTaskRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartExportLabelsTaskRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartExportLabelsTaskRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10880,7 +10880,7 @@ export const deserializeAws_json1_1StartImportLabelsTaskRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartImportLabelsTaskRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartImportLabelsTaskRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10967,7 +10967,7 @@ export const deserializeAws_json1_1StartJobRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartJobRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartJobRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11062,7 +11062,7 @@ export const deserializeAws_json1_1StartMLEvaluationTaskRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMLEvaluationTaskRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartMLEvaluationTaskRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11157,7 +11157,7 @@ export const deserializeAws_json1_1StartMLLabelingSetGenerationTaskRunCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMLLabelingSetGenerationTaskRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartMLLabelingSetGenerationTaskRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11244,7 +11244,7 @@ export const deserializeAws_json1_1StartTriggerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartTriggerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartTriggerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11339,7 +11339,7 @@ export const deserializeAws_json1_1StartWorkflowRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartWorkflowRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartWorkflowRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11434,7 +11434,7 @@ export const deserializeAws_json1_1StopCrawlerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopCrawlerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopCrawlerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11513,7 +11513,7 @@ export const deserializeAws_json1_1StopCrawlerScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopCrawlerScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopCrawlerScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11592,7 +11592,7 @@ export const deserializeAws_json1_1StopTriggerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopTriggerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopTriggerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11679,7 +11679,7 @@ export const deserializeAws_json1_1StopWorkflowRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopWorkflowRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopWorkflowRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11766,7 +11766,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11845,7 +11845,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11924,7 +11924,7 @@ export const deserializeAws_json1_1UpdateClassifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateClassifierCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateClassifierCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12003,7 +12003,7 @@ export const deserializeAws_json1_1UpdateColumnStatisticsForPartitionCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateColumnStatisticsForPartitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateColumnStatisticsForPartitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12090,7 +12090,7 @@ export const deserializeAws_json1_1UpdateColumnStatisticsForTableCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateColumnStatisticsForTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateColumnStatisticsForTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12177,7 +12177,7 @@ export const deserializeAws_json1_1UpdateConnectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConnectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateConnectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12256,7 +12256,7 @@ export const deserializeAws_json1_1UpdateCrawlerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCrawlerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateCrawlerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12343,7 +12343,7 @@ export const deserializeAws_json1_1UpdateCrawlerScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCrawlerScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateCrawlerScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12430,7 +12430,7 @@ export const deserializeAws_json1_1UpdateDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12517,7 +12517,7 @@ export const deserializeAws_json1_1UpdateDevEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDevEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDevEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12604,7 +12604,7 @@ export const deserializeAws_json1_1UpdateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12691,7 +12691,7 @@ export const deserializeAws_json1_1UpdateMLTransformCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMLTransformCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMLTransformCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12778,7 +12778,7 @@ export const deserializeAws_json1_1UpdatePartitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePartitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePartitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12865,7 +12865,7 @@ export const deserializeAws_json1_1UpdateTableCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTableCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTableCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12968,7 +12968,7 @@ export const deserializeAws_json1_1UpdateTriggerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTriggerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTriggerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13055,7 +13055,7 @@ export const deserializeAws_json1_1UpdateUserDefinedFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserDefinedFunctionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateUserDefinedFunctionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13142,7 +13142,7 @@ export const deserializeAws_json1_1UpdateWorkflowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateWorkflowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateWorkflowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-greengrass/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1.ts
@@ -3285,7 +3285,7 @@ export const deserializeAws_restJson1AssociateRoleToGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateRoleToGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateRoleToGroupCommandError(output, context);
   }
   const contents: AssociateRoleToGroupCommandOutput = {
@@ -3348,7 +3348,7 @@ export const deserializeAws_restJson1AssociateServiceRoleToAccountCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateServiceRoleToAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateServiceRoleToAccountCommandError(output, context);
   }
   const contents: AssociateServiceRoleToAccountCommandOutput = {
@@ -3411,7 +3411,7 @@ export const deserializeAws_restJson1CreateConnectorDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConnectorDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConnectorDefinitionCommandError(output, context);
   }
   const contents: CreateConnectorDefinitionCommandOutput = {
@@ -3490,7 +3490,7 @@ export const deserializeAws_restJson1CreateConnectorDefinitionVersionCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConnectorDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConnectorDefinitionVersionCommandError(output, context);
   }
   const contents: CreateConnectorDefinitionVersionCommandOutput = {
@@ -3557,7 +3557,7 @@ export const deserializeAws_restJson1CreateCoreDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCoreDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCoreDefinitionCommandError(output, context);
   }
   const contents: CreateCoreDefinitionCommandOutput = {
@@ -3636,7 +3636,7 @@ export const deserializeAws_restJson1CreateCoreDefinitionVersionCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCoreDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCoreDefinitionVersionCommandError(output, context);
   }
   const contents: CreateCoreDefinitionVersionCommandOutput = {
@@ -3703,7 +3703,7 @@ export const deserializeAws_restJson1CreateDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeploymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeploymentCommandError(output, context);
   }
   const contents: CreateDeploymentCommandOutput = {
@@ -3762,7 +3762,7 @@ export const deserializeAws_restJson1CreateDeviceDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeviceDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeviceDefinitionCommandError(output, context);
   }
   const contents: CreateDeviceDefinitionCommandOutput = {
@@ -3841,7 +3841,7 @@ export const deserializeAws_restJson1CreateDeviceDefinitionVersionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeviceDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeviceDefinitionVersionCommandError(output, context);
   }
   const contents: CreateDeviceDefinitionVersionCommandOutput = {
@@ -3908,7 +3908,7 @@ export const deserializeAws_restJson1CreateFunctionDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFunctionDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFunctionDefinitionCommandError(output, context);
   }
   const contents: CreateFunctionDefinitionCommandOutput = {
@@ -3987,7 +3987,7 @@ export const deserializeAws_restJson1CreateFunctionDefinitionVersionCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFunctionDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFunctionDefinitionVersionCommandError(output, context);
   }
   const contents: CreateFunctionDefinitionVersionCommandOutput = {
@@ -4054,7 +4054,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGroupCommandError(output, context);
   }
   const contents: CreateGroupCommandOutput = {
@@ -4133,7 +4133,7 @@ export const deserializeAws_restJson1CreateGroupCertificateAuthorityCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGroupCertificateAuthorityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGroupCertificateAuthorityCommandError(output, context);
   }
   const contents: CreateGroupCertificateAuthorityCommandOutput = {
@@ -4196,7 +4196,7 @@ export const deserializeAws_restJson1CreateGroupVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGroupVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGroupVersionCommandError(output, context);
   }
   const contents: CreateGroupVersionCommandOutput = {
@@ -4263,7 +4263,7 @@ export const deserializeAws_restJson1CreateLoggerDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLoggerDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateLoggerDefinitionCommandError(output, context);
   }
   const contents: CreateLoggerDefinitionCommandOutput = {
@@ -4342,7 +4342,7 @@ export const deserializeAws_restJson1CreateLoggerDefinitionVersionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLoggerDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateLoggerDefinitionVersionCommandError(output, context);
   }
   const contents: CreateLoggerDefinitionVersionCommandOutput = {
@@ -4409,7 +4409,7 @@ export const deserializeAws_restJson1CreateResourceDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResourceDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateResourceDefinitionCommandError(output, context);
   }
   const contents: CreateResourceDefinitionCommandOutput = {
@@ -4488,7 +4488,7 @@ export const deserializeAws_restJson1CreateResourceDefinitionVersionCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResourceDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateResourceDefinitionVersionCommandError(output, context);
   }
   const contents: CreateResourceDefinitionVersionCommandOutput = {
@@ -4555,7 +4555,7 @@ export const deserializeAws_restJson1CreateSoftwareUpdateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSoftwareUpdateJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSoftwareUpdateJobCommandError(output, context);
   }
   const contents: CreateSoftwareUpdateJobCommandOutput = {
@@ -4626,7 +4626,7 @@ export const deserializeAws_restJson1CreateSubscriptionDefinitionCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSubscriptionDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSubscriptionDefinitionCommandError(output, context);
   }
   const contents: CreateSubscriptionDefinitionCommandOutput = {
@@ -4705,7 +4705,7 @@ export const deserializeAws_restJson1CreateSubscriptionDefinitionVersionCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSubscriptionDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSubscriptionDefinitionVersionCommandError(output, context);
   }
   const contents: CreateSubscriptionDefinitionVersionCommandOutput = {
@@ -4772,7 +4772,7 @@ export const deserializeAws_restJson1DeleteConnectorDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConnectorDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteConnectorDefinitionCommandError(output, context);
   }
   const contents: DeleteConnectorDefinitionCommandOutput = {
@@ -4823,7 +4823,7 @@ export const deserializeAws_restJson1DeleteCoreDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCoreDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteCoreDefinitionCommandError(output, context);
   }
   const contents: DeleteCoreDefinitionCommandOutput = {
@@ -4874,7 +4874,7 @@ export const deserializeAws_restJson1DeleteDeviceDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeviceDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDeviceDefinitionCommandError(output, context);
   }
   const contents: DeleteDeviceDefinitionCommandOutput = {
@@ -4925,7 +4925,7 @@ export const deserializeAws_restJson1DeleteFunctionDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFunctionDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFunctionDefinitionCommandError(output, context);
   }
   const contents: DeleteFunctionDefinitionCommandOutput = {
@@ -4976,7 +4976,7 @@ export const deserializeAws_restJson1DeleteGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGroupCommandError(output, context);
   }
   const contents: DeleteGroupCommandOutput = {
@@ -5027,7 +5027,7 @@ export const deserializeAws_restJson1DeleteLoggerDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoggerDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteLoggerDefinitionCommandError(output, context);
   }
   const contents: DeleteLoggerDefinitionCommandOutput = {
@@ -5078,7 +5078,7 @@ export const deserializeAws_restJson1DeleteResourceDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourceDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteResourceDefinitionCommandError(output, context);
   }
   const contents: DeleteResourceDefinitionCommandOutput = {
@@ -5129,7 +5129,7 @@ export const deserializeAws_restJson1DeleteSubscriptionDefinitionCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSubscriptionDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSubscriptionDefinitionCommandError(output, context);
   }
   const contents: DeleteSubscriptionDefinitionCommandOutput = {
@@ -5180,7 +5180,7 @@ export const deserializeAws_restJson1DisassociateRoleFromGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateRoleFromGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateRoleFromGroupCommandError(output, context);
   }
   const contents: DisassociateRoleFromGroupCommandOutput = {
@@ -5243,7 +5243,7 @@ export const deserializeAws_restJson1DisassociateServiceRoleFromAccountCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateServiceRoleFromAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateServiceRoleFromAccountCommandError(output, context);
   }
   const contents: DisassociateServiceRoleFromAccountCommandOutput = {
@@ -5298,7 +5298,7 @@ export const deserializeAws_restJson1GetAssociatedRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAssociatedRoleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAssociatedRoleCommandError(output, context);
   }
   const contents: GetAssociatedRoleCommandOutput = {
@@ -5365,7 +5365,7 @@ export const deserializeAws_restJson1GetBulkDeploymentStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBulkDeploymentStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBulkDeploymentStatusCommandError(output, context);
   }
   const contents: GetBulkDeploymentStatusCommandOutput = {
@@ -5440,7 +5440,7 @@ export const deserializeAws_restJson1GetConnectivityInfoCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConnectivityInfoCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConnectivityInfoCommandError(output, context);
   }
   const contents: GetConnectivityInfoCommandOutput = {
@@ -5507,7 +5507,7 @@ export const deserializeAws_restJson1GetConnectorDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConnectorDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConnectorDefinitionCommandError(output, context);
   }
   const contents: GetConnectorDefinitionCommandOutput = {
@@ -5590,7 +5590,7 @@ export const deserializeAws_restJson1GetConnectorDefinitionVersionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConnectorDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConnectorDefinitionVersionCommandError(output, context);
   }
   const contents: GetConnectorDefinitionVersionCommandOutput = {
@@ -5665,7 +5665,7 @@ export const deserializeAws_restJson1GetCoreDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCoreDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCoreDefinitionCommandError(output, context);
   }
   const contents: GetCoreDefinitionCommandOutput = {
@@ -5748,7 +5748,7 @@ export const deserializeAws_restJson1GetCoreDefinitionVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCoreDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCoreDefinitionVersionCommandError(output, context);
   }
   const contents: GetCoreDefinitionVersionCommandOutput = {
@@ -5823,7 +5823,7 @@ export const deserializeAws_restJson1GetDeploymentStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeploymentStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeploymentStatusCommandError(output, context);
   }
   const contents: GetDeploymentStatusCommandOutput = {
@@ -5894,7 +5894,7 @@ export const deserializeAws_restJson1GetDeviceDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeviceDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeviceDefinitionCommandError(output, context);
   }
   const contents: GetDeviceDefinitionCommandOutput = {
@@ -5977,7 +5977,7 @@ export const deserializeAws_restJson1GetDeviceDefinitionVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeviceDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeviceDefinitionVersionCommandError(output, context);
   }
   const contents: GetDeviceDefinitionVersionCommandOutput = {
@@ -6052,7 +6052,7 @@ export const deserializeAws_restJson1GetFunctionDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFunctionDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFunctionDefinitionCommandError(output, context);
   }
   const contents: GetFunctionDefinitionCommandOutput = {
@@ -6135,7 +6135,7 @@ export const deserializeAws_restJson1GetFunctionDefinitionVersionCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFunctionDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFunctionDefinitionVersionCommandError(output, context);
   }
   const contents: GetFunctionDefinitionVersionCommandOutput = {
@@ -6210,7 +6210,7 @@ export const deserializeAws_restJson1GetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGroupCommandError(output, context);
   }
   const contents: GetGroupCommandOutput = {
@@ -6293,7 +6293,7 @@ export const deserializeAws_restJson1GetGroupCertificateAuthorityCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupCertificateAuthorityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGroupCertificateAuthorityCommandError(output, context);
   }
   const contents: GetGroupCertificateAuthorityCommandOutput = {
@@ -6364,7 +6364,7 @@ export const deserializeAws_restJson1GetGroupCertificateConfigurationCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupCertificateConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGroupCertificateConfigurationCommandError(output, context);
   }
   const contents: GetGroupCertificateConfigurationCommandOutput = {
@@ -6438,7 +6438,7 @@ export const deserializeAws_restJson1GetGroupVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGroupVersionCommandError(output, context);
   }
   const contents: GetGroupVersionCommandOutput = {
@@ -6509,7 +6509,7 @@ export const deserializeAws_restJson1GetLoggerDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoggerDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLoggerDefinitionCommandError(output, context);
   }
   const contents: GetLoggerDefinitionCommandOutput = {
@@ -6592,7 +6592,7 @@ export const deserializeAws_restJson1GetLoggerDefinitionVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoggerDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLoggerDefinitionVersionCommandError(output, context);
   }
   const contents: GetLoggerDefinitionVersionCommandOutput = {
@@ -6663,7 +6663,7 @@ export const deserializeAws_restJson1GetResourceDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourceDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResourceDefinitionCommandError(output, context);
   }
   const contents: GetResourceDefinitionCommandOutput = {
@@ -6746,7 +6746,7 @@ export const deserializeAws_restJson1GetResourceDefinitionVersionCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourceDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResourceDefinitionVersionCommandError(output, context);
   }
   const contents: GetResourceDefinitionVersionCommandOutput = {
@@ -6817,7 +6817,7 @@ export const deserializeAws_restJson1GetServiceRoleForAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServiceRoleForAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetServiceRoleForAccountCommandError(output, context);
   }
   const contents: GetServiceRoleForAccountCommandOutput = {
@@ -6876,7 +6876,7 @@ export const deserializeAws_restJson1GetSubscriptionDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSubscriptionDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSubscriptionDefinitionCommandError(output, context);
   }
   const contents: GetSubscriptionDefinitionCommandOutput = {
@@ -6959,7 +6959,7 @@ export const deserializeAws_restJson1GetSubscriptionDefinitionVersionCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSubscriptionDefinitionVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSubscriptionDefinitionVersionCommandError(output, context);
   }
   const contents: GetSubscriptionDefinitionVersionCommandOutput = {
@@ -7034,7 +7034,7 @@ export const deserializeAws_restJson1ListBulkDeploymentDetailedReportsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBulkDeploymentDetailedReportsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBulkDeploymentDetailedReportsCommandError(output, context);
   }
   const contents: ListBulkDeploymentDetailedReportsCommandOutput = {
@@ -7093,7 +7093,7 @@ export const deserializeAws_restJson1ListBulkDeploymentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBulkDeploymentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBulkDeploymentsCommandError(output, context);
   }
   const contents: ListBulkDeploymentsCommandOutput = {
@@ -7152,7 +7152,7 @@ export const deserializeAws_restJson1ListConnectorDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConnectorDefinitionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConnectorDefinitionsCommandError(output, context);
   }
   const contents: ListConnectorDefinitionsCommandOutput = {
@@ -7203,7 +7203,7 @@ export const deserializeAws_restJson1ListConnectorDefinitionVersionsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConnectorDefinitionVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConnectorDefinitionVersionsCommandError(output, context);
   }
   const contents: ListConnectorDefinitionVersionsCommandOutput = {
@@ -7262,7 +7262,7 @@ export const deserializeAws_restJson1ListCoreDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCoreDefinitionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListCoreDefinitionsCommandError(output, context);
   }
   const contents: ListCoreDefinitionsCommandOutput = {
@@ -7313,7 +7313,7 @@ export const deserializeAws_restJson1ListCoreDefinitionVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCoreDefinitionVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListCoreDefinitionVersionsCommandError(output, context);
   }
   const contents: ListCoreDefinitionVersionsCommandOutput = {
@@ -7372,7 +7372,7 @@ export const deserializeAws_restJson1ListDeploymentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeploymentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDeploymentsCommandError(output, context);
   }
   const contents: ListDeploymentsCommandOutput = {
@@ -7431,7 +7431,7 @@ export const deserializeAws_restJson1ListDeviceDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeviceDefinitionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDeviceDefinitionsCommandError(output, context);
   }
   const contents: ListDeviceDefinitionsCommandOutput = {
@@ -7482,7 +7482,7 @@ export const deserializeAws_restJson1ListDeviceDefinitionVersionsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeviceDefinitionVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDeviceDefinitionVersionsCommandError(output, context);
   }
   const contents: ListDeviceDefinitionVersionsCommandOutput = {
@@ -7541,7 +7541,7 @@ export const deserializeAws_restJson1ListFunctionDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFunctionDefinitionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFunctionDefinitionsCommandError(output, context);
   }
   const contents: ListFunctionDefinitionsCommandOutput = {
@@ -7592,7 +7592,7 @@ export const deserializeAws_restJson1ListFunctionDefinitionVersionsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFunctionDefinitionVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFunctionDefinitionVersionsCommandError(output, context);
   }
   const contents: ListFunctionDefinitionVersionsCommandOutput = {
@@ -7651,7 +7651,7 @@ export const deserializeAws_restJson1ListGroupCertificateAuthoritiesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupCertificateAuthoritiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGroupCertificateAuthoritiesCommandError(output, context);
   }
   const contents: ListGroupCertificateAuthoritiesCommandOutput = {
@@ -7717,7 +7717,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGroupsCommandError(output, context);
   }
   const contents: ListGroupsCommandOutput = {
@@ -7768,7 +7768,7 @@ export const deserializeAws_restJson1ListGroupVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGroupVersionsCommandError(output, context);
   }
   const contents: ListGroupVersionsCommandOutput = {
@@ -7827,7 +7827,7 @@ export const deserializeAws_restJson1ListLoggerDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLoggerDefinitionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListLoggerDefinitionsCommandError(output, context);
   }
   const contents: ListLoggerDefinitionsCommandOutput = {
@@ -7878,7 +7878,7 @@ export const deserializeAws_restJson1ListLoggerDefinitionVersionsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLoggerDefinitionVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListLoggerDefinitionVersionsCommandError(output, context);
   }
   const contents: ListLoggerDefinitionVersionsCommandOutput = {
@@ -7937,7 +7937,7 @@ export const deserializeAws_restJson1ListResourceDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceDefinitionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListResourceDefinitionsCommandError(output, context);
   }
   const contents: ListResourceDefinitionsCommandOutput = {
@@ -7988,7 +7988,7 @@ export const deserializeAws_restJson1ListResourceDefinitionVersionsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceDefinitionVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListResourceDefinitionVersionsCommandError(output, context);
   }
   const contents: ListResourceDefinitionVersionsCommandOutput = {
@@ -8047,7 +8047,7 @@ export const deserializeAws_restJson1ListSubscriptionDefinitionsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSubscriptionDefinitionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSubscriptionDefinitionsCommandError(output, context);
   }
   const contents: ListSubscriptionDefinitionsCommandOutput = {
@@ -8098,7 +8098,7 @@ export const deserializeAws_restJson1ListSubscriptionDefinitionVersionsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSubscriptionDefinitionVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSubscriptionDefinitionVersionsCommandError(output, context);
   }
   const contents: ListSubscriptionDefinitionVersionsCommandOutput = {
@@ -8157,7 +8157,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -8212,7 +8212,7 @@ export const deserializeAws_restJson1ResetDeploymentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetDeploymentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ResetDeploymentsCommandError(output, context);
   }
   const contents: ResetDeploymentsCommandOutput = {
@@ -8271,7 +8271,7 @@ export const deserializeAws_restJson1StartBulkDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartBulkDeploymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartBulkDeploymentCommandError(output, context);
   }
   const contents: StartBulkDeploymentCommandOutput = {
@@ -8330,7 +8330,7 @@ export const deserializeAws_restJson1StopBulkDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopBulkDeploymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopBulkDeploymentCommandError(output, context);
   }
   const contents: StopBulkDeploymentCommandOutput = {
@@ -8381,7 +8381,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -8432,7 +8432,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -8483,7 +8483,7 @@ export const deserializeAws_restJson1UpdateConnectivityInfoCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConnectivityInfoCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateConnectivityInfoCommandError(output, context);
   }
   const contents: UpdateConnectivityInfoCommandOutput = {
@@ -8550,7 +8550,7 @@ export const deserializeAws_restJson1UpdateConnectorDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConnectorDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateConnectorDefinitionCommandError(output, context);
   }
   const contents: UpdateConnectorDefinitionCommandOutput = {
@@ -8601,7 +8601,7 @@ export const deserializeAws_restJson1UpdateCoreDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCoreDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateCoreDefinitionCommandError(output, context);
   }
   const contents: UpdateCoreDefinitionCommandOutput = {
@@ -8652,7 +8652,7 @@ export const deserializeAws_restJson1UpdateDeviceDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDeviceDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDeviceDefinitionCommandError(output, context);
   }
   const contents: UpdateDeviceDefinitionCommandOutput = {
@@ -8703,7 +8703,7 @@ export const deserializeAws_restJson1UpdateFunctionDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFunctionDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFunctionDefinitionCommandError(output, context);
   }
   const contents: UpdateFunctionDefinitionCommandOutput = {
@@ -8754,7 +8754,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGroupCommandError(output, context);
   }
   const contents: UpdateGroupCommandOutput = {
@@ -8805,7 +8805,7 @@ export const deserializeAws_restJson1UpdateGroupCertificateConfigurationCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGroupCertificateConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGroupCertificateConfigurationCommandError(output, context);
   }
   const contents: UpdateGroupCertificateConfigurationCommandOutput = {
@@ -8879,7 +8879,7 @@ export const deserializeAws_restJson1UpdateLoggerDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLoggerDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateLoggerDefinitionCommandError(output, context);
   }
   const contents: UpdateLoggerDefinitionCommandOutput = {
@@ -8930,7 +8930,7 @@ export const deserializeAws_restJson1UpdateResourceDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateResourceDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateResourceDefinitionCommandError(output, context);
   }
   const contents: UpdateResourceDefinitionCommandOutput = {
@@ -8981,7 +8981,7 @@ export const deserializeAws_restJson1UpdateSubscriptionDefinitionCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSubscriptionDefinitionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSubscriptionDefinitionCommandError(output, context);
   }
   const contents: UpdateSubscriptionDefinitionCommandOutput = {

--- a/clients/client-groundstation/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1.ts
@@ -883,7 +883,7 @@ export const deserializeAws_restJson1CancelContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelContactCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelContactCommandError(output, context);
   }
   const contents: CancelContactCommandOutput = {
@@ -954,7 +954,7 @@ export const deserializeAws_restJson1CreateConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConfigCommandError(output, context);
   }
   const contents: CreateConfigCommandOutput = {
@@ -1041,7 +1041,7 @@ export const deserializeAws_restJson1CreateDataflowEndpointGroupCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataflowEndpointGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDataflowEndpointGroupCommandError(output, context);
   }
   const contents: CreateDataflowEndpointGroupCommandOutput = {
@@ -1112,7 +1112,7 @@ export const deserializeAws_restJson1CreateMissionProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMissionProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMissionProfileCommandError(output, context);
   }
   const contents: CreateMissionProfileCommandOutput = {
@@ -1183,7 +1183,7 @@ export const deserializeAws_restJson1DeleteConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteConfigCommandError(output, context);
   }
   const contents: DeleteConfigCommandOutput = {
@@ -1262,7 +1262,7 @@ export const deserializeAws_restJson1DeleteDataflowEndpointGroupCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDataflowEndpointGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDataflowEndpointGroupCommandError(output, context);
   }
   const contents: DeleteDataflowEndpointGroupCommandOutput = {
@@ -1333,7 +1333,7 @@ export const deserializeAws_restJson1DeleteMissionProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMissionProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMissionProfileCommandError(output, context);
   }
   const contents: DeleteMissionProfileCommandOutput = {
@@ -1404,7 +1404,7 @@ export const deserializeAws_restJson1DescribeContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeContactCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeContactCommandError(output, context);
   }
   const contents: DescribeContactCommandOutput = {
@@ -1523,7 +1523,7 @@ export const deserializeAws_restJson1GetConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConfigCommandError(output, context);
   }
   const contents: GetConfigCommandOutput = {
@@ -1614,7 +1614,7 @@ export const deserializeAws_restJson1GetDataflowEndpointGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDataflowEndpointGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDataflowEndpointGroupCommandError(output, context);
   }
   const contents: GetDataflowEndpointGroupCommandOutput = {
@@ -1697,7 +1697,7 @@ export const deserializeAws_restJson1GetMinuteUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMinuteUsageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMinuteUsageCommandError(output, context);
   }
   const contents: GetMinuteUsageCommandOutput = {
@@ -1784,7 +1784,7 @@ export const deserializeAws_restJson1GetMissionProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMissionProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMissionProfileCommandError(output, context);
   }
   const contents: GetMissionProfileCommandOutput = {
@@ -1891,7 +1891,7 @@ export const deserializeAws_restJson1GetSatelliteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSatelliteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSatelliteCommandError(output, context);
   }
   const contents: GetSatelliteCommandOutput = {
@@ -1974,7 +1974,7 @@ export const deserializeAws_restJson1ListConfigsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConfigsCommandError(output, context);
   }
   const contents: ListConfigsCommandOutput = {
@@ -2049,7 +2049,7 @@ export const deserializeAws_restJson1ListContactsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListContactsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListContactsCommandError(output, context);
   }
   const contents: ListContactsCommandOutput = {
@@ -2124,7 +2124,7 @@ export const deserializeAws_restJson1ListDataflowEndpointGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDataflowEndpointGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDataflowEndpointGroupsCommandError(output, context);
   }
   const contents: ListDataflowEndpointGroupsCommandOutput = {
@@ -2202,7 +2202,7 @@ export const deserializeAws_restJson1ListGroundStationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroundStationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGroundStationsCommandError(output, context);
   }
   const contents: ListGroundStationsCommandOutput = {
@@ -2277,7 +2277,7 @@ export const deserializeAws_restJson1ListMissionProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMissionProfilesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMissionProfilesCommandError(output, context);
   }
   const contents: ListMissionProfilesCommandOutput = {
@@ -2352,7 +2352,7 @@ export const deserializeAws_restJson1ListSatellitesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSatellitesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSatellitesCommandError(output, context);
   }
   const contents: ListSatellitesCommandOutput = {
@@ -2427,7 +2427,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -2498,7 +2498,7 @@ export const deserializeAws_restJson1ReserveContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReserveContactCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ReserveContactCommandError(output, context);
   }
   const contents: ReserveContactCommandOutput = {
@@ -2569,7 +2569,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -2636,7 +2636,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -2703,7 +2703,7 @@ export const deserializeAws_restJson1UpdateConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateConfigCommandError(output, context);
   }
   const contents: UpdateConfigCommandOutput = {
@@ -2782,7 +2782,7 @@ export const deserializeAws_restJson1UpdateMissionProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMissionProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMissionProfileCommandError(output, context);
   }
   const contents: UpdateMissionProfileCommandOutput = {

--- a/clients/client-guardduty/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1.ts
@@ -2217,7 +2217,7 @@ export const deserializeAws_restJson1AcceptInvitationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptInvitationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AcceptInvitationCommandError(output, context);
   }
   const contents: AcceptInvitationCommandOutput = {
@@ -2276,7 +2276,7 @@ export const deserializeAws_restJson1ArchiveFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ArchiveFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ArchiveFindingsCommandError(output, context);
   }
   const contents: ArchiveFindingsCommandOutput = {
@@ -2335,7 +2335,7 @@ export const deserializeAws_restJson1CreateDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDetectorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDetectorCommandError(output, context);
   }
   const contents: CreateDetectorCommandOutput = {
@@ -2398,7 +2398,7 @@ export const deserializeAws_restJson1CreateFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFilterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFilterCommandError(output, context);
   }
   const contents: CreateFilterCommandOutput = {
@@ -2461,7 +2461,7 @@ export const deserializeAws_restJson1CreateIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIPSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateIPSetCommandError(output, context);
   }
   const contents: CreateIPSetCommandOutput = {
@@ -2524,7 +2524,7 @@ export const deserializeAws_restJson1CreateMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMembersCommandError(output, context);
   }
   const contents: CreateMembersCommandOutput = {
@@ -2587,7 +2587,7 @@ export const deserializeAws_restJson1CreatePublishingDestinationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePublishingDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePublishingDestinationCommandError(output, context);
   }
   const contents: CreatePublishingDestinationCommandOutput = {
@@ -2650,7 +2650,7 @@ export const deserializeAws_restJson1CreateSampleFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSampleFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSampleFindingsCommandError(output, context);
   }
   const contents: CreateSampleFindingsCommandOutput = {
@@ -2709,7 +2709,7 @@ export const deserializeAws_restJson1CreateThreatIntelSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateThreatIntelSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateThreatIntelSetCommandError(output, context);
   }
   const contents: CreateThreatIntelSetCommandOutput = {
@@ -2772,7 +2772,7 @@ export const deserializeAws_restJson1DeclineInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeclineInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeclineInvitationsCommandError(output, context);
   }
   const contents: DeclineInvitationsCommandOutput = {
@@ -2835,7 +2835,7 @@ export const deserializeAws_restJson1DeleteDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDetectorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDetectorCommandError(output, context);
   }
   const contents: DeleteDetectorCommandOutput = {
@@ -2894,7 +2894,7 @@ export const deserializeAws_restJson1DeleteFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFilterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFilterCommandError(output, context);
   }
   const contents: DeleteFilterCommandOutput = {
@@ -2953,7 +2953,7 @@ export const deserializeAws_restJson1DeleteInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteInvitationsCommandError(output, context);
   }
   const contents: DeleteInvitationsCommandOutput = {
@@ -3016,7 +3016,7 @@ export const deserializeAws_restJson1DeleteIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIPSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteIPSetCommandError(output, context);
   }
   const contents: DeleteIPSetCommandOutput = {
@@ -3075,7 +3075,7 @@ export const deserializeAws_restJson1DeleteMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMembersCommandError(output, context);
   }
   const contents: DeleteMembersCommandOutput = {
@@ -3138,7 +3138,7 @@ export const deserializeAws_restJson1DeletePublishingDestinationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePublishingDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePublishingDestinationCommandError(output, context);
   }
   const contents: DeletePublishingDestinationCommandOutput = {
@@ -3197,7 +3197,7 @@ export const deserializeAws_restJson1DeleteThreatIntelSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteThreatIntelSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteThreatIntelSetCommandError(output, context);
   }
   const contents: DeleteThreatIntelSetCommandOutput = {
@@ -3256,7 +3256,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrganizationConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeOrganizationConfigurationCommandError(output, context);
   }
   const contents: DescribeOrganizationConfigurationCommandOutput = {
@@ -3330,7 +3330,7 @@ export const deserializeAws_restJson1DescribePublishingDestinationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePublishingDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribePublishingDestinationCommandError(output, context);
   }
   const contents: DescribePublishingDestinationCommandOutput = {
@@ -3409,7 +3409,7 @@ export const deserializeAws_restJson1DisableOrganizationAdminAccountCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableOrganizationAdminAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisableOrganizationAdminAccountCommandError(output, context);
   }
   const contents: DisableOrganizationAdminAccountCommandOutput = {
@@ -3468,7 +3468,7 @@ export const deserializeAws_restJson1DisassociateFromMasterAccountCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateFromMasterAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateFromMasterAccountCommandError(output, context);
   }
   const contents: DisassociateFromMasterAccountCommandOutput = {
@@ -3527,7 +3527,7 @@ export const deserializeAws_restJson1DisassociateMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateMembersCommandError(output, context);
   }
   const contents: DisassociateMembersCommandOutput = {
@@ -3590,7 +3590,7 @@ export const deserializeAws_restJson1EnableOrganizationAdminAccountCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableOrganizationAdminAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1EnableOrganizationAdminAccountCommandError(output, context);
   }
   const contents: EnableOrganizationAdminAccountCommandOutput = {
@@ -3649,7 +3649,7 @@ export const deserializeAws_restJson1GetDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDetectorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDetectorCommandError(output, context);
   }
   const contents: GetDetectorCommandOutput = {
@@ -3736,7 +3736,7 @@ export const deserializeAws_restJson1GetFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFilterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFilterCommandError(output, context);
   }
   const contents: GetFilterCommandOutput = {
@@ -3819,7 +3819,7 @@ export const deserializeAws_restJson1GetFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFindingsCommandError(output, context);
   }
   const contents: GetFindingsCommandOutput = {
@@ -3882,7 +3882,7 @@ export const deserializeAws_restJson1GetFindingsStatisticsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFindingsStatisticsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFindingsStatisticsCommandError(output, context);
   }
   const contents: GetFindingsStatisticsCommandOutput = {
@@ -3945,7 +3945,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInvitationsCountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetInvitationsCountCommandError(output, context);
   }
   const contents: GetInvitationsCountCommandOutput = {
@@ -4008,7 +4008,7 @@ export const deserializeAws_restJson1GetIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIPSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIPSetCommandError(output, context);
   }
   const contents: GetIPSetCommandOutput = {
@@ -4087,7 +4087,7 @@ export const deserializeAws_restJson1GetMasterAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMasterAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMasterAccountCommandError(output, context);
   }
   const contents: GetMasterAccountCommandOutput = {
@@ -4150,7 +4150,7 @@ export const deserializeAws_restJson1GetMemberDetectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMemberDetectorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMemberDetectorsCommandError(output, context);
   }
   const contents: GetMemberDetectorsCommandOutput = {
@@ -4220,7 +4220,7 @@ export const deserializeAws_restJson1GetMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMembersCommandError(output, context);
   }
   const contents: GetMembersCommandOutput = {
@@ -4287,7 +4287,7 @@ export const deserializeAws_restJson1GetThreatIntelSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetThreatIntelSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetThreatIntelSetCommandError(output, context);
   }
   const contents: GetThreatIntelSetCommandOutput = {
@@ -4366,7 +4366,7 @@ export const deserializeAws_restJson1GetUsageStatisticsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUsageStatisticsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUsageStatisticsCommandError(output, context);
   }
   const contents: GetUsageStatisticsCommandOutput = {
@@ -4433,7 +4433,7 @@ export const deserializeAws_restJson1InviteMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InviteMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1InviteMembersCommandError(output, context);
   }
   const contents: InviteMembersCommandOutput = {
@@ -4496,7 +4496,7 @@ export const deserializeAws_restJson1ListDetectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDetectorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDetectorsCommandError(output, context);
   }
   const contents: ListDetectorsCommandOutput = {
@@ -4563,7 +4563,7 @@ export const deserializeAws_restJson1ListFiltersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFiltersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFiltersCommandError(output, context);
   }
   const contents: ListFiltersCommandOutput = {
@@ -4630,7 +4630,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFindingsCommandError(output, context);
   }
   const contents: ListFindingsCommandOutput = {
@@ -4697,7 +4697,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListInvitationsCommandError(output, context);
   }
   const contents: ListInvitationsCommandOutput = {
@@ -4764,7 +4764,7 @@ export const deserializeAws_restJson1ListIPSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIPSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListIPSetsCommandError(output, context);
   }
   const contents: ListIPSetsCommandOutput = {
@@ -4831,7 +4831,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMembersCommandError(output, context);
   }
   const contents: ListMembersCommandOutput = {
@@ -4898,7 +4898,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOrganizationAdminAccountsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListOrganizationAdminAccountsCommandError(output, context);
   }
   const contents: ListOrganizationAdminAccountsCommandOutput = {
@@ -4965,7 +4965,7 @@ export const deserializeAws_restJson1ListPublishingDestinationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPublishingDestinationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPublishingDestinationsCommandError(output, context);
   }
   const contents: ListPublishingDestinationsCommandOutput = {
@@ -5032,7 +5032,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -5095,7 +5095,7 @@ export const deserializeAws_restJson1ListThreatIntelSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThreatIntelSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThreatIntelSetsCommandError(output, context);
   }
   const contents: ListThreatIntelSetsCommandOutput = {
@@ -5162,7 +5162,7 @@ export const deserializeAws_restJson1StartMonitoringMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMonitoringMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartMonitoringMembersCommandError(output, context);
   }
   const contents: StartMonitoringMembersCommandOutput = {
@@ -5225,7 +5225,7 @@ export const deserializeAws_restJson1StopMonitoringMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopMonitoringMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopMonitoringMembersCommandError(output, context);
   }
   const contents: StopMonitoringMembersCommandOutput = {
@@ -5288,7 +5288,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -5347,7 +5347,7 @@ export const deserializeAws_restJson1UnarchiveFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnarchiveFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UnarchiveFindingsCommandError(output, context);
   }
   const contents: UnarchiveFindingsCommandOutput = {
@@ -5406,7 +5406,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -5465,7 +5465,7 @@ export const deserializeAws_restJson1UpdateDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDetectorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDetectorCommandError(output, context);
   }
   const contents: UpdateDetectorCommandOutput = {
@@ -5524,7 +5524,7 @@ export const deserializeAws_restJson1UpdateFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFilterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFilterCommandError(output, context);
   }
   const contents: UpdateFilterCommandOutput = {
@@ -5587,7 +5587,7 @@ export const deserializeAws_restJson1UpdateFindingsFeedbackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFindingsFeedbackCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFindingsFeedbackCommandError(output, context);
   }
   const contents: UpdateFindingsFeedbackCommandOutput = {
@@ -5646,7 +5646,7 @@ export const deserializeAws_restJson1UpdateIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIPSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateIPSetCommandError(output, context);
   }
   const contents: UpdateIPSetCommandOutput = {
@@ -5705,7 +5705,7 @@ export const deserializeAws_restJson1UpdateMemberDetectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMemberDetectorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMemberDetectorsCommandError(output, context);
   }
   const contents: UpdateMemberDetectorsCommandOutput = {
@@ -5768,7 +5768,7 @@ export const deserializeAws_restJson1UpdateOrganizationConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateOrganizationConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateOrganizationConfigurationCommandError(output, context);
   }
   const contents: UpdateOrganizationConfigurationCommandOutput = {
@@ -5827,7 +5827,7 @@ export const deserializeAws_restJson1UpdatePublishingDestinationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePublishingDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePublishingDestinationCommandError(output, context);
   }
   const contents: UpdatePublishingDestinationCommandOutput = {
@@ -5886,7 +5886,7 @@ export const deserializeAws_restJson1UpdateThreatIntelSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateThreatIntelSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateThreatIntelSetCommandError(output, context);
   }
   const contents: UpdateThreatIntelSetCommandOutput = {

--- a/clients/client-health/protocols/Aws_json1_1.ts
+++ b/clients/client-health/protocols/Aws_json1_1.ts
@@ -268,7 +268,7 @@ export const deserializeAws_json1_1DescribeAffectedAccountsForOrganizationComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAffectedAccountsForOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAffectedAccountsForOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -323,7 +323,7 @@ export const deserializeAws_json1_1DescribeAffectedEntitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAffectedEntitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAffectedEntitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -386,7 +386,7 @@ export const deserializeAws_json1_1DescribeAffectedEntitiesForOrganizationComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAffectedEntitiesForOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAffectedEntitiesForOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -449,7 +449,7 @@ export const deserializeAws_json1_1DescribeEntityAggregatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEntityAggregatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEntityAggregatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -496,7 +496,7 @@ export const deserializeAws_json1_1DescribeEventAggregatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventAggregatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventAggregatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -551,7 +551,7 @@ export const deserializeAws_json1_1DescribeEventDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -606,7 +606,7 @@ export const deserializeAws_json1_1DescribeEventDetailsForOrganizationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventDetailsForOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventDetailsForOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -661,7 +661,7 @@ export const deserializeAws_json1_1DescribeEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -724,7 +724,7 @@ export const deserializeAws_json1_1DescribeEventsForOrganizationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsForOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventsForOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -787,7 +787,7 @@ export const deserializeAws_json1_1DescribeEventTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -850,7 +850,7 @@ export const deserializeAws_json1_1DescribeHealthServiceStatusForOrganizationCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHealthServiceStatusForOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeHealthServiceStatusForOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -897,7 +897,7 @@ export const deserializeAws_json1_1DisableHealthServiceAccessForOrganizationComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableHealthServiceAccessForOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableHealthServiceAccessForOrganizationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -949,7 +949,7 @@ export const deserializeAws_json1_1EnableHealthServiceAccessForOrganizationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableHealthServiceAccessForOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableHealthServiceAccessForOrganizationCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-honeycode/protocols/Aws_restJson1.ts
+++ b/clients/client-honeycode/protocols/Aws_restJson1.ts
@@ -130,7 +130,7 @@ export const deserializeAws_restJson1GetScreenDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetScreenDataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetScreenDataCommandError(output, context);
   }
   const contents: GetScreenDataCommandOutput = {
@@ -241,7 +241,7 @@ export const deserializeAws_restJson1InvokeScreenAutomationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InvokeScreenAutomationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1InvokeScreenAutomationCommandError(output, context);
   }
   const contents: InvokeScreenAutomationCommandOutput = {

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -2882,7 +2882,7 @@ export const deserializeAws_queryAddClientIDToOpenIDConnectProviderCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddClientIDToOpenIDConnectProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddClientIDToOpenIDConnectProviderCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2957,7 +2957,7 @@ export const deserializeAws_queryAddRoleToInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddRoleToInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddRoleToInstanceProfileCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3040,7 +3040,7 @@ export const deserializeAws_queryAddUserToGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddUserToGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddUserToGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3107,7 +3107,7 @@ export const deserializeAws_queryAttachGroupPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachGroupPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAttachGroupPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3190,7 +3190,7 @@ export const deserializeAws_queryAttachRolePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachRolePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAttachRolePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3281,7 +3281,7 @@ export const deserializeAws_queryAttachUserPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachUserPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAttachUserPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3364,7 +3364,7 @@ export const deserializeAws_queryChangePasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ChangePasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryChangePasswordCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3455,7 +3455,7 @@ export const deserializeAws_queryCreateAccessKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAccessKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateAccessKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3525,7 +3525,7 @@ export const deserializeAws_queryCreateAccountAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAccountAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateAccountAliasCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3592,7 +3592,7 @@ export const deserializeAws_queryCreateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3670,7 +3670,7 @@ export const deserializeAws_queryCreateInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateInstanceProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3740,7 +3740,7 @@ export const deserializeAws_queryCreateLoginProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLoginProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateLoginProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3826,7 +3826,7 @@ export const deserializeAws_queryCreateOpenIDConnectProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOpenIDConnectProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateOpenIDConnectProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3904,7 +3904,7 @@ export const deserializeAws_queryCreatePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreatePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3990,7 +3990,7 @@ export const deserializeAws_queryCreatePolicyVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePolicyVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreatePolicyVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4076,7 +4076,7 @@ export const deserializeAws_queryCreateRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4170,7 +4170,7 @@ export const deserializeAws_queryCreateSAMLProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSAMLProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateSAMLProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4248,7 +4248,7 @@ export const deserializeAws_queryCreateServiceLinkedRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateServiceLinkedRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateServiceLinkedRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4326,7 +4326,7 @@ export const deserializeAws_queryCreateServiceSpecificCredentialCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateServiceSpecificCredentialCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateServiceSpecificCredentialCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4399,7 +4399,7 @@ export const deserializeAws_queryCreateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4493,7 +4493,7 @@ export const deserializeAws_queryCreateVirtualMFADeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVirtualMFADeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateVirtualMFADeviceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4563,7 +4563,7 @@ export const deserializeAws_queryDeactivateMFADeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeactivateMFADeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeactivateMFADeviceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4638,7 +4638,7 @@ export const deserializeAws_queryDeleteAccessKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccessKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteAccessKeyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4705,7 +4705,7 @@ export const deserializeAws_queryDeleteAccountAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccountAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteAccountAliasCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4772,7 +4772,7 @@ export const deserializeAws_queryDeleteAccountPasswordPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccountPasswordPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteAccountPasswordPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4839,7 +4839,7 @@ export const deserializeAws_queryDeleteGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4914,7 +4914,7 @@ export const deserializeAws_queryDeleteGroupPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGroupPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteGroupPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4981,7 +4981,7 @@ export const deserializeAws_queryDeleteInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteInstanceProfileCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5056,7 +5056,7 @@ export const deserializeAws_queryDeleteLoginProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoginProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteLoginProfileCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5131,7 +5131,7 @@ export const deserializeAws_queryDeleteOpenIDConnectProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOpenIDConnectProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteOpenIDConnectProviderCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5198,7 +5198,7 @@ export const deserializeAws_queryDeletePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeletePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5281,7 +5281,7 @@ export const deserializeAws_queryDeletePolicyVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePolicyVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeletePolicyVersionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5364,7 +5364,7 @@ export const deserializeAws_queryDeleteRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteRoleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5455,7 +5455,7 @@ export const deserializeAws_queryDeleteRolePermissionsBoundaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRolePermissionsBoundaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteRolePermissionsBoundaryCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5522,7 +5522,7 @@ export const deserializeAws_queryDeleteRolePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRolePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteRolePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5597,7 +5597,7 @@ export const deserializeAws_queryDeleteSAMLProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSAMLProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteSAMLProviderCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5672,7 +5672,7 @@ export const deserializeAws_queryDeleteServerCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteServerCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteServerCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5747,7 +5747,7 @@ export const deserializeAws_queryDeleteServiceLinkedRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteServiceLinkedRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteServiceLinkedRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5817,7 +5817,7 @@ export const deserializeAws_queryDeleteServiceSpecificCredentialCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteServiceSpecificCredentialCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteServiceSpecificCredentialCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5868,7 +5868,7 @@ export const deserializeAws_queryDeleteSigningCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSigningCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteSigningCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5935,7 +5935,7 @@ export const deserializeAws_queryDeleteSSHPublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSSHPublicKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteSSHPublicKeyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5986,7 +5986,7 @@ export const deserializeAws_queryDeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteUserCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6069,7 +6069,7 @@ export const deserializeAws_queryDeleteUserPermissionsBoundaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserPermissionsBoundaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteUserPermissionsBoundaryCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6128,7 +6128,7 @@ export const deserializeAws_queryDeleteUserPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteUserPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6195,7 +6195,7 @@ export const deserializeAws_queryDeleteVirtualMFADeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVirtualMFADeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteVirtualMFADeviceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6270,7 +6270,7 @@ export const deserializeAws_queryDetachGroupPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachGroupPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDetachGroupPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6345,7 +6345,7 @@ export const deserializeAws_queryDetachRolePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachRolePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDetachRolePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6428,7 +6428,7 @@ export const deserializeAws_queryDetachUserPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachUserPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDetachUserPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6503,7 +6503,7 @@ export const deserializeAws_queryEnableMFADeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableMFADeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryEnableMFADeviceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6594,7 +6594,7 @@ export const deserializeAws_queryGenerateCredentialReportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateCredentialReportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGenerateCredentialReportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6656,7 +6656,7 @@ export const deserializeAws_queryGenerateOrganizationsAccessReportCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateOrganizationsAccessReportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGenerateOrganizationsAccessReportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6713,7 +6713,7 @@ export const deserializeAws_queryGenerateServiceLastAccessedDetailsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateServiceLastAccessedDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGenerateServiceLastAccessedDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6778,7 +6778,7 @@ export const deserializeAws_queryGetAccessKeyLastUsedCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccessKeyLastUsedCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetAccessKeyLastUsedCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6824,7 +6824,7 @@ export const deserializeAws_queryGetAccountAuthorizationDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountAuthorizationDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetAccountAuthorizationDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6881,7 +6881,7 @@ export const deserializeAws_queryGetAccountPasswordPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountPasswordPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetAccountPasswordPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6943,7 +6943,7 @@ export const deserializeAws_queryGetAccountSummaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountSummaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetAccountSummaryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6997,7 +6997,7 @@ export const deserializeAws_queryGetContextKeysForCustomPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetContextKeysForCustomPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetContextKeysForCustomPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7051,7 +7051,7 @@ export const deserializeAws_queryGetContextKeysForPrincipalPolicyCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetContextKeysForPrincipalPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetContextKeysForPrincipalPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7113,7 +7113,7 @@ export const deserializeAws_queryGetCredentialReportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCredentialReportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetCredentialReportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7191,7 +7191,7 @@ export const deserializeAws_queryGetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7253,7 +7253,7 @@ export const deserializeAws_queryGetGroupPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetGroupPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7315,7 +7315,7 @@ export const deserializeAws_queryGetInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetInstanceProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7377,7 +7377,7 @@ export const deserializeAws_queryGetLoginProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoginProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetLoginProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7439,7 +7439,7 @@ export const deserializeAws_queryGetOpenIDConnectProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOpenIDConnectProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetOpenIDConnectProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7509,7 +7509,7 @@ export const deserializeAws_queryGetOrganizationsAccessReportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOrganizationsAccessReportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetOrganizationsAccessReportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7563,7 +7563,7 @@ export const deserializeAws_queryGetPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7633,7 +7633,7 @@ export const deserializeAws_queryGetPolicyVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPolicyVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetPolicyVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7703,7 +7703,7 @@ export const deserializeAws_queryGetRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7765,7 +7765,7 @@ export const deserializeAws_queryGetRolePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRolePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetRolePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7827,7 +7827,7 @@ export const deserializeAws_queryGetSAMLProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSAMLProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetSAMLProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7897,7 +7897,7 @@ export const deserializeAws_queryGetServerCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServerCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetServerCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7959,7 +7959,7 @@ export const deserializeAws_queryGetServiceLastAccessedDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServiceLastAccessedDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetServiceLastAccessedDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8024,7 +8024,7 @@ export const deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServiceLastAccessedDetailsWithEntitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetServiceLastAccessedDetailsWithEntitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8089,7 +8089,7 @@ export const deserializeAws_queryGetServiceLinkedRoleDeletionStatusCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServiceLinkedRoleDeletionStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetServiceLinkedRoleDeletionStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8162,7 +8162,7 @@ export const deserializeAws_queryGetSSHPublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSSHPublicKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetSSHPublicKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8224,7 +8224,7 @@ export const deserializeAws_queryGetUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8286,7 +8286,7 @@ export const deserializeAws_queryGetUserPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUserPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetUserPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8348,7 +8348,7 @@ export const deserializeAws_queryListAccessKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAccessKeysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListAccessKeysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8410,7 +8410,7 @@ export const deserializeAws_queryListAccountAliasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAccountAliasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListAccountAliasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8464,7 +8464,7 @@ export const deserializeAws_queryListAttachedGroupPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAttachedGroupPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListAttachedGroupPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8534,7 +8534,7 @@ export const deserializeAws_queryListAttachedRolePoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAttachedRolePoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListAttachedRolePoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8604,7 +8604,7 @@ export const deserializeAws_queryListAttachedUserPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAttachedUserPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListAttachedUserPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8674,7 +8674,7 @@ export const deserializeAws_queryListEntitiesForPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEntitiesForPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListEntitiesForPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8744,7 +8744,7 @@ export const deserializeAws_queryListGroupPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListGroupPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8806,7 +8806,7 @@ export const deserializeAws_queryListGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8860,7 +8860,7 @@ export const deserializeAws_queryListGroupsForUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupsForUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListGroupsForUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8922,7 +8922,7 @@ export const deserializeAws_queryListInstanceProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInstanceProfilesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListInstanceProfilesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8976,7 +8976,7 @@ export const deserializeAws_queryListInstanceProfilesForRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInstanceProfilesForRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListInstanceProfilesForRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9038,7 +9038,7 @@ export const deserializeAws_queryListMFADevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMFADevicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListMFADevicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9100,7 +9100,7 @@ export const deserializeAws_queryListOpenIDConnectProvidersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOpenIDConnectProvidersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListOpenIDConnectProvidersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9154,7 +9154,7 @@ export const deserializeAws_queryListPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9208,7 +9208,7 @@ export const deserializeAws_queryListPoliciesGrantingServiceAccessCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPoliciesGrantingServiceAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListPoliciesGrantingServiceAccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9273,7 +9273,7 @@ export const deserializeAws_queryListPolicyVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPolicyVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListPolicyVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9343,7 +9343,7 @@ export const deserializeAws_queryListRolePoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRolePoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListRolePoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9405,7 +9405,7 @@ export const deserializeAws_queryListRolesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRolesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListRolesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9459,7 +9459,7 @@ export const deserializeAws_queryListRoleTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRoleTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListRoleTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9521,7 +9521,7 @@ export const deserializeAws_queryListSAMLProvidersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSAMLProvidersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListSAMLProvidersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9575,7 +9575,7 @@ export const deserializeAws_queryListServerCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServerCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListServerCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9629,7 +9629,7 @@ export const deserializeAws_queryListServiceSpecificCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServiceSpecificCredentialsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListServiceSpecificCredentialsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9694,7 +9694,7 @@ export const deserializeAws_queryListSigningCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSigningCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListSigningCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9756,7 +9756,7 @@ export const deserializeAws_queryListSSHPublicKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSSHPublicKeysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListSSHPublicKeysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9810,7 +9810,7 @@ export const deserializeAws_queryListUserPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUserPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListUserPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9872,7 +9872,7 @@ export const deserializeAws_queryListUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUsersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListUsersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9926,7 +9926,7 @@ export const deserializeAws_queryListUserTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUserTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListUserTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9988,7 +9988,7 @@ export const deserializeAws_queryListVirtualMFADevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVirtualMFADevicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListVirtualMFADevicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10034,7 +10034,7 @@ export const deserializeAws_queryPutGroupPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutGroupPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutGroupPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10109,7 +10109,7 @@ export const deserializeAws_queryPutRolePermissionsBoundaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRolePermissionsBoundaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutRolePermissionsBoundaryCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10192,7 +10192,7 @@ export const deserializeAws_queryPutRolePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRolePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutRolePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10275,7 +10275,7 @@ export const deserializeAws_queryPutUserPermissionsBoundaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutUserPermissionsBoundaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutUserPermissionsBoundaryCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10350,7 +10350,7 @@ export const deserializeAws_queryPutUserPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutUserPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutUserPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10425,7 +10425,7 @@ export const deserializeAws_queryRemoveClientIDFromOpenIDConnectProviderCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveClientIDFromOpenIDConnectProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveClientIDFromOpenIDConnectProviderCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10492,7 +10492,7 @@ export const deserializeAws_queryRemoveRoleFromInstanceProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveRoleFromInstanceProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveRoleFromInstanceProfileCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10567,7 +10567,7 @@ export const deserializeAws_queryRemoveUserFromGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveUserFromGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveUserFromGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10634,7 +10634,7 @@ export const deserializeAws_queryResetServiceSpecificCredentialCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetServiceSpecificCredentialCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResetServiceSpecificCredentialCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10691,7 +10691,7 @@ export const deserializeAws_queryResyncMFADeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResyncMFADeviceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResyncMFADeviceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10766,7 +10766,7 @@ export const deserializeAws_querySetDefaultPolicyVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetDefaultPolicyVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetDefaultPolicyVersionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10841,7 +10841,7 @@ export const deserializeAws_querySetSecurityTokenServicePreferencesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetSecurityTokenServicePreferencesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetSecurityTokenServicePreferencesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10892,7 +10892,7 @@ export const deserializeAws_querySimulateCustomPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SimulateCustomPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySimulateCustomPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10954,7 +10954,7 @@ export const deserializeAws_querySimulatePrincipalPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SimulatePrincipalPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySimulatePrincipalPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11024,7 +11024,7 @@ export const deserializeAws_queryTagRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryTagRoleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11107,7 +11107,7 @@ export const deserializeAws_queryTagUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryTagUserCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11190,7 +11190,7 @@ export const deserializeAws_queryUntagRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUntagRoleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11257,7 +11257,7 @@ export const deserializeAws_queryUntagUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUntagUserCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11324,7 +11324,7 @@ export const deserializeAws_queryUpdateAccessKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAccessKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateAccessKeyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11391,7 +11391,7 @@ export const deserializeAws_queryUpdateAccountPasswordPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAccountPasswordPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateAccountPasswordPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11466,7 +11466,7 @@ export const deserializeAws_queryUpdateAssumeRolePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAssumeRolePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateAssumeRolePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11549,7 +11549,7 @@ export const deserializeAws_queryUpdateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11624,7 +11624,7 @@ export const deserializeAws_queryUpdateLoginProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLoginProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateLoginProfileCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11707,7 +11707,7 @@ export const deserializeAws_queryUpdateOpenIDConnectProviderThumbprintCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateOpenIDConnectProviderThumbprintCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateOpenIDConnectProviderThumbprintCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -11774,7 +11774,7 @@ export const deserializeAws_queryUpdateRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11844,7 +11844,7 @@ export const deserializeAws_queryUpdateRoleDescriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRoleDescriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateRoleDescriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11914,7 +11914,7 @@ export const deserializeAws_queryUpdateSAMLProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSAMLProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateSAMLProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11992,7 +11992,7 @@ export const deserializeAws_queryUpdateServerCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServerCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateServerCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -12067,7 +12067,7 @@ export const deserializeAws_queryUpdateServiceSpecificCredentialCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServiceSpecificCredentialCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateServiceSpecificCredentialCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -12118,7 +12118,7 @@ export const deserializeAws_queryUpdateSigningCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSigningCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateSigningCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -12185,7 +12185,7 @@ export const deserializeAws_queryUpdateSSHPublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSSHPublicKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateSSHPublicKeyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -12236,7 +12236,7 @@ export const deserializeAws_queryUpdateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateUserCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -12327,7 +12327,7 @@ export const deserializeAws_queryUploadServerCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UploadServerCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUploadServerCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12413,7 +12413,7 @@ export const deserializeAws_queryUploadSigningCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UploadSigningCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUploadSigningCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12515,7 +12515,7 @@ export const deserializeAws_queryUploadSSHPublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UploadSSHPublicKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUploadSSHPublicKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-imagebuilder/protocols/Aws_restJson1.ts
+++ b/clients/client-imagebuilder/protocols/Aws_restJson1.ts
@@ -1388,7 +1388,7 @@ export const deserializeAws_restJson1CancelImageCreationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelImageCreationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelImageCreationCommandError(output, context);
   }
   const contents: CancelImageCreationCommandOutput = {
@@ -1507,7 +1507,7 @@ export const deserializeAws_restJson1CreateComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateComponentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateComponentCommandError(output, context);
   }
   const contents: CreateComponentCommandOutput = {
@@ -1650,7 +1650,7 @@ export const deserializeAws_restJson1CreateDistributionConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDistributionConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDistributionConfigurationCommandError(output, context);
   }
   const contents: CreateDistributionConfigurationCommandOutput = {
@@ -1793,7 +1793,7 @@ export const deserializeAws_restJson1CreateImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateImageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateImageCommandError(output, context);
   }
   const contents: CreateImageCommandOutput = {
@@ -1920,7 +1920,7 @@ export const deserializeAws_restJson1CreateImagePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateImagePipelineCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateImagePipelineCommandError(output, context);
   }
   const contents: CreateImagePipelineCommandOutput = {
@@ -2055,7 +2055,7 @@ export const deserializeAws_restJson1CreateImageRecipeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateImageRecipeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateImageRecipeCommandError(output, context);
   }
   const contents: CreateImageRecipeCommandOutput = {
@@ -2198,7 +2198,7 @@ export const deserializeAws_restJson1CreateInfrastructureConfigurationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInfrastructureConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateInfrastructureConfigurationCommandError(output, context);
   }
   const contents: CreateInfrastructureConfigurationCommandOutput = {
@@ -2333,7 +2333,7 @@ export const deserializeAws_restJson1DeleteComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteComponentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteComponentCommandError(output, context);
   }
   const contents: DeleteComponentCommandOutput = {
@@ -2440,7 +2440,7 @@ export const deserializeAws_restJson1DeleteDistributionConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDistributionConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDistributionConfigurationCommandError(output, context);
   }
   const contents: DeleteDistributionConfigurationCommandOutput = {
@@ -2547,7 +2547,7 @@ export const deserializeAws_restJson1DeleteImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteImageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteImageCommandError(output, context);
   }
   const contents: DeleteImageCommandOutput = {
@@ -2654,7 +2654,7 @@ export const deserializeAws_restJson1DeleteImagePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteImagePipelineCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteImagePipelineCommandError(output, context);
   }
   const contents: DeleteImagePipelineCommandOutput = {
@@ -2761,7 +2761,7 @@ export const deserializeAws_restJson1DeleteImageRecipeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteImageRecipeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteImageRecipeCommandError(output, context);
   }
   const contents: DeleteImageRecipeCommandOutput = {
@@ -2868,7 +2868,7 @@ export const deserializeAws_restJson1DeleteInfrastructureConfigurationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInfrastructureConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteInfrastructureConfigurationCommandError(output, context);
   }
   const contents: DeleteInfrastructureConfigurationCommandOutput = {
@@ -2975,7 +2975,7 @@ export const deserializeAws_restJson1GetComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetComponentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetComponentCommandError(output, context);
   }
   const contents: GetComponentCommandOutput = {
@@ -3074,7 +3074,7 @@ export const deserializeAws_restJson1GetComponentPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetComponentPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetComponentPolicyCommandError(output, context);
   }
   const contents: GetComponentPolicyCommandOutput = {
@@ -3173,7 +3173,7 @@ export const deserializeAws_restJson1GetDistributionConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDistributionConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDistributionConfigurationCommandError(output, context);
   }
   const contents: GetDistributionConfigurationCommandOutput = {
@@ -3275,7 +3275,7 @@ export const deserializeAws_restJson1GetImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetImageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetImageCommandError(output, context);
   }
   const contents: GetImageCommandOutput = {
@@ -3374,7 +3374,7 @@ export const deserializeAws_restJson1GetImagePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetImagePipelineCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetImagePipelineCommandError(output, context);
   }
   const contents: GetImagePipelineCommandOutput = {
@@ -3473,7 +3473,7 @@ export const deserializeAws_restJson1GetImagePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetImagePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetImagePolicyCommandError(output, context);
   }
   const contents: GetImagePolicyCommandOutput = {
@@ -3572,7 +3572,7 @@ export const deserializeAws_restJson1GetImageRecipeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetImageRecipeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetImageRecipeCommandError(output, context);
   }
   const contents: GetImageRecipeCommandOutput = {
@@ -3671,7 +3671,7 @@ export const deserializeAws_restJson1GetImageRecipePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetImageRecipePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetImageRecipePolicyCommandError(output, context);
   }
   const contents: GetImageRecipePolicyCommandOutput = {
@@ -3770,7 +3770,7 @@ export const deserializeAws_restJson1GetInfrastructureConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInfrastructureConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetInfrastructureConfigurationCommandError(output, context);
   }
   const contents: GetInfrastructureConfigurationCommandOutput = {
@@ -3872,7 +3872,7 @@ export const deserializeAws_restJson1ImportComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportComponentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ImportComponentCommandError(output, context);
   }
   const contents: ImportComponentCommandOutput = {
@@ -4007,7 +4007,7 @@ export const deserializeAws_restJson1ListComponentBuildVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListComponentBuildVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListComponentBuildVersionsCommandError(output, context);
   }
   const contents: ListComponentBuildVersionsCommandOutput = {
@@ -4118,7 +4118,7 @@ export const deserializeAws_restJson1ListComponentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListComponentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListComponentsCommandError(output, context);
   }
   const contents: ListComponentsCommandOutput = {
@@ -4229,7 +4229,7 @@ export const deserializeAws_restJson1ListDistributionConfigurationsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDistributionConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDistributionConfigurationsCommandError(output, context);
   }
   const contents: ListDistributionConfigurationsCommandOutput = {
@@ -4343,7 +4343,7 @@ export const deserializeAws_restJson1ListImageBuildVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListImageBuildVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListImageBuildVersionsCommandError(output, context);
   }
   const contents: ListImageBuildVersionsCommandOutput = {
@@ -4454,7 +4454,7 @@ export const deserializeAws_restJson1ListImagePipelineImagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListImagePipelineImagesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListImagePipelineImagesCommandError(output, context);
   }
   const contents: ListImagePipelineImagesCommandOutput = {
@@ -4573,7 +4573,7 @@ export const deserializeAws_restJson1ListImagePipelinesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListImagePipelinesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListImagePipelinesCommandError(output, context);
   }
   const contents: ListImagePipelinesCommandOutput = {
@@ -4684,7 +4684,7 @@ export const deserializeAws_restJson1ListImageRecipesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListImageRecipesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListImageRecipesCommandError(output, context);
   }
   const contents: ListImageRecipesCommandOutput = {
@@ -4798,7 +4798,7 @@ export const deserializeAws_restJson1ListImagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListImagesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListImagesCommandError(output, context);
   }
   const contents: ListImagesCommandOutput = {
@@ -4909,7 +4909,7 @@ export const deserializeAws_restJson1ListInfrastructureConfigurationsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInfrastructureConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListInfrastructureConfigurationsCommandError(output, context);
   }
   const contents: ListInfrastructureConfigurationsCommandOutput = {
@@ -5026,7 +5026,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -5097,7 +5097,7 @@ export const deserializeAws_restJson1PutComponentPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutComponentPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutComponentPolicyCommandError(output, context);
   }
   const contents: PutComponentPolicyCommandOutput = {
@@ -5212,7 +5212,7 @@ export const deserializeAws_restJson1PutImagePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutImagePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutImagePolicyCommandError(output, context);
   }
   const contents: PutImagePolicyCommandOutput = {
@@ -5327,7 +5327,7 @@ export const deserializeAws_restJson1PutImageRecipePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutImageRecipePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutImageRecipePolicyCommandError(output, context);
   }
   const contents: PutImageRecipePolicyCommandOutput = {
@@ -5442,7 +5442,7 @@ export const deserializeAws_restJson1StartImagePipelineExecutionCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartImagePipelineExecutionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartImagePipelineExecutionCommandError(output, context);
   }
   const contents: StartImagePipelineExecutionCommandOutput = {
@@ -5569,7 +5569,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -5636,7 +5636,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -5703,7 +5703,7 @@ export const deserializeAws_restJson1UpdateDistributionConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDistributionConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDistributionConfigurationCommandError(output, context);
   }
   const contents: UpdateDistributionConfigurationCommandOutput = {
@@ -5830,7 +5830,7 @@ export const deserializeAws_restJson1UpdateImagePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateImagePipelineCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateImagePipelineCommandError(output, context);
   }
   const contents: UpdateImagePipelineCommandOutput = {
@@ -5949,7 +5949,7 @@ export const deserializeAws_restJson1UpdateInfrastructureConfigurationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateInfrastructureConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateInfrastructureConfigurationCommandError(output, context);
   }
   const contents: UpdateInfrastructureConfigurationCommandOutput = {

--- a/clients/client-inspector/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/protocols/Aws_json1_1.ts
@@ -720,7 +720,7 @@ export const deserializeAws_json1_1AddAttributesToFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddAttributesToFindingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddAttributesToFindingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -807,7 +807,7 @@ export const deserializeAws_json1_1CreateAssessmentTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAssessmentTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAssessmentTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -910,7 +910,7 @@ export const deserializeAws_json1_1CreateAssessmentTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAssessmentTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAssessmentTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1005,7 +1005,7 @@ export const deserializeAws_json1_1CreateExclusionsPreviewCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateExclusionsPreviewCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateExclusionsPreviewCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1100,7 +1100,7 @@ export const deserializeAws_json1_1CreateResourceGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResourceGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateResourceGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1187,7 +1187,7 @@ export const deserializeAws_json1_1DeleteAssessmentRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAssessmentRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAssessmentRunCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1279,7 +1279,7 @@ export const deserializeAws_json1_1DeleteAssessmentTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAssessmentTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAssessmentTargetCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1371,7 +1371,7 @@ export const deserializeAws_json1_1DeleteAssessmentTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAssessmentTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAssessmentTemplateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1463,7 +1463,7 @@ export const deserializeAws_json1_1DescribeAssessmentRunsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAssessmentRunsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAssessmentRunsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1526,7 +1526,7 @@ export const deserializeAws_json1_1DescribeAssessmentTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAssessmentTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAssessmentTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1589,7 +1589,7 @@ export const deserializeAws_json1_1DescribeAssessmentTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAssessmentTemplatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAssessmentTemplatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1652,7 +1652,7 @@ export const deserializeAws_json1_1DescribeCrossAccountAccessRoleCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCrossAccountAccessRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCrossAccountAccessRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1707,7 +1707,7 @@ export const deserializeAws_json1_1DescribeExclusionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeExclusionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeExclusionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1770,7 +1770,7 @@ export const deserializeAws_json1_1DescribeFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFindingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFindingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1833,7 +1833,7 @@ export const deserializeAws_json1_1DescribeResourceGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeResourceGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeResourceGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1896,7 +1896,7 @@ export const deserializeAws_json1_1DescribeRulesPackagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRulesPackagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRulesPackagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1959,7 +1959,7 @@ export const deserializeAws_json1_1GetAssessmentReportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAssessmentReportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAssessmentReportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2062,7 +2062,7 @@ export const deserializeAws_json1_1GetExclusionsPreviewCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetExclusionsPreviewCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetExclusionsPreviewCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2141,7 +2141,7 @@ export const deserializeAws_json1_1GetTelemetryMetadataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTelemetryMetadataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTelemetryMetadataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2220,7 +2220,7 @@ export const deserializeAws_json1_1ListAssessmentRunAgentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssessmentRunAgentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssessmentRunAgentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2299,7 +2299,7 @@ export const deserializeAws_json1_1ListAssessmentRunsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssessmentRunsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssessmentRunsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2378,7 +2378,7 @@ export const deserializeAws_json1_1ListAssessmentTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssessmentTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssessmentTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2449,7 +2449,7 @@ export const deserializeAws_json1_1ListAssessmentTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssessmentTemplatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssessmentTemplatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2528,7 +2528,7 @@ export const deserializeAws_json1_1ListEventSubscriptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEventSubscriptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEventSubscriptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2607,7 +2607,7 @@ export const deserializeAws_json1_1ListExclusionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListExclusionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListExclusionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2686,7 +2686,7 @@ export const deserializeAws_json1_1ListFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFindingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListFindingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2765,7 +2765,7 @@ export const deserializeAws_json1_1ListRulesPackagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRulesPackagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRulesPackagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2836,7 +2836,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2915,7 +2915,7 @@ export const deserializeAws_json1_1PreviewAgentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PreviewAgentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PreviewAgentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3002,7 +3002,7 @@ export const deserializeAws_json1_1RegisterCrossAccountAccessRoleCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterCrossAccountAccessRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterCrossAccountAccessRoleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3086,7 +3086,7 @@ export const deserializeAws_json1_1RemoveAttributesFromFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveAttributesFromFindingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveAttributesFromFindingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3173,7 +3173,7 @@ export const deserializeAws_json1_1SetTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetTagsForResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3257,7 +3257,7 @@ export const deserializeAws_json1_1StartAssessmentRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartAssessmentRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartAssessmentRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3368,7 +3368,7 @@ export const deserializeAws_json1_1StopAssessmentRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopAssessmentRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopAssessmentRunCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3452,7 +3452,7 @@ export const deserializeAws_json1_1SubscribeToEventCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SubscribeToEventCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SubscribeToEventCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3544,7 +3544,7 @@ export const deserializeAws_json1_1UnsubscribeFromEventCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnsubscribeFromEventCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UnsubscribeFromEventCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3628,7 +3628,7 @@ export const deserializeAws_json1_1UpdateAssessmentTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAssessmentTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAssessmentTargetCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-iot-1click-devices-service/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-devices-service/protocols/Aws_restJson1.ts
@@ -470,7 +470,7 @@ export const deserializeAws_restJson1ClaimDevicesByClaimCodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ClaimDevicesByClaimCodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ClaimDevicesByClaimCodeCommandError(output, context);
   }
   const contents: ClaimDevicesByClaimCodeCommandOutput = {
@@ -545,7 +545,7 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDeviceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDeviceCommandError(output, context);
   }
   const contents: DescribeDeviceCommandOutput = {
@@ -616,7 +616,7 @@ export const deserializeAws_restJson1FinalizeDeviceClaimCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FinalizeDeviceClaimCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1FinalizeDeviceClaimCommandError(output, context);
   }
   const contents: FinalizeDeviceClaimCommandOutput = {
@@ -703,7 +703,7 @@ export const deserializeAws_restJson1GetDeviceMethodsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeviceMethodsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeviceMethodsCommandError(output, context);
   }
   const contents: GetDeviceMethodsCommandOutput = {
@@ -774,7 +774,7 @@ export const deserializeAws_restJson1InitiateDeviceClaimCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InitiateDeviceClaimCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1InitiateDeviceClaimCommandError(output, context);
   }
   const contents: InitiateDeviceClaimCommandOutput = {
@@ -853,7 +853,7 @@ export const deserializeAws_restJson1InvokeDeviceMethodCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InvokeDeviceMethodCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1InvokeDeviceMethodCommandError(output, context);
   }
   const contents: InvokeDeviceMethodCommandOutput = {
@@ -948,7 +948,7 @@ export const deserializeAws_restJson1ListDeviceEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeviceEventsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDeviceEventsCommandError(output, context);
   }
   const contents: ListDeviceEventsCommandOutput = {
@@ -1031,7 +1031,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDevicesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDevicesCommandError(output, context);
   }
   const contents: ListDevicesCommandOutput = {
@@ -1106,7 +1106,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1169,7 +1169,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1236,7 +1236,7 @@ export const deserializeAws_restJson1UnclaimDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnclaimDeviceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UnclaimDeviceCommandError(output, context);
   }
   const contents: UnclaimDeviceCommandOutput = {
@@ -1307,7 +1307,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -1374,7 +1374,7 @@ export const deserializeAws_restJson1UpdateDeviceStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDeviceStateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDeviceStateCommandError(output, context);
   }
   const contents: UpdateDeviceStateCommandOutput = {

--- a/clients/client-iot-1click-projects/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-projects/protocols/Aws_restJson1.ts
@@ -634,7 +634,7 @@ export const deserializeAws_restJson1AssociateDeviceWithPlacementCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateDeviceWithPlacementCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateDeviceWithPlacementCommandError(output, context);
   }
   const contents: AssociateDeviceWithPlacementCommandOutput = {
@@ -709,7 +709,7 @@ export const deserializeAws_restJson1CreatePlacementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePlacementCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePlacementCommandError(output, context);
   }
   const contents: CreatePlacementCommandOutput = {
@@ -784,7 +784,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateProjectCommandError(output, context);
   }
   const contents: CreateProjectCommandOutput = {
@@ -851,7 +851,7 @@ export const deserializeAws_restJson1DeletePlacementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePlacementCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePlacementCommandError(output, context);
   }
   const contents: DeletePlacementCommandOutput = {
@@ -926,7 +926,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteProjectCommandError(output, context);
   }
   const contents: DeleteProjectCommandOutput = {
@@ -1001,7 +1001,7 @@ export const deserializeAws_restJson1DescribePlacementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePlacementCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribePlacementCommandError(output, context);
   }
   const contents: DescribePlacementCommandOutput = {
@@ -1072,7 +1072,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeProjectCommandError(output, context);
   }
   const contents: DescribeProjectCommandOutput = {
@@ -1143,7 +1143,7 @@ export const deserializeAws_restJson1DisassociateDeviceFromPlacementCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateDeviceFromPlacementCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateDeviceFromPlacementCommandError(output, context);
   }
   const contents: DisassociateDeviceFromPlacementCommandOutput = {
@@ -1218,7 +1218,7 @@ export const deserializeAws_restJson1GetDevicesInPlacementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDevicesInPlacementCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDevicesInPlacementCommandError(output, context);
   }
   const contents: GetDevicesInPlacementCommandOutput = {
@@ -1289,7 +1289,7 @@ export const deserializeAws_restJson1ListPlacementsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPlacementsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPlacementsCommandError(output, context);
   }
   const contents: ListPlacementsCommandOutput = {
@@ -1364,7 +1364,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProjectsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProjectsCommandError(output, context);
   }
   const contents: ListProjectsCommandOutput = {
@@ -1431,7 +1431,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1502,7 +1502,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1569,7 +1569,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -1636,7 +1636,7 @@ export const deserializeAws_restJson1UpdatePlacementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePlacementCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePlacementCommandError(output, context);
   }
   const contents: UpdatePlacementCommandOutput = {
@@ -1711,7 +1711,7 @@ export const deserializeAws_restJson1UpdateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateProjectCommandError(output, context);
   }
   const contents: UpdateProjectCommandOutput = {

--- a/clients/client-iot-data-plane/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-data-plane/protocols/Aws_restJson1.ts
@@ -211,7 +211,7 @@ export const deserializeAws_restJson1DeleteThingShadowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteThingShadowCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteThingShadowCommandError(output, context);
   }
   const contents: DeleteThingShadowCommandOutput = {
@@ -320,7 +320,7 @@ export const deserializeAws_restJson1GetThingShadowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetThingShadowCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetThingShadowCommandError(output, context);
   }
   const contents: GetThingShadowCommandOutput = {
@@ -429,7 +429,7 @@ export const deserializeAws_restJson1ListNamedShadowsForThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNamedShadowsForThingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListNamedShadowsForThingCommandError(output, context);
   }
   const contents: ListNamedShadowsForThingCommandOutput = {
@@ -540,7 +540,7 @@ export const deserializeAws_restJson1PublishCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PublishCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PublishCommandError(output, context);
   }
   const contents: PublishCommandOutput = {
@@ -615,7 +615,7 @@ export const deserializeAws_restJson1UpdateThingShadowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateThingShadowCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateThingShadowCommandError(output, context);
   }
   const contents: UpdateThingShadowCommandOutput = {

--- a/clients/client-iot-events-data/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events-data/protocols/Aws_restJson1.ts
@@ -161,7 +161,7 @@ export const deserializeAws_restJson1BatchPutMessageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchPutMessageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchPutMessageCommandError(output, context);
   }
   const contents: BatchPutMessageCommandOutput = {
@@ -243,7 +243,7 @@ export const deserializeAws_restJson1BatchUpdateDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchUpdateDetectorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchUpdateDetectorCommandError(output, context);
   }
   const contents: BatchUpdateDetectorCommandOutput = {
@@ -325,7 +325,7 @@ export const deserializeAws_restJson1DescribeDetectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDetectorCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDetectorCommandError(output, context);
   }
   const contents: DescribeDetectorCommandOutput = {
@@ -412,7 +412,7 @@ export const deserializeAws_restJson1ListDetectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDetectorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDetectorsCommandError(output, context);
   }
   const contents: ListDetectorsCommandOutput = {

--- a/clients/client-iot-events/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events/protocols/Aws_restJson1.ts
@@ -572,7 +572,7 @@ export const deserializeAws_restJson1CreateDetectorModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDetectorModelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDetectorModelCommandError(output, context);
   }
   const contents: CreateDetectorModelCommandOutput = {
@@ -678,7 +678,7 @@ export const deserializeAws_restJson1CreateInputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInputCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateInputCommandError(output, context);
   }
   const contents: CreateInputCommandOutput = {
@@ -765,7 +765,7 @@ export const deserializeAws_restJson1DeleteDetectorModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDetectorModelCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDetectorModelCommandError(output, context);
   }
   const contents: DeleteDetectorModelCommandOutput = {
@@ -856,7 +856,7 @@ export const deserializeAws_restJson1DeleteInputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteInputCommandError(output, context);
   }
   const contents: DeleteInputCommandOutput = {
@@ -947,7 +947,7 @@ export const deserializeAws_restJson1DescribeDetectorModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDetectorModelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDetectorModelCommandError(output, context);
   }
   const contents: DescribeDetectorModelCommandOutput = {
@@ -1034,7 +1034,7 @@ export const deserializeAws_restJson1DescribeInputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeInputCommandError(output, context);
   }
   const contents: DescribeInputCommandOutput = {
@@ -1121,7 +1121,7 @@ export const deserializeAws_restJson1DescribeLoggingOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoggingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeLoggingOptionsCommandError(output, context);
   }
   const contents: DescribeLoggingOptionsCommandOutput = {
@@ -1216,7 +1216,7 @@ export const deserializeAws_restJson1ListDetectorModelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDetectorModelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDetectorModelsCommandError(output, context);
   }
   const contents: ListDetectorModelsCommandOutput = {
@@ -1302,7 +1302,7 @@ export const deserializeAws_restJson1ListDetectorModelVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDetectorModelVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDetectorModelVersionsCommandError(output, context);
   }
   const contents: ListDetectorModelVersionsCommandOutput = {
@@ -1396,7 +1396,7 @@ export const deserializeAws_restJson1ListInputsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInputsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListInputsCommandError(output, context);
   }
   const contents: ListInputsCommandOutput = {
@@ -1479,7 +1479,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1566,7 +1566,7 @@ export const deserializeAws_restJson1PutLoggingOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLoggingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutLoggingOptionsCommandError(output, context);
   }
   const contents: PutLoggingOptionsCommandOutput = {
@@ -1657,7 +1657,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1748,7 +1748,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -1831,7 +1831,7 @@ export const deserializeAws_restJson1UpdateDetectorModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDetectorModelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDetectorModelCommandError(output, context);
   }
   const contents: UpdateDetectorModelCommandOutput = {
@@ -1929,7 +1929,7 @@ export const deserializeAws_restJson1UpdateInputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateInputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateInputCommandError(output, context);
   }
   const contents: UpdateInputCommandOutput = {

--- a/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1.ts
@@ -199,7 +199,7 @@ export const deserializeAws_restJson1DescribeJobExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJobExecutionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeJobExecutionCommandError(output, context);
   }
   const contents: DescribeJobExecutionCommandOutput = {
@@ -294,7 +294,7 @@ export const deserializeAws_restJson1GetPendingJobExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPendingJobExecutionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPendingJobExecutionsCommandError(output, context);
   }
   const contents: GetPendingJobExecutionsCommandOutput = {
@@ -385,7 +385,7 @@ export const deserializeAws_restJson1StartNextPendingJobExecutionCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartNextPendingJobExecutionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartNextPendingJobExecutionCommandError(output, context);
   }
   const contents: StartNextPendingJobExecutionCommandOutput = {
@@ -472,7 +472,7 @@ export const deserializeAws_restJson1UpdateJobExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateJobExecutionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateJobExecutionCommandError(output, context);
   }
   const contents: UpdateJobExecutionCommandOutput = {

--- a/clients/client-iot/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1.ts
@@ -7390,7 +7390,7 @@ export const deserializeAws_restJson1AcceptCertificateTransferCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptCertificateTransferCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AcceptCertificateTransferCommandError(output, context);
   }
   const contents: AcceptCertificateTransferCommandOutput = {
@@ -7489,7 +7489,7 @@ export const deserializeAws_restJson1AddThingToBillingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddThingToBillingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddThingToBillingGroupCommandError(output, context);
   }
   const contents: AddThingToBillingGroupCommandOutput = {
@@ -7564,7 +7564,7 @@ export const deserializeAws_restJson1AddThingToThingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddThingToThingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddThingToThingGroupCommandError(output, context);
   }
   const contents: AddThingToThingGroupCommandOutput = {
@@ -7639,7 +7639,7 @@ export const deserializeAws_restJson1AssociateTargetsWithJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateTargetsWithJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateTargetsWithJobCommandError(output, context);
   }
   const contents: AssociateTargetsWithJobCommandOutput = {
@@ -7734,7 +7734,7 @@ export const deserializeAws_restJson1AttachPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AttachPolicyCommandError(output, context);
   }
   const contents: AttachPolicyCommandOutput = {
@@ -7833,7 +7833,7 @@ export const deserializeAws_restJson1AttachPrincipalPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachPrincipalPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AttachPrincipalPolicyCommandError(output, context);
   }
   const contents: AttachPrincipalPolicyCommandOutput = {
@@ -7932,7 +7932,7 @@ export const deserializeAws_restJson1AttachSecurityProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachSecurityProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AttachSecurityProfileCommandError(output, context);
   }
   const contents: AttachSecurityProfileCommandOutput = {
@@ -8023,7 +8023,7 @@ export const deserializeAws_restJson1AttachThingPrincipalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachThingPrincipalCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AttachThingPrincipalCommandError(output, context);
   }
   const contents: AttachThingPrincipalCommandOutput = {
@@ -8114,7 +8114,7 @@ export const deserializeAws_restJson1CancelAuditMitigationActionsTaskCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelAuditMitigationActionsTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelAuditMitigationActionsTaskCommandError(output, context);
   }
   const contents: CancelAuditMitigationActionsTaskCommandOutput = {
@@ -8189,7 +8189,7 @@ export const deserializeAws_restJson1CancelAuditTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelAuditTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelAuditTaskCommandError(output, context);
   }
   const contents: CancelAuditTaskCommandOutput = {
@@ -8264,7 +8264,7 @@ export const deserializeAws_restJson1CancelCertificateTransferCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelCertificateTransferCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelCertificateTransferCommandError(output, context);
   }
   const contents: CancelCertificateTransferCommandOutput = {
@@ -8363,7 +8363,7 @@ export const deserializeAws_restJson1CancelJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelJobCommandError(output, context);
   }
   const contents: CancelJobCommandOutput = {
@@ -8450,7 +8450,7 @@ export const deserializeAws_restJson1CancelJobExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelJobExecutionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelJobExecutionCommandError(output, context);
   }
   const contents: CancelJobExecutionCommandOutput = {
@@ -8541,7 +8541,7 @@ export const deserializeAws_restJson1ClearDefaultAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ClearDefaultAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ClearDefaultAuthorizerCommandError(output, context);
   }
   const contents: ClearDefaultAuthorizerCommandOutput = {
@@ -8632,7 +8632,7 @@ export const deserializeAws_restJson1ConfirmTopicRuleDestinationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfirmTopicRuleDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ConfirmTopicRuleDestinationCommandError(output, context);
   }
   const contents: ConfirmTopicRuleDestinationCommandOutput = {
@@ -8715,7 +8715,7 @@ export const deserializeAws_restJson1CreateAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAuthorizerCommandError(output, context);
   }
   const contents: CreateAuthorizerCommandOutput = {
@@ -8822,7 +8822,7 @@ export const deserializeAws_restJson1CreateBillingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBillingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateBillingGroupCommandError(output, context);
   }
   const contents: CreateBillingGroupCommandOutput = {
@@ -8909,7 +8909,7 @@ export const deserializeAws_restJson1CreateCertificateFromCsrCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCertificateFromCsrCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCertificateFromCsrCommandError(output, context);
   }
   const contents: CreateCertificateFromCsrCommandOutput = {
@@ -9004,7 +9004,7 @@ export const deserializeAws_restJson1CreateDimensionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDimensionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDimensionCommandError(output, context);
   }
   const contents: CreateDimensionCommandOutput = {
@@ -9095,7 +9095,7 @@ export const deserializeAws_restJson1CreateDomainConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDomainConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDomainConfigurationCommandError(output, context);
   }
   const contents: CreateDomainConfigurationCommandOutput = {
@@ -9210,7 +9210,7 @@ export const deserializeAws_restJson1CreateDynamicThingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDynamicThingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDynamicThingGroupCommandError(output, context);
   }
   const contents: CreateDynamicThingGroupCommandOutput = {
@@ -9333,7 +9333,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateJobCommandError(output, context);
   }
   const contents: CreateJobCommandOutput = {
@@ -9436,7 +9436,7 @@ export const deserializeAws_restJson1CreateKeysAndCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateKeysAndCertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateKeysAndCertificateCommandError(output, context);
   }
   const contents: CreateKeysAndCertificateCommandOutput = {
@@ -9535,7 +9535,7 @@ export const deserializeAws_restJson1CreateMitigationActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMitigationActionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMitigationActionCommandError(output, context);
   }
   const contents: CreateMitigationActionCommandOutput = {
@@ -9626,7 +9626,7 @@ export const deserializeAws_restJson1CreateOTAUpdateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOTAUpdateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateOTAUpdateCommandError(output, context);
   }
   const contents: CreateOTAUpdateCommandOutput = {
@@ -9753,7 +9753,7 @@ export const deserializeAws_restJson1CreatePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePolicyCommandError(output, context);
   }
   const contents: CreatePolicyCommandOutput = {
@@ -9868,7 +9868,7 @@ export const deserializeAws_restJson1CreatePolicyVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePolicyVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePolicyVersionCommandError(output, context);
   }
   const contents: CreatePolicyVersionCommandOutput = {
@@ -9991,7 +9991,7 @@ export const deserializeAws_restJson1CreateProvisioningClaimCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProvisioningClaimCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateProvisioningClaimCommandError(output, context);
   }
   const contents: CreateProvisioningClaimCommandOutput = {
@@ -10098,7 +10098,7 @@ export const deserializeAws_restJson1CreateProvisioningTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProvisioningTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateProvisioningTemplateCommandError(output, context);
   }
   const contents: CreateProvisioningTemplateCommandOutput = {
@@ -10201,7 +10201,7 @@ export const deserializeAws_restJson1CreateProvisioningTemplateVersionCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProvisioningTemplateVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateProvisioningTemplateVersionCommandError(output, context);
   }
   const contents: CreateProvisioningTemplateVersionCommandOutput = {
@@ -10316,7 +10316,7 @@ export const deserializeAws_restJson1CreateRoleAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRoleAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRoleAliasCommandError(output, context);
   }
   const contents: CreateRoleAliasCommandOutput = {
@@ -10423,7 +10423,7 @@ export const deserializeAws_restJson1CreateScheduledAuditCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateScheduledAuditCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateScheduledAuditCommandError(output, context);
   }
   const contents: CreateScheduledAuditCommandOutput = {
@@ -10510,7 +10510,7 @@ export const deserializeAws_restJson1CreateSecurityProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSecurityProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSecurityProfileCommandError(output, context);
   }
   const contents: CreateSecurityProfileCommandOutput = {
@@ -10593,7 +10593,7 @@ export const deserializeAws_restJson1CreateStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateStreamCommandError(output, context);
   }
   const contents: CreateStreamCommandOutput = {
@@ -10716,7 +10716,7 @@ export const deserializeAws_restJson1CreateThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateThingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateThingCommandError(output, context);
   }
   const contents: CreateThingCommandOutput = {
@@ -10827,7 +10827,7 @@ export const deserializeAws_restJson1CreateThingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateThingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateThingGroupCommandError(output, context);
   }
   const contents: CreateThingGroupCommandOutput = {
@@ -10914,7 +10914,7 @@ export const deserializeAws_restJson1CreateThingTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateThingTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateThingTypeCommandError(output, context);
   }
   const contents: CreateThingTypeCommandOutput = {
@@ -11017,7 +11017,7 @@ export const deserializeAws_restJson1CreateTopicRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTopicRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateTopicRuleCommandError(output, context);
   }
   const contents: CreateTopicRuleCommandOutput = {
@@ -11108,7 +11108,7 @@ export const deserializeAws_restJson1CreateTopicRuleDestinationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTopicRuleDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateTopicRuleDestinationCommandError(output, context);
   }
   const contents: CreateTopicRuleDestinationCommandOutput = {
@@ -11195,7 +11195,7 @@ export const deserializeAws_restJson1DeleteAccountAuditConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccountAuditConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAccountAuditConfigurationCommandError(output, context);
   }
   const contents: DeleteAccountAuditConfigurationCommandOutput = {
@@ -11270,7 +11270,7 @@ export const deserializeAws_restJson1DeleteAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAuthorizerCommandError(output, context);
   }
   const contents: DeleteAuthorizerCommandOutput = {
@@ -11369,7 +11369,7 @@ export const deserializeAws_restJson1DeleteBillingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBillingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBillingGroupCommandError(output, context);
   }
   const contents: DeleteBillingGroupCommandOutput = {
@@ -11444,7 +11444,7 @@ export const deserializeAws_restJson1DeleteCACertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCACertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteCACertificateCommandError(output, context);
   }
   const contents: DeleteCACertificateCommandOutput = {
@@ -11543,7 +11543,7 @@ export const deserializeAws_restJson1DeleteCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteCertificateCommandError(output, context);
   }
   const contents: DeleteCertificateCommandOutput = {
@@ -11650,7 +11650,7 @@ export const deserializeAws_restJson1DeleteDimensionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDimensionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDimensionCommandError(output, context);
   }
   const contents: DeleteDimensionCommandOutput = {
@@ -11717,7 +11717,7 @@ export const deserializeAws_restJson1DeleteDomainConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDomainConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDomainConfigurationCommandError(output, context);
   }
   const contents: DeleteDomainConfigurationCommandOutput = {
@@ -11808,7 +11808,7 @@ export const deserializeAws_restJson1DeleteDynamicThingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDynamicThingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDynamicThingGroupCommandError(output, context);
   }
   const contents: DeleteDynamicThingGroupCommandOutput = {
@@ -11883,7 +11883,7 @@ export const deserializeAws_restJson1DeleteJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteJobCommandError(output, context);
   }
   const contents: DeleteJobCommandOutput = {
@@ -11974,7 +11974,7 @@ export const deserializeAws_restJson1DeleteJobExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteJobExecutionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteJobExecutionCommandError(output, context);
   }
   const contents: DeleteJobExecutionCommandOutput = {
@@ -12057,7 +12057,7 @@ export const deserializeAws_restJson1DeleteMitigationActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMitigationActionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMitigationActionCommandError(output, context);
   }
   const contents: DeleteMitigationActionCommandOutput = {
@@ -12124,7 +12124,7 @@ export const deserializeAws_restJson1DeleteOTAUpdateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOTAUpdateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteOTAUpdateCommandError(output, context);
   }
   const contents: DeleteOTAUpdateCommandOutput = {
@@ -12223,7 +12223,7 @@ export const deserializeAws_restJson1DeletePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePolicyCommandError(output, context);
   }
   const contents: DeletePolicyCommandOutput = {
@@ -12322,7 +12322,7 @@ export const deserializeAws_restJson1DeletePolicyVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePolicyVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePolicyVersionCommandError(output, context);
   }
   const contents: DeletePolicyVersionCommandOutput = {
@@ -12421,7 +12421,7 @@ export const deserializeAws_restJson1DeleteProvisioningTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProvisioningTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteProvisioningTemplateCommandError(output, context);
   }
   const contents: DeleteProvisioningTemplateCommandOutput = {
@@ -12512,7 +12512,7 @@ export const deserializeAws_restJson1DeleteProvisioningTemplateVersionCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProvisioningTemplateVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteProvisioningTemplateVersionCommandError(output, context);
   }
   const contents: DeleteProvisioningTemplateVersionCommandOutput = {
@@ -12603,7 +12603,7 @@ export const deserializeAws_restJson1DeleteRegistrationCodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRegistrationCodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRegistrationCodeCommandError(output, context);
   }
   const contents: DeleteRegistrationCodeCommandOutput = {
@@ -12686,7 +12686,7 @@ export const deserializeAws_restJson1DeleteRoleAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRoleAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRoleAliasCommandError(output, context);
   }
   const contents: DeleteRoleAliasCommandOutput = {
@@ -12785,7 +12785,7 @@ export const deserializeAws_restJson1DeleteScheduledAuditCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteScheduledAuditCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteScheduledAuditCommandError(output, context);
   }
   const contents: DeleteScheduledAuditCommandOutput = {
@@ -12860,7 +12860,7 @@ export const deserializeAws_restJson1DeleteSecurityProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSecurityProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSecurityProfileCommandError(output, context);
   }
   const contents: DeleteSecurityProfileCommandOutput = {
@@ -12935,7 +12935,7 @@ export const deserializeAws_restJson1DeleteStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteStreamCommandError(output, context);
   }
   const contents: DeleteStreamCommandOutput = {
@@ -13034,7 +13034,7 @@ export const deserializeAws_restJson1DeleteThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteThingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteThingCommandError(output, context);
   }
   const contents: DeleteThingCommandOutput = {
@@ -13133,7 +13133,7 @@ export const deserializeAws_restJson1DeleteThingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteThingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteThingGroupCommandError(output, context);
   }
   const contents: DeleteThingGroupCommandOutput = {
@@ -13208,7 +13208,7 @@ export const deserializeAws_restJson1DeleteThingTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteThingTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteThingTypeCommandError(output, context);
   }
   const contents: DeleteThingTypeCommandOutput = {
@@ -13299,7 +13299,7 @@ export const deserializeAws_restJson1DeleteTopicRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTopicRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteTopicRuleCommandError(output, context);
   }
   const contents: DeleteTopicRuleCommandOutput = {
@@ -13382,7 +13382,7 @@ export const deserializeAws_restJson1DeleteTopicRuleDestinationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTopicRuleDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteTopicRuleDestinationCommandError(output, context);
   }
   const contents: DeleteTopicRuleDestinationCommandOutput = {
@@ -13465,7 +13465,7 @@ export const deserializeAws_restJson1DeleteV2LoggingLevelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteV2LoggingLevelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteV2LoggingLevelCommandError(output, context);
   }
   const contents: DeleteV2LoggingLevelCommandOutput = {
@@ -13532,7 +13532,7 @@ export const deserializeAws_restJson1DeprecateThingTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeprecateThingTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeprecateThingTypeCommandError(output, context);
   }
   const contents: DeprecateThingTypeCommandOutput = {
@@ -13623,7 +13623,7 @@ export const deserializeAws_restJson1DescribeAccountAuditConfigurationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountAuditConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAccountAuditConfigurationCommandError(output, context);
   }
   const contents: DescribeAccountAuditConfigurationCommandOutput = {
@@ -13700,7 +13700,7 @@ export const deserializeAws_restJson1DescribeAuditFindingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAuditFindingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAuditFindingCommandError(output, context);
   }
   const contents: DescribeAuditFindingCommandOutput = {
@@ -13779,7 +13779,7 @@ export const deserializeAws_restJson1DescribeAuditMitigationActionsTaskCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAuditMitigationActionsTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAuditMitigationActionsTaskCommandError(output, context);
   }
   const contents: DescribeAuditMitigationActionsTaskCommandOutput = {
@@ -13888,7 +13888,7 @@ export const deserializeAws_restJson1DescribeAuditTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAuditTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAuditTaskCommandError(output, context);
   }
   const contents: DescribeAuditTaskCommandOutput = {
@@ -13987,7 +13987,7 @@ export const deserializeAws_restJson1DescribeAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAuthorizerCommandError(output, context);
   }
   const contents: DescribeAuthorizerCommandOutput = {
@@ -14082,7 +14082,7 @@ export const deserializeAws_restJson1DescribeBillingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBillingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeBillingGroupCommandError(output, context);
   }
   const contents: DescribeBillingGroupCommandOutput = {
@@ -14184,7 +14184,7 @@ export const deserializeAws_restJson1DescribeCACertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCACertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeCACertificateCommandError(output, context);
   }
   const contents: DescribeCACertificateCommandOutput = {
@@ -14286,7 +14286,7 @@ export const deserializeAws_restJson1DescribeCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeCertificateCommandError(output, context);
   }
   const contents: DescribeCertificateCommandOutput = {
@@ -14384,7 +14384,7 @@ export const deserializeAws_restJson1DescribeDefaultAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDefaultAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDefaultAuthorizerCommandError(output, context);
   }
   const contents: DescribeDefaultAuthorizerCommandOutput = {
@@ -14479,7 +14479,7 @@ export const deserializeAws_restJson1DescribeDimensionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDimensionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDimensionCommandError(output, context);
   }
   const contents: DescribeDimensionCommandOutput = {
@@ -14578,7 +14578,7 @@ export const deserializeAws_restJson1DescribeDomainConfigurationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDomainConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDomainConfigurationCommandError(output, context);
   }
   const contents: DescribeDomainConfigurationCommandOutput = {
@@ -14701,7 +14701,7 @@ export const deserializeAws_restJson1DescribeEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEndpointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeEndpointCommandError(output, context);
   }
   const contents: DescribeEndpointCommandOutput = {
@@ -14780,7 +14780,7 @@ export const deserializeAws_restJson1DescribeEventConfigurationsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeEventConfigurationsCommandError(output, context);
   }
   const contents: DescribeEventConfigurationsCommandOutput = {
@@ -14851,7 +14851,7 @@ export const deserializeAws_restJson1DescribeIndexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIndexCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeIndexCommandError(output, context);
   }
   const contents: DescribeIndexCommandOutput = {
@@ -14954,7 +14954,7 @@ export const deserializeAws_restJson1DescribeJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeJobCommandError(output, context);
   }
   const contents: DescribeJobCommandOutput = {
@@ -15037,7 +15037,7 @@ export const deserializeAws_restJson1DescribeJobExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJobExecutionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeJobExecutionCommandError(output, context);
   }
   const contents: DescribeJobExecutionCommandOutput = {
@@ -15116,7 +15116,7 @@ export const deserializeAws_restJson1DescribeMitigationActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMitigationActionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeMitigationActionCommandError(output, context);
   }
   const contents: DescribeMitigationActionCommandOutput = {
@@ -15223,7 +15223,7 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProvisioningTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeProvisioningTemplateCommandError(output, context);
   }
   const contents: DescribeProvisioningTemplateCommandOutput = {
@@ -15346,7 +15346,7 @@ export const deserializeAws_restJson1DescribeProvisioningTemplateVersionCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProvisioningTemplateVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeProvisioningTemplateVersionCommandError(output, context);
   }
   const contents: DescribeProvisioningTemplateVersionCommandOutput = {
@@ -15445,7 +15445,7 @@ export const deserializeAws_restJson1DescribeRoleAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRoleAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRoleAliasCommandError(output, context);
   }
   const contents: DescribeRoleAliasCommandOutput = {
@@ -15540,7 +15540,7 @@ export const deserializeAws_restJson1DescribeScheduledAuditCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScheduledAuditCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeScheduledAuditCommandError(output, context);
   }
   const contents: DescribeScheduledAuditCommandOutput = {
@@ -15639,7 +15639,7 @@ export const deserializeAws_restJson1DescribeSecurityProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSecurityProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSecurityProfileCommandError(output, context);
   }
   const contents: DescribeSecurityProfileCommandOutput = {
@@ -15760,7 +15760,7 @@ export const deserializeAws_restJson1DescribeStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeStreamCommandError(output, context);
   }
   const contents: DescribeStreamCommandOutput = {
@@ -15855,7 +15855,7 @@ export const deserializeAws_restJson1DescribeThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeThingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeThingCommandError(output, context);
   }
   const contents: DescribeThingCommandOutput = {
@@ -15978,7 +15978,7 @@ export const deserializeAws_restJson1DescribeThingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeThingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeThingGroupCommandError(output, context);
   }
   const contents: DescribeThingGroupCommandOutput = {
@@ -16093,7 +16093,7 @@ export const deserializeAws_restJson1DescribeThingRegistrationTaskCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeThingRegistrationTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeThingRegistrationTaskCommandError(output, context);
   }
   const contents: DescribeThingRegistrationTaskCommandOutput = {
@@ -16224,7 +16224,7 @@ export const deserializeAws_restJson1DescribeThingTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeThingTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeThingTypeCommandError(output, context);
   }
   const contents: DescribeThingTypeCommandOutput = {
@@ -16335,7 +16335,7 @@ export const deserializeAws_restJson1DetachPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DetachPolicyCommandError(output, context);
   }
   const contents: DetachPolicyCommandOutput = {
@@ -16426,7 +16426,7 @@ export const deserializeAws_restJson1DetachPrincipalPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachPrincipalPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DetachPrincipalPolicyCommandError(output, context);
   }
   const contents: DetachPrincipalPolicyCommandOutput = {
@@ -16517,7 +16517,7 @@ export const deserializeAws_restJson1DetachSecurityProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachSecurityProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DetachSecurityProfileCommandError(output, context);
   }
   const contents: DetachSecurityProfileCommandOutput = {
@@ -16592,7 +16592,7 @@ export const deserializeAws_restJson1DetachThingPrincipalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachThingPrincipalCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DetachThingPrincipalCommandError(output, context);
   }
   const contents: DetachThingPrincipalCommandOutput = {
@@ -16683,7 +16683,7 @@ export const deserializeAws_restJson1DisableTopicRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableTopicRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisableTopicRuleCommandError(output, context);
   }
   const contents: DisableTopicRuleCommandOutput = {
@@ -16766,7 +16766,7 @@ export const deserializeAws_restJson1EnableTopicRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableTopicRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1EnableTopicRuleCommandError(output, context);
   }
   const contents: EnableTopicRuleCommandOutput = {
@@ -16849,7 +16849,7 @@ export const deserializeAws_restJson1GetCardinalityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCardinalityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCardinalityCommandError(output, context);
   }
   const contents: GetCardinalityCommandOutput = {
@@ -16968,7 +16968,7 @@ export const deserializeAws_restJson1GetEffectivePoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEffectivePoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEffectivePoliciesCommandError(output, context);
   }
   const contents: GetEffectivePoliciesCommandOutput = {
@@ -17071,7 +17071,7 @@ export const deserializeAws_restJson1GetIndexingConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIndexingConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIndexingConfigurationCommandError(output, context);
   }
   const contents: GetIndexingConfigurationCommandOutput = {
@@ -17168,7 +17168,7 @@ export const deserializeAws_restJson1GetJobDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobDocumentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJobDocumentCommandError(output, context);
   }
   const contents: GetJobDocumentCommandOutput = {
@@ -17247,7 +17247,7 @@ export const deserializeAws_restJson1GetLoggingOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoggingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLoggingOptionsCommandError(output, context);
   }
   const contents: GetLoggingOptionsCommandOutput = {
@@ -17322,7 +17322,7 @@ export const deserializeAws_restJson1GetOTAUpdateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOTAUpdateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetOTAUpdateCommandError(output, context);
   }
   const contents: GetOTAUpdateCommandOutput = {
@@ -17417,7 +17417,7 @@ export const deserializeAws_restJson1GetPercentilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPercentilesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPercentilesCommandError(output, context);
   }
   const contents: GetPercentilesCommandOutput = {
@@ -17536,7 +17536,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPolicyCommandError(output, context);
   }
   const contents: GetPolicyCommandOutput = {
@@ -17655,7 +17655,7 @@ export const deserializeAws_restJson1GetPolicyVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPolicyVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPolicyVersionCommandError(output, context);
   }
   const contents: GetPolicyVersionCommandOutput = {
@@ -17778,7 +17778,7 @@ export const deserializeAws_restJson1GetRegistrationCodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRegistrationCodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRegistrationCodeCommandError(output, context);
   }
   const contents: GetRegistrationCodeCommandOutput = {
@@ -17865,7 +17865,7 @@ export const deserializeAws_restJson1GetStatisticsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStatisticsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetStatisticsCommandError(output, context);
   }
   const contents: GetStatisticsCommandOutput = {
@@ -17984,7 +17984,7 @@ export const deserializeAws_restJson1GetTopicRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTopicRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTopicRuleCommandError(output, context);
   }
   const contents: GetTopicRuleCommandOutput = {
@@ -18067,7 +18067,7 @@ export const deserializeAws_restJson1GetTopicRuleDestinationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTopicRuleDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTopicRuleDestinationCommandError(output, context);
   }
   const contents: GetTopicRuleDestinationCommandOutput = {
@@ -18146,7 +18146,7 @@ export const deserializeAws_restJson1GetV2LoggingOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetV2LoggingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetV2LoggingOptionsCommandError(output, context);
   }
   const contents: GetV2LoggingOptionsCommandOutput = {
@@ -18225,7 +18225,7 @@ export const deserializeAws_restJson1ListActiveViolationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListActiveViolationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListActiveViolationsCommandError(output, context);
   }
   const contents: ListActiveViolationsCommandOutput = {
@@ -18308,7 +18308,7 @@ export const deserializeAws_restJson1ListAttachedPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAttachedPoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAttachedPoliciesCommandError(output, context);
   }
   const contents: ListAttachedPoliciesCommandOutput = {
@@ -18415,7 +18415,7 @@ export const deserializeAws_restJson1ListAuditFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAuditFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAuditFindingsCommandError(output, context);
   }
   const contents: ListAuditFindingsCommandOutput = {
@@ -18490,7 +18490,7 @@ export const deserializeAws_restJson1ListAuditMitigationActionsExecutionsCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAuditMitigationActionsExecutionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAuditMitigationActionsExecutionsCommandError(output, context);
   }
   const contents: ListAuditMitigationActionsExecutionsCommandOutput = {
@@ -18568,7 +18568,7 @@ export const deserializeAws_restJson1ListAuditMitigationActionsTasksCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAuditMitigationActionsTasksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAuditMitigationActionsTasksCommandError(output, context);
   }
   const contents: ListAuditMitigationActionsTasksCommandOutput = {
@@ -18643,7 +18643,7 @@ export const deserializeAws_restJson1ListAuditTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAuditTasksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAuditTasksCommandError(output, context);
   }
   const contents: ListAuditTasksCommandOutput = {
@@ -18718,7 +18718,7 @@ export const deserializeAws_restJson1ListAuthorizersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAuthorizersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAuthorizersCommandError(output, context);
   }
   const contents: ListAuthorizersCommandOutput = {
@@ -18809,7 +18809,7 @@ export const deserializeAws_restJson1ListBillingGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBillingGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBillingGroupsCommandError(output, context);
   }
   const contents: ListBillingGroupsCommandOutput = {
@@ -18892,7 +18892,7 @@ export const deserializeAws_restJson1ListCACertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCACertificatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListCACertificatesCommandError(output, context);
   }
   const contents: ListCACertificatesCommandOutput = {
@@ -18983,7 +18983,7 @@ export const deserializeAws_restJson1ListCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCertificatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListCertificatesCommandError(output, context);
   }
   const contents: ListCertificatesCommandOutput = {
@@ -19074,7 +19074,7 @@ export const deserializeAws_restJson1ListCertificatesByCACommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCertificatesByCACommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListCertificatesByCACommandError(output, context);
   }
   const contents: ListCertificatesByCACommandOutput = {
@@ -19165,7 +19165,7 @@ export const deserializeAws_restJson1ListDimensionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDimensionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDimensionsCommandError(output, context);
   }
   const contents: ListDimensionsCommandOutput = {
@@ -19240,7 +19240,7 @@ export const deserializeAws_restJson1ListDomainConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDomainConfigurationsCommandError(output, context);
   }
   const contents: ListDomainConfigurationsCommandOutput = {
@@ -19331,7 +19331,7 @@ export const deserializeAws_restJson1ListIndicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIndicesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListIndicesCommandError(output, context);
   }
   const contents: ListIndicesCommandOutput = {
@@ -19422,7 +19422,7 @@ export const deserializeAws_restJson1ListJobExecutionsForJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobExecutionsForJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobExecutionsForJobCommandError(output, context);
   }
   const contents: ListJobExecutionsForJobCommandOutput = {
@@ -19508,7 +19508,7 @@ export const deserializeAws_restJson1ListJobExecutionsForThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobExecutionsForThingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobExecutionsForThingCommandError(output, context);
   }
   const contents: ListJobExecutionsForThingCommandOutput = {
@@ -19594,7 +19594,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobsCommandError(output, context);
   }
   const contents: ListJobsCommandOutput = {
@@ -19677,7 +19677,7 @@ export const deserializeAws_restJson1ListMitigationActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMitigationActionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMitigationActionsCommandError(output, context);
   }
   const contents: ListMitigationActionsCommandOutput = {
@@ -19755,7 +19755,7 @@ export const deserializeAws_restJson1ListOTAUpdatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOTAUpdatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListOTAUpdatesCommandError(output, context);
   }
   const contents: ListOTAUpdatesCommandOutput = {
@@ -19846,7 +19846,7 @@ export const deserializeAws_restJson1ListOutgoingCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOutgoingCertificatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListOutgoingCertificatesCommandError(output, context);
   }
   const contents: ListOutgoingCertificatesCommandOutput = {
@@ -19937,7 +19937,7 @@ export const deserializeAws_restJson1ListPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPoliciesCommandError(output, context);
   }
   const contents: ListPoliciesCommandOutput = {
@@ -20028,7 +20028,7 @@ export const deserializeAws_restJson1ListPolicyPrincipalsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPolicyPrincipalsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPolicyPrincipalsCommandError(output, context);
   }
   const contents: ListPolicyPrincipalsCommandOutput = {
@@ -20127,7 +20127,7 @@ export const deserializeAws_restJson1ListPolicyVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPolicyVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPolicyVersionsCommandError(output, context);
   }
   const contents: ListPolicyVersionsCommandOutput = {
@@ -20222,7 +20222,7 @@ export const deserializeAws_restJson1ListPrincipalPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPrincipalPoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPrincipalPoliciesCommandError(output, context);
   }
   const contents: ListPrincipalPoliciesCommandOutput = {
@@ -20321,7 +20321,7 @@ export const deserializeAws_restJson1ListPrincipalThingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPrincipalThingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPrincipalThingsCommandError(output, context);
   }
   const contents: ListPrincipalThingsCommandOutput = {
@@ -20420,7 +20420,7 @@ export const deserializeAws_restJson1ListProvisioningTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProvisioningTemplatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProvisioningTemplatesCommandError(output, context);
   }
   const contents: ListProvisioningTemplatesCommandOutput = {
@@ -20503,7 +20503,7 @@ export const deserializeAws_restJson1ListProvisioningTemplateVersionsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProvisioningTemplateVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProvisioningTemplateVersionsCommandError(output, context);
   }
   const contents: ListProvisioningTemplateVersionsCommandOutput = {
@@ -20594,7 +20594,7 @@ export const deserializeAws_restJson1ListRoleAliasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRoleAliasesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRoleAliasesCommandError(output, context);
   }
   const contents: ListRoleAliasesCommandOutput = {
@@ -20685,7 +20685,7 @@ export const deserializeAws_restJson1ListScheduledAuditsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListScheduledAuditsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListScheduledAuditsCommandError(output, context);
   }
   const contents: ListScheduledAuditsCommandOutput = {
@@ -20760,7 +20760,7 @@ export const deserializeAws_restJson1ListSecurityProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSecurityProfilesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSecurityProfilesCommandError(output, context);
   }
   const contents: ListSecurityProfilesCommandOutput = {
@@ -20846,7 +20846,7 @@ export const deserializeAws_restJson1ListSecurityProfilesForTargetCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSecurityProfilesForTargetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSecurityProfilesForTargetCommandError(output, context);
   }
   const contents: ListSecurityProfilesForTargetCommandOutput = {
@@ -20932,7 +20932,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStreamsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListStreamsCommandError(output, context);
   }
   const contents: ListStreamsCommandOutput = {
@@ -21023,7 +21023,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -21106,7 +21106,7 @@ export const deserializeAws_restJson1ListTargetsForPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTargetsForPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTargetsForPolicyCommandError(output, context);
   }
   const contents: ListTargetsForPolicyCommandOutput = {
@@ -21213,7 +21213,7 @@ export const deserializeAws_restJson1ListTargetsForSecurityProfileCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTargetsForSecurityProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTargetsForSecurityProfileCommandError(output, context);
   }
   const contents: ListTargetsForSecurityProfileCommandOutput = {
@@ -21299,7 +21299,7 @@ export const deserializeAws_restJson1ListThingGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThingGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThingGroupsCommandError(output, context);
   }
   const contents: ListThingGroupsCommandOutput = {
@@ -21374,7 +21374,7 @@ export const deserializeAws_restJson1ListThingGroupsForThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThingGroupsForThingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThingGroupsForThingCommandError(output, context);
   }
   const contents: ListThingGroupsForThingCommandOutput = {
@@ -21449,7 +21449,7 @@ export const deserializeAws_restJson1ListThingPrincipalsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThingPrincipalsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThingPrincipalsCommandError(output, context);
   }
   const contents: ListThingPrincipalsCommandOutput = {
@@ -21544,7 +21544,7 @@ export const deserializeAws_restJson1ListThingRegistrationTaskReportsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThingRegistrationTaskReportsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThingRegistrationTaskReportsCommandError(output, context);
   }
   const contents: ListThingRegistrationTaskReportsCommandOutput = {
@@ -21631,7 +21631,7 @@ export const deserializeAws_restJson1ListThingRegistrationTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThingRegistrationTasksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThingRegistrationTasksCommandError(output, context);
   }
   const contents: ListThingRegistrationTasksCommandOutput = {
@@ -21714,7 +21714,7 @@ export const deserializeAws_restJson1ListThingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThingsCommandError(output, context);
   }
   const contents: ListThingsCommandOutput = {
@@ -21805,7 +21805,7 @@ export const deserializeAws_restJson1ListThingsInBillingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThingsInBillingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThingsInBillingGroupCommandError(output, context);
   }
   const contents: ListThingsInBillingGroupCommandOutput = {
@@ -21888,7 +21888,7 @@ export const deserializeAws_restJson1ListThingsInThingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThingsInThingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThingsInThingGroupCommandError(output, context);
   }
   const contents: ListThingsInThingGroupCommandOutput = {
@@ -21963,7 +21963,7 @@ export const deserializeAws_restJson1ListThingTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThingTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThingTypesCommandError(output, context);
   }
   const contents: ListThingTypesCommandOutput = {
@@ -22054,7 +22054,7 @@ export const deserializeAws_restJson1ListTopicRuleDestinationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTopicRuleDestinationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTopicRuleDestinationsCommandError(output, context);
   }
   const contents: ListTopicRuleDestinationsCommandOutput = {
@@ -22140,7 +22140,7 @@ export const deserializeAws_restJson1ListTopicRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTopicRulesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTopicRulesCommandError(output, context);
   }
   const contents: ListTopicRulesCommandOutput = {
@@ -22215,7 +22215,7 @@ export const deserializeAws_restJson1ListV2LoggingLevelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListV2LoggingLevelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListV2LoggingLevelsCommandError(output, context);
   }
   const contents: ListV2LoggingLevelsCommandOutput = {
@@ -22301,7 +22301,7 @@ export const deserializeAws_restJson1ListViolationEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListViolationEventsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListViolationEventsCommandError(output, context);
   }
   const contents: ListViolationEventsCommandOutput = {
@@ -22376,7 +22376,7 @@ export const deserializeAws_restJson1RegisterCACertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterCACertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegisterCACertificateCommandError(output, context);
   }
   const contents: RegisterCACertificateCommandOutput = {
@@ -22499,7 +22499,7 @@ export const deserializeAws_restJson1RegisterCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterCertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegisterCertificateCommandError(output, context);
   }
   const contents: RegisterCertificateCommandOutput = {
@@ -22622,7 +22622,7 @@ export const deserializeAws_restJson1RegisterCertificateWithoutCACommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterCertificateWithoutCACommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegisterCertificateWithoutCACommandError(output, context);
   }
   const contents: RegisterCertificateWithoutCACommandOutput = {
@@ -22737,7 +22737,7 @@ export const deserializeAws_restJson1RegisterThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterThingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegisterThingCommandError(output, context);
   }
   const contents: RegisterThingCommandOutput = {
@@ -22844,7 +22844,7 @@ export const deserializeAws_restJson1RejectCertificateTransferCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectCertificateTransferCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RejectCertificateTransferCommandError(output, context);
   }
   const contents: RejectCertificateTransferCommandOutput = {
@@ -22943,7 +22943,7 @@ export const deserializeAws_restJson1RemoveThingFromBillingGroupCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveThingFromBillingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveThingFromBillingGroupCommandError(output, context);
   }
   const contents: RemoveThingFromBillingGroupCommandOutput = {
@@ -23018,7 +23018,7 @@ export const deserializeAws_restJson1RemoveThingFromThingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveThingFromThingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveThingFromThingGroupCommandError(output, context);
   }
   const contents: RemoveThingFromThingGroupCommandOutput = {
@@ -23093,7 +23093,7 @@ export const deserializeAws_restJson1ReplaceTopicRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReplaceTopicRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ReplaceTopicRuleCommandError(output, context);
   }
   const contents: ReplaceTopicRuleCommandOutput = {
@@ -23184,7 +23184,7 @@ export const deserializeAws_restJson1SearchIndexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchIndexCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SearchIndexCommandError(output, context);
   }
   const contents: SearchIndexCommandOutput = {
@@ -23303,7 +23303,7 @@ export const deserializeAws_restJson1SetDefaultAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetDefaultAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SetDefaultAuthorizerCommandError(output, context);
   }
   const contents: SetDefaultAuthorizerCommandOutput = {
@@ -23410,7 +23410,7 @@ export const deserializeAws_restJson1SetDefaultPolicyVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetDefaultPolicyVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SetDefaultPolicyVersionCommandError(output, context);
   }
   const contents: SetDefaultPolicyVersionCommandOutput = {
@@ -23501,7 +23501,7 @@ export const deserializeAws_restJson1SetLoggingOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetLoggingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SetLoggingOptionsCommandError(output, context);
   }
   const contents: SetLoggingOptionsCommandOutput = {
@@ -23568,7 +23568,7 @@ export const deserializeAws_restJson1SetV2LoggingLevelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetV2LoggingLevelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SetV2LoggingLevelCommandError(output, context);
   }
   const contents: SetV2LoggingLevelCommandOutput = {
@@ -23643,7 +23643,7 @@ export const deserializeAws_restJson1SetV2LoggingOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetV2LoggingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SetV2LoggingOptionsCommandError(output, context);
   }
   const contents: SetV2LoggingOptionsCommandOutput = {
@@ -23710,7 +23710,7 @@ export const deserializeAws_restJson1StartAuditMitigationActionsTaskCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartAuditMitigationActionsTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartAuditMitigationActionsTaskCommandError(output, context);
   }
   const contents: StartAuditMitigationActionsTaskCommandOutput = {
@@ -23797,7 +23797,7 @@ export const deserializeAws_restJson1StartOnDemandAuditTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartOnDemandAuditTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartOnDemandAuditTaskCommandError(output, context);
   }
   const contents: StartOnDemandAuditTaskCommandOutput = {
@@ -23876,7 +23876,7 @@ export const deserializeAws_restJson1StartThingRegistrationTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartThingRegistrationTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartThingRegistrationTaskCommandError(output, context);
   }
   const contents: StartThingRegistrationTaskCommandOutput = {
@@ -23955,7 +23955,7 @@ export const deserializeAws_restJson1StopThingRegistrationTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopThingRegistrationTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopThingRegistrationTaskCommandError(output, context);
   }
   const contents: StopThingRegistrationTaskCommandOutput = {
@@ -24038,7 +24038,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -24121,7 +24121,7 @@ export const deserializeAws_restJson1TestAuthorizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestAuthorizationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TestAuthorizationCommandError(output, context);
   }
   const contents: TestAuthorizationCommandOutput = {
@@ -24224,7 +24224,7 @@ export const deserializeAws_restJson1TestInvokeAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestInvokeAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TestInvokeAuthorizerCommandError(output, context);
   }
   const contents: TestInvokeAuthorizerCommandOutput = {
@@ -24343,7 +24343,7 @@ export const deserializeAws_restJson1TransferCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TransferCertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TransferCertificateCommandError(output, context);
   }
   const contents: TransferCertificateCommandOutput = {
@@ -24454,7 +24454,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -24529,7 +24529,7 @@ export const deserializeAws_restJson1UpdateAccountAuditConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAccountAuditConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAccountAuditConfigurationCommandError(output, context);
   }
   const contents: UpdateAccountAuditConfigurationCommandOutput = {
@@ -24596,7 +24596,7 @@ export const deserializeAws_restJson1UpdateAuthorizerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAuthorizerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAuthorizerCommandError(output, context);
   }
   const contents: UpdateAuthorizerCommandOutput = {
@@ -24703,7 +24703,7 @@ export const deserializeAws_restJson1UpdateBillingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBillingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateBillingGroupCommandError(output, context);
   }
   const contents: UpdateBillingGroupCommandOutput = {
@@ -24790,7 +24790,7 @@ export const deserializeAws_restJson1UpdateCACertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCACertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateCACertificateCommandError(output, context);
   }
   const contents: UpdateCACertificateCommandOutput = {
@@ -24881,7 +24881,7 @@ export const deserializeAws_restJson1UpdateCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCertificateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateCertificateCommandError(output, context);
   }
   const contents: UpdateCertificateCommandOutput = {
@@ -24980,7 +24980,7 @@ export const deserializeAws_restJson1UpdateDimensionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDimensionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDimensionCommandError(output, context);
   }
   const contents: UpdateDimensionCommandOutput = {
@@ -25079,7 +25079,7 @@ export const deserializeAws_restJson1UpdateDomainConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDomainConfigurationCommandError(output, context);
   }
   const contents: UpdateDomainConfigurationCommandOutput = {
@@ -25186,7 +25186,7 @@ export const deserializeAws_restJson1UpdateDynamicThingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDynamicThingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDynamicThingGroupCommandError(output, context);
   }
   const contents: UpdateDynamicThingGroupCommandOutput = {
@@ -25281,7 +25281,7 @@ export const deserializeAws_restJson1UpdateEventConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEventConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateEventConfigurationsCommandError(output, context);
   }
   const contents: UpdateEventConfigurationsCommandOutput = {
@@ -25348,7 +25348,7 @@ export const deserializeAws_restJson1UpdateIndexingConfigurationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIndexingConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateIndexingConfigurationCommandError(output, context);
   }
   const contents: UpdateIndexingConfigurationCommandOutput = {
@@ -25431,7 +25431,7 @@ export const deserializeAws_restJson1UpdateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateJobCommandError(output, context);
   }
   const contents: UpdateJobCommandOutput = {
@@ -25506,7 +25506,7 @@ export const deserializeAws_restJson1UpdateMitigationActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMitigationActionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMitigationActionCommandError(output, context);
   }
   const contents: UpdateMitigationActionCommandOutput = {
@@ -25589,7 +25589,7 @@ export const deserializeAws_restJson1UpdateProvisioningTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProvisioningTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateProvisioningTemplateCommandError(output, context);
   }
   const contents: UpdateProvisioningTemplateCommandOutput = {
@@ -25672,7 +25672,7 @@ export const deserializeAws_restJson1UpdateRoleAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRoleAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRoleAliasCommandError(output, context);
   }
   const contents: UpdateRoleAliasCommandOutput = {
@@ -25771,7 +25771,7 @@ export const deserializeAws_restJson1UpdateScheduledAuditCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateScheduledAuditCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateScheduledAuditCommandError(output, context);
   }
   const contents: UpdateScheduledAuditCommandOutput = {
@@ -25850,7 +25850,7 @@ export const deserializeAws_restJson1UpdateSecurityProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSecurityProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSecurityProfileCommandError(output, context);
   }
   const contents: UpdateSecurityProfileCommandOutput = {
@@ -25979,7 +25979,7 @@ export const deserializeAws_restJson1UpdateStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateStreamCommandError(output, context);
   }
   const contents: UpdateStreamCommandOutput = {
@@ -26086,7 +26086,7 @@ export const deserializeAws_restJson1UpdateThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateThingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateThingCommandError(output, context);
   }
   const contents: UpdateThingCommandOutput = {
@@ -26185,7 +26185,7 @@ export const deserializeAws_restJson1UpdateThingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateThingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateThingGroupCommandError(output, context);
   }
   const contents: UpdateThingGroupCommandOutput = {
@@ -26272,7 +26272,7 @@ export const deserializeAws_restJson1UpdateThingGroupsForThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateThingGroupsForThingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateThingGroupsForThingCommandError(output, context);
   }
   const contents: UpdateThingGroupsForThingCommandOutput = {
@@ -26347,7 +26347,7 @@ export const deserializeAws_restJson1UpdateTopicRuleDestinationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTopicRuleDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateTopicRuleDestinationCommandError(output, context);
   }
   const contents: UpdateTopicRuleDestinationCommandOutput = {
@@ -26430,7 +26430,7 @@ export const deserializeAws_restJson1ValidateSecurityProfileBehaviorsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ValidateSecurityProfileBehaviorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ValidateSecurityProfileBehaviorsCommandError(output, context);
   }
   const contents: ValidateSecurityProfileBehaviorsCommandOutput = {

--- a/clients/client-iotanalytics/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1.ts
@@ -1202,7 +1202,7 @@ export const deserializeAws_restJson1BatchPutMessageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchPutMessageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchPutMessageCommandError(output, context);
   }
   const contents: BatchPutMessageCommandOutput = {
@@ -1292,7 +1292,7 @@ export const deserializeAws_restJson1CancelPipelineReprocessingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelPipelineReprocessingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelPipelineReprocessingCommandError(output, context);
   }
   const contents: CancelPipelineReprocessingCommandOutput = {
@@ -1375,7 +1375,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateChannelCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateChannelCommandError(output, context);
   }
   const contents: CreateChannelCommandOutput = {
@@ -1478,7 +1478,7 @@ export const deserializeAws_restJson1CreateDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDatasetCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDatasetCommandError(output, context);
   }
   const contents: CreateDatasetCommandOutput = {
@@ -1581,7 +1581,7 @@ export const deserializeAws_restJson1CreateDatasetContentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDatasetContentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDatasetContentCommandError(output, context);
   }
   const contents: CreateDatasetContentCommandOutput = {
@@ -1668,7 +1668,7 @@ export const deserializeAws_restJson1CreateDatastoreCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDatastoreCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDatastoreCommandError(output, context);
   }
   const contents: CreateDatastoreCommandOutput = {
@@ -1771,7 +1771,7 @@ export const deserializeAws_restJson1CreatePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePipelineCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePipelineCommandError(output, context);
   }
   const contents: CreatePipelineCommandOutput = {
@@ -1870,7 +1870,7 @@ export const deserializeAws_restJson1DeleteChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteChannelCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteChannelCommandError(output, context);
   }
   const contents: DeleteChannelCommandOutput = {
@@ -1953,7 +1953,7 @@ export const deserializeAws_restJson1DeleteDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDatasetCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDatasetCommandError(output, context);
   }
   const contents: DeleteDatasetCommandOutput = {
@@ -2036,7 +2036,7 @@ export const deserializeAws_restJson1DeleteDatasetContentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDatasetContentCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDatasetContentCommandError(output, context);
   }
   const contents: DeleteDatasetContentCommandOutput = {
@@ -2119,7 +2119,7 @@ export const deserializeAws_restJson1DeleteDatastoreCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDatastoreCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDatastoreCommandError(output, context);
   }
   const contents: DeleteDatastoreCommandOutput = {
@@ -2202,7 +2202,7 @@ export const deserializeAws_restJson1DeletePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePipelineCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePipelineCommandError(output, context);
   }
   const contents: DeletePipelineCommandOutput = {
@@ -2285,7 +2285,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeChannelCommandError(output, context);
   }
   const contents: DescribeChannelCommandOutput = {
@@ -2376,7 +2376,7 @@ export const deserializeAws_restJson1DescribeDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDatasetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDatasetCommandError(output, context);
   }
   const contents: DescribeDatasetCommandOutput = {
@@ -2463,7 +2463,7 @@ export const deserializeAws_restJson1DescribeDatastoreCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDatastoreCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDatastoreCommandError(output, context);
   }
   const contents: DescribeDatastoreCommandOutput = {
@@ -2554,7 +2554,7 @@ export const deserializeAws_restJson1DescribeLoggingOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoggingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeLoggingOptionsCommandError(output, context);
   }
   const contents: DescribeLoggingOptionsCommandOutput = {
@@ -2641,7 +2641,7 @@ export const deserializeAws_restJson1DescribePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePipelineCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribePipelineCommandError(output, context);
   }
   const contents: DescribePipelineCommandOutput = {
@@ -2728,7 +2728,7 @@ export const deserializeAws_restJson1GetDatasetContentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDatasetContentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDatasetContentCommandError(output, context);
   }
   const contents: GetDatasetContentCommandOutput = {
@@ -2823,7 +2823,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListChannelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListChannelsCommandError(output, context);
   }
   const contents: ListChannelsCommandOutput = {
@@ -2906,7 +2906,7 @@ export const deserializeAws_restJson1ListDatasetContentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatasetContentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDatasetContentsCommandError(output, context);
   }
   const contents: ListDatasetContentsCommandOutput = {
@@ -3000,7 +3000,7 @@ export const deserializeAws_restJson1ListDatasetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatasetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDatasetsCommandError(output, context);
   }
   const contents: ListDatasetsCommandOutput = {
@@ -3083,7 +3083,7 @@ export const deserializeAws_restJson1ListDatastoresCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatastoresCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDatastoresCommandError(output, context);
   }
   const contents: ListDatastoresCommandOutput = {
@@ -3166,7 +3166,7 @@ export const deserializeAws_restJson1ListPipelinesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPipelinesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPipelinesCommandError(output, context);
   }
   const contents: ListPipelinesCommandOutput = {
@@ -3249,7 +3249,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -3344,7 +3344,7 @@ export const deserializeAws_restJson1PutLoggingOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLoggingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutLoggingOptionsCommandError(output, context);
   }
   const contents: PutLoggingOptionsCommandOutput = {
@@ -3419,7 +3419,7 @@ export const deserializeAws_restJson1RunPipelineActivityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RunPipelineActivityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RunPipelineActivityCommandError(output, context);
   }
   const contents: RunPipelineActivityCommandOutput = {
@@ -3502,7 +3502,7 @@ export const deserializeAws_restJson1SampleChannelDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SampleChannelDataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SampleChannelDataCommandError(output, context);
   }
   const contents: SampleChannelDataCommandOutput = {
@@ -3589,7 +3589,7 @@ export const deserializeAws_restJson1StartPipelineReprocessingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartPipelineReprocessingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartPipelineReprocessingCommandError(output, context);
   }
   const contents: StartPipelineReprocessingCommandOutput = {
@@ -3684,7 +3684,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -3775,7 +3775,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -3866,7 +3866,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateChannelCommandError(output, context);
   }
   const contents: UpdateChannelCommandOutput = {
@@ -3949,7 +3949,7 @@ export const deserializeAws_restJson1UpdateDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDatasetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDatasetCommandError(output, context);
   }
   const contents: UpdateDatasetCommandOutput = {
@@ -4032,7 +4032,7 @@ export const deserializeAws_restJson1UpdateDatastoreCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDatastoreCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDatastoreCommandError(output, context);
   }
   const contents: UpdateDatastoreCommandOutput = {
@@ -4115,7 +4115,7 @@ export const deserializeAws_restJson1UpdatePipelineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePipelineCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePipelineCommandError(output, context);
   }
   const contents: UpdatePipelineCommandOutput = {

--- a/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
+++ b/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
@@ -137,7 +137,7 @@ export const deserializeAws_json1_1CloseTunnelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CloseTunnelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CloseTunnelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -192,7 +192,7 @@ export const deserializeAws_json1_1DescribeTunnelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTunnelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTunnelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -247,7 +247,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -302,7 +302,7 @@ export const deserializeAws_json1_1ListTunnelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTunnelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTunnelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -349,7 +349,7 @@ export const deserializeAws_json1_1OpenTunnelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<OpenTunnelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1OpenTunnelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -404,7 +404,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -459,7 +459,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-iotsitewise/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/protocols/Aws_restJson1.ts
@@ -2252,7 +2252,7 @@ export const deserializeAws_restJson1AssociateAssetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateAssetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateAssetsCommandError(output, context);
   }
   const contents: AssociateAssetsCommandOutput = {
@@ -2343,7 +2343,7 @@ export const deserializeAws_restJson1BatchAssociateProjectAssetsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchAssociateProjectAssetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchAssociateProjectAssetsCommandError(output, context);
   }
   const contents: BatchAssociateProjectAssetsCommandOutput = {
@@ -2430,7 +2430,7 @@ export const deserializeAws_restJson1BatchDisassociateProjectAssetsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDisassociateProjectAssetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchDisassociateProjectAssetsCommandError(output, context);
   }
   const contents: BatchDisassociateProjectAssetsCommandOutput = {
@@ -2509,7 +2509,7 @@ export const deserializeAws_restJson1BatchPutAssetPropertyValueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchPutAssetPropertyValueCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchPutAssetPropertyValueCommandError(output, context);
   }
   const contents: BatchPutAssetPropertyValueCommandOutput = {
@@ -2612,7 +2612,7 @@ export const deserializeAws_restJson1CreateAccessPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAccessPolicyCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAccessPolicyCommandError(output, context);
   }
   const contents: CreateAccessPolicyCommandOutput = {
@@ -2703,7 +2703,7 @@ export const deserializeAws_restJson1CreateAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAssetCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAssetCommandError(output, context);
   }
   const contents: CreateAssetCommandOutput = {
@@ -2814,7 +2814,7 @@ export const deserializeAws_restJson1CreateAssetModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAssetModelCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAssetModelCommandError(output, context);
   }
   const contents: CreateAssetModelCommandOutput = {
@@ -2925,7 +2925,7 @@ export const deserializeAws_restJson1CreateDashboardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDashboardCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDashboardCommandError(output, context);
   }
   const contents: CreateDashboardCommandOutput = {
@@ -3016,7 +3016,7 @@ export const deserializeAws_restJson1CreateGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGatewayCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGatewayCommandError(output, context);
   }
   const contents: CreateGatewayCommandOutput = {
@@ -3107,7 +3107,7 @@ export const deserializeAws_restJson1CreatePortalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePortalCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePortalCommandError(output, context);
   }
   const contents: CreatePortalCommandOutput = {
@@ -3210,7 +3210,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProjectCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateProjectCommandError(output, context);
   }
   const contents: CreateProjectCommandOutput = {
@@ -3301,7 +3301,7 @@ export const deserializeAws_restJson1DeleteAccessPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccessPolicyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAccessPolicyCommandError(output, context);
   }
   const contents: DeleteAccessPolicyCommandOutput = {
@@ -3376,7 +3376,7 @@ export const deserializeAws_restJson1DeleteAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAssetCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAssetCommandError(output, context);
   }
   const contents: DeleteAssetCommandOutput = {
@@ -3463,7 +3463,7 @@ export const deserializeAws_restJson1DeleteAssetModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAssetModelCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAssetModelCommandError(output, context);
   }
   const contents: DeleteAssetModelCommandOutput = {
@@ -3550,7 +3550,7 @@ export const deserializeAws_restJson1DeleteDashboardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDashboardCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDashboardCommandError(output, context);
   }
   const contents: DeleteDashboardCommandOutput = {
@@ -3625,7 +3625,7 @@ export const deserializeAws_restJson1DeleteGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGatewayCommandError(output, context);
   }
   const contents: DeleteGatewayCommandOutput = {
@@ -3700,7 +3700,7 @@ export const deserializeAws_restJson1DeletePortalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePortalCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePortalCommandError(output, context);
   }
   const contents: DeletePortalCommandOutput = {
@@ -3787,7 +3787,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProjectCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteProjectCommandError(output, context);
   }
   const contents: DeleteProjectCommandOutput = {
@@ -3862,7 +3862,7 @@ export const deserializeAws_restJson1DescribeAccessPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccessPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAccessPolicyCommandError(output, context);
   }
   const contents: DescribeAccessPolicyCommandOutput = {
@@ -3965,7 +3965,7 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAssetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAssetCommandError(output, context);
   }
   const contents: DescribeAssetCommandOutput = {
@@ -4076,7 +4076,7 @@ export const deserializeAws_restJson1DescribeAssetModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAssetModelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAssetModelCommandError(output, context);
   }
   const contents: DescribeAssetModelCommandOutput = {
@@ -4187,7 +4187,7 @@ export const deserializeAws_restJson1DescribeAssetPropertyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAssetPropertyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAssetPropertyCommandError(output, context);
   }
   const contents: DescribeAssetPropertyCommandOutput = {
@@ -4278,7 +4278,7 @@ export const deserializeAws_restJson1DescribeDashboardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDashboardCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDashboardCommandError(output, context);
   }
   const contents: DescribeDashboardCommandOutput = {
@@ -4385,7 +4385,7 @@ export const deserializeAws_restJson1DescribeGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeGatewayCommandError(output, context);
   }
   const contents: DescribeGatewayCommandOutput = {
@@ -4491,7 +4491,7 @@ export const deserializeAws_restJson1DescribeGatewayCapabilityConfigurationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGatewayCapabilityConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeGatewayCapabilityConfigurationCommandError(output, context);
   }
   const contents: DescribeGatewayCapabilityConfigurationCommandOutput = {
@@ -4582,7 +4582,7 @@ export const deserializeAws_restJson1DescribeLoggingOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoggingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeLoggingOptionsCommandError(output, context);
   }
   const contents: DescribeLoggingOptionsCommandOutput = {
@@ -4661,7 +4661,7 @@ export const deserializeAws_restJson1DescribePortalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePortalCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribePortalCommandError(output, context);
   }
   const contents: DescribePortalCommandOutput = {
@@ -4784,7 +4784,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeProjectCommandError(output, context);
   }
   const contents: DescribeProjectCommandOutput = {
@@ -4887,7 +4887,7 @@ export const deserializeAws_restJson1DisassociateAssetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateAssetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateAssetsCommandError(output, context);
   }
   const contents: DisassociateAssetsCommandOutput = {
@@ -4970,7 +4970,7 @@ export const deserializeAws_restJson1GetAssetPropertyAggregatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAssetPropertyAggregatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAssetPropertyAggregatesCommandError(output, context);
   }
   const contents: GetAssetPropertyAggregatesCommandOutput = {
@@ -5061,7 +5061,7 @@ export const deserializeAws_restJson1GetAssetPropertyValueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAssetPropertyValueCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAssetPropertyValueCommandError(output, context);
   }
   const contents: GetAssetPropertyValueCommandOutput = {
@@ -5148,7 +5148,7 @@ export const deserializeAws_restJson1GetAssetPropertyValueHistoryCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAssetPropertyValueHistoryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAssetPropertyValueHistoryCommandError(output, context);
   }
   const contents: GetAssetPropertyValueHistoryCommandOutput = {
@@ -5242,7 +5242,7 @@ export const deserializeAws_restJson1ListAccessPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAccessPoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAccessPoliciesCommandError(output, context);
   }
   const contents: ListAccessPoliciesCommandOutput = {
@@ -5317,7 +5317,7 @@ export const deserializeAws_restJson1ListAssetModelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssetModelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAssetModelsCommandError(output, context);
   }
   const contents: ListAssetModelsCommandOutput = {
@@ -5392,7 +5392,7 @@ export const deserializeAws_restJson1ListAssetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAssetsCommandError(output, context);
   }
   const contents: ListAssetsCommandOutput = {
@@ -5475,7 +5475,7 @@ export const deserializeAws_restJson1ListAssociatedAssetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssociatedAssetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAssociatedAssetsCommandError(output, context);
   }
   const contents: ListAssociatedAssetsCommandOutput = {
@@ -5558,7 +5558,7 @@ export const deserializeAws_restJson1ListDashboardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDashboardsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDashboardsCommandError(output, context);
   }
   const contents: ListDashboardsCommandOutput = {
@@ -5633,7 +5633,7 @@ export const deserializeAws_restJson1ListGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGatewaysCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGatewaysCommandError(output, context);
   }
   const contents: ListGatewaysCommandOutput = {
@@ -5708,7 +5708,7 @@ export const deserializeAws_restJson1ListPortalsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPortalsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPortalsCommandError(output, context);
   }
   const contents: ListPortalsCommandOutput = {
@@ -5783,7 +5783,7 @@ export const deserializeAws_restJson1ListProjectAssetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProjectAssetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProjectAssetsCommandError(output, context);
   }
   const contents: ListProjectAssetsCommandOutput = {
@@ -5858,7 +5858,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProjectsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProjectsCommandError(output, context);
   }
   const contents: ListProjectsCommandOutput = {
@@ -5933,7 +5933,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -6012,7 +6012,7 @@ export const deserializeAws_restJson1PutLoggingOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLoggingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutLoggingOptionsCommandError(output, context);
   }
   const contents: PutLoggingOptionsCommandOutput = {
@@ -6095,7 +6095,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -6178,7 +6178,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -6253,7 +6253,7 @@ export const deserializeAws_restJson1UpdateAccessPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAccessPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAccessPolicyCommandError(output, context);
   }
   const contents: UpdateAccessPolicyCommandOutput = {
@@ -6328,7 +6328,7 @@ export const deserializeAws_restJson1UpdateAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAssetCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAssetCommandError(output, context);
   }
   const contents: UpdateAssetCommandOutput = {
@@ -6423,7 +6423,7 @@ export const deserializeAws_restJson1UpdateAssetModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAssetModelCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAssetModelCommandError(output, context);
   }
   const contents: UpdateAssetModelCommandOutput = {
@@ -6526,7 +6526,7 @@ export const deserializeAws_restJson1UpdateAssetPropertyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAssetPropertyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAssetPropertyCommandError(output, context);
   }
   const contents: UpdateAssetPropertyCommandOutput = {
@@ -6609,7 +6609,7 @@ export const deserializeAws_restJson1UpdateDashboardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDashboardCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDashboardCommandError(output, context);
   }
   const contents: UpdateDashboardCommandOutput = {
@@ -6684,7 +6684,7 @@ export const deserializeAws_restJson1UpdateGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGatewayCommandError(output, context);
   }
   const contents: UpdateGatewayCommandOutput = {
@@ -6767,7 +6767,7 @@ export const deserializeAws_restJson1UpdateGatewayCapabilityConfigurationCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGatewayCapabilityConfigurationCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGatewayCapabilityConfigurationCommandError(output, context);
   }
   const contents: UpdateGatewayCapabilityConfigurationCommandOutput = {
@@ -6866,7 +6866,7 @@ export const deserializeAws_restJson1UpdatePortalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePortalCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePortalCommandError(output, context);
   }
   const contents: UpdatePortalCommandOutput = {
@@ -6953,7 +6953,7 @@ export const deserializeAws_restJson1UpdateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateProjectCommandError(output, context);
   }
   const contents: UpdateProjectCommandOutput = {

--- a/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
+++ b/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
@@ -663,7 +663,7 @@ export const deserializeAws_json1_1AssociateEntityToThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateEntityToThingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateEntityToThingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -742,7 +742,7 @@ export const deserializeAws_json1_1CreateFlowTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFlowTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateFlowTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -829,7 +829,7 @@ export const deserializeAws_json1_1CreateSystemInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSystemInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSystemInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -916,7 +916,7 @@ export const deserializeAws_json1_1CreateSystemTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSystemTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSystemTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -995,7 +995,7 @@ export const deserializeAws_json1_1DeleteFlowTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFlowTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFlowTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1074,7 +1074,7 @@ export const deserializeAws_json1_1DeleteNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNamespaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteNamespaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1137,7 +1137,7 @@ export const deserializeAws_json1_1DeleteSystemInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSystemInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSystemInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1216,7 +1216,7 @@ export const deserializeAws_json1_1DeleteSystemTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSystemTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSystemTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1295,7 +1295,7 @@ export const deserializeAws_json1_1DeploySystemInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeploySystemInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeploySystemInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1382,7 +1382,7 @@ export const deserializeAws_json1_1DeprecateFlowTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeprecateFlowTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeprecateFlowTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1461,7 +1461,7 @@ export const deserializeAws_json1_1DeprecateSystemTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeprecateSystemTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeprecateSystemTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1540,7 +1540,7 @@ export const deserializeAws_json1_1DescribeNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNamespaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeNamespaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1619,7 +1619,7 @@ export const deserializeAws_json1_1DissociateEntityFromThingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DissociateEntityFromThingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DissociateEntityFromThingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1698,7 +1698,7 @@ export const deserializeAws_json1_1GetEntitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEntitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetEntitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1777,7 +1777,7 @@ export const deserializeAws_json1_1GetFlowTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFlowTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetFlowTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1856,7 +1856,7 @@ export const deserializeAws_json1_1GetFlowTemplateRevisionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFlowTemplateRevisionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetFlowTemplateRevisionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1935,7 +1935,7 @@ export const deserializeAws_json1_1GetNamespaceDeletionStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetNamespaceDeletionStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetNamespaceDeletionStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2006,7 +2006,7 @@ export const deserializeAws_json1_1GetSystemInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSystemInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSystemInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2085,7 +2085,7 @@ export const deserializeAws_json1_1GetSystemTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSystemTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSystemTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2164,7 +2164,7 @@ export const deserializeAws_json1_1GetSystemTemplateRevisionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSystemTemplateRevisionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSystemTemplateRevisionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2243,7 +2243,7 @@ export const deserializeAws_json1_1GetUploadStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUploadStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetUploadStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2322,7 +2322,7 @@ export const deserializeAws_json1_1ListFlowExecutionMessagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFlowExecutionMessagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListFlowExecutionMessagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2401,7 +2401,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2480,7 +2480,7 @@ export const deserializeAws_json1_1SearchEntitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchEntitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchEntitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2551,7 +2551,7 @@ export const deserializeAws_json1_1SearchFlowExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchFlowExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchFlowExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2630,7 +2630,7 @@ export const deserializeAws_json1_1SearchFlowTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchFlowTemplatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchFlowTemplatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2701,7 +2701,7 @@ export const deserializeAws_json1_1SearchSystemInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchSystemInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchSystemInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2772,7 +2772,7 @@ export const deserializeAws_json1_1SearchSystemTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchSystemTemplatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchSystemTemplatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2843,7 +2843,7 @@ export const deserializeAws_json1_1SearchThingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchThingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchThingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2922,7 +2922,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3001,7 +3001,7 @@ export const deserializeAws_json1_1UndeploySystemInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UndeploySystemInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UndeploySystemInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3088,7 +3088,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3167,7 +3167,7 @@ export const deserializeAws_json1_1UpdateFlowTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFlowTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateFlowTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3246,7 +3246,7 @@ export const deserializeAws_json1_1UpdateSystemTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSystemTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSystemTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3325,7 +3325,7 @@ export const deserializeAws_json1_1UploadEntityDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UploadEntityDefinitionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UploadEntityDefinitionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-ivs/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/protocols/Aws_restJson1.ts
@@ -528,7 +528,7 @@ export const deserializeAws_restJson1BatchGetChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchGetChannelCommandError(output, context);
   }
   const contents: BatchGetChannelCommandOutput = {
@@ -579,7 +579,7 @@ export const deserializeAws_restJson1BatchGetStreamKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetStreamKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchGetStreamKeyCommandError(output, context);
   }
   const contents: BatchGetStreamKeyCommandOutput = {
@@ -630,7 +630,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateChannelCommandError(output, context);
   }
   const contents: CreateChannelCommandOutput = {
@@ -713,7 +713,7 @@ export const deserializeAws_restJson1CreateStreamKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStreamKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateStreamKeyCommandError(output, context);
   }
   const contents: CreateStreamKeyCommandOutput = {
@@ -800,7 +800,7 @@ export const deserializeAws_restJson1DeleteChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteChannelCommandError(output, context);
   }
   const contents: DeleteChannelCommandOutput = {
@@ -883,7 +883,7 @@ export const deserializeAws_restJson1DeleteStreamKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStreamKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteStreamKeyCommandError(output, context);
   }
   const contents: DeleteStreamKeyCommandOutput = {
@@ -958,7 +958,7 @@ export const deserializeAws_restJson1GetChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetChannelCommandError(output, context);
   }
   const contents: GetChannelCommandOutput = {
@@ -1029,7 +1029,7 @@ export const deserializeAws_restJson1GetStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetStreamCommandError(output, context);
   }
   const contents: GetStreamCommandOutput = {
@@ -1108,7 +1108,7 @@ export const deserializeAws_restJson1GetStreamKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStreamKeyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetStreamKeyCommandError(output, context);
   }
   const contents: GetStreamKeyCommandOutput = {
@@ -1179,7 +1179,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListChannelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListChannelsCommandError(output, context);
   }
   const contents: ListChannelsCommandOutput = {
@@ -1246,7 +1246,7 @@ export const deserializeAws_restJson1ListStreamKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStreamKeysCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListStreamKeysCommandError(output, context);
   }
   const contents: ListStreamKeysCommandOutput = {
@@ -1321,7 +1321,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStreamsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListStreamsCommandError(output, context);
   }
   const contents: ListStreamsCommandOutput = {
@@ -1380,7 +1380,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1455,7 +1455,7 @@ export const deserializeAws_restJson1PutMetadataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutMetadataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutMetadataCommandError(output, context);
   }
   const contents: PutMetadataCommandOutput = {
@@ -1538,7 +1538,7 @@ export const deserializeAws_restJson1StopStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopStreamCommandError(output, context);
   }
   const contents: StopStreamCommandOutput = {
@@ -1621,7 +1621,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1688,7 +1688,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -1755,7 +1755,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateChannelCommandError(output, context);
   }
   const contents: UpdateChannelCommandOutput = {

--- a/clients/client-kafka/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/protocols/Aws_restJson1.ts
@@ -919,7 +919,7 @@ export const deserializeAws_restJson1CreateClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateClusterCommandError(output, context);
   }
   const contents: CreateClusterCommandOutput = {
@@ -1030,7 +1030,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConfigurationCommandError(output, context);
   }
   const contents: CreateConfigurationCommandOutput = {
@@ -1145,7 +1145,7 @@ export const deserializeAws_restJson1DeleteClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClusterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteClusterCommandError(output, context);
   }
   const contents: DeleteClusterCommandOutput = {
@@ -1228,7 +1228,7 @@ export const deserializeAws_restJson1DescribeClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeClusterCommandError(output, context);
   }
   const contents: DescribeClusterCommandOutput = {
@@ -1315,7 +1315,7 @@ export const deserializeAws_restJson1DescribeClusterOperationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterOperationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeClusterOperationCommandError(output, context);
   }
   const contents: DescribeClusterOperationCommandOutput = {
@@ -1402,7 +1402,7 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeConfigurationCommandError(output, context);
   }
   const contents: DescribeConfigurationCommandOutput = {
@@ -1517,7 +1517,7 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationRevisionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeConfigurationRevisionCommandError(output, context);
   }
   const contents: DescribeConfigurationRevisionCommandOutput = {
@@ -1628,7 +1628,7 @@ export const deserializeAws_restJson1GetBootstrapBrokersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBootstrapBrokersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBootstrapBrokersCommandError(output, context);
   }
   const contents: GetBootstrapBrokersCommandOutput = {
@@ -1719,7 +1719,7 @@ export const deserializeAws_restJson1GetCompatibleKafkaVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCompatibleKafkaVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCompatibleKafkaVersionsCommandError(output, context);
   }
   const contents: GetCompatibleKafkaVersionsCommandOutput = {
@@ -1825,7 +1825,7 @@ export const deserializeAws_restJson1ListClusterOperationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListClusterOperationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListClusterOperationsCommandError(output, context);
   }
   const contents: ListClusterOperationsCommandOutput = {
@@ -1911,7 +1911,7 @@ export const deserializeAws_restJson1ListClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListClustersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListClustersCommandError(output, context);
   }
   const contents: ListClustersCommandOutput = {
@@ -1994,7 +1994,7 @@ export const deserializeAws_restJson1ListConfigurationRevisionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationRevisionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConfigurationRevisionsCommandError(output, context);
   }
   const contents: ListConfigurationRevisionsCommandOutput = {
@@ -2093,7 +2093,7 @@ export const deserializeAws_restJson1ListConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConfigurationsCommandError(output, context);
   }
   const contents: ListConfigurationsCommandOutput = {
@@ -2184,7 +2184,7 @@ export const deserializeAws_restJson1ListKafkaVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListKafkaVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListKafkaVersionsCommandError(output, context);
   }
   const contents: ListKafkaVersionsCommandOutput = {
@@ -2267,7 +2267,7 @@ export const deserializeAws_restJson1ListNodesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNodesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListNodesCommandError(output, context);
   }
   const contents: ListNodesCommandOutput = {
@@ -2350,7 +2350,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -2421,7 +2421,7 @@ export const deserializeAws_restJson1RebootBrokerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootBrokerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RebootBrokerCommandError(output, context);
   }
   const contents: RebootBrokerCommandOutput = {
@@ -2528,7 +2528,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -2595,7 +2595,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -2662,7 +2662,7 @@ export const deserializeAws_restJson1UpdateBrokerCountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBrokerCountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateBrokerCountCommandError(output, context);
   }
   const contents: UpdateBrokerCountCommandOutput = {
@@ -2753,7 +2753,7 @@ export const deserializeAws_restJson1UpdateBrokerStorageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBrokerStorageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateBrokerStorageCommandError(output, context);
   }
   const contents: UpdateBrokerStorageCommandOutput = {
@@ -2844,7 +2844,7 @@ export const deserializeAws_restJson1UpdateClusterConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateClusterConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateClusterConfigurationCommandError(output, context);
   }
   const contents: UpdateClusterConfigurationCommandOutput = {
@@ -2943,7 +2943,7 @@ export const deserializeAws_restJson1UpdateClusterKafkaVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateClusterKafkaVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateClusterKafkaVersionCommandError(output, context);
   }
   const contents: UpdateClusterKafkaVersionCommandOutput = {
@@ -3050,7 +3050,7 @@ export const deserializeAws_restJson1UpdateMonitoringCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMonitoringCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMonitoringCommandError(output, context);
   }
   const contents: UpdateMonitoringCommandOutput = {

--- a/clients/client-kendra/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/protocols/Aws_json1_1.ts
@@ -478,7 +478,7 @@ export const deserializeAws_json1_1BatchDeleteDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeleteDocumentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDeleteDocumentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -573,7 +573,7 @@ export const deserializeAws_json1_1BatchPutDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchPutDocumentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchPutDocumentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -676,7 +676,7 @@ export const deserializeAws_json1_1CreateDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDataSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -787,7 +787,7 @@ export const deserializeAws_json1_1CreateFaqCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFaqCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateFaqCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -890,7 +890,7 @@ export const deserializeAws_json1_1CreateIndexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIndexCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateIndexCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -993,7 +993,7 @@ export const deserializeAws_json1_1DeleteDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDataSourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1085,7 +1085,7 @@ export const deserializeAws_json1_1DeleteFaqCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFaqCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFaqCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1177,7 +1177,7 @@ export const deserializeAws_json1_1DeleteIndexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIndexCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteIndexCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1269,7 +1269,7 @@ export const deserializeAws_json1_1DescribeDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDataSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1356,7 +1356,7 @@ export const deserializeAws_json1_1DescribeFaqCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFaqCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFaqCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1443,7 +1443,7 @@ export const deserializeAws_json1_1DescribeIndexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIndexCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeIndexCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1530,7 +1530,7 @@ export const deserializeAws_json1_1ListDataSourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDataSourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDataSourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1617,7 +1617,7 @@ export const deserializeAws_json1_1ListDataSourceSyncJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDataSourceSyncJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDataSourceSyncJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1712,7 +1712,7 @@ export const deserializeAws_json1_1ListFaqsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFaqsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListFaqsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1799,7 +1799,7 @@ export const deserializeAws_json1_1ListIndicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIndicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListIndicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1878,7 +1878,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1965,7 +1965,7 @@ export const deserializeAws_json1_1QueryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1QueryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2068,7 +2068,7 @@ export const deserializeAws_json1_1StartDataSourceSyncJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDataSourceSyncJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartDataSourceSyncJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2171,7 +2171,7 @@ export const deserializeAws_json1_1StopDataSourceSyncJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDataSourceSyncJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopDataSourceSyncJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2255,7 +2255,7 @@ export const deserializeAws_json1_1SubmitFeedbackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SubmitFeedbackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SubmitFeedbackCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2347,7 +2347,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2434,7 +2434,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2521,7 +2521,7 @@ export const deserializeAws_json1_1UpdateDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDataSourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2613,7 +2613,7 @@ export const deserializeAws_json1_1UpdateIndexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIndexCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateIndexCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
@@ -592,7 +592,7 @@ export const deserializeAws_json1_1AddApplicationCloudWatchLoggingOptionCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationCloudWatchLoggingOptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationCloudWatchLoggingOptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -687,7 +687,7 @@ export const deserializeAws_json1_1AddApplicationInputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationInputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationInputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -782,7 +782,7 @@ export const deserializeAws_json1_1AddApplicationInputProcessingConfigurationCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationInputProcessingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationInputProcessingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -869,7 +869,7 @@ export const deserializeAws_json1_1AddApplicationOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationOutputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -956,7 +956,7 @@ export const deserializeAws_json1_1AddApplicationReferenceDataSourceCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationReferenceDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationReferenceDataSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1043,7 +1043,7 @@ export const deserializeAws_json1_1AddApplicationVpcConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationVpcConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationVpcConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1122,7 +1122,7 @@ export const deserializeAws_json1_1CreateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1225,7 +1225,7 @@ export const deserializeAws_json1_1CreateApplicationSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateApplicationSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1320,7 +1320,7 @@ export const deserializeAws_json1_1DeleteApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1415,7 +1415,7 @@ export const deserializeAws_json1_1DeleteApplicationCloudWatchLoggingOptionComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationCloudWatchLoggingOptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationCloudWatchLoggingOptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1510,7 +1510,7 @@ export const deserializeAws_json1_1DeleteApplicationInputProcessingConfiguration
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationInputProcessingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationInputProcessingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1597,7 +1597,7 @@ export const deserializeAws_json1_1DeleteApplicationOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationOutputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1684,7 +1684,7 @@ export const deserializeAws_json1_1DeleteApplicationReferenceDataSourceCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationReferenceDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationReferenceDataSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1771,7 +1771,7 @@ export const deserializeAws_json1_1DeleteApplicationSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1858,7 +1858,7 @@ export const deserializeAws_json1_1DeleteApplicationVpcConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationVpcConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationVpcConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1937,7 +1937,7 @@ export const deserializeAws_json1_1DescribeApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2008,7 +2008,7 @@ export const deserializeAws_json1_1DescribeApplicationSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeApplicationSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeApplicationSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2079,7 +2079,7 @@ export const deserializeAws_json1_1DiscoverInputSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DiscoverInputSchemaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DiscoverInputSchemaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2166,7 +2166,7 @@ export const deserializeAws_json1_1ListApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListApplicationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2221,7 +2221,7 @@ export const deserializeAws_json1_1ListApplicationSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListApplicationSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2284,7 +2284,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2355,7 +2355,7 @@ export const deserializeAws_json1_1StartApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2442,7 +2442,7 @@ export const deserializeAws_json1_1StopApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2529,7 +2529,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2616,7 +2616,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2703,7 +2703,7 @@ export const deserializeAws_json1_1UpdateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
@@ -435,7 +435,7 @@ export const deserializeAws_json1_1AddApplicationCloudWatchLoggingOptionCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationCloudWatchLoggingOptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationCloudWatchLoggingOptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -522,7 +522,7 @@ export const deserializeAws_json1_1AddApplicationInputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationInputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationInputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -617,7 +617,7 @@ export const deserializeAws_json1_1AddApplicationInputProcessingConfigurationCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationInputProcessingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationInputProcessingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -704,7 +704,7 @@ export const deserializeAws_json1_1AddApplicationOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationOutputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -791,7 +791,7 @@ export const deserializeAws_json1_1AddApplicationReferenceDataSourceCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddApplicationReferenceDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddApplicationReferenceDataSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -878,7 +878,7 @@ export const deserializeAws_json1_1CreateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -973,7 +973,7 @@ export const deserializeAws_json1_1DeleteApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1052,7 +1052,7 @@ export const deserializeAws_json1_1DeleteApplicationCloudWatchLoggingOptionComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationCloudWatchLoggingOptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationCloudWatchLoggingOptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1139,7 +1139,7 @@ export const deserializeAws_json1_1DeleteApplicationInputProcessingConfiguration
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationInputProcessingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationInputProcessingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1226,7 +1226,7 @@ export const deserializeAws_json1_1DeleteApplicationOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationOutputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1313,7 +1313,7 @@ export const deserializeAws_json1_1DeleteApplicationReferenceDataSourceCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationReferenceDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteApplicationReferenceDataSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1400,7 +1400,7 @@ export const deserializeAws_json1_1DescribeApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1463,7 +1463,7 @@ export const deserializeAws_json1_1DiscoverInputSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DiscoverInputSchemaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DiscoverInputSchemaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1542,7 +1542,7 @@ export const deserializeAws_json1_1ListApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListApplicationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1589,7 +1589,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1660,7 +1660,7 @@ export const deserializeAws_json1_1StartApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1747,7 +1747,7 @@ export const deserializeAws_json1_1StopApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1818,7 +1818,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1905,7 +1905,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1992,7 +1992,7 @@ export const deserializeAws_json1_1UpdateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1.ts
@@ -200,7 +200,7 @@ export const deserializeAws_restJson1GetClipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetClipCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetClipCommandError(output, context);
   }
   const contents: GetClipCommandOutput = {
@@ -321,7 +321,7 @@ export const deserializeAws_restJson1GetDASHStreamingSessionURLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDASHStreamingSessionURLCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDASHStreamingSessionURLCommandError(output, context);
   }
   const contents: GetDASHStreamingSessionURLCommandOutput = {
@@ -432,7 +432,7 @@ export const deserializeAws_restJson1GetHLSStreamingSessionURLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHLSStreamingSessionURLCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetHLSStreamingSessionURLCommandError(output, context);
   }
   const contents: GetHLSStreamingSessionURLCommandOutput = {
@@ -543,7 +543,7 @@ export const deserializeAws_restJson1GetMediaForFragmentListCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMediaForFragmentListCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMediaForFragmentListCommandError(output, context);
   }
   const contents: GetMediaForFragmentListCommandOutput = {
@@ -624,7 +624,7 @@ export const deserializeAws_restJson1ListFragmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFragmentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFragmentsCommandError(output, context);
   }
   const contents: ListFragmentsCommandOutput = {

--- a/clients/client-kinesis-video-media/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-media/protocols/Aws_restJson1.ts
@@ -49,7 +49,7 @@ export const deserializeAws_restJson1GetMediaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMediaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMediaCommandError(output, context);
   }
   const contents: GetMediaCommandOutput = {

--- a/clients/client-kinesis-video-signaling/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-signaling/protocols/Aws_restJson1.ts
@@ -78,7 +78,7 @@ export const deserializeAws_restJson1GetIceServerConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIceServerConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIceServerConfigCommandError(output, context);
   }
   const contents: GetIceServerConfigCommandOutput = {
@@ -173,7 +173,7 @@ export const deserializeAws_restJson1SendAlexaOfferToMasterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendAlexaOfferToMasterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SendAlexaOfferToMasterCommandError(output, context);
   }
   const contents: SendAlexaOfferToMasterCommandOutput = {

--- a/clients/client-kinesis-video/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video/protocols/Aws_restJson1.ts
@@ -593,7 +593,7 @@ export const deserializeAws_restJson1CreateSignalingChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSignalingChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSignalingChannelCommandError(output, context);
   }
   const contents: CreateSignalingChannelCommandOutput = {
@@ -688,7 +688,7 @@ export const deserializeAws_restJson1CreateStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateStreamCommandError(output, context);
   }
   const contents: CreateStreamCommandOutput = {
@@ -791,7 +791,7 @@ export const deserializeAws_restJson1DeleteSignalingChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSignalingChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSignalingChannelCommandError(output, context);
   }
   const contents: DeleteSignalingChannelCommandOutput = {
@@ -882,7 +882,7 @@ export const deserializeAws_restJson1DeleteStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteStreamCommandError(output, context);
   }
   const contents: DeleteStreamCommandOutput = {
@@ -973,7 +973,7 @@ export const deserializeAws_restJson1DescribeSignalingChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSignalingChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSignalingChannelCommandError(output, context);
   }
   const contents: DescribeSignalingChannelCommandOutput = {
@@ -1052,7 +1052,7 @@ export const deserializeAws_restJson1DescribeStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeStreamCommandError(output, context);
   }
   const contents: DescribeStreamCommandOutput = {
@@ -1131,7 +1131,7 @@ export const deserializeAws_restJson1GetDataEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDataEndpointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDataEndpointCommandError(output, context);
   }
   const contents: GetDataEndpointCommandOutput = {
@@ -1210,7 +1210,7 @@ export const deserializeAws_restJson1GetSignalingChannelEndpointCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSignalingChannelEndpointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSignalingChannelEndpointCommandError(output, context);
   }
   const contents: GetSignalingChannelEndpointCommandOutput = {
@@ -1297,7 +1297,7 @@ export const deserializeAws_restJson1ListSignalingChannelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSignalingChannelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSignalingChannelsCommandError(output, context);
   }
   const contents: ListSignalingChannelsCommandOutput = {
@@ -1372,7 +1372,7 @@ export const deserializeAws_restJson1ListStreamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStreamsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListStreamsCommandError(output, context);
   }
   const contents: ListStreamsCommandOutput = {
@@ -1439,7 +1439,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1522,7 +1522,7 @@ export const deserializeAws_restJson1ListTagsForStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForStreamCommandError(output, context);
   }
   const contents: ListTagsForStreamCommandOutput = {
@@ -1613,7 +1613,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1696,7 +1696,7 @@ export const deserializeAws_restJson1TagStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagStreamCommandError(output, context);
   }
   const contents: TagStreamCommandOutput = {
@@ -1787,7 +1787,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -1862,7 +1862,7 @@ export const deserializeAws_restJson1UntagStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagStreamCommandError(output, context);
   }
   const contents: UntagStreamCommandOutput = {
@@ -1945,7 +1945,7 @@ export const deserializeAws_restJson1UpdateDataRetentionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDataRetentionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDataRetentionCommandError(output, context);
   }
   const contents: UpdateDataRetentionCommandOutput = {
@@ -2036,7 +2036,7 @@ export const deserializeAws_restJson1UpdateSignalingChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSignalingChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSignalingChannelCommandError(output, context);
   }
   const contents: UpdateSignalingChannelCommandOutput = {
@@ -2127,7 +2127,7 @@ export const deserializeAws_restJson1UpdateStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateStreamCommandError(output, context);
   }
   const contents: UpdateStreamCommandOutput = {

--- a/clients/client-kinesis/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/protocols/Aws_json1_1.ts
@@ -516,7 +516,7 @@ export const deserializeAws_json1_1AddTagsToStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsToStreamCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -592,7 +592,7 @@ export const deserializeAws_json1_1CreateStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateStreamCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -660,7 +660,7 @@ export const deserializeAws_json1_1DecreaseStreamRetentionPeriodCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DecreaseStreamRetentionPeriodCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DecreaseStreamRetentionPeriodCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -736,7 +736,7 @@ export const deserializeAws_json1_1DeleteStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteStreamCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -804,7 +804,7 @@ export const deserializeAws_json1_1DeregisterStreamConsumerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterStreamConsumerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterStreamConsumerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -872,7 +872,7 @@ export const deserializeAws_json1_1DescribeLimitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLimitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLimitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -927,7 +927,7 @@ export const deserializeAws_json1_1DescribeStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -990,7 +990,7 @@ export const deserializeAws_json1_1DescribeStreamConsumerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStreamConsumerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeStreamConsumerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1061,7 +1061,7 @@ export const deserializeAws_json1_1DescribeStreamSummaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStreamSummaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeStreamSummaryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1124,7 +1124,7 @@ export const deserializeAws_json1_1DisableEnhancedMonitoringCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableEnhancedMonitoringCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableEnhancedMonitoringCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1203,7 +1203,7 @@ export const deserializeAws_json1_1EnableEnhancedMonitoringCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableEnhancedMonitoringCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableEnhancedMonitoringCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1282,7 +1282,7 @@ export const deserializeAws_json1_1GetRecordsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRecordsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRecordsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1409,7 +1409,7 @@ export const deserializeAws_json1_1GetShardIteratorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetShardIteratorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetShardIteratorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1480,7 +1480,7 @@ export const deserializeAws_json1_1IncreaseStreamRetentionPeriodCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IncreaseStreamRetentionPeriodCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1IncreaseStreamRetentionPeriodCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1556,7 +1556,7 @@ export const deserializeAws_json1_1ListShardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListShardsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListShardsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1643,7 +1643,7 @@ export const deserializeAws_json1_1ListStreamConsumersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStreamConsumersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListStreamConsumersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1730,7 +1730,7 @@ export const deserializeAws_json1_1ListStreamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStreamsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListStreamsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1785,7 +1785,7 @@ export const deserializeAws_json1_1ListTagsForStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1856,7 +1856,7 @@ export const deserializeAws_json1_1MergeShardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MergeShardsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MergeShardsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1932,7 +1932,7 @@ export const deserializeAws_json1_1PutRecordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRecordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRecordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2051,7 +2051,7 @@ export const deserializeAws_json1_1PutRecordsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutRecordsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutRecordsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2170,7 +2170,7 @@ export const deserializeAws_json1_1RegisterStreamConsumerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterStreamConsumerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterStreamConsumerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2249,7 +2249,7 @@ export const deserializeAws_json1_1RemoveTagsFromStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsFromStreamCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2325,7 +2325,7 @@ export const deserializeAws_json1_1SplitShardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SplitShardCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SplitShardCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2401,7 +2401,7 @@ export const deserializeAws_json1_1StartStreamEncryptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartStreamEncryptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartStreamEncryptionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2525,7 +2525,7 @@ export const deserializeAws_json1_1StopStreamEncryptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopStreamEncryptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopStreamEncryptionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2601,7 +2601,7 @@ export const deserializeAws_json1_1SubscribeToShardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SubscribeToShardCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SubscribeToShardCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2680,7 +2680,7 @@ export const deserializeAws_json1_1UpdateShardCountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateShardCountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateShardCountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-kms/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/protocols/Aws_json1_1.ts
@@ -823,7 +823,7 @@ export const deserializeAws_json1_1CancelKeyDeletionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelKeyDeletionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelKeyDeletionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -910,7 +910,7 @@ export const deserializeAws_json1_1ConnectCustomKeyStoreCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConnectCustomKeyStoreCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ConnectCustomKeyStoreCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -997,7 +997,7 @@ export const deserializeAws_json1_1CreateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAliasCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1097,7 +1097,7 @@ export const deserializeAws_json1_1CreateCustomKeyStoreCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCustomKeyStoreCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCustomKeyStoreCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1200,7 +1200,7 @@ export const deserializeAws_json1_1CreateGrantCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGrantCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateGrantCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1311,7 +1311,7 @@ export const deserializeAws_json1_1CreateKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1438,7 +1438,7 @@ export const deserializeAws_json1_1DecryptCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DecryptCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DecryptCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1565,7 +1565,7 @@ export const deserializeAws_json1_1DeleteAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAliasCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1641,7 +1641,7 @@ export const deserializeAws_json1_1DeleteCustomKeyStoreCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCustomKeyStoreCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCustomKeyStoreCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1720,7 +1720,7 @@ export const deserializeAws_json1_1DeleteImportedKeyMaterialCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteImportedKeyMaterialCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteImportedKeyMaterialCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1812,7 +1812,7 @@ export const deserializeAws_json1_1DescribeCustomKeyStoresCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCustomKeyStoresCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCustomKeyStoresCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1875,7 +1875,7 @@ export const deserializeAws_json1_1DescribeKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1954,7 +1954,7 @@ export const deserializeAws_json1_1DisableKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableKeyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2038,7 +2038,7 @@ export const deserializeAws_json1_1DisableKeyRotationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableKeyRotationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableKeyRotationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2138,7 +2138,7 @@ export const deserializeAws_json1_1DisconnectCustomKeyStoreCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisconnectCustomKeyStoreCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisconnectCustomKeyStoreCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2209,7 +2209,7 @@ export const deserializeAws_json1_1EnableKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableKeyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2301,7 +2301,7 @@ export const deserializeAws_json1_1EnableKeyRotationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableKeyRotationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableKeyRotationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2401,7 +2401,7 @@ export const deserializeAws_json1_1EncryptCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EncryptCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EncryptCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2512,7 +2512,7 @@ export const deserializeAws_json1_1GenerateDataKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateDataKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GenerateDataKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2623,7 +2623,7 @@ export const deserializeAws_json1_1GenerateDataKeyPairCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateDataKeyPairCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GenerateDataKeyPairCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2742,7 +2742,7 @@ export const deserializeAws_json1_1GenerateDataKeyPairWithoutPlaintextCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateDataKeyPairWithoutPlaintextCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GenerateDataKeyPairWithoutPlaintextCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2861,7 +2861,7 @@ export const deserializeAws_json1_1GenerateDataKeyWithoutPlaintextCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateDataKeyWithoutPlaintextCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GenerateDataKeyWithoutPlaintextCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2972,7 +2972,7 @@ export const deserializeAws_json1_1GenerateRandomCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateRandomCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GenerateRandomCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3051,7 +3051,7 @@ export const deserializeAws_json1_1GetKeyPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetKeyPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetKeyPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3138,7 +3138,7 @@ export const deserializeAws_json1_1GetKeyRotationStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetKeyRotationStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetKeyRotationStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3233,7 +3233,7 @@ export const deserializeAws_json1_1GetParametersForImportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetParametersForImportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetParametersForImportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3328,7 +3328,7 @@ export const deserializeAws_json1_1GetPublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPublicKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPublicKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3455,7 +3455,7 @@ export const deserializeAws_json1_1ImportKeyMaterialCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportKeyMaterialCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportKeyMaterialCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3582,7 +3582,7 @@ export const deserializeAws_json1_1ListAliasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAliasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAliasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3669,7 +3669,7 @@ export const deserializeAws_json1_1ListGrantsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGrantsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGrantsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3764,7 +3764,7 @@ export const deserializeAws_json1_1ListKeyPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListKeyPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListKeyPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3851,7 +3851,7 @@ export const deserializeAws_json1_1ListKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListKeysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListKeysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3922,7 +3922,7 @@ export const deserializeAws_json1_1ListResourceTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourceTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4001,7 +4001,7 @@ export const deserializeAws_json1_1ListRetirableGrantsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRetirableGrantsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRetirableGrantsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4088,7 +4088,7 @@ export const deserializeAws_json1_1PutKeyPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutKeyPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutKeyPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4196,7 +4196,7 @@ export const deserializeAws_json1_1ReEncryptCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReEncryptCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ReEncryptCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4323,7 +4323,7 @@ export const deserializeAws_json1_1RetireGrantCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RetireGrantCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RetireGrantCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4423,7 +4423,7 @@ export const deserializeAws_json1_1RevokeGrantCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeGrantCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RevokeGrantCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4515,7 +4515,7 @@ export const deserializeAws_json1_1ScheduleKeyDeletionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ScheduleKeyDeletionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ScheduleKeyDeletionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4602,7 +4602,7 @@ export const deserializeAws_json1_1SignCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SignCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SignCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4713,7 +4713,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4805,7 +4805,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4889,7 +4889,7 @@ export const deserializeAws_json1_1UpdateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAliasCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4973,7 +4973,7 @@ export const deserializeAws_json1_1UpdateCustomKeyStoreCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCustomKeyStoreCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateCustomKeyStoreCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5084,7 +5084,7 @@ export const deserializeAws_json1_1UpdateKeyDescriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateKeyDescriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateKeyDescriptionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5168,7 +5168,7 @@ export const deserializeAws_json1_1VerifyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<VerifyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1VerifyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-lakeformation/protocols/Aws_json1_1.ts
+++ b/clients/client-lakeformation/protocols/Aws_json1_1.ts
@@ -261,7 +261,7 @@ export const deserializeAws_json1_1BatchGrantPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGrantPermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchGrantPermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -324,7 +324,7 @@ export const deserializeAws_json1_1BatchRevokePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchRevokePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchRevokePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -387,7 +387,7 @@ export const deserializeAws_json1_1DeregisterResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -466,7 +466,7 @@ export const deserializeAws_json1_1DescribeResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -545,7 +545,7 @@ export const deserializeAws_json1_1GetDataLakeSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDataLakeSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDataLakeSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -616,7 +616,7 @@ export const deserializeAws_json1_1GetEffectivePermissionsForPathCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEffectivePermissionsForPathCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetEffectivePermissionsForPathCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -695,7 +695,7 @@ export const deserializeAws_json1_1GrantPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GrantPermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GrantPermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -766,7 +766,7 @@ export const deserializeAws_json1_1ListPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -837,7 +837,7 @@ export const deserializeAws_json1_1ListResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -908,7 +908,7 @@ export const deserializeAws_json1_1PutDataLakeSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDataLakeSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutDataLakeSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -971,7 +971,7 @@ export const deserializeAws_json1_1RegisterResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1050,7 +1050,7 @@ export const deserializeAws_json1_1RevokePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RevokePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1121,7 +1121,7 @@ export const deserializeAws_json1_1UpdateResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-lambda/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1.ts
@@ -2005,7 +2005,7 @@ export const deserializeAws_restJson1AddLayerVersionPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddLayerVersionPermissionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddLayerVersionPermissionCommandError(output, context);
   }
   const contents: AddLayerVersionPermissionCommandOutput = {
@@ -2112,7 +2112,7 @@ export const deserializeAws_restJson1AddPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddPermissionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddPermissionCommandError(output, context);
   }
   const contents: AddPermissionCommandOutput = {
@@ -2215,7 +2215,7 @@ export const deserializeAws_restJson1CreateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAliasCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAliasCommandError(output, context);
   }
   const contents: CreateAliasCommandOutput = {
@@ -2322,7 +2322,7 @@ export const deserializeAws_restJson1CreateEventSourceMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEventSourceMappingCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateEventSourceMappingCommandError(output, context);
   }
   const contents: CreateEventSourceMappingCommandOutput = {
@@ -2461,7 +2461,7 @@ export const deserializeAws_restJson1CreateFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFunctionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFunctionCommandError(output, context);
   }
   const contents: CreateFunctionCommandOutput = {
@@ -2660,7 +2660,7 @@ export const deserializeAws_restJson1DeleteAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAliasCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAliasCommandError(output, context);
   }
   const contents: DeleteAliasCommandOutput = {
@@ -2735,7 +2735,7 @@ export const deserializeAws_restJson1DeleteEventSourceMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventSourceMappingCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEventSourceMappingCommandError(output, context);
   }
   const contents: DeleteEventSourceMappingCommandOutput = {
@@ -2874,7 +2874,7 @@ export const deserializeAws_restJson1DeleteFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFunctionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFunctionCommandError(output, context);
   }
   const contents: DeleteFunctionCommandOutput = {
@@ -2957,7 +2957,7 @@ export const deserializeAws_restJson1DeleteFunctionConcurrencyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFunctionConcurrencyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFunctionConcurrencyCommandError(output, context);
   }
   const contents: DeleteFunctionConcurrencyCommandOutput = {
@@ -3040,7 +3040,7 @@ export const deserializeAws_restJson1DeleteFunctionEventInvokeConfigCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFunctionEventInvokeConfigCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFunctionEventInvokeConfigCommandError(output, context);
   }
   const contents: DeleteFunctionEventInvokeConfigCommandOutput = {
@@ -3115,7 +3115,7 @@ export const deserializeAws_restJson1DeleteLayerVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLayerVersionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteLayerVersionCommandError(output, context);
   }
   const contents: DeleteLayerVersionCommandOutput = {
@@ -3174,7 +3174,7 @@ export const deserializeAws_restJson1DeleteProvisionedConcurrencyConfigCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProvisionedConcurrencyConfigCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteProvisionedConcurrencyConfigCommandError(output, context);
   }
   const contents: DeleteProvisionedConcurrencyConfigCommandOutput = {
@@ -3257,7 +3257,7 @@ export const deserializeAws_restJson1GetAccountSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAccountSettingsCommandError(output, context);
   }
   const contents: GetAccountSettingsCommandOutput = {
@@ -3324,7 +3324,7 @@ export const deserializeAws_restJson1GetAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAliasCommandError(output, context);
   }
   const contents: GetAliasCommandOutput = {
@@ -3423,7 +3423,7 @@ export const deserializeAws_restJson1GetEventSourceMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEventSourceMappingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEventSourceMappingCommandError(output, context);
   }
   const contents: GetEventSourceMappingCommandOutput = {
@@ -3554,7 +3554,7 @@ export const deserializeAws_restJson1GetFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFunctionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFunctionCommandError(output, context);
   }
   const contents: GetFunctionCommandOutput = {
@@ -3645,7 +3645,7 @@ export const deserializeAws_restJson1GetFunctionConcurrencyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFunctionConcurrencyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFunctionConcurrencyCommandError(output, context);
   }
   const contents: GetFunctionConcurrencyCommandOutput = {
@@ -3724,7 +3724,7 @@ export const deserializeAws_restJson1GetFunctionConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFunctionConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFunctionConfigurationCommandError(output, context);
   }
   const contents: GetFunctionConfigurationCommandOutput = {
@@ -3907,7 +3907,7 @@ export const deserializeAws_restJson1GetFunctionEventInvokeConfigCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFunctionEventInvokeConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFunctionEventInvokeConfigCommandError(output, context);
   }
   const contents: GetFunctionEventInvokeConfigCommandOutput = {
@@ -4002,7 +4002,7 @@ export const deserializeAws_restJson1GetLayerVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLayerVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLayerVersionCommandError(output, context);
   }
   const contents: GetLayerVersionCommandOutput = {
@@ -4109,7 +4109,7 @@ export const deserializeAws_restJson1GetLayerVersionByArnCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLayerVersionByArnCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLayerVersionByArnCommandError(output, context);
   }
   const contents: GetLayerVersionByArnCommandOutput = {
@@ -4216,7 +4216,7 @@ export const deserializeAws_restJson1GetLayerVersionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLayerVersionPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLayerVersionPolicyCommandError(output, context);
   }
   const contents: GetLayerVersionPolicyCommandOutput = {
@@ -4299,7 +4299,7 @@ export const deserializeAws_restJson1GetPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPolicyCommandError(output, context);
   }
   const contents: GetPolicyCommandOutput = {
@@ -4382,7 +4382,7 @@ export const deserializeAws_restJson1GetProvisionedConcurrencyConfigCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetProvisionedConcurrencyConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetProvisionedConcurrencyConfigCommandError(output, context);
   }
   const contents: GetProvisionedConcurrencyConfigCommandOutput = {
@@ -4498,7 +4498,7 @@ export const deserializeAws_restJson1InvokeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InvokeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1InvokeCommandError(output, context);
   }
   const contents: InvokeCommandOutput = {
@@ -4763,7 +4763,7 @@ export const deserializeAws_restJson1InvokeAsyncCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InvokeAsyncCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1InvokeAsyncCommandError(output, context);
   }
   const contents: InvokeAsyncCommandOutput = {
@@ -4846,7 +4846,7 @@ export const deserializeAws_restJson1ListAliasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAliasesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAliasesCommandError(output, context);
   }
   const contents: ListAliasesCommandOutput = {
@@ -4929,7 +4929,7 @@ export const deserializeAws_restJson1ListEventSourceMappingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEventSourceMappingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListEventSourceMappingsCommandError(output, context);
   }
   const contents: ListEventSourceMappingsCommandOutput = {
@@ -5012,7 +5012,7 @@ export const deserializeAws_restJson1ListFunctionEventInvokeConfigsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFunctionEventInvokeConfigsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFunctionEventInvokeConfigsCommandError(output, context);
   }
   const contents: ListFunctionEventInvokeConfigsCommandOutput = {
@@ -5098,7 +5098,7 @@ export const deserializeAws_restJson1ListFunctionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFunctionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFunctionsCommandError(output, context);
   }
   const contents: ListFunctionsCommandOutput = {
@@ -5173,7 +5173,7 @@ export const deserializeAws_restJson1ListLayersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLayersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListLayersCommandError(output, context);
   }
   const contents: ListLayersCommandOutput = {
@@ -5248,7 +5248,7 @@ export const deserializeAws_restJson1ListLayerVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLayerVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListLayerVersionsCommandError(output, context);
   }
   const contents: ListLayerVersionsCommandOutput = {
@@ -5331,7 +5331,7 @@ export const deserializeAws_restJson1ListProvisionedConcurrencyConfigsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProvisionedConcurrencyConfigsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProvisionedConcurrencyConfigsCommandError(output, context);
   }
   const contents: ListProvisionedConcurrencyConfigsCommandOutput = {
@@ -5417,7 +5417,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsCommandError(output, context);
   }
   const contents: ListTagsCommandOutput = {
@@ -5496,7 +5496,7 @@ export const deserializeAws_restJson1ListVersionsByFunctionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVersionsByFunctionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListVersionsByFunctionCommandError(output, context);
   }
   const contents: ListVersionsByFunctionCommandOutput = {
@@ -5579,7 +5579,7 @@ export const deserializeAws_restJson1PublishLayerVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PublishLayerVersionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PublishLayerVersionCommandError(output, context);
   }
   const contents: PublishLayerVersionCommandOutput = {
@@ -5694,7 +5694,7 @@ export const deserializeAws_restJson1PublishVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PublishVersionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PublishVersionCommandError(output, context);
   }
   const contents: PublishVersionCommandOutput = {
@@ -5901,7 +5901,7 @@ export const deserializeAws_restJson1PutFunctionConcurrencyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutFunctionConcurrencyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutFunctionConcurrencyCommandError(output, context);
   }
   const contents: PutFunctionConcurrencyCommandOutput = {
@@ -5988,7 +5988,7 @@ export const deserializeAws_restJson1PutFunctionEventInvokeConfigCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutFunctionEventInvokeConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutFunctionEventInvokeConfigCommandError(output, context);
   }
   const contents: PutFunctionEventInvokeConfigCommandOutput = {
@@ -6083,7 +6083,7 @@ export const deserializeAws_restJson1PutProvisionedConcurrencyConfigCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutProvisionedConcurrencyConfigCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutProvisionedConcurrencyConfigCommandError(output, context);
   }
   const contents: PutProvisionedConcurrencyConfigCommandOutput = {
@@ -6199,7 +6199,7 @@ export const deserializeAws_restJson1RemoveLayerVersionPermissionCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveLayerVersionPermissionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveLayerVersionPermissionCommandError(output, context);
   }
   const contents: RemoveLayerVersionPermissionCommandOutput = {
@@ -6282,7 +6282,7 @@ export const deserializeAws_restJson1RemovePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemovePermissionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemovePermissionCommandError(output, context);
   }
   const contents: RemovePermissionCommandOutput = {
@@ -6365,7 +6365,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -6448,7 +6448,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -6531,7 +6531,7 @@ export const deserializeAws_restJson1UpdateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAliasCommandError(output, context);
   }
   const contents: UpdateAliasCommandOutput = {
@@ -6646,7 +6646,7 @@ export const deserializeAws_restJson1UpdateEventSourceMappingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEventSourceMappingCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateEventSourceMappingCommandError(output, context);
   }
   const contents: UpdateEventSourceMappingCommandOutput = {
@@ -6793,7 +6793,7 @@ export const deserializeAws_restJson1UpdateFunctionCodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFunctionCodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFunctionCodeCommandError(output, context);
   }
   const contents: UpdateFunctionCodeCommandOutput = {
@@ -7000,7 +7000,7 @@ export const deserializeAws_restJson1UpdateFunctionConfigurationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFunctionConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFunctionConfigurationCommandError(output, context);
   }
   const contents: UpdateFunctionConfigurationCommandOutput = {
@@ -7199,7 +7199,7 @@ export const deserializeAws_restJson1UpdateFunctionEventInvokeConfigCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFunctionEventInvokeConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFunctionEventInvokeConfigCommandError(output, context);
   }
   const contents: UpdateFunctionEventInvokeConfigCommandOutput = {

--- a/clients/client-lex-model-building-service/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-model-building-service/protocols/Aws_restJson1.ts
@@ -1529,7 +1529,7 @@ export const deserializeAws_restJson1CreateBotVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBotVersionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateBotVersionCommandError(output, context);
   }
   const contents: CreateBotVersionCommandOutput = {
@@ -1684,7 +1684,7 @@ export const deserializeAws_restJson1CreateIntentVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIntentVersionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateIntentVersionCommandError(output, context);
   }
   const contents: CreateIntentVersionCommandOutput = {
@@ -1839,7 +1839,7 @@ export const deserializeAws_restJson1CreateSlotTypeVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSlotTypeVersionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSlotTypeVersionCommandError(output, context);
   }
   const contents: CreateSlotTypeVersionCommandOutput = {
@@ -1973,7 +1973,7 @@ export const deserializeAws_restJson1DeleteBotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBotCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBotCommandError(output, context);
   }
   const contents: DeleteBotCommandOutput = {
@@ -2064,7 +2064,7 @@ export const deserializeAws_restJson1DeleteBotAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBotAliasCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBotAliasCommandError(output, context);
   }
   const contents: DeleteBotAliasCommandOutput = {
@@ -2155,7 +2155,7 @@ export const deserializeAws_restJson1DeleteBotChannelAssociationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBotChannelAssociationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBotChannelAssociationCommandError(output, context);
   }
   const contents: DeleteBotChannelAssociationCommandOutput = {
@@ -2238,7 +2238,7 @@ export const deserializeAws_restJson1DeleteBotVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBotVersionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBotVersionCommandError(output, context);
   }
   const contents: DeleteBotVersionCommandOutput = {
@@ -2329,7 +2329,7 @@ export const deserializeAws_restJson1DeleteIntentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIntentCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteIntentCommandError(output, context);
   }
   const contents: DeleteIntentCommandOutput = {
@@ -2420,7 +2420,7 @@ export const deserializeAws_restJson1DeleteIntentVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIntentVersionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteIntentVersionCommandError(output, context);
   }
   const contents: DeleteIntentVersionCommandOutput = {
@@ -2511,7 +2511,7 @@ export const deserializeAws_restJson1DeleteSlotTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSlotTypeCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSlotTypeCommandError(output, context);
   }
   const contents: DeleteSlotTypeCommandOutput = {
@@ -2602,7 +2602,7 @@ export const deserializeAws_restJson1DeleteSlotTypeVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSlotTypeVersionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSlotTypeVersionCommandError(output, context);
   }
   const contents: DeleteSlotTypeVersionCommandOutput = {
@@ -2693,7 +2693,7 @@ export const deserializeAws_restJson1DeleteUtterancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUtterancesCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteUtterancesCommandError(output, context);
   }
   const contents: DeleteUtterancesCommandOutput = {
@@ -2768,7 +2768,7 @@ export const deserializeAws_restJson1GetBotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBotCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBotCommandError(output, context);
   }
   const contents: GetBotCommandOutput = {
@@ -2907,7 +2907,7 @@ export const deserializeAws_restJson1GetBotAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBotAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBotAliasCommandError(output, context);
   }
   const contents: GetBotAliasCommandOutput = {
@@ -3014,7 +3014,7 @@ export const deserializeAws_restJson1GetBotAliasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBotAliasesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBotAliasesCommandError(output, context);
   }
   const contents: GetBotAliasesCommandOutput = {
@@ -3089,7 +3089,7 @@ export const deserializeAws_restJson1GetBotChannelAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBotChannelAssociationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBotChannelAssociationCommandError(output, context);
   }
   const contents: GetBotChannelAssociationCommandOutput = {
@@ -3200,7 +3200,7 @@ export const deserializeAws_restJson1GetBotChannelAssociationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBotChannelAssociationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBotChannelAssociationsCommandError(output, context);
   }
   const contents: GetBotChannelAssociationsCommandOutput = {
@@ -3278,7 +3278,7 @@ export const deserializeAws_restJson1GetBotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBotsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBotsCommandError(output, context);
   }
   const contents: GetBotsCommandOutput = {
@@ -3361,7 +3361,7 @@ export const deserializeAws_restJson1GetBotVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBotVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBotVersionsCommandError(output, context);
   }
   const contents: GetBotVersionsCommandOutput = {
@@ -3444,7 +3444,7 @@ export const deserializeAws_restJson1GetBuiltinIntentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBuiltinIntentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBuiltinIntentCommandError(output, context);
   }
   const contents: GetBuiltinIntentCommandOutput = {
@@ -3531,7 +3531,7 @@ export const deserializeAws_restJson1GetBuiltinIntentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBuiltinIntentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBuiltinIntentsCommandError(output, context);
   }
   const contents: GetBuiltinIntentsCommandOutput = {
@@ -3606,7 +3606,7 @@ export const deserializeAws_restJson1GetBuiltinSlotTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBuiltinSlotTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBuiltinSlotTypesCommandError(output, context);
   }
   const contents: GetBuiltinSlotTypesCommandOutput = {
@@ -3681,7 +3681,7 @@ export const deserializeAws_restJson1GetExportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetExportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetExportCommandError(output, context);
   }
   const contents: GetExportCommandOutput = {
@@ -3784,7 +3784,7 @@ export const deserializeAws_restJson1GetImportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetImportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetImportCommandError(output, context);
   }
   const contents: GetImportCommandOutput = {
@@ -3887,7 +3887,7 @@ export const deserializeAws_restJson1GetIntentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIntentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIntentCommandError(output, context);
   }
   const contents: GetIntentCommandOutput = {
@@ -4026,7 +4026,7 @@ export const deserializeAws_restJson1GetIntentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIntentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIntentsCommandError(output, context);
   }
   const contents: GetIntentsCommandOutput = {
@@ -4109,7 +4109,7 @@ export const deserializeAws_restJson1GetIntentVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIntentVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetIntentVersionsCommandError(output, context);
   }
   const contents: GetIntentVersionsCommandOutput = {
@@ -4192,7 +4192,7 @@ export const deserializeAws_restJson1GetSlotTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSlotTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSlotTypeCommandError(output, context);
   }
   const contents: GetSlotTypeCommandOutput = {
@@ -4310,7 +4310,7 @@ export const deserializeAws_restJson1GetSlotTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSlotTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSlotTypesCommandError(output, context);
   }
   const contents: GetSlotTypesCommandOutput = {
@@ -4393,7 +4393,7 @@ export const deserializeAws_restJson1GetSlotTypeVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSlotTypeVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSlotTypeVersionsCommandError(output, context);
   }
   const contents: GetSlotTypeVersionsCommandOutput = {
@@ -4476,7 +4476,7 @@ export const deserializeAws_restJson1GetUtterancesViewCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUtterancesViewCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUtterancesViewCommandError(output, context);
   }
   const contents: GetUtterancesViewCommandOutput = {
@@ -4551,7 +4551,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -4630,7 +4630,7 @@ export const deserializeAws_restJson1PutBotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBotCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutBotCommandError(output, context);
   }
   const contents: PutBotCommandOutput = {
@@ -4785,7 +4785,7 @@ export const deserializeAws_restJson1PutBotAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBotAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutBotAliasCommandError(output, context);
   }
   const contents: PutBotAliasCommandOutput = {
@@ -4904,7 +4904,7 @@ export const deserializeAws_restJson1PutIntentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutIntentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutIntentCommandError(output, context);
   }
   const contents: PutIntentCommandOutput = {
@@ -5055,7 +5055,7 @@ export const deserializeAws_restJson1PutSlotTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutSlotTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutSlotTypeCommandError(output, context);
   }
   const contents: PutSlotTypeCommandOutput = {
@@ -5185,7 +5185,7 @@ export const deserializeAws_restJson1StartImportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartImportCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartImportCommandError(output, context);
   }
   const contents: StartImportCommandOutput = {
@@ -5280,7 +5280,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -5363,7 +5363,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {

--- a/clients/client-lex-runtime-service/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/protocols/Aws_restJson1.ts
@@ -316,7 +316,7 @@ export const deserializeAws_restJson1DeleteSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSessionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSessionCommandError(output, context);
   }
   const contents: DeleteSessionCommandOutput = {
@@ -415,7 +415,7 @@ export const deserializeAws_restJson1GetSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSessionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSessionCommandError(output, context);
   }
   const contents: GetSessionCommandOutput = {
@@ -506,7 +506,7 @@ export const deserializeAws_restJson1PostContentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PostContentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PostContentCommandError(output, context);
   }
   const contents: PostContentCommandOutput = {
@@ -683,7 +683,7 @@ export const deserializeAws_restJson1PostTextCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PostTextCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PostTextCommandError(output, context);
   }
   const contents: PostTextCommandOutput = {
@@ -830,7 +830,7 @@ export const deserializeAws_restJson1PutSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutSessionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutSessionCommandError(output, context);
   }
   const contents: PutSessionCommandOutput = {

--- a/clients/client-license-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-license-manager/protocols/Aws_json1_1.ts
@@ -335,7 +335,7 @@ export const deserializeAws_json1_1CreateLicenseConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLicenseConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLicenseConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -430,7 +430,7 @@ export const deserializeAws_json1_1DeleteLicenseConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLicenseConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLicenseConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -517,7 +517,7 @@ export const deserializeAws_json1_1GetLicenseConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLicenseConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLicenseConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -604,7 +604,7 @@ export const deserializeAws_json1_1GetServiceSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServiceSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetServiceSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -683,7 +683,7 @@ export const deserializeAws_json1_1ListAssociationsForLicenseConfigurationComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssociationsForLicenseConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssociationsForLicenseConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -778,7 +778,7 @@ export const deserializeAws_json1_1ListFailuresForLicenseConfigurationOperations
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFailuresForLicenseConfigurationOperationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListFailuresForLicenseConfigurationOperationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -865,7 +865,7 @@ export const deserializeAws_json1_1ListLicenseConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLicenseConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLicenseConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -960,7 +960,7 @@ export const deserializeAws_json1_1ListLicenseSpecificationsForResourceCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLicenseSpecificationsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLicenseSpecificationsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1047,7 +1047,7 @@ export const deserializeAws_json1_1ListResourceInventoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceInventoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourceInventoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1150,7 +1150,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1237,7 +1237,7 @@ export const deserializeAws_json1_1ListUsageForLicenseConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUsageForLicenseConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUsageForLicenseConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1332,7 +1332,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1419,7 +1419,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1506,7 +1506,7 @@ export const deserializeAws_json1_1UpdateLicenseConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLicenseConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateLicenseConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1593,7 +1593,7 @@ export const deserializeAws_json1_1UpdateLicenseSpecificationsForResourceCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLicenseSpecificationsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateLicenseSpecificationsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1696,7 +1696,7 @@ export const deserializeAws_json1_1UpdateServiceSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServiceSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateServiceSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-lightsail/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/protocols/Aws_json1_1.ts
@@ -2313,7 +2313,7 @@ export const deserializeAws_json1_1AllocateStaticIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AllocateStaticIpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AllocateStaticIpCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2416,7 +2416,7 @@ export const deserializeAws_json1_1AttachCertificateToDistributionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachCertificateToDistributionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AttachCertificateToDistributionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2511,7 +2511,7 @@ export const deserializeAws_json1_1AttachDiskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachDiskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AttachDiskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2614,7 +2614,7 @@ export const deserializeAws_json1_1AttachInstancesToLoadBalancerCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachInstancesToLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AttachInstancesToLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2717,7 +2717,7 @@ export const deserializeAws_json1_1AttachLoadBalancerTlsCertificateCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachLoadBalancerTlsCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AttachLoadBalancerTlsCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2820,7 +2820,7 @@ export const deserializeAws_json1_1AttachStaticIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachStaticIpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AttachStaticIpCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2923,7 +2923,7 @@ export const deserializeAws_json1_1CloseInstancePublicPortsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CloseInstancePublicPortsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CloseInstancePublicPortsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3026,7 +3026,7 @@ export const deserializeAws_json1_1CopySnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopySnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CopySnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3129,7 +3129,7 @@ export const deserializeAws_json1_1CreateCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3216,7 +3216,7 @@ export const deserializeAws_json1_1CreateCloudFormationStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCloudFormationStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCloudFormationStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3319,7 +3319,7 @@ export const deserializeAws_json1_1CreateContactMethodCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateContactMethodCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateContactMethodCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3414,7 +3414,7 @@ export const deserializeAws_json1_1CreateDiskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDiskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDiskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3517,7 +3517,7 @@ export const deserializeAws_json1_1CreateDiskFromSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDiskFromSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDiskFromSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3620,7 +3620,7 @@ export const deserializeAws_json1_1CreateDiskSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDiskSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDiskSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3723,7 +3723,7 @@ export const deserializeAws_json1_1CreateDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDistributionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDistributionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3818,7 +3818,7 @@ export const deserializeAws_json1_1CreateDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3921,7 +3921,7 @@ export const deserializeAws_json1_1CreateDomainEntryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDomainEntryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDomainEntryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4024,7 +4024,7 @@ export const deserializeAws_json1_1CreateInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4127,7 +4127,7 @@ export const deserializeAws_json1_1CreateInstancesFromSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInstancesFromSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateInstancesFromSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4230,7 +4230,7 @@ export const deserializeAws_json1_1CreateInstanceSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInstanceSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateInstanceSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4333,7 +4333,7 @@ export const deserializeAws_json1_1CreateKeyPairCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateKeyPairCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateKeyPairCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4436,7 +4436,7 @@ export const deserializeAws_json1_1CreateLoadBalancerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4539,7 +4539,7 @@ export const deserializeAws_json1_1CreateLoadBalancerTlsCertificateCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLoadBalancerTlsCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLoadBalancerTlsCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4642,7 +4642,7 @@ export const deserializeAws_json1_1CreateRelationalDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRelationalDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRelationalDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4745,7 +4745,7 @@ export const deserializeAws_json1_1CreateRelationalDatabaseFromSnapshotCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRelationalDatabaseFromSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRelationalDatabaseFromSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4848,7 +4848,7 @@ export const deserializeAws_json1_1CreateRelationalDatabaseSnapshotCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRelationalDatabaseSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRelationalDatabaseSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4951,7 +4951,7 @@ export const deserializeAws_json1_1DeleteAlarmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAlarmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAlarmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5046,7 +5046,7 @@ export const deserializeAws_json1_1DeleteAutoSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAutoSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAutoSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5141,7 +5141,7 @@ export const deserializeAws_json1_1DeleteCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5228,7 +5228,7 @@ export const deserializeAws_json1_1DeleteContactMethodCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteContactMethodCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteContactMethodCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5323,7 +5323,7 @@ export const deserializeAws_json1_1DeleteDiskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDiskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDiskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5426,7 +5426,7 @@ export const deserializeAws_json1_1DeleteDiskSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDiskSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDiskSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5529,7 +5529,7 @@ export const deserializeAws_json1_1DeleteDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDistributionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDistributionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5624,7 +5624,7 @@ export const deserializeAws_json1_1DeleteDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5727,7 +5727,7 @@ export const deserializeAws_json1_1DeleteDomainEntryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDomainEntryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDomainEntryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5830,7 +5830,7 @@ export const deserializeAws_json1_1DeleteInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5933,7 +5933,7 @@ export const deserializeAws_json1_1DeleteInstanceSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInstanceSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteInstanceSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6036,7 +6036,7 @@ export const deserializeAws_json1_1DeleteKeyPairCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteKeyPairCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteKeyPairCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6139,7 +6139,7 @@ export const deserializeAws_json1_1DeleteKnownHostKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteKnownHostKeysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteKnownHostKeysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6242,7 +6242,7 @@ export const deserializeAws_json1_1DeleteLoadBalancerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6345,7 +6345,7 @@ export const deserializeAws_json1_1DeleteLoadBalancerTlsCertificateCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoadBalancerTlsCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLoadBalancerTlsCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6448,7 +6448,7 @@ export const deserializeAws_json1_1DeleteRelationalDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRelationalDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRelationalDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6551,7 +6551,7 @@ export const deserializeAws_json1_1DeleteRelationalDatabaseSnapshotCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRelationalDatabaseSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRelationalDatabaseSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6654,7 +6654,7 @@ export const deserializeAws_json1_1DetachCertificateFromDistributionCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachCertificateFromDistributionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetachCertificateFromDistributionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6749,7 +6749,7 @@ export const deserializeAws_json1_1DetachDiskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachDiskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetachDiskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6852,7 +6852,7 @@ export const deserializeAws_json1_1DetachInstancesFromLoadBalancerCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachInstancesFromLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetachInstancesFromLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6955,7 +6955,7 @@ export const deserializeAws_json1_1DetachStaticIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachStaticIpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetachStaticIpCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7058,7 +7058,7 @@ export const deserializeAws_json1_1DisableAddOnCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableAddOnCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableAddOnCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7153,7 +7153,7 @@ export const deserializeAws_json1_1DownloadDefaultKeyPairCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DownloadDefaultKeyPairCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DownloadDefaultKeyPairCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7256,7 +7256,7 @@ export const deserializeAws_json1_1EnableAddOnCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableAddOnCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableAddOnCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7351,7 +7351,7 @@ export const deserializeAws_json1_1ExportSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ExportSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7454,7 +7454,7 @@ export const deserializeAws_json1_1GetActiveNamesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetActiveNamesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetActiveNamesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7557,7 +7557,7 @@ export const deserializeAws_json1_1GetAlarmsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAlarmsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAlarmsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7652,7 +7652,7 @@ export const deserializeAws_json1_1GetAutoSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAutoSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAutoSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7747,7 +7747,7 @@ export const deserializeAws_json1_1GetBlueprintsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBlueprintsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetBlueprintsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7850,7 +7850,7 @@ export const deserializeAws_json1_1GetBundlesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBundlesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetBundlesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7953,7 +7953,7 @@ export const deserializeAws_json1_1GetCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8040,7 +8040,7 @@ export const deserializeAws_json1_1GetCloudFormationStackRecordsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCloudFormationStackRecordsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCloudFormationStackRecordsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8143,7 +8143,7 @@ export const deserializeAws_json1_1GetContactMethodsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetContactMethodsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetContactMethodsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8238,7 +8238,7 @@ export const deserializeAws_json1_1GetDiskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDiskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDiskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8341,7 +8341,7 @@ export const deserializeAws_json1_1GetDisksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDisksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDisksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8444,7 +8444,7 @@ export const deserializeAws_json1_1GetDiskSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDiskSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDiskSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8547,7 +8547,7 @@ export const deserializeAws_json1_1GetDiskSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDiskSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDiskSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8650,7 +8650,7 @@ export const deserializeAws_json1_1GetDistributionBundlesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDistributionBundlesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDistributionBundlesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8745,7 +8745,7 @@ export const deserializeAws_json1_1GetDistributionLatestCacheResetCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDistributionLatestCacheResetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDistributionLatestCacheResetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8840,7 +8840,7 @@ export const deserializeAws_json1_1GetDistributionMetricDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDistributionMetricDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDistributionMetricDataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8935,7 +8935,7 @@ export const deserializeAws_json1_1GetDistributionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDistributionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDistributionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9030,7 +9030,7 @@ export const deserializeAws_json1_1GetDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9133,7 +9133,7 @@ export const deserializeAws_json1_1GetDomainsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDomainsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9236,7 +9236,7 @@ export const deserializeAws_json1_1GetExportSnapshotRecordsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetExportSnapshotRecordsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetExportSnapshotRecordsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9339,7 +9339,7 @@ export const deserializeAws_json1_1GetInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9442,7 +9442,7 @@ export const deserializeAws_json1_1GetInstanceAccessDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstanceAccessDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstanceAccessDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9545,7 +9545,7 @@ export const deserializeAws_json1_1GetInstanceMetricDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstanceMetricDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstanceMetricDataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9648,7 +9648,7 @@ export const deserializeAws_json1_1GetInstancePortStatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstancePortStatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstancePortStatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9751,7 +9751,7 @@ export const deserializeAws_json1_1GetInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9854,7 +9854,7 @@ export const deserializeAws_json1_1GetInstanceSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstanceSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstanceSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9957,7 +9957,7 @@ export const deserializeAws_json1_1GetInstanceSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstanceSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstanceSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10060,7 +10060,7 @@ export const deserializeAws_json1_1GetInstanceStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstanceStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstanceStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10163,7 +10163,7 @@ export const deserializeAws_json1_1GetKeyPairCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetKeyPairCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetKeyPairCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10266,7 +10266,7 @@ export const deserializeAws_json1_1GetKeyPairsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetKeyPairsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetKeyPairsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10369,7 +10369,7 @@ export const deserializeAws_json1_1GetLoadBalancerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLoadBalancerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10472,7 +10472,7 @@ export const deserializeAws_json1_1GetLoadBalancerMetricDataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoadBalancerMetricDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLoadBalancerMetricDataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10575,7 +10575,7 @@ export const deserializeAws_json1_1GetLoadBalancersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoadBalancersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLoadBalancersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10678,7 +10678,7 @@ export const deserializeAws_json1_1GetLoadBalancerTlsCertificatesCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoadBalancerTlsCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLoadBalancerTlsCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10781,7 +10781,7 @@ export const deserializeAws_json1_1GetOperationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOperationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOperationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10884,7 +10884,7 @@ export const deserializeAws_json1_1GetOperationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOperationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOperationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10987,7 +10987,7 @@ export const deserializeAws_json1_1GetOperationsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOperationsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOperationsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11090,7 +11090,7 @@ export const deserializeAws_json1_1GetRegionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRegionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRegionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11193,7 +11193,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11296,7 +11296,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseBlueprintsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseBlueprintsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseBlueprintsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11399,7 +11399,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseBundlesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseBundlesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseBundlesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11502,7 +11502,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11605,7 +11605,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseLogEventsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseLogEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseLogEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11708,7 +11708,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseLogStreamsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseLogStreamsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseLogStreamsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11811,7 +11811,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseMasterUserPasswordComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseMasterUserPasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseMasterUserPasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11914,7 +11914,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseMetricDataCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseMetricDataCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseMetricDataCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12017,7 +12017,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseParametersCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12120,7 +12120,7 @@ export const deserializeAws_json1_1GetRelationalDatabasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12223,7 +12223,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseSnapshotCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12326,7 +12326,7 @@ export const deserializeAws_json1_1GetRelationalDatabaseSnapshotsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRelationalDatabaseSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRelationalDatabaseSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12429,7 +12429,7 @@ export const deserializeAws_json1_1GetStaticIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStaticIpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetStaticIpCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12532,7 +12532,7 @@ export const deserializeAws_json1_1GetStaticIpsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetStaticIpsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetStaticIpsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12635,7 +12635,7 @@ export const deserializeAws_json1_1ImportKeyPairCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportKeyPairCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportKeyPairCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12738,7 +12738,7 @@ export const deserializeAws_json1_1IsVpcPeeredCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IsVpcPeeredCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1IsVpcPeeredCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12841,7 +12841,7 @@ export const deserializeAws_json1_1OpenInstancePublicPortsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<OpenInstancePublicPortsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1OpenInstancePublicPortsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12944,7 +12944,7 @@ export const deserializeAws_json1_1PeerVpcCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PeerVpcCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PeerVpcCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13047,7 +13047,7 @@ export const deserializeAws_json1_1PutAlarmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAlarmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutAlarmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13142,7 +13142,7 @@ export const deserializeAws_json1_1PutInstancePublicPortsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutInstancePublicPortsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutInstancePublicPortsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13245,7 +13245,7 @@ export const deserializeAws_json1_1RebootInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RebootInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13348,7 +13348,7 @@ export const deserializeAws_json1_1RebootRelationalDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootRelationalDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RebootRelationalDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13451,7 +13451,7 @@ export const deserializeAws_json1_1ReleaseStaticIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReleaseStaticIpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ReleaseStaticIpCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13554,7 +13554,7 @@ export const deserializeAws_json1_1ResetDistributionCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetDistributionCacheCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResetDistributionCacheCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13649,7 +13649,7 @@ export const deserializeAws_json1_1SendContactMethodVerificationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendContactMethodVerificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SendContactMethodVerificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13744,7 +13744,7 @@ export const deserializeAws_json1_1StartInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13847,7 +13847,7 @@ export const deserializeAws_json1_1StartRelationalDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartRelationalDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartRelationalDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -13950,7 +13950,7 @@ export const deserializeAws_json1_1StopInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14053,7 +14053,7 @@ export const deserializeAws_json1_1StopRelationalDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopRelationalDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopRelationalDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14156,7 +14156,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14259,7 +14259,7 @@ export const deserializeAws_json1_1TestAlarmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestAlarmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TestAlarmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14354,7 +14354,7 @@ export const deserializeAws_json1_1UnpeerVpcCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnpeerVpcCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UnpeerVpcCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14457,7 +14457,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14560,7 +14560,7 @@ export const deserializeAws_json1_1UpdateDistributionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDistributionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDistributionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14655,7 +14655,7 @@ export const deserializeAws_json1_1UpdateDistributionBundleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDistributionBundleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDistributionBundleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14750,7 +14750,7 @@ export const deserializeAws_json1_1UpdateDomainEntryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainEntryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDomainEntryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14853,7 +14853,7 @@ export const deserializeAws_json1_1UpdateLoadBalancerAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLoadBalancerAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateLoadBalancerAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -14956,7 +14956,7 @@ export const deserializeAws_json1_1UpdateRelationalDatabaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRelationalDatabaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRelationalDatabaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -15059,7 +15059,7 @@ export const deserializeAws_json1_1UpdateRelationalDatabaseParametersCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRelationalDatabaseParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRelationalDatabaseParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-machine-learning/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/protocols/Aws_json1_1.ts
@@ -521,7 +521,7 @@ export const deserializeAws_json1_1AddTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -608,7 +608,7 @@ export const deserializeAws_json1_1CreateBatchPredictionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBatchPredictionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateBatchPredictionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -679,7 +679,7 @@ export const deserializeAws_json1_1CreateDataSourceFromRDSCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataSourceFromRDSCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDataSourceFromRDSCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -750,7 +750,7 @@ export const deserializeAws_json1_1CreateDataSourceFromRedshiftCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataSourceFromRedshiftCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDataSourceFromRedshiftCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -821,7 +821,7 @@ export const deserializeAws_json1_1CreateDataSourceFromS3Command = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataSourceFromS3CommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDataSourceFromS3CommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -892,7 +892,7 @@ export const deserializeAws_json1_1CreateEvaluationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEvaluationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEvaluationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -963,7 +963,7 @@ export const deserializeAws_json1_1CreateMLModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMLModelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateMLModelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1034,7 +1034,7 @@ export const deserializeAws_json1_1CreateRealtimeEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRealtimeEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRealtimeEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1105,7 +1105,7 @@ export const deserializeAws_json1_1DeleteBatchPredictionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBatchPredictionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBatchPredictionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1176,7 +1176,7 @@ export const deserializeAws_json1_1DeleteDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDataSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1247,7 +1247,7 @@ export const deserializeAws_json1_1DeleteEvaluationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEvaluationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEvaluationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1318,7 +1318,7 @@ export const deserializeAws_json1_1DeleteMLModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMLModelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMLModelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1389,7 +1389,7 @@ export const deserializeAws_json1_1DeleteRealtimeEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRealtimeEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRealtimeEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1460,7 +1460,7 @@ export const deserializeAws_json1_1DeleteTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1539,7 +1539,7 @@ export const deserializeAws_json1_1DescribeBatchPredictionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBatchPredictionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeBatchPredictionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1602,7 +1602,7 @@ export const deserializeAws_json1_1DescribeDataSourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDataSourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDataSourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1665,7 +1665,7 @@ export const deserializeAws_json1_1DescribeEvaluationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEvaluationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEvaluationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1728,7 +1728,7 @@ export const deserializeAws_json1_1DescribeMLModelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMLModelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMLModelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1791,7 +1791,7 @@ export const deserializeAws_json1_1DescribeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1862,7 +1862,7 @@ export const deserializeAws_json1_1GetBatchPredictionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBatchPredictionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetBatchPredictionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1933,7 +1933,7 @@ export const deserializeAws_json1_1GetDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDataSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2004,7 +2004,7 @@ export const deserializeAws_json1_1GetEvaluationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEvaluationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetEvaluationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2075,7 +2075,7 @@ export const deserializeAws_json1_1GetMLModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMLModelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMLModelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2146,7 +2146,7 @@ export const deserializeAws_json1_1PredictCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PredictCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PredictCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2233,7 +2233,7 @@ export const deserializeAws_json1_1UpdateBatchPredictionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBatchPredictionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateBatchPredictionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2304,7 +2304,7 @@ export const deserializeAws_json1_1UpdateDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDataSourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDataSourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2375,7 +2375,7 @@ export const deserializeAws_json1_1UpdateEvaluationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEvaluationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateEvaluationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2446,7 +2446,7 @@ export const deserializeAws_json1_1UpdateMLModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMLModelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMLModelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-macie/protocols/Aws_json1_1.ts
+++ b/clients/client-macie/protocols/Aws_json1_1.ts
@@ -147,7 +147,7 @@ export const deserializeAws_json1_1AssociateMemberAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateMemberAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateMemberAccountCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -215,7 +215,7 @@ export const deserializeAws_json1_1AssociateS3ResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateS3ResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateS3ResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -294,7 +294,7 @@ export const deserializeAws_json1_1DisassociateMemberAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateMemberAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateMemberAccountCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -354,7 +354,7 @@ export const deserializeAws_json1_1DisassociateS3ResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateS3ResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateS3ResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -425,7 +425,7 @@ export const deserializeAws_json1_1ListMemberAccountsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMemberAccountsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListMemberAccountsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -488,7 +488,7 @@ export const deserializeAws_json1_1ListS3ResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListS3ResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListS3ResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -559,7 +559,7 @@ export const deserializeAws_json1_1UpdateS3ResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateS3ResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateS3ResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-macie2/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/protocols/Aws_restJson1.ts
@@ -1669,7 +1669,7 @@ export const deserializeAws_restJson1AcceptInvitationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptInvitationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AcceptInvitationCommandError(output, context);
   }
   const contents: AcceptInvitationCommandOutput = {
@@ -1768,7 +1768,7 @@ export const deserializeAws_restJson1BatchGetCustomDataIdentifiersCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetCustomDataIdentifiersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchGetCustomDataIdentifiersCommandError(output, context);
   }
   const contents: BatchGetCustomDataIdentifiersCommandOutput = {
@@ -1878,7 +1878,7 @@ export const deserializeAws_restJson1CreateClassificationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClassificationJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateClassificationJobCommandError(output, context);
   }
   const contents: CreateClassificationJobCommandOutput = {
@@ -1985,7 +1985,7 @@ export const deserializeAws_restJson1CreateCustomDataIdentifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCustomDataIdentifierCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCustomDataIdentifierCommandError(output, context);
   }
   const contents: CreateCustomDataIdentifierCommandOutput = {
@@ -2088,7 +2088,7 @@ export const deserializeAws_restJson1CreateFindingsFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFindingsFilterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFindingsFilterCommandError(output, context);
   }
   const contents: CreateFindingsFilterCommandOutput = {
@@ -2195,7 +2195,7 @@ export const deserializeAws_restJson1CreateInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateInvitationsCommandError(output, context);
   }
   const contents: CreateInvitationsCommandOutput = {
@@ -2301,7 +2301,7 @@ export const deserializeAws_restJson1CreateMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMemberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMemberCommandError(output, context);
   }
   const contents: CreateMemberCommandOutput = {
@@ -2404,7 +2404,7 @@ export const deserializeAws_restJson1CreateSampleFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSampleFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSampleFindingsCommandError(output, context);
   }
   const contents: CreateSampleFindingsCommandOutput = {
@@ -2503,7 +2503,7 @@ export const deserializeAws_restJson1DeclineInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeclineInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeclineInvitationsCommandError(output, context);
   }
   const contents: DeclineInvitationsCommandOutput = {
@@ -2609,7 +2609,7 @@ export const deserializeAws_restJson1DeleteCustomDataIdentifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCustomDataIdentifierCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteCustomDataIdentifierCommandError(output, context);
   }
   const contents: DeleteCustomDataIdentifierCommandOutput = {
@@ -2708,7 +2708,7 @@ export const deserializeAws_restJson1DeleteFindingsFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFindingsFilterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFindingsFilterCommandError(output, context);
   }
   const contents: DeleteFindingsFilterCommandOutput = {
@@ -2807,7 +2807,7 @@ export const deserializeAws_restJson1DeleteInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteInvitationsCommandError(output, context);
   }
   const contents: DeleteInvitationsCommandOutput = {
@@ -2913,7 +2913,7 @@ export const deserializeAws_restJson1DeleteMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMemberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMemberCommandError(output, context);
   }
   const contents: DeleteMemberCommandOutput = {
@@ -3012,7 +3012,7 @@ export const deserializeAws_restJson1DescribeBucketsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBucketsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeBucketsCommandError(output, context);
   }
   const contents: DescribeBucketsCommandOutput = {
@@ -3119,7 +3119,7 @@ export const deserializeAws_restJson1DescribeClassificationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClassificationJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeClassificationJobCommandError(output, context);
   }
   const contents: DescribeClassificationJobCommandOutput = {
@@ -3282,7 +3282,7 @@ export const deserializeAws_restJson1DescribeOrganizationConfigurationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrganizationConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeOrganizationConfigurationCommandError(output, context);
   }
   const contents: DescribeOrganizationConfigurationCommandOutput = {
@@ -3389,7 +3389,7 @@ export const deserializeAws_restJson1DisableMacieCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableMacieCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisableMacieCommandError(output, context);
   }
   const contents: DisableMacieCommandOutput = {
@@ -3488,7 +3488,7 @@ export const deserializeAws_restJson1DisableOrganizationAdminAccountCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableOrganizationAdminAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisableOrganizationAdminAccountCommandError(output, context);
   }
   const contents: DisableOrganizationAdminAccountCommandOutput = {
@@ -3587,7 +3587,7 @@ export const deserializeAws_restJson1DisassociateFromMasterAccountCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateFromMasterAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateFromMasterAccountCommandError(output, context);
   }
   const contents: DisassociateFromMasterAccountCommandOutput = {
@@ -3686,7 +3686,7 @@ export const deserializeAws_restJson1DisassociateMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateMemberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateMemberCommandError(output, context);
   }
   const contents: DisassociateMemberCommandOutput = {
@@ -3785,7 +3785,7 @@ export const deserializeAws_restJson1EnableMacieCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableMacieCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1EnableMacieCommandError(output, context);
   }
   const contents: EnableMacieCommandOutput = {
@@ -3884,7 +3884,7 @@ export const deserializeAws_restJson1EnableOrganizationAdminAccountCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableOrganizationAdminAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1EnableOrganizationAdminAccountCommandError(output, context);
   }
   const contents: EnableOrganizationAdminAccountCommandOutput = {
@@ -3983,7 +3983,7 @@ export const deserializeAws_restJson1GetBucketStatisticsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketStatisticsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBucketStatisticsCommandError(output, context);
   }
   const contents: GetBucketStatisticsCommandOutput = {
@@ -4127,7 +4127,7 @@ export const deserializeAws_restJson1GetClassificationExportConfigurationCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetClassificationExportConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetClassificationExportConfigurationCommandError(output, context);
   }
   const contents: GetClassificationExportConfigurationCommandOutput = {
@@ -4230,7 +4230,7 @@ export const deserializeAws_restJson1GetCustomDataIdentifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCustomDataIdentifierCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCustomDataIdentifierCommandError(output, context);
   }
   const contents: GetCustomDataIdentifierCommandOutput = {
@@ -4373,7 +4373,7 @@ export const deserializeAws_restJson1GetFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFindingsCommandError(output, context);
   }
   const contents: GetFindingsCommandOutput = {
@@ -4476,7 +4476,7 @@ export const deserializeAws_restJson1GetFindingsFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFindingsFilterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFindingsFilterCommandError(output, context);
   }
   const contents: GetFindingsFilterCommandOutput = {
@@ -4607,7 +4607,7 @@ export const deserializeAws_restJson1GetFindingStatisticsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFindingStatisticsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFindingStatisticsCommandError(output, context);
   }
   const contents: GetFindingStatisticsCommandOutput = {
@@ -4710,7 +4710,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInvitationsCountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetInvitationsCountCommandError(output, context);
   }
   const contents: GetInvitationsCountCommandOutput = {
@@ -4813,7 +4813,7 @@ export const deserializeAws_restJson1GetMacieSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMacieSessionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMacieSessionCommandError(output, context);
   }
   const contents: GetMacieSessionCommandOutput = {
@@ -4932,7 +4932,7 @@ export const deserializeAws_restJson1GetMasterAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMasterAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMasterAccountCommandError(output, context);
   }
   const contents: GetMasterAccountCommandOutput = {
@@ -5035,7 +5035,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMemberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMemberCommandError(output, context);
   }
   const contents: GetMemberCommandOutput = {
@@ -5166,7 +5166,7 @@ export const deserializeAws_restJson1GetUsageStatisticsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUsageStatisticsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUsageStatisticsCommandError(output, context);
   }
   const contents: GetUsageStatisticsCommandOutput = {
@@ -5273,7 +5273,7 @@ export const deserializeAws_restJson1GetUsageTotalsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUsageTotalsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUsageTotalsCommandError(output, context);
   }
   const contents: GetUsageTotalsCommandOutput = {
@@ -5376,7 +5376,7 @@ export const deserializeAws_restJson1ListClassificationJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListClassificationJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListClassificationJobsCommandError(output, context);
   }
   const contents: ListClassificationJobsCommandOutput = {
@@ -5483,7 +5483,7 @@ export const deserializeAws_restJson1ListCustomDataIdentifiersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCustomDataIdentifiersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListCustomDataIdentifiersCommandError(output, context);
   }
   const contents: ListCustomDataIdentifiersCommandOutput = {
@@ -5590,7 +5590,7 @@ export const deserializeAws_restJson1ListFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFindingsCommandError(output, context);
   }
   const contents: ListFindingsCommandOutput = {
@@ -5697,7 +5697,7 @@ export const deserializeAws_restJson1ListFindingsFiltersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFindingsFiltersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFindingsFiltersCommandError(output, context);
   }
   const contents: ListFindingsFiltersCommandOutput = {
@@ -5807,7 +5807,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListInvitationsCommandError(output, context);
   }
   const contents: ListInvitationsCommandOutput = {
@@ -5914,7 +5914,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMembersCommandError(output, context);
   }
   const contents: ListMembersCommandOutput = {
@@ -6021,7 +6021,7 @@ export const deserializeAws_restJson1ListOrganizationAdminAccountsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOrganizationAdminAccountsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListOrganizationAdminAccountsCommandError(output, context);
   }
   const contents: ListOrganizationAdminAccountsCommandOutput = {
@@ -6128,7 +6128,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -6175,7 +6175,7 @@ export const deserializeAws_restJson1PutClassificationExportConfigurationCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutClassificationExportConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutClassificationExportConfigurationCommandError(output, context);
   }
   const contents: PutClassificationExportConfigurationCommandOutput = {
@@ -6278,7 +6278,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -6321,7 +6321,7 @@ export const deserializeAws_restJson1TestCustomDataIdentifierCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestCustomDataIdentifierCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TestCustomDataIdentifierCommandError(output, context);
   }
   const contents: TestCustomDataIdentifierCommandOutput = {
@@ -6424,7 +6424,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -6467,7 +6467,7 @@ export const deserializeAws_restJson1UpdateClassificationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateClassificationJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateClassificationJobCommandError(output, context);
   }
   const contents: UpdateClassificationJobCommandOutput = {
@@ -6566,7 +6566,7 @@ export const deserializeAws_restJson1UpdateFindingsFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFindingsFilterCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFindingsFilterCommandError(output, context);
   }
   const contents: UpdateFindingsFilterCommandOutput = {
@@ -6673,7 +6673,7 @@ export const deserializeAws_restJson1UpdateMacieSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMacieSessionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMacieSessionCommandError(output, context);
   }
   const contents: UpdateMacieSessionCommandOutput = {
@@ -6772,7 +6772,7 @@ export const deserializeAws_restJson1UpdateMemberSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMemberSessionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMemberSessionCommandError(output, context);
   }
   const contents: UpdateMemberSessionCommandOutput = {
@@ -6871,7 +6871,7 @@ export const deserializeAws_restJson1UpdateOrganizationConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateOrganizationConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateOrganizationConfigurationCommandError(output, context);
   }
   const contents: UpdateOrganizationConfigurationCommandOutput = {

--- a/clients/client-managedblockchain/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/protocols/Aws_restJson1.ts
@@ -873,7 +873,7 @@ export const deserializeAws_restJson1CreateMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMemberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMemberCommandError(output, context);
   }
   const contents: CreateMemberCommandOutput = {
@@ -984,7 +984,7 @@ export const deserializeAws_restJson1CreateNetworkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNetworkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateNetworkCommandError(output, context);
   }
   const contents: CreateNetworkCommandOutput = {
@@ -1083,7 +1083,7 @@ export const deserializeAws_restJson1CreateNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateNodeCommandError(output, context);
   }
   const contents: CreateNodeCommandOutput = {
@@ -1194,7 +1194,7 @@ export const deserializeAws_restJson1CreateProposalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProposalCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateProposalCommandError(output, context);
   }
   const contents: CreateProposalCommandOutput = {
@@ -1289,7 +1289,7 @@ export const deserializeAws_restJson1DeleteMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMemberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMemberCommandError(output, context);
   }
   const contents: DeleteMemberCommandOutput = {
@@ -1380,7 +1380,7 @@ export const deserializeAws_restJson1DeleteNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteNodeCommandError(output, context);
   }
   const contents: DeleteNodeCommandOutput = {
@@ -1471,7 +1471,7 @@ export const deserializeAws_restJson1GetMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMemberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMemberCommandError(output, context);
   }
   const contents: GetMemberCommandOutput = {
@@ -1558,7 +1558,7 @@ export const deserializeAws_restJson1GetNetworkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetNetworkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetNetworkCommandError(output, context);
   }
   const contents: GetNetworkCommandOutput = {
@@ -1645,7 +1645,7 @@ export const deserializeAws_restJson1GetNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetNodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetNodeCommandError(output, context);
   }
   const contents: GetNodeCommandOutput = {
@@ -1732,7 +1732,7 @@ export const deserializeAws_restJson1GetProposalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetProposalCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetProposalCommandError(output, context);
   }
   const contents: GetProposalCommandOutput = {
@@ -1819,7 +1819,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListInvitationsCommandError(output, context);
   }
   const contents: ListInvitationsCommandOutput = {
@@ -1918,7 +1918,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMembersCommandError(output, context);
   }
   const contents: ListMembersCommandOutput = {
@@ -2001,7 +2001,7 @@ export const deserializeAws_restJson1ListNetworksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNetworksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListNetworksCommandError(output, context);
   }
   const contents: ListNetworksCommandOutput = {
@@ -2084,7 +2084,7 @@ export const deserializeAws_restJson1ListNodesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNodesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListNodesCommandError(output, context);
   }
   const contents: ListNodesCommandOutput = {
@@ -2167,7 +2167,7 @@ export const deserializeAws_restJson1ListProposalsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProposalsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProposalsCommandError(output, context);
   }
   const contents: ListProposalsCommandOutput = {
@@ -2258,7 +2258,7 @@ export const deserializeAws_restJson1ListProposalVotesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProposalVotesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProposalVotesCommandError(output, context);
   }
   const contents: ListProposalVotesCommandOutput = {
@@ -2341,7 +2341,7 @@ export const deserializeAws_restJson1RejectInvitationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectInvitationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RejectInvitationCommandError(output, context);
   }
   const contents: RejectInvitationCommandOutput = {
@@ -2432,7 +2432,7 @@ export const deserializeAws_restJson1UpdateMemberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMemberCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMemberCommandError(output, context);
   }
   const contents: UpdateMemberCommandOutput = {
@@ -2515,7 +2515,7 @@ export const deserializeAws_restJson1UpdateNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNodeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateNodeCommandError(output, context);
   }
   const contents: UpdateNodeCommandOutput = {
@@ -2598,7 +2598,7 @@ export const deserializeAws_restJson1VoteOnProposalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<VoteOnProposalCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1VoteOnProposalCommandError(output, context);
   }
   const contents: VoteOnProposalCommandOutput = {

--- a/clients/client-marketplace-catalog/protocols/Aws_restJson1.ts
+++ b/clients/client-marketplace-catalog/protocols/Aws_restJson1.ts
@@ -202,7 +202,7 @@ export const deserializeAws_restJson1CancelChangeSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelChangeSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelChangeSetCommandError(output, context);
   }
   const contents: CancelChangeSetCommandOutput = {
@@ -301,7 +301,7 @@ export const deserializeAws_restJson1DescribeChangeSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeChangeSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeChangeSetCommandError(output, context);
   }
   const contents: DescribeChangeSetCommandOutput = {
@@ -416,7 +416,7 @@ export const deserializeAws_restJson1DescribeEntityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEntityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeEntityCommandError(output, context);
   }
   const contents: DescribeEntityCommandOutput = {
@@ -527,7 +527,7 @@ export const deserializeAws_restJson1ListChangeSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListChangeSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListChangeSetsCommandError(output, context);
   }
   const contents: ListChangeSetsCommandOutput = {
@@ -610,7 +610,7 @@ export const deserializeAws_restJson1ListEntitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEntitiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListEntitiesCommandError(output, context);
   }
   const contents: ListEntitiesCommandOutput = {
@@ -701,7 +701,7 @@ export const deserializeAws_restJson1StartChangeSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartChangeSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartChangeSetCommandError(output, context);
   }
   const contents: StartChangeSetCommandOutput = {

--- a/clients/client-marketplace-commerce-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-commerce-analytics/protocols/Aws_json1_1.ts
@@ -50,7 +50,7 @@ export const deserializeAws_json1_1GenerateDataSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateDataSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GenerateDataSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -105,7 +105,7 @@ export const deserializeAws_json1_1StartSupportDataExportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSupportDataExportCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartSupportDataExportCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
@@ -36,7 +36,7 @@ export const deserializeAws_json1_1GetEntitlementsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEntitlementsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetEntitlementsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
@@ -95,7 +95,7 @@ export const deserializeAws_json1_1BatchMeterUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchMeterUsageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchMeterUsageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -198,7 +198,7 @@ export const deserializeAws_json1_1MeterUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MeterUsageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MeterUsageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -309,7 +309,7 @@ export const deserializeAws_json1_1RegisterUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterUsageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterUsageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -420,7 +420,7 @@ export const deserializeAws_json1_1ResolveCustomerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResolveCustomerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResolveCustomerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-mediaconnect/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconnect/protocols/Aws_restJson1.ts
@@ -884,7 +884,7 @@ export const deserializeAws_restJson1AddFlowOutputsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddFlowOutputsCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddFlowOutputsCommandError(output, context);
   }
   const contents: AddFlowOutputsCommandOutput = {
@@ -991,7 +991,7 @@ export const deserializeAws_restJson1AddFlowSourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddFlowSourcesCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddFlowSourcesCommandError(output, context);
   }
   const contents: AddFlowSourcesCommandOutput = {
@@ -1090,7 +1090,7 @@ export const deserializeAws_restJson1AddFlowVpcInterfacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddFlowVpcInterfacesCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddFlowVpcInterfacesCommandError(output, context);
   }
   const contents: AddFlowVpcInterfacesCommandOutput = {
@@ -1189,7 +1189,7 @@ export const deserializeAws_restJson1CreateFlowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFlowCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFlowCommandError(output, context);
   }
   const contents: CreateFlowCommandOutput = {
@@ -1284,7 +1284,7 @@ export const deserializeAws_restJson1DeleteFlowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFlowCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFlowCommandError(output, context);
   }
   const contents: DeleteFlowCommandOutput = {
@@ -1383,7 +1383,7 @@ export const deserializeAws_restJson1DescribeFlowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFlowCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeFlowCommandError(output, context);
   }
   const contents: DescribeFlowCommandOutput = {
@@ -1482,7 +1482,7 @@ export const deserializeAws_restJson1GrantFlowEntitlementsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GrantFlowEntitlementsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GrantFlowEntitlementsCommandError(output, context);
   }
   const contents: GrantFlowEntitlementsCommandOutput = {
@@ -1589,7 +1589,7 @@ export const deserializeAws_restJson1ListEntitlementsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEntitlementsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListEntitlementsCommandError(output, context);
   }
   const contents: ListEntitlementsCommandOutput = {
@@ -1672,7 +1672,7 @@ export const deserializeAws_restJson1ListFlowsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFlowsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFlowsCommandError(output, context);
   }
   const contents: ListFlowsCommandOutput = {
@@ -1755,7 +1755,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1826,7 +1826,7 @@ export const deserializeAws_restJson1RemoveFlowOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveFlowOutputCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveFlowOutputCommandError(output, context);
   }
   const contents: RemoveFlowOutputCommandOutput = {
@@ -1925,7 +1925,7 @@ export const deserializeAws_restJson1RemoveFlowSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveFlowSourceCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveFlowSourceCommandError(output, context);
   }
   const contents: RemoveFlowSourceCommandOutput = {
@@ -2024,7 +2024,7 @@ export const deserializeAws_restJson1RemoveFlowVpcInterfaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveFlowVpcInterfaceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveFlowVpcInterfaceCommandError(output, context);
   }
   const contents: RemoveFlowVpcInterfaceCommandOutput = {
@@ -2130,7 +2130,7 @@ export const deserializeAws_restJson1RevokeFlowEntitlementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeFlowEntitlementCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1RevokeFlowEntitlementCommandError(output, context);
   }
   const contents: RevokeFlowEntitlementCommandOutput = {
@@ -2229,7 +2229,7 @@ export const deserializeAws_restJson1StartFlowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartFlowCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartFlowCommandError(output, context);
   }
   const contents: StartFlowCommandOutput = {
@@ -2328,7 +2328,7 @@ export const deserializeAws_restJson1StopFlowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopFlowCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopFlowCommandError(output, context);
   }
   const contents: StopFlowCommandOutput = {
@@ -2427,7 +2427,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -2494,7 +2494,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -2561,7 +2561,7 @@ export const deserializeAws_restJson1UpdateFlowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFlowCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFlowCommandError(output, context);
   }
   const contents: UpdateFlowCommandOutput = {
@@ -2656,7 +2656,7 @@ export const deserializeAws_restJson1UpdateFlowEntitlementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFlowEntitlementCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFlowEntitlementCommandError(output, context);
   }
   const contents: UpdateFlowEntitlementCommandOutput = {
@@ -2755,7 +2755,7 @@ export const deserializeAws_restJson1UpdateFlowOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFlowOutputCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFlowOutputCommandError(output, context);
   }
   const contents: UpdateFlowOutputCommandOutput = {
@@ -2854,7 +2854,7 @@ export const deserializeAws_restJson1UpdateFlowSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFlowSourceCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFlowSourceCommandError(output, context);
   }
   const contents: UpdateFlowSourceCommandOutput = {

--- a/clients/client-mediaconvert/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1.ts
@@ -982,7 +982,7 @@ export const deserializeAws_restJson1AssociateCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateCertificateCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateCertificateCommandError(output, context);
   }
   const contents: AssociateCertificateCommandOutput = {
@@ -1073,7 +1073,7 @@ export const deserializeAws_restJson1CancelJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelJobCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelJobCommandError(output, context);
   }
   const contents: CancelJobCommandOutput = {
@@ -1164,7 +1164,7 @@ export const deserializeAws_restJson1CreateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateJobCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateJobCommandError(output, context);
   }
   const contents: CreateJobCommandOutput = {
@@ -1259,7 +1259,7 @@ export const deserializeAws_restJson1CreateJobTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateJobTemplateCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateJobTemplateCommandError(output, context);
   }
   const contents: CreateJobTemplateCommandOutput = {
@@ -1354,7 +1354,7 @@ export const deserializeAws_restJson1CreatePresetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePresetCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePresetCommandError(output, context);
   }
   const contents: CreatePresetCommandOutput = {
@@ -1449,7 +1449,7 @@ export const deserializeAws_restJson1CreateQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateQueueCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateQueueCommandError(output, context);
   }
   const contents: CreateQueueCommandOutput = {
@@ -1544,7 +1544,7 @@ export const deserializeAws_restJson1DeleteJobTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteJobTemplateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteJobTemplateCommandError(output, context);
   }
   const contents: DeleteJobTemplateCommandOutput = {
@@ -1635,7 +1635,7 @@ export const deserializeAws_restJson1DeletePresetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePresetCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePresetCommandError(output, context);
   }
   const contents: DeletePresetCommandOutput = {
@@ -1726,7 +1726,7 @@ export const deserializeAws_restJson1DeleteQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteQueueCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteQueueCommandError(output, context);
   }
   const contents: DeleteQueueCommandOutput = {
@@ -1817,7 +1817,7 @@ export const deserializeAws_restJson1DescribeEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEndpointsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeEndpointsCommandError(output, context);
   }
   const contents: DescribeEndpointsCommandOutput = {
@@ -1916,7 +1916,7 @@ export const deserializeAws_restJson1DisassociateCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateCertificateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateCertificateCommandError(output, context);
   }
   const contents: DisassociateCertificateCommandOutput = {
@@ -2007,7 +2007,7 @@ export const deserializeAws_restJson1GetJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJobCommandError(output, context);
   }
   const contents: GetJobCommandOutput = {
@@ -2102,7 +2102,7 @@ export const deserializeAws_restJson1GetJobTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJobTemplateCommandError(output, context);
   }
   const contents: GetJobTemplateCommandOutput = {
@@ -2197,7 +2197,7 @@ export const deserializeAws_restJson1GetPresetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPresetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPresetCommandError(output, context);
   }
   const contents: GetPresetCommandOutput = {
@@ -2292,7 +2292,7 @@ export const deserializeAws_restJson1GetQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetQueueCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetQueueCommandError(output, context);
   }
   const contents: GetQueueCommandOutput = {
@@ -2387,7 +2387,7 @@ export const deserializeAws_restJson1ListJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobsCommandError(output, context);
   }
   const contents: ListJobsCommandOutput = {
@@ -2486,7 +2486,7 @@ export const deserializeAws_restJson1ListJobTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobTemplatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJobTemplatesCommandError(output, context);
   }
   const contents: ListJobTemplatesCommandOutput = {
@@ -2585,7 +2585,7 @@ export const deserializeAws_restJson1ListPresetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPresetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPresetsCommandError(output, context);
   }
   const contents: ListPresetsCommandOutput = {
@@ -2684,7 +2684,7 @@ export const deserializeAws_restJson1ListQueuesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListQueuesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListQueuesCommandError(output, context);
   }
   const contents: ListQueuesCommandOutput = {
@@ -2783,7 +2783,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -2878,7 +2878,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -2969,7 +2969,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -3060,7 +3060,7 @@ export const deserializeAws_restJson1UpdateJobTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateJobTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateJobTemplateCommandError(output, context);
   }
   const contents: UpdateJobTemplateCommandOutput = {
@@ -3155,7 +3155,7 @@ export const deserializeAws_restJson1UpdatePresetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePresetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePresetCommandError(output, context);
   }
   const contents: UpdatePresetCommandOutput = {
@@ -3250,7 +3250,7 @@ export const deserializeAws_restJson1UpdateQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateQueueCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateQueueCommandError(output, context);
   }
   const contents: UpdateQueueCommandOutput = {

--- a/clients/client-medialive/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1.ts
@@ -1870,7 +1870,7 @@ export const deserializeAws_restJson1BatchUpdateScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchUpdateScheduleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchUpdateScheduleCommandError(output, context);
   }
   const contents: BatchUpdateScheduleCommandOutput = {
@@ -1985,7 +1985,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateChannelCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateChannelCommandError(output, context);
   }
   const contents: CreateChannelCommandOutput = {
@@ -2096,7 +2096,7 @@ export const deserializeAws_restJson1CreateInputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInputCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateInputCommandError(output, context);
   }
   const contents: CreateInputCommandOutput = {
@@ -2191,7 +2191,7 @@ export const deserializeAws_restJson1CreateInputSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInputSecurityGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateInputSecurityGroupCommandError(output, context);
   }
   const contents: CreateInputSecurityGroupCommandOutput = {
@@ -2286,7 +2286,7 @@ export const deserializeAws_restJson1CreateMultiplexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMultiplexCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMultiplexCommandError(output, context);
   }
   const contents: CreateMultiplexCommandOutput = {
@@ -2397,7 +2397,7 @@ export const deserializeAws_restJson1CreateMultiplexProgramCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMultiplexProgramCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMultiplexProgramCommandError(output, context);
   }
   const contents: CreateMultiplexProgramCommandOutput = {
@@ -2508,7 +2508,7 @@ export const deserializeAws_restJson1CreateTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTagsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateTagsCommandError(output, context);
   }
   const contents: CreateTagsCommandOutput = {
@@ -2583,7 +2583,7 @@ export const deserializeAws_restJson1DeleteChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteChannelCommandError(output, context);
   }
   const contents: DeleteChannelCommandOutput = {
@@ -2750,7 +2750,7 @@ export const deserializeAws_restJson1DeleteInputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteInputCommandError(output, context);
   }
   const contents: DeleteInputCommandOutput = {
@@ -2857,7 +2857,7 @@ export const deserializeAws_restJson1DeleteInputSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInputSecurityGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteInputSecurityGroupCommandError(output, context);
   }
   const contents: DeleteInputSecurityGroupCommandOutput = {
@@ -2956,7 +2956,7 @@ export const deserializeAws_restJson1DeleteMultiplexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMultiplexCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMultiplexCommandError(output, context);
   }
   const contents: DeleteMultiplexCommandOutput = {
@@ -3103,7 +3103,7 @@ export const deserializeAws_restJson1DeleteMultiplexProgramCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMultiplexProgramCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMultiplexProgramCommandError(output, context);
   }
   const contents: DeleteMultiplexProgramCommandOutput = {
@@ -3232,7 +3232,7 @@ export const deserializeAws_restJson1DeleteReservationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReservationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteReservationCommandError(output, context);
   }
   const contents: DeleteReservationCommandOutput = {
@@ -3414,7 +3414,7 @@ export const deserializeAws_restJson1DeleteScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteScheduleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteScheduleCommandError(output, context);
   }
   const contents: DeleteScheduleCommandOutput = {
@@ -3513,7 +3513,7 @@ export const deserializeAws_restJson1DeleteTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteTagsCommandError(output, context);
   }
   const contents: DeleteTagsCommandOutput = {
@@ -3588,7 +3588,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeChannelCommandError(output, context);
   }
   const contents: DescribeChannelCommandOutput = {
@@ -3747,7 +3747,7 @@ export const deserializeAws_restJson1DescribeInputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeInputCommandError(output, context);
   }
   const contents: DescribeInputCommandOutput = {
@@ -3906,7 +3906,7 @@ export const deserializeAws_restJson1DescribeInputDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInputDeviceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeInputDeviceCommandError(output, context);
   }
   const contents: DescribeInputDeviceCommandOutput = {
@@ -4045,7 +4045,7 @@ export const deserializeAws_restJson1DescribeInputDeviceThumbnailCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInputDeviceThumbnailCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeInputDeviceThumbnailCommandError(output, context);
   }
   const contents: DescribeInputDeviceThumbnailCommandOutput = {
@@ -4162,7 +4162,7 @@ export const deserializeAws_restJson1DescribeInputSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInputSecurityGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeInputSecurityGroupCommandError(output, context);
   }
   const contents: DescribeInputSecurityGroupCommandOutput = {
@@ -4285,7 +4285,7 @@ export const deserializeAws_restJson1DescribeMultiplexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMultiplexCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeMultiplexCommandError(output, context);
   }
   const contents: DescribeMultiplexCommandOutput = {
@@ -4424,7 +4424,7 @@ export const deserializeAws_restJson1DescribeMultiplexProgramCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMultiplexProgramCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeMultiplexProgramCommandError(output, context);
   }
   const contents: DescribeMultiplexProgramCommandOutput = {
@@ -4545,7 +4545,7 @@ export const deserializeAws_restJson1DescribeOfferingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOfferingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeOfferingCommandError(output, context);
   }
   const contents: DescribeOfferingCommandOutput = {
@@ -4691,7 +4691,7 @@ export const deserializeAws_restJson1DescribeReservationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeReservationCommandError(output, context);
   }
   const contents: DescribeReservationCommandOutput = {
@@ -4865,7 +4865,7 @@ export const deserializeAws_restJson1DescribeScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScheduleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeScheduleCommandError(output, context);
   }
   const contents: DescribeScheduleCommandOutput = {
@@ -4972,7 +4972,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListChannelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListChannelsCommandError(output, context);
   }
   const contents: ListChannelsCommandOutput = {
@@ -5071,7 +5071,7 @@ export const deserializeAws_restJson1ListInputDevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInputDevicesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListInputDevicesCommandError(output, context);
   }
   const contents: ListInputDevicesCommandOutput = {
@@ -5170,7 +5170,7 @@ export const deserializeAws_restJson1ListInputsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInputsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListInputsCommandError(output, context);
   }
   const contents: ListInputsCommandOutput = {
@@ -5269,7 +5269,7 @@ export const deserializeAws_restJson1ListInputSecurityGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInputSecurityGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListInputSecurityGroupsCommandError(output, context);
   }
   const contents: ListInputSecurityGroupsCommandOutput = {
@@ -5371,7 +5371,7 @@ export const deserializeAws_restJson1ListMultiplexesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMultiplexesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMultiplexesCommandError(output, context);
   }
   const contents: ListMultiplexesCommandOutput = {
@@ -5470,7 +5470,7 @@ export const deserializeAws_restJson1ListMultiplexProgramsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMultiplexProgramsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMultiplexProgramsCommandError(output, context);
   }
   const contents: ListMultiplexProgramsCommandOutput = {
@@ -5580,7 +5580,7 @@ export const deserializeAws_restJson1ListOfferingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOfferingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListOfferingsCommandError(output, context);
   }
   const contents: ListOfferingsCommandOutput = {
@@ -5679,7 +5679,7 @@ export const deserializeAws_restJson1ListReservationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListReservationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListReservationsCommandError(output, context);
   }
   const contents: ListReservationsCommandOutput = {
@@ -5778,7 +5778,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -5857,7 +5857,7 @@ export const deserializeAws_restJson1PurchaseOfferingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurchaseOfferingCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1PurchaseOfferingCommandError(output, context);
   }
   const contents: PurchaseOfferingCommandOutput = {
@@ -5968,7 +5968,7 @@ export const deserializeAws_restJson1StartChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartChannelCommandError(output, context);
   }
   const contents: StartChannelCommandOutput = {
@@ -6135,7 +6135,7 @@ export const deserializeAws_restJson1StartMultiplexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMultiplexCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartMultiplexCommandError(output, context);
   }
   const contents: StartMultiplexCommandOutput = {
@@ -6282,7 +6282,7 @@ export const deserializeAws_restJson1StopChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopChannelCommandError(output, context);
   }
   const contents: StopChannelCommandOutput = {
@@ -6449,7 +6449,7 @@ export const deserializeAws_restJson1StopMultiplexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopMultiplexCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopMultiplexCommandError(output, context);
   }
   const contents: StopMultiplexCommandOutput = {
@@ -6596,7 +6596,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateChannelCommandError(output, context);
   }
   const contents: UpdateChannelCommandOutput = {
@@ -6699,7 +6699,7 @@ export const deserializeAws_restJson1UpdateChannelClassCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateChannelClassCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateChannelClassCommandError(output, context);
   }
   const contents: UpdateChannelClassCommandOutput = {
@@ -6818,7 +6818,7 @@ export const deserializeAws_restJson1UpdateInputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateInputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateInputCommandError(output, context);
   }
   const contents: UpdateInputCommandOutput = {
@@ -6921,7 +6921,7 @@ export const deserializeAws_restJson1UpdateInputDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateInputDeviceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateInputDeviceCommandError(output, context);
   }
   const contents: UpdateInputDeviceCommandOutput = {
@@ -7068,7 +7068,7 @@ export const deserializeAws_restJson1UpdateInputSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateInputSecurityGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateInputSecurityGroupCommandError(output, context);
   }
   const contents: UpdateInputSecurityGroupCommandOutput = {
@@ -7171,7 +7171,7 @@ export const deserializeAws_restJson1UpdateMultiplexCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMultiplexCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMultiplexCommandError(output, context);
   }
   const contents: UpdateMultiplexCommandOutput = {
@@ -7282,7 +7282,7 @@ export const deserializeAws_restJson1UpdateMultiplexProgramCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMultiplexProgramCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateMultiplexProgramCommandError(output, context);
   }
   const contents: UpdateMultiplexProgramCommandOutput = {
@@ -7393,7 +7393,7 @@ export const deserializeAws_restJson1UpdateReservationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateReservationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateReservationCommandError(output, context);
   }
   const contents: UpdateReservationCommandOutput = {

--- a/clients/client-mediapackage-vod/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage-vod/protocols/Aws_restJson1.ts
@@ -570,7 +570,7 @@ export const deserializeAws_restJson1CreateAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAssetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAssetCommandError(output, context);
   }
   const contents: CreateAssetCommandOutput = {
@@ -697,7 +697,7 @@ export const deserializeAws_restJson1CreatePackagingConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePackagingConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePackagingConfigurationCommandError(output, context);
   }
   const contents: CreatePackagingConfigurationCommandOutput = {
@@ -820,7 +820,7 @@ export const deserializeAws_restJson1CreatePackagingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePackagingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePackagingGroupCommandError(output, context);
   }
   const contents: CreatePackagingGroupCommandOutput = {
@@ -931,7 +931,7 @@ export const deserializeAws_restJson1DeleteAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAssetCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAssetCommandError(output, context);
   }
   const contents: DeleteAssetCommandOutput = {
@@ -1022,7 +1022,7 @@ export const deserializeAws_restJson1DeletePackagingConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePackagingConfigurationCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePackagingConfigurationCommandError(output, context);
   }
   const contents: DeletePackagingConfigurationCommandOutput = {
@@ -1113,7 +1113,7 @@ export const deserializeAws_restJson1DeletePackagingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePackagingGroupCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePackagingGroupCommandError(output, context);
   }
   const contents: DeletePackagingGroupCommandOutput = {
@@ -1204,7 +1204,7 @@ export const deserializeAws_restJson1DescribeAssetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAssetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAssetCommandError(output, context);
   }
   const contents: DescribeAssetCommandOutput = {
@@ -1331,7 +1331,7 @@ export const deserializeAws_restJson1DescribePackagingConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePackagingConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribePackagingConfigurationCommandError(output, context);
   }
   const contents: DescribePackagingConfigurationCommandOutput = {
@@ -1454,7 +1454,7 @@ export const deserializeAws_restJson1DescribePackagingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePackagingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribePackagingGroupCommandError(output, context);
   }
   const contents: DescribePackagingGroupCommandOutput = {
@@ -1565,7 +1565,7 @@ export const deserializeAws_restJson1ListAssetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAssetsCommandError(output, context);
   }
   const contents: ListAssetsCommandOutput = {
@@ -1664,7 +1664,7 @@ export const deserializeAws_restJson1ListPackagingConfigurationsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPackagingConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPackagingConfigurationsCommandError(output, context);
   }
   const contents: ListPackagingConfigurationsCommandOutput = {
@@ -1766,7 +1766,7 @@ export const deserializeAws_restJson1ListPackagingGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPackagingGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPackagingGroupsCommandError(output, context);
   }
   const contents: ListPackagingGroupsCommandOutput = {
@@ -1865,7 +1865,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1912,7 +1912,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1955,7 +1955,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -1998,7 +1998,7 @@ export const deserializeAws_restJson1UpdatePackagingGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePackagingGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePackagingGroupCommandError(output, context);
   }
   const contents: UpdatePackagingGroupCommandOutput = {

--- a/clients/client-mediapackage/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage/protocols/Aws_restJson1.ts
@@ -668,7 +668,7 @@ export const deserializeAws_restJson1CreateChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateChannelCommandError(output, context);
   }
   const contents: CreateChannelCommandOutput = {
@@ -779,7 +779,7 @@ export const deserializeAws_restJson1CreateHarvestJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHarvestJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateHarvestJobCommandError(output, context);
   }
   const contents: CreateHarvestJobCommandOutput = {
@@ -906,7 +906,7 @@ export const deserializeAws_restJson1CreateOriginEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOriginEndpointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateOriginEndpointCommandError(output, context);
   }
   const contents: CreateOriginEndpointCommandOutput = {
@@ -1061,7 +1061,7 @@ export const deserializeAws_restJson1DeleteChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteChannelCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteChannelCommandError(output, context);
   }
   const contents: DeleteChannelCommandOutput = {
@@ -1152,7 +1152,7 @@ export const deserializeAws_restJson1DeleteOriginEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOriginEndpointCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteOriginEndpointCommandError(output, context);
   }
   const contents: DeleteOriginEndpointCommandOutput = {
@@ -1243,7 +1243,7 @@ export const deserializeAws_restJson1DescribeChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeChannelCommandError(output, context);
   }
   const contents: DescribeChannelCommandOutput = {
@@ -1354,7 +1354,7 @@ export const deserializeAws_restJson1DescribeHarvestJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHarvestJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeHarvestJobCommandError(output, context);
   }
   const contents: DescribeHarvestJobCommandOutput = {
@@ -1481,7 +1481,7 @@ export const deserializeAws_restJson1DescribeOriginEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOriginEndpointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeOriginEndpointCommandError(output, context);
   }
   const contents: DescribeOriginEndpointCommandOutput = {
@@ -1636,7 +1636,7 @@ export const deserializeAws_restJson1ListChannelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListChannelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListChannelsCommandError(output, context);
   }
   const contents: ListChannelsCommandOutput = {
@@ -1735,7 +1735,7 @@ export const deserializeAws_restJson1ListHarvestJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHarvestJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListHarvestJobsCommandError(output, context);
   }
   const contents: ListHarvestJobsCommandOutput = {
@@ -1834,7 +1834,7 @@ export const deserializeAws_restJson1ListOriginEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOriginEndpointsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListOriginEndpointsCommandError(output, context);
   }
   const contents: ListOriginEndpointsCommandOutput = {
@@ -1933,7 +1933,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1980,7 +1980,7 @@ export const deserializeAws_restJson1RotateChannelCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RotateChannelCredentialsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RotateChannelCredentialsCommandError(output, context);
   }
   const contents: RotateChannelCredentialsCommandOutput = {
@@ -2091,7 +2091,7 @@ export const deserializeAws_restJson1RotateIngestEndpointCredentialsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RotateIngestEndpointCredentialsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RotateIngestEndpointCredentialsCommandError(output, context);
   }
   const contents: RotateIngestEndpointCredentialsCommandOutput = {
@@ -2202,7 +2202,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -2245,7 +2245,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -2288,7 +2288,7 @@ export const deserializeAws_restJson1UpdateChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateChannelCommandError(output, context);
   }
   const contents: UpdateChannelCommandOutput = {
@@ -2399,7 +2399,7 @@ export const deserializeAws_restJson1UpdateOriginEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateOriginEndpointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateOriginEndpointCommandError(output, context);
   }
   const contents: UpdateOriginEndpointCommandOutput = {

--- a/clients/client-mediastore-data/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/protocols/Aws_restJson1.ts
@@ -205,7 +205,7 @@ export const deserializeAws_restJson1DeleteObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteObjectCommandError(output, context);
   }
   const contents: DeleteObjectCommandOutput = {
@@ -272,7 +272,7 @@ export const deserializeAws_restJson1DescribeObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeObjectCommandError(output, context);
   }
   const contents: DescribeObjectCommandOutput = {
@@ -359,7 +359,7 @@ export const deserializeAws_restJson1GetObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetObjectCommandError(output, context);
   }
   const contents: GetObjectCommandOutput = {
@@ -460,7 +460,7 @@ export const deserializeAws_restJson1ListItemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListItemsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListItemsCommandError(output, context);
   }
   const contents: ListItemsCommandOutput = {
@@ -527,7 +527,7 @@ export const deserializeAws_restJson1PutObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutObjectCommandError(output, context);
   }
   const contents: PutObjectCommandOutput = {

--- a/clients/client-mediastore/protocols/Aws_json1_1.ts
+++ b/clients/client-mediastore/protocols/Aws_json1_1.ts
@@ -371,7 +371,7 @@ export const deserializeAws_json1_1CreateContainerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateContainerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateContainerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -442,7 +442,7 @@ export const deserializeAws_json1_1DeleteContainerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteContainerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteContainerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -513,7 +513,7 @@ export const deserializeAws_json1_1DeleteContainerPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteContainerPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteContainerPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -592,7 +592,7 @@ export const deserializeAws_json1_1DeleteCorsPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCorsPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCorsPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -671,7 +671,7 @@ export const deserializeAws_json1_1DeleteLifecyclePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLifecyclePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLifecyclePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -750,7 +750,7 @@ export const deserializeAws_json1_1DeleteMetricPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMetricPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMetricPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -829,7 +829,7 @@ export const deserializeAws_json1_1DescribeContainerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeContainerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeContainerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -892,7 +892,7 @@ export const deserializeAws_json1_1GetContainerPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetContainerPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetContainerPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -971,7 +971,7 @@ export const deserializeAws_json1_1GetCorsPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCorsPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCorsPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1050,7 +1050,7 @@ export const deserializeAws_json1_1GetLifecyclePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLifecyclePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLifecyclePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1129,7 +1129,7 @@ export const deserializeAws_json1_1GetMetricPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMetricPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMetricPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1208,7 +1208,7 @@ export const deserializeAws_json1_1ListContainersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListContainersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListContainersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1263,7 +1263,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1334,7 +1334,7 @@ export const deserializeAws_json1_1PutContainerPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutContainerPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutContainerPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1405,7 +1405,7 @@ export const deserializeAws_json1_1PutCorsPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutCorsPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutCorsPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1476,7 +1476,7 @@ export const deserializeAws_json1_1PutLifecyclePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLifecyclePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutLifecyclePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1547,7 +1547,7 @@ export const deserializeAws_json1_1PutMetricPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutMetricPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutMetricPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1618,7 +1618,7 @@ export const deserializeAws_json1_1StartAccessLoggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartAccessLoggingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartAccessLoggingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1689,7 +1689,7 @@ export const deserializeAws_json1_1StopAccessLoggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopAccessLoggingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopAccessLoggingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1760,7 +1760,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1831,7 +1831,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-mediatailor/protocols/Aws_restJson1.ts
+++ b/clients/client-mediatailor/protocols/Aws_restJson1.ts
@@ -275,7 +275,7 @@ export const deserializeAws_restJson1DeletePlaybackConfigurationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePlaybackConfigurationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePlaybackConfigurationCommandError(output, context);
   }
   const contents: DeletePlaybackConfigurationCommandOutput = {
@@ -318,7 +318,7 @@ export const deserializeAws_restJson1GetPlaybackConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPlaybackConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPlaybackConfigurationCommandError(output, context);
   }
   const contents: GetPlaybackConfigurationCommandOutput = {
@@ -428,7 +428,7 @@ export const deserializeAws_restJson1ListPlaybackConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPlaybackConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPlaybackConfigurationsCommandError(output, context);
   }
   const contents: ListPlaybackConfigurationsCommandOutput = {
@@ -479,7 +479,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -534,7 +534,7 @@ export const deserializeAws_restJson1PutPlaybackConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPlaybackConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutPlaybackConfigurationCommandError(output, context);
   }
   const contents: PutPlaybackConfigurationCommandOutput = {
@@ -644,7 +644,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -695,7 +695,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {

--- a/clients/client-migration-hub/protocols/Aws_json1_1.ts
+++ b/clients/client-migration-hub/protocols/Aws_json1_1.ts
@@ -352,7 +352,7 @@ export const deserializeAws_json1_1AssociateCreatedArtifactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateCreatedArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateCreatedArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -471,7 +471,7 @@ export const deserializeAws_json1_1AssociateDiscoveredResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateDiscoveredResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateDiscoveredResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -598,7 +598,7 @@ export const deserializeAws_json1_1CreateProgressUpdateStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProgressUpdateStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProgressUpdateStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -709,7 +709,7 @@ export const deserializeAws_json1_1DeleteProgressUpdateStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProgressUpdateStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProgressUpdateStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -828,7 +828,7 @@ export const deserializeAws_json1_1DescribeApplicationStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeApplicationStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeApplicationStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -939,7 +939,7 @@ export const deserializeAws_json1_1DescribeMigrationTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMigrationTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMigrationTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1042,7 +1042,7 @@ export const deserializeAws_json1_1DisassociateCreatedArtifactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateCreatedArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateCreatedArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1161,7 +1161,7 @@ export const deserializeAws_json1_1DisassociateDiscoveredResourceCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateDiscoveredResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateDiscoveredResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1280,7 +1280,7 @@ export const deserializeAws_json1_1ImportMigrationTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportMigrationTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportMigrationTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1399,7 +1399,7 @@ export const deserializeAws_json1_1ListApplicationStatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationStatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListApplicationStatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1494,7 +1494,7 @@ export const deserializeAws_json1_1ListCreatedArtifactsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCreatedArtifactsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCreatedArtifactsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1597,7 +1597,7 @@ export const deserializeAws_json1_1ListDiscoveredResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDiscoveredResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDiscoveredResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1700,7 +1700,7 @@ export const deserializeAws_json1_1ListMigrationTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMigrationTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListMigrationTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1811,7 +1811,7 @@ export const deserializeAws_json1_1ListProgressUpdateStreamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProgressUpdateStreamsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProgressUpdateStreamsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1906,7 +1906,7 @@ export const deserializeAws_json1_1NotifyApplicationStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NotifyApplicationStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1NotifyApplicationStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2033,7 +2033,7 @@ export const deserializeAws_json1_1NotifyMigrationTaskStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NotifyMigrationTaskStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1NotifyMigrationTaskStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2152,7 +2152,7 @@ export const deserializeAws_json1_1PutResourceAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutResourceAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutResourceAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-migrationhub-config/protocols/Aws_json1_1.ts
+++ b/clients/client-migrationhub-config/protocols/Aws_json1_1.ts
@@ -76,7 +76,7 @@ export const deserializeAws_json1_1CreateHomeRegionControlCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHomeRegionControlCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateHomeRegionControlCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -171,7 +171,7 @@ export const deserializeAws_json1_1DescribeHomeRegionControlsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHomeRegionControlsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeHomeRegionControlsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -258,7 +258,7 @@ export const deserializeAws_json1_1GetHomeRegionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHomeRegionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetHomeRegionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-mobile/protocols/Aws_restJson1.ts
+++ b/clients/client-mobile/protocols/Aws_restJson1.ts
@@ -299,7 +299,7 @@ export const deserializeAws_restJson1CreateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateProjectCommandError(output, context);
   }
   const contents: CreateProjectCommandOutput = {
@@ -402,7 +402,7 @@ export const deserializeAws_restJson1DeleteProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteProjectCommandError(output, context);
   }
   const contents: DeleteProjectCommandOutput = {
@@ -493,7 +493,7 @@ export const deserializeAws_restJson1DescribeBundleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBundleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeBundleCommandError(output, context);
   }
   const contents: DescribeBundleCommandOutput = {
@@ -588,7 +588,7 @@ export const deserializeAws_restJson1DescribeProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeProjectCommandError(output, context);
   }
   const contents: DescribeProjectCommandOutput = {
@@ -683,7 +683,7 @@ export const deserializeAws_restJson1ExportBundleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportBundleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ExportBundleCommandError(output, context);
   }
   const contents: ExportBundleCommandOutput = {
@@ -778,7 +778,7 @@ export const deserializeAws_restJson1ExportProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ExportProjectCommandError(output, context);
   }
   const contents: ExportProjectCommandOutput = {
@@ -881,7 +881,7 @@ export const deserializeAws_restJson1ListBundlesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBundlesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBundlesCommandError(output, context);
   }
   const contents: ListBundlesCommandOutput = {
@@ -972,7 +972,7 @@ export const deserializeAws_restJson1ListProjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProjectsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListProjectsCommandError(output, context);
   }
   const contents: ListProjectsCommandOutput = {
@@ -1063,7 +1063,7 @@ export const deserializeAws_restJson1UpdateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateProjectCommandError(output, context);
   }
   const contents: UpdateProjectCommandOutput = {

--- a/clients/client-mq/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1.ts
@@ -850,7 +850,7 @@ export const deserializeAws_restJson1CreateBrokerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBrokerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateBrokerCommandError(output, context);
   }
   const contents: CreateBrokerCommandOutput = {
@@ -941,7 +941,7 @@ export const deserializeAws_restJson1CreateConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConfigurationCommandError(output, context);
   }
   const contents: CreateConfigurationCommandOutput = {
@@ -1040,7 +1040,7 @@ export const deserializeAws_restJson1CreateTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTagsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateTagsCommandError(output, context);
   }
   const contents: CreateTagsCommandOutput = {
@@ -1115,7 +1115,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateUserCommandError(output, context);
   }
   const contents: CreateUserCommandOutput = {
@@ -1198,7 +1198,7 @@ export const deserializeAws_restJson1DeleteBrokerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBrokerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBrokerCommandError(output, context);
   }
   const contents: DeleteBrokerCommandOutput = {
@@ -1277,7 +1277,7 @@ export const deserializeAws_restJson1DeleteTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteTagsCommandError(output, context);
   }
   const contents: DeleteTagsCommandOutput = {
@@ -1352,7 +1352,7 @@ export const deserializeAws_restJson1DeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteUserCommandError(output, context);
   }
   const contents: DeleteUserCommandOutput = {
@@ -1427,7 +1427,7 @@ export const deserializeAws_restJson1DescribeBrokerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBrokerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeBrokerCommandError(output, context);
   }
   const contents: DescribeBrokerCommandOutput = {
@@ -1620,7 +1620,7 @@ export const deserializeAws_restJson1DescribeBrokerEngineTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBrokerEngineTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeBrokerEngineTypesCommandError(output, context);
   }
   const contents: DescribeBrokerEngineTypesCommandOutput = {
@@ -1699,7 +1699,7 @@ export const deserializeAws_restJson1DescribeBrokerInstanceOptionsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBrokerInstanceOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeBrokerInstanceOptionsCommandError(output, context);
   }
   const contents: DescribeBrokerInstanceOptionsCommandOutput = {
@@ -1781,7 +1781,7 @@ export const deserializeAws_restJson1DescribeConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeConfigurationCommandError(output, context);
   }
   const contents: DescribeConfigurationCommandOutput = {
@@ -1896,7 +1896,7 @@ export const deserializeAws_restJson1DescribeConfigurationRevisionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationRevisionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeConfigurationRevisionCommandError(output, context);
   }
   const contents: DescribeConfigurationRevisionCommandOutput = {
@@ -1987,7 +1987,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeUserCommandError(output, context);
   }
   const contents: DescribeUserCommandOutput = {
@@ -2082,7 +2082,7 @@ export const deserializeAws_restJson1ListBrokersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBrokersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListBrokersCommandError(output, context);
   }
   const contents: ListBrokersCommandOutput = {
@@ -2157,7 +2157,7 @@ export const deserializeAws_restJson1ListConfigurationRevisionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationRevisionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConfigurationRevisionsCommandError(output, context);
   }
   const contents: ListConfigurationRevisionsCommandOutput = {
@@ -2248,7 +2248,7 @@ export const deserializeAws_restJson1ListConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConfigurationsCommandError(output, context);
   }
   const contents: ListConfigurationsCommandOutput = {
@@ -2327,7 +2327,7 @@ export const deserializeAws_restJson1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsCommandError(output, context);
   }
   const contents: ListTagsCommandOutput = {
@@ -2406,7 +2406,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUsersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListUsersCommandError(output, context);
   }
   const contents: ListUsersCommandOutput = {
@@ -2497,7 +2497,7 @@ export const deserializeAws_restJson1RebootBrokerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootBrokerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RebootBrokerCommandError(output, context);
   }
   const contents: RebootBrokerCommandOutput = {
@@ -2572,7 +2572,7 @@ export const deserializeAws_restJson1UpdateBrokerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBrokerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateBrokerCommandError(output, context);
   }
   const contents: UpdateBrokerCommandOutput = {
@@ -2691,7 +2691,7 @@ export const deserializeAws_restJson1UpdateConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateConfigurationCommandError(output, context);
   }
   const contents: UpdateConfigurationCommandOutput = {
@@ -2798,7 +2798,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUserCommandError(output, context);
   }
   const contents: UpdateUserCommandOutput = {

--- a/clients/client-mturk/protocols/Aws_json1_1.ts
+++ b/clients/client-mturk/protocols/Aws_json1_1.ts
@@ -724,7 +724,7 @@ export const deserializeAws_json1_1AcceptQualificationRequestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptQualificationRequestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AcceptQualificationRequestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -787,7 +787,7 @@ export const deserializeAws_json1_1ApproveAssignmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ApproveAssignmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ApproveAssignmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -850,7 +850,7 @@ export const deserializeAws_json1_1AssociateQualificationWithWorkerCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateQualificationWithWorkerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateQualificationWithWorkerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -913,7 +913,7 @@ export const deserializeAws_json1_1CreateAdditionalAssignmentsForHITCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAdditionalAssignmentsForHITCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAdditionalAssignmentsForHITCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -976,7 +976,7 @@ export const deserializeAws_json1_1CreateHITCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHITCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateHITCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1039,7 +1039,7 @@ export const deserializeAws_json1_1CreateHITTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHITTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateHITTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1102,7 +1102,7 @@ export const deserializeAws_json1_1CreateHITWithHITTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHITWithHITTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateHITWithHITTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1165,7 +1165,7 @@ export const deserializeAws_json1_1CreateQualificationTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateQualificationTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateQualificationTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1228,7 +1228,7 @@ export const deserializeAws_json1_1CreateWorkerBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWorkerBlockCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWorkerBlockCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1291,7 +1291,7 @@ export const deserializeAws_json1_1DeleteHITCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHITCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteHITCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1354,7 +1354,7 @@ export const deserializeAws_json1_1DeleteQualificationTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteQualificationTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteQualificationTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1417,7 +1417,7 @@ export const deserializeAws_json1_1DeleteWorkerBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWorkerBlockCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWorkerBlockCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1480,7 +1480,7 @@ export const deserializeAws_json1_1DisassociateQualificationFromWorkerCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateQualificationFromWorkerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateQualificationFromWorkerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1543,7 +1543,7 @@ export const deserializeAws_json1_1GetAccountBalanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountBalanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAccountBalanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1606,7 +1606,7 @@ export const deserializeAws_json1_1GetAssignmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAssignmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAssignmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1669,7 +1669,7 @@ export const deserializeAws_json1_1GetFileUploadURLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFileUploadURLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetFileUploadURLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1732,7 +1732,7 @@ export const deserializeAws_json1_1GetHITCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHITCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetHITCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1795,7 +1795,7 @@ export const deserializeAws_json1_1GetQualificationScoreCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetQualificationScoreCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetQualificationScoreCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1858,7 +1858,7 @@ export const deserializeAws_json1_1GetQualificationTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetQualificationTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetQualificationTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1921,7 +1921,7 @@ export const deserializeAws_json1_1ListAssignmentsForHITCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssignmentsForHITCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssignmentsForHITCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1984,7 +1984,7 @@ export const deserializeAws_json1_1ListBonusPaymentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBonusPaymentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBonusPaymentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2047,7 +2047,7 @@ export const deserializeAws_json1_1ListHITsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHITsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListHITsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2110,7 +2110,7 @@ export const deserializeAws_json1_1ListHITsForQualificationTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHITsForQualificationTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListHITsForQualificationTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2173,7 +2173,7 @@ export const deserializeAws_json1_1ListQualificationRequestsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListQualificationRequestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListQualificationRequestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2236,7 +2236,7 @@ export const deserializeAws_json1_1ListQualificationTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListQualificationTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListQualificationTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2299,7 +2299,7 @@ export const deserializeAws_json1_1ListReviewableHITsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListReviewableHITsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListReviewableHITsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2362,7 +2362,7 @@ export const deserializeAws_json1_1ListReviewPolicyResultsForHITCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListReviewPolicyResultsForHITCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListReviewPolicyResultsForHITCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2425,7 +2425,7 @@ export const deserializeAws_json1_1ListWorkerBlocksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWorkerBlocksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListWorkerBlocksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2488,7 +2488,7 @@ export const deserializeAws_json1_1ListWorkersWithQualificationTypeCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWorkersWithQualificationTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListWorkersWithQualificationTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2551,7 +2551,7 @@ export const deserializeAws_json1_1NotifyWorkersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NotifyWorkersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1NotifyWorkersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2614,7 +2614,7 @@ export const deserializeAws_json1_1RejectAssignmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectAssignmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RejectAssignmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2677,7 +2677,7 @@ export const deserializeAws_json1_1RejectQualificationRequestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectQualificationRequestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RejectQualificationRequestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2740,7 +2740,7 @@ export const deserializeAws_json1_1SendBonusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendBonusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SendBonusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2803,7 +2803,7 @@ export const deserializeAws_json1_1SendTestEventNotificationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendTestEventNotificationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SendTestEventNotificationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2866,7 +2866,7 @@ export const deserializeAws_json1_1UpdateExpirationForHITCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateExpirationForHITCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateExpirationForHITCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2929,7 +2929,7 @@ export const deserializeAws_json1_1UpdateHITReviewStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateHITReviewStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateHITReviewStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2992,7 +2992,7 @@ export const deserializeAws_json1_1UpdateHITTypeOfHITCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateHITTypeOfHITCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateHITTypeOfHITCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3055,7 +3055,7 @@ export const deserializeAws_json1_1UpdateNotificationSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNotificationSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateNotificationSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3118,7 +3118,7 @@ export const deserializeAws_json1_1UpdateQualificationTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateQualificationTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateQualificationTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-neptune/protocols/Aws_query.ts
+++ b/clients/client-neptune/protocols/Aws_query.ts
@@ -1367,7 +1367,7 @@ export const deserializeAws_queryAddRoleToDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddRoleToDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddRoleToDBClusterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1442,7 +1442,7 @@ export const deserializeAws_queryAddSourceIdentifierToSubscriptionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddSourceIdentifierToSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddSourceIdentifierToSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1507,7 +1507,7 @@ export const deserializeAws_queryAddTagsToResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddTagsToResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1574,7 +1574,7 @@ export const deserializeAws_queryApplyPendingMaintenanceActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ApplyPendingMaintenanceActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryApplyPendingMaintenanceActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1628,7 +1628,7 @@ export const deserializeAws_queryCopyDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1698,7 +1698,7 @@ export const deserializeAws_queryCopyDBClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyDBClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyDBClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1792,7 +1792,7 @@ export const deserializeAws_queryCopyDBParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyDBParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyDBParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1862,7 +1862,7 @@ export const deserializeAws_queryCreateDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2028,7 +2028,7 @@ export const deserializeAws_queryCreateDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2090,7 +2090,7 @@ export const deserializeAws_queryCreateDBClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2176,7 +2176,7 @@ export const deserializeAws_queryCreateDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2366,7 +2366,7 @@ export const deserializeAws_queryCreateDBParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2428,7 +2428,7 @@ export const deserializeAws_queryCreateDBSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2514,7 +2514,7 @@ export const deserializeAws_queryCreateEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2616,7 +2616,7 @@ export const deserializeAws_queryDeleteDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2702,7 +2702,7 @@ export const deserializeAws_queryDeleteDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBClusterParameterGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2761,7 +2761,7 @@ export const deserializeAws_queryDeleteDBClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2823,7 +2823,7 @@ export const deserializeAws_queryDeleteDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2909,7 +2909,7 @@ export const deserializeAws_queryDeleteDBParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBParameterGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2968,7 +2968,7 @@ export const deserializeAws_queryDeleteDBSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBSubnetGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3035,7 +3035,7 @@ export const deserializeAws_queryDeleteEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3097,7 +3097,7 @@ export const deserializeAws_queryDescribeDBClusterParameterGroupsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterParameterGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterParameterGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3151,7 +3151,7 @@ export const deserializeAws_queryDescribeDBClusterParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3205,7 +3205,7 @@ export const deserializeAws_queryDescribeDBClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3259,7 +3259,7 @@ export const deserializeAws_queryDescribeDBClusterSnapshotAttributesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterSnapshotAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterSnapshotAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3316,7 +3316,7 @@ export const deserializeAws_queryDescribeDBClusterSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3370,7 +3370,7 @@ export const deserializeAws_queryDescribeDBEngineVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBEngineVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBEngineVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3416,7 +3416,7 @@ export const deserializeAws_queryDescribeDBInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3470,7 +3470,7 @@ export const deserializeAws_queryDescribeDBParameterGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBParameterGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBParameterGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3524,7 +3524,7 @@ export const deserializeAws_queryDescribeDBParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3578,7 +3578,7 @@ export const deserializeAws_queryDescribeDBSubnetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBSubnetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBSubnetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3632,7 +3632,7 @@ export const deserializeAws_queryDescribeEngineDefaultClusterParametersCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEngineDefaultClusterParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEngineDefaultClusterParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3681,7 +3681,7 @@ export const deserializeAws_queryDescribeEngineDefaultParametersCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEngineDefaultParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEngineDefaultParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3730,7 +3730,7 @@ export const deserializeAws_queryDescribeEventCategoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventCategoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventCategoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3776,7 +3776,7 @@ export const deserializeAws_queryDescribeEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3822,7 +3822,7 @@ export const deserializeAws_queryDescribeEventSubscriptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventSubscriptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventSubscriptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3876,7 +3876,7 @@ export const deserializeAws_queryDescribeOrderableDBInstanceOptionsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrderableDBInstanceOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeOrderableDBInstanceOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3925,7 +3925,7 @@ export const deserializeAws_queryDescribePendingMaintenanceActionsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePendingMaintenanceActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribePendingMaintenanceActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3982,7 +3982,7 @@ export const deserializeAws_queryDescribeValidDBInstanceModificationsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeValidDBInstanceModificationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeValidDBInstanceModificationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4047,7 +4047,7 @@ export const deserializeAws_queryFailoverDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FailoverDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryFailoverDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4117,7 +4117,7 @@ export const deserializeAws_queryListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4187,7 +4187,7 @@ export const deserializeAws_queryModifyDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4321,7 +4321,7 @@ export const deserializeAws_queryModifyDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4383,7 +4383,7 @@ export const deserializeAws_queryModifyDBClusterSnapshotAttributeCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBClusterSnapshotAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBClusterSnapshotAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4456,7 +4456,7 @@ export const deserializeAws_queryModifyDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4630,7 +4630,7 @@ export const deserializeAws_queryModifyDBParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4692,7 +4692,7 @@ export const deserializeAws_queryModifyDBSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4778,7 +4778,7 @@ export const deserializeAws_queryModifyEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4872,7 +4872,7 @@ export const deserializeAws_queryPromoteReadReplicaDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PromoteReadReplicaDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPromoteReadReplicaDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4934,7 +4934,7 @@ export const deserializeAws_queryRebootDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRebootDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4996,7 +4996,7 @@ export const deserializeAws_queryRemoveRoleFromDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveRoleFromDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveRoleFromDBClusterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5063,7 +5063,7 @@ export const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveSourceIdentifierFromSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveSourceIdentifierFromSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5128,7 +5128,7 @@ export const deserializeAws_queryRemoveTagsFromResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveTagsFromResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5195,7 +5195,7 @@ export const deserializeAws_queryResetDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResetDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5257,7 +5257,7 @@ export const deserializeAws_queryResetDBParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetDBParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResetDBParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5319,7 +5319,7 @@ export const deserializeAws_queryRestoreDBClusterFromSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDBClusterFromSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreDBClusterFromSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5493,7 +5493,7 @@ export const deserializeAws_queryRestoreDBClusterToPointInTimeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDBClusterToPointInTimeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreDBClusterToPointInTimeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5675,7 +5675,7 @@ export const deserializeAws_queryStartDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStartDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5745,7 +5745,7 @@ export const deserializeAws_queryStopDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStopDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-networkmanager/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmanager/protocols/Aws_restJson1.ts
@@ -1119,7 +1119,7 @@ export const deserializeAws_restJson1AssociateCustomerGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateCustomerGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateCustomerGatewayCommandError(output, context);
   }
   const contents: AssociateCustomerGatewayCommandOutput = {
@@ -1225,7 +1225,7 @@ export const deserializeAws_restJson1AssociateLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateLinkCommandError(output, context);
   }
   const contents: AssociateLinkCommandOutput = {
@@ -1328,7 +1328,7 @@ export const deserializeAws_restJson1CreateDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeviceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeviceCommandError(output, context);
   }
   const contents: CreateDeviceCommandOutput = {
@@ -1431,7 +1431,7 @@ export const deserializeAws_restJson1CreateGlobalNetworkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGlobalNetworkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGlobalNetworkCommandError(output, context);
   }
   const contents: CreateGlobalNetworkCommandOutput = {
@@ -1526,7 +1526,7 @@ export const deserializeAws_restJson1CreateLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateLinkCommandError(output, context);
   }
   const contents: CreateLinkCommandOutput = {
@@ -1629,7 +1629,7 @@ export const deserializeAws_restJson1CreateSiteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSiteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSiteCommandError(output, context);
   }
   const contents: CreateSiteCommandOutput = {
@@ -1732,7 +1732,7 @@ export const deserializeAws_restJson1DeleteDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDeviceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDeviceCommandError(output, context);
   }
   const contents: DeleteDeviceCommandOutput = {
@@ -1827,7 +1827,7 @@ export const deserializeAws_restJson1DeleteGlobalNetworkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGlobalNetworkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGlobalNetworkCommandError(output, context);
   }
   const contents: DeleteGlobalNetworkCommandOutput = {
@@ -1922,7 +1922,7 @@ export const deserializeAws_restJson1DeleteLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteLinkCommandError(output, context);
   }
   const contents: DeleteLinkCommandOutput = {
@@ -2017,7 +2017,7 @@ export const deserializeAws_restJson1DeleteSiteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSiteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSiteCommandError(output, context);
   }
   const contents: DeleteSiteCommandOutput = {
@@ -2112,7 +2112,7 @@ export const deserializeAws_restJson1DeregisterTransitGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterTransitGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeregisterTransitGatewayCommandError(output, context);
   }
   const contents: DeregisterTransitGatewayCommandOutput = {
@@ -2210,7 +2210,7 @@ export const deserializeAws_restJson1DescribeGlobalNetworksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGlobalNetworksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeGlobalNetworksCommandError(output, context);
   }
   const contents: DescribeGlobalNetworksCommandOutput = {
@@ -2301,7 +2301,7 @@ export const deserializeAws_restJson1DisassociateCustomerGatewayCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateCustomerGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateCustomerGatewayCommandError(output, context);
   }
   const contents: DisassociateCustomerGatewayCommandOutput = {
@@ -2399,7 +2399,7 @@ export const deserializeAws_restJson1DisassociateLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateLinkCommandError(output, context);
   }
   const contents: DisassociateLinkCommandOutput = {
@@ -2494,7 +2494,7 @@ export const deserializeAws_restJson1GetCustomerGatewayAssociationsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCustomerGatewayAssociationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCustomerGatewayAssociationsCommandError(output, context);
   }
   const contents: GetCustomerGatewayAssociationsCommandOutput = {
@@ -2596,7 +2596,7 @@ export const deserializeAws_restJson1GetDevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDevicesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDevicesCommandError(output, context);
   }
   const contents: GetDevicesCommandOutput = {
@@ -2687,7 +2687,7 @@ export const deserializeAws_restJson1GetLinkAssociationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLinkAssociationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLinkAssociationsCommandError(output, context);
   }
   const contents: GetLinkAssociationsCommandOutput = {
@@ -2778,7 +2778,7 @@ export const deserializeAws_restJson1GetLinksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLinksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLinksCommandError(output, context);
   }
   const contents: GetLinksCommandOutput = {
@@ -2869,7 +2869,7 @@ export const deserializeAws_restJson1GetSitesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSitesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSitesCommandError(output, context);
   }
   const contents: GetSitesCommandOutput = {
@@ -2960,7 +2960,7 @@ export const deserializeAws_restJson1GetTransitGatewayRegistrationsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTransitGatewayRegistrationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTransitGatewayRegistrationsCommandError(output, context);
   }
   const contents: GetTransitGatewayRegistrationsCommandOutput = {
@@ -3054,7 +3054,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -3141,7 +3141,7 @@ export const deserializeAws_restJson1RegisterTransitGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterTransitGatewayCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegisterTransitGatewayCommandError(output, context);
   }
   const contents: RegisterTransitGatewayCommandOutput = {
@@ -3239,7 +3239,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -3338,7 +3338,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -3429,7 +3429,7 @@ export const deserializeAws_restJson1UpdateDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDeviceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDeviceCommandError(output, context);
   }
   const contents: UpdateDeviceCommandOutput = {
@@ -3524,7 +3524,7 @@ export const deserializeAws_restJson1UpdateGlobalNetworkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGlobalNetworkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGlobalNetworkCommandError(output, context);
   }
   const contents: UpdateGlobalNetworkCommandOutput = {
@@ -3619,7 +3619,7 @@ export const deserializeAws_restJson1UpdateLinkCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLinkCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateLinkCommandError(output, context);
   }
   const contents: UpdateLinkCommandOutput = {
@@ -3722,7 +3722,7 @@ export const deserializeAws_restJson1UpdateSiteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSiteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSiteCommandError(output, context);
   }
   const contents: UpdateSiteCommandOutput = {

--- a/clients/client-opsworks/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/protocols/Aws_json1_1.ts
@@ -1280,7 +1280,7 @@ export const deserializeAws_json1_1AssignInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssignInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssignInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1340,7 +1340,7 @@ export const deserializeAws_json1_1AssignVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssignVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssignVolumeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1400,7 +1400,7 @@ export const deserializeAws_json1_1AssociateElasticIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateElasticIpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateElasticIpCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1460,7 +1460,7 @@ export const deserializeAws_json1_1AttachElasticLoadBalancerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachElasticLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AttachElasticLoadBalancerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1520,7 +1520,7 @@ export const deserializeAws_json1_1CloneStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CloneStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CloneStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1583,7 +1583,7 @@ export const deserializeAws_json1_1CreateAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAppCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1646,7 +1646,7 @@ export const deserializeAws_json1_1CreateDeploymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeploymentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDeploymentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1709,7 +1709,7 @@ export const deserializeAws_json1_1CreateInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1772,7 +1772,7 @@ export const deserializeAws_json1_1CreateLayerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLayerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLayerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1835,7 +1835,7 @@ export const deserializeAws_json1_1CreateStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1890,7 +1890,7 @@ export const deserializeAws_json1_1CreateUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1945,7 +1945,7 @@ export const deserializeAws_json1_1DeleteAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAppCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2005,7 +2005,7 @@ export const deserializeAws_json1_1DeleteInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2065,7 +2065,7 @@ export const deserializeAws_json1_1DeleteLayerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLayerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLayerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2125,7 +2125,7 @@ export const deserializeAws_json1_1DeleteStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteStackCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2185,7 +2185,7 @@ export const deserializeAws_json1_1DeleteUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserProfileCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2245,7 +2245,7 @@ export const deserializeAws_json1_1DeregisterEcsClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterEcsClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterEcsClusterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2305,7 +2305,7 @@ export const deserializeAws_json1_1DeregisterElasticIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterElasticIpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterElasticIpCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2365,7 +2365,7 @@ export const deserializeAws_json1_1DeregisterInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2425,7 +2425,7 @@ export const deserializeAws_json1_1DeregisterRdsDbInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterRdsDbInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterRdsDbInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2485,7 +2485,7 @@ export const deserializeAws_json1_1DeregisterVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterVolumeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2545,7 +2545,7 @@ export const deserializeAws_json1_1DescribeAgentVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAgentVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAgentVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2608,7 +2608,7 @@ export const deserializeAws_json1_1DescribeAppsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAppsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAppsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2671,7 +2671,7 @@ export const deserializeAws_json1_1DescribeCommandsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCommandsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCommandsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2734,7 +2734,7 @@ export const deserializeAws_json1_1DescribeDeploymentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDeploymentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDeploymentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2797,7 +2797,7 @@ export const deserializeAws_json1_1DescribeEcsClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEcsClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEcsClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2860,7 +2860,7 @@ export const deserializeAws_json1_1DescribeElasticIpsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeElasticIpsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeElasticIpsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2923,7 +2923,7 @@ export const deserializeAws_json1_1DescribeElasticLoadBalancersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeElasticLoadBalancersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeElasticLoadBalancersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2986,7 +2986,7 @@ export const deserializeAws_json1_1DescribeInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3049,7 +3049,7 @@ export const deserializeAws_json1_1DescribeLayersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLayersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLayersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3112,7 +3112,7 @@ export const deserializeAws_json1_1DescribeLoadBasedAutoScalingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoadBasedAutoScalingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLoadBasedAutoScalingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3175,7 +3175,7 @@ export const deserializeAws_json1_1DescribeMyUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMyUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMyUserProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3222,7 +3222,7 @@ export const deserializeAws_json1_1DescribeOperatingSystemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOperatingSystemsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeOperatingSystemsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3269,7 +3269,7 @@ export const deserializeAws_json1_1DescribePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3332,7 +3332,7 @@ export const deserializeAws_json1_1DescribeRaidArraysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRaidArraysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRaidArraysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3395,7 +3395,7 @@ export const deserializeAws_json1_1DescribeRdsDbInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRdsDbInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRdsDbInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3458,7 +3458,7 @@ export const deserializeAws_json1_1DescribeServiceErrorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeServiceErrorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeServiceErrorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3521,7 +3521,7 @@ export const deserializeAws_json1_1DescribeStackProvisioningParametersCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStackProvisioningParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeStackProvisioningParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3584,7 +3584,7 @@ export const deserializeAws_json1_1DescribeStacksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStacksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeStacksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3647,7 +3647,7 @@ export const deserializeAws_json1_1DescribeStackSummaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStackSummaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeStackSummaryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3710,7 +3710,7 @@ export const deserializeAws_json1_1DescribeTimeBasedAutoScalingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTimeBasedAutoScalingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTimeBasedAutoScalingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3773,7 +3773,7 @@ export const deserializeAws_json1_1DescribeUserProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserProfilesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUserProfilesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3836,7 +3836,7 @@ export const deserializeAws_json1_1DescribeVolumesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVolumesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeVolumesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3899,7 +3899,7 @@ export const deserializeAws_json1_1DetachElasticLoadBalancerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachElasticLoadBalancerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetachElasticLoadBalancerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3951,7 +3951,7 @@ export const deserializeAws_json1_1DisassociateElasticIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateElasticIpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateElasticIpCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4011,7 +4011,7 @@ export const deserializeAws_json1_1GetHostnameSuggestionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHostnameSuggestionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetHostnameSuggestionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4074,7 +4074,7 @@ export const deserializeAws_json1_1GrantAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GrantAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GrantAccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4137,7 +4137,7 @@ export const deserializeAws_json1_1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4200,7 +4200,7 @@ export const deserializeAws_json1_1RebootInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RebootInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4260,7 +4260,7 @@ export const deserializeAws_json1_1RegisterEcsClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterEcsClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterEcsClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4323,7 +4323,7 @@ export const deserializeAws_json1_1RegisterElasticIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterElasticIpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterElasticIpCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4386,7 +4386,7 @@ export const deserializeAws_json1_1RegisterInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4449,7 +4449,7 @@ export const deserializeAws_json1_1RegisterRdsDbInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterRdsDbInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterRdsDbInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4509,7 +4509,7 @@ export const deserializeAws_json1_1RegisterVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4572,7 +4572,7 @@ export const deserializeAws_json1_1SetLoadBasedAutoScalingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetLoadBasedAutoScalingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetLoadBasedAutoScalingCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4632,7 +4632,7 @@ export const deserializeAws_json1_1SetPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetPermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetPermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4692,7 +4692,7 @@ export const deserializeAws_json1_1SetTimeBasedAutoScalingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetTimeBasedAutoScalingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetTimeBasedAutoScalingCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4752,7 +4752,7 @@ export const deserializeAws_json1_1StartInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4812,7 +4812,7 @@ export const deserializeAws_json1_1StartStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartStackCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4872,7 +4872,7 @@ export const deserializeAws_json1_1StopInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4932,7 +4932,7 @@ export const deserializeAws_json1_1StopStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopStackCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4992,7 +4992,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5052,7 +5052,7 @@ export const deserializeAws_json1_1UnassignInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnassignInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UnassignInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5112,7 +5112,7 @@ export const deserializeAws_json1_1UnassignVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnassignVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UnassignVolumeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5172,7 +5172,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5232,7 +5232,7 @@ export const deserializeAws_json1_1UpdateAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAppCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5292,7 +5292,7 @@ export const deserializeAws_json1_1UpdateElasticIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateElasticIpCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateElasticIpCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5352,7 +5352,7 @@ export const deserializeAws_json1_1UpdateInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5412,7 +5412,7 @@ export const deserializeAws_json1_1UpdateLayerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLayerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateLayerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5472,7 +5472,7 @@ export const deserializeAws_json1_1UpdateMyUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMyUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMyUserProfileCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5524,7 +5524,7 @@ export const deserializeAws_json1_1UpdateRdsDbInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRdsDbInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRdsDbInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5584,7 +5584,7 @@ export const deserializeAws_json1_1UpdateStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateStackCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5644,7 +5644,7 @@ export const deserializeAws_json1_1UpdateUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateUserProfileCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5704,7 +5704,7 @@ export const deserializeAws_json1_1UpdateVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateVolumeCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-opsworkscm/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworkscm/protocols/Aws_json1_1.ts
@@ -345,7 +345,7 @@ export const deserializeAws_json1_1AssociateNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateNodeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateNodeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -416,7 +416,7 @@ export const deserializeAws_json1_1CreateBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -495,7 +495,7 @@ export const deserializeAws_json1_1CreateServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -574,7 +574,7 @@ export const deserializeAws_json1_1DeleteBackupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -645,7 +645,7 @@ export const deserializeAws_json1_1DeleteServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -716,7 +716,7 @@ export const deserializeAws_json1_1DescribeAccountAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAccountAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -763,7 +763,7 @@ export const deserializeAws_json1_1DescribeBackupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBackupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeBackupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -834,7 +834,7 @@ export const deserializeAws_json1_1DescribeEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -905,7 +905,7 @@ export const deserializeAws_json1_1DescribeNodeAssociationStatusCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNodeAssociationStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeNodeAssociationStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -968,7 +968,7 @@ export const deserializeAws_json1_1DescribeServersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeServersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeServersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1039,7 +1039,7 @@ export const deserializeAws_json1_1DisassociateNodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateNodeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateNodeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1110,7 +1110,7 @@ export const deserializeAws_json1_1ExportServerEngineAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportServerEngineAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ExportServerEngineAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1181,7 +1181,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1244,7 +1244,7 @@ export const deserializeAws_json1_1RestoreServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RestoreServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1315,7 +1315,7 @@ export const deserializeAws_json1_1StartMaintenanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMaintenanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartMaintenanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1386,7 +1386,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1457,7 +1457,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1528,7 +1528,7 @@ export const deserializeAws_json1_1UpdateServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1599,7 +1599,7 @@ export const deserializeAws_json1_1UpdateServerEngineAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServerEngineAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateServerEngineAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-organizations/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/protocols/Aws_json1_1.ts
@@ -947,7 +947,7 @@ export const deserializeAws_json1_1AcceptHandshakeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptHandshakeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AcceptHandshakeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1082,7 +1082,7 @@ export const deserializeAws_json1_1AttachPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AttachPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1230,7 +1230,7 @@ export const deserializeAws_json1_1CancelHandshakeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelHandshakeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelHandshakeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1341,7 +1341,7 @@ export const deserializeAws_json1_1CreateAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1460,7 +1460,7 @@ export const deserializeAws_json1_1CreateGovCloudAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGovCloudAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateGovCloudAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1579,7 +1579,7 @@ export const deserializeAws_json1_1CreateOrganizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1690,7 +1690,7 @@ export const deserializeAws_json1_1CreateOrganizationalUnitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOrganizationalUnitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateOrganizationalUnitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1809,7 +1809,7 @@ export const deserializeAws_json1_1CreatePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1944,7 +1944,7 @@ export const deserializeAws_json1_1DeclineHandshakeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeclineHandshakeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeclineHandshakeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2055,7 +2055,7 @@ export const deserializeAws_json1_1DeleteOrganizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteOrganizationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2155,7 +2155,7 @@ export const deserializeAws_json1_1DeleteOrganizationalUnitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOrganizationalUnitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteOrganizationalUnitCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2263,7 +2263,7 @@ export const deserializeAws_json1_1DeletePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2379,7 +2379,7 @@ export const deserializeAws_json1_1DeregisterDelegatedAdministratorCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterDelegatedAdministratorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterDelegatedAdministratorCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2503,7 +2503,7 @@ export const deserializeAws_json1_1DescribeAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2598,7 +2598,7 @@ export const deserializeAws_json1_1DescribeCreateAccountStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCreateAccountStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCreateAccountStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2701,7 +2701,7 @@ export const deserializeAws_json1_1DescribeEffectivePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEffectivePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEffectivePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2820,7 +2820,7 @@ export const deserializeAws_json1_1DescribeHandshakeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHandshakeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeHandshakeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2915,7 +2915,7 @@ export const deserializeAws_json1_1DescribeOrganizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3002,7 +3002,7 @@ export const deserializeAws_json1_1DescribeOrganizationalUnitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrganizationalUnitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeOrganizationalUnitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3097,7 +3097,7 @@ export const deserializeAws_json1_1DescribePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3200,7 +3200,7 @@ export const deserializeAws_json1_1DetachPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetachPolicyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3340,7 +3340,7 @@ export const deserializeAws_json1_1DisableAWSServiceAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableAWSServiceAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableAWSServiceAccessCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3448,7 +3448,7 @@ export const deserializeAws_json1_1DisablePolicyTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisablePolicyTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisablePolicyTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3583,7 +3583,7 @@ export const deserializeAws_json1_1EnableAllFeaturesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableAllFeaturesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableAllFeaturesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3686,7 +3686,7 @@ export const deserializeAws_json1_1EnableAWSServiceAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableAWSServiceAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableAWSServiceAccessCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3794,7 +3794,7 @@ export const deserializeAws_json1_1EnablePolicyTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnablePolicyTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnablePolicyTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3937,7 +3937,7 @@ export const deserializeAws_json1_1InviteAccountToOrganizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InviteAccountToOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1InviteAccountToOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4064,7 +4064,7 @@ export const deserializeAws_json1_1LeaveOrganizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<LeaveOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1LeaveOrganizationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4180,7 +4180,7 @@ export const deserializeAws_json1_1ListAccountsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAccountsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAccountsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4267,7 +4267,7 @@ export const deserializeAws_json1_1ListAccountsForParentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAccountsForParentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAccountsForParentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4362,7 +4362,7 @@ export const deserializeAws_json1_1ListAWSServiceAccessForOrganizationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAWSServiceAccessForOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAWSServiceAccessForOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4465,7 +4465,7 @@ export const deserializeAws_json1_1ListChildrenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListChildrenCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListChildrenCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4560,7 +4560,7 @@ export const deserializeAws_json1_1ListCreateAccountStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCreateAccountStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCreateAccountStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4655,7 +4655,7 @@ export const deserializeAws_json1_1ListDelegatedAdministratorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDelegatedAdministratorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDelegatedAdministratorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4758,7 +4758,7 @@ export const deserializeAws_json1_1ListDelegatedServicesForAccountCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDelegatedServicesForAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDelegatedServicesForAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4877,7 +4877,7 @@ export const deserializeAws_json1_1ListHandshakesForAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHandshakesForAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListHandshakesForAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4964,7 +4964,7 @@ export const deserializeAws_json1_1ListHandshakesForOrganizationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHandshakesForOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListHandshakesForOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5059,7 +5059,7 @@ export const deserializeAws_json1_1ListOrganizationalUnitsForParentCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOrganizationalUnitsForParentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListOrganizationalUnitsForParentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5154,7 +5154,7 @@ export const deserializeAws_json1_1ListParentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListParentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListParentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5249,7 +5249,7 @@ export const deserializeAws_json1_1ListPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5344,7 +5344,7 @@ export const deserializeAws_json1_1ListPoliciesForTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPoliciesForTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPoliciesForTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5447,7 +5447,7 @@ export const deserializeAws_json1_1ListRootsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRootsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRootsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5534,7 +5534,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5629,7 +5629,7 @@ export const deserializeAws_json1_1ListTargetsForPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTargetsForPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTargetsForPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5732,7 +5732,7 @@ export const deserializeAws_json1_1MoveAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MoveAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MoveAccountCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5856,7 +5856,7 @@ export const deserializeAws_json1_1RegisterDelegatedAdministratorCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterDelegatedAdministratorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterDelegatedAdministratorCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5980,7 +5980,7 @@ export const deserializeAws_json1_1RemoveAccountFromOrganizationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveAccountFromOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveAccountFromOrganizationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6096,7 +6096,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6204,7 +6204,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6312,7 +6312,7 @@ export const deserializeAws_json1_1UpdateOrganizationalUnitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateOrganizationalUnitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateOrganizationalUnitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6423,7 +6423,7 @@ export const deserializeAws_json1_1UpdatePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-outposts/protocols/Aws_restJson1.ts
+++ b/clients/client-outposts/protocols/Aws_restJson1.ts
@@ -239,7 +239,7 @@ export const deserializeAws_restJson1CreateOutpostCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOutpostCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateOutpostCommandError(output, context);
   }
   const contents: CreateOutpostCommandOutput = {
@@ -326,7 +326,7 @@ export const deserializeAws_restJson1DeleteOutpostCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOutpostCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteOutpostCommandError(output, context);
   }
   const contents: DeleteOutpostCommandOutput = {
@@ -401,7 +401,7 @@ export const deserializeAws_restJson1DeleteSiteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSiteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSiteCommandError(output, context);
   }
   const contents: DeleteSiteCommandOutput = {
@@ -476,7 +476,7 @@ export const deserializeAws_restJson1GetOutpostCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOutpostCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetOutpostCommandError(output, context);
   }
   const contents: GetOutpostCommandOutput = {
@@ -555,7 +555,7 @@ export const deserializeAws_restJson1GetOutpostInstanceTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOutpostInstanceTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetOutpostInstanceTypesCommandError(output, context);
   }
   const contents: GetOutpostInstanceTypesCommandOutput = {
@@ -646,7 +646,7 @@ export const deserializeAws_restJson1ListOutpostsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOutpostsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListOutpostsCommandError(output, context);
   }
   const contents: ListOutpostsCommandOutput = {
@@ -721,7 +721,7 @@ export const deserializeAws_restJson1ListSitesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSitesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSitesCommandError(output, context);
   }
   const contents: ListSitesCommandOutput = {

--- a/clients/client-personalize-events/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-events/protocols/Aws_restJson1.ts
@@ -40,7 +40,7 @@ export const deserializeAws_restJson1PutEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEventsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEventsCommandError(output, context);
   }
   const contents: PutEventsCommandOutput = {

--- a/clients/client-personalize-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-runtime/protocols/Aws_restJson1.ts
@@ -73,7 +73,7 @@ export const deserializeAws_restJson1GetPersonalizedRankingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPersonalizedRankingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPersonalizedRankingCommandError(output, context);
   }
   const contents: GetPersonalizedRankingCommandOutput = {
@@ -136,7 +136,7 @@ export const deserializeAws_restJson1GetRecommendationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRecommendationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRecommendationsCommandError(output, context);
   }
   const contents: GetRecommendationsCommandOutput = {

--- a/clients/client-personalize/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/protocols/Aws_json1_1.ts
@@ -782,7 +782,7 @@ export const deserializeAws_json1_1CreateBatchInferenceJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBatchInferenceJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateBatchInferenceJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -869,7 +869,7 @@ export const deserializeAws_json1_1CreateCampaignCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCampaignCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCampaignCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -956,7 +956,7 @@ export const deserializeAws_json1_1CreateDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDatasetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDatasetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1043,7 +1043,7 @@ export const deserializeAws_json1_1CreateDatasetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDatasetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDatasetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1114,7 +1114,7 @@ export const deserializeAws_json1_1CreateDatasetImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDatasetImportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDatasetImportJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1201,7 +1201,7 @@ export const deserializeAws_json1_1CreateEventTrackerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEventTrackerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEventTrackerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1288,7 +1288,7 @@ export const deserializeAws_json1_1CreateFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateFilterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1367,7 +1367,7 @@ export const deserializeAws_json1_1CreateSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSchemaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSchemaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1438,7 +1438,7 @@ export const deserializeAws_json1_1CreateSolutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSolutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSolutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1525,7 +1525,7 @@ export const deserializeAws_json1_1CreateSolutionVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSolutionVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSolutionVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1596,7 +1596,7 @@ export const deserializeAws_json1_1DeleteCampaignCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCampaignCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCampaignCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1664,7 +1664,7 @@ export const deserializeAws_json1_1DeleteDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDatasetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDatasetCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1732,7 +1732,7 @@ export const deserializeAws_json1_1DeleteDatasetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDatasetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDatasetGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1800,7 +1800,7 @@ export const deserializeAws_json1_1DeleteEventTrackerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventTrackerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEventTrackerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1868,7 +1868,7 @@ export const deserializeAws_json1_1DeleteFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFilterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1928,7 +1928,7 @@ export const deserializeAws_json1_1DeleteSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSchemaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSchemaCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1996,7 +1996,7 @@ export const deserializeAws_json1_1DeleteSolutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSolutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSolutionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2064,7 +2064,7 @@ export const deserializeAws_json1_1DescribeAlgorithmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAlgorithmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAlgorithmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2127,7 +2127,7 @@ export const deserializeAws_json1_1DescribeBatchInferenceJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBatchInferenceJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeBatchInferenceJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2190,7 +2190,7 @@ export const deserializeAws_json1_1DescribeCampaignCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCampaignCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCampaignCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2253,7 +2253,7 @@ export const deserializeAws_json1_1DescribeDatasetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDatasetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDatasetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2316,7 +2316,7 @@ export const deserializeAws_json1_1DescribeDatasetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDatasetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDatasetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2379,7 +2379,7 @@ export const deserializeAws_json1_1DescribeDatasetImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDatasetImportJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDatasetImportJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2442,7 +2442,7 @@ export const deserializeAws_json1_1DescribeEventTrackerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventTrackerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEventTrackerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2505,7 +2505,7 @@ export const deserializeAws_json1_1DescribeFeatureTransformationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFeatureTransformationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFeatureTransformationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2568,7 +2568,7 @@ export const deserializeAws_json1_1DescribeFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFilterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2631,7 +2631,7 @@ export const deserializeAws_json1_1DescribeRecipeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRecipeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRecipeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2694,7 +2694,7 @@ export const deserializeAws_json1_1DescribeSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSchemaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSchemaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2757,7 +2757,7 @@ export const deserializeAws_json1_1DescribeSolutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSolutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSolutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2820,7 +2820,7 @@ export const deserializeAws_json1_1DescribeSolutionVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSolutionVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSolutionVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2883,7 +2883,7 @@ export const deserializeAws_json1_1GetSolutionMetricsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSolutionMetricsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSolutionMetricsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2954,7 +2954,7 @@ export const deserializeAws_json1_1ListBatchInferenceJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBatchInferenceJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBatchInferenceJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3017,7 +3017,7 @@ export const deserializeAws_json1_1ListCampaignsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCampaignsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCampaignsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3080,7 +3080,7 @@ export const deserializeAws_json1_1ListDatasetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatasetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDatasetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3135,7 +3135,7 @@ export const deserializeAws_json1_1ListDatasetImportJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatasetImportJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDatasetImportJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3198,7 +3198,7 @@ export const deserializeAws_json1_1ListDatasetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDatasetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDatasetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3261,7 +3261,7 @@ export const deserializeAws_json1_1ListEventTrackersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEventTrackersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEventTrackersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3324,7 +3324,7 @@ export const deserializeAws_json1_1ListFiltersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFiltersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListFiltersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3387,7 +3387,7 @@ export const deserializeAws_json1_1ListRecipesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRecipesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRecipesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3442,7 +3442,7 @@ export const deserializeAws_json1_1ListSchemasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSchemasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSchemasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3497,7 +3497,7 @@ export const deserializeAws_json1_1ListSolutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSolutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSolutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3560,7 +3560,7 @@ export const deserializeAws_json1_1ListSolutionVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSolutionVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSolutionVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3631,7 +3631,7 @@ export const deserializeAws_json1_1UpdateCampaignCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCampaignCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateCampaignCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-pi/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/protocols/Aws_json1_1.ts
@@ -59,7 +59,7 @@ export const deserializeAws_json1_1DescribeDimensionKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDimensionKeysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDimensionKeysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -130,7 +130,7 @@ export const deserializeAws_json1_1GetResourceMetricsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourceMetricsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResourceMetricsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
@@ -1473,7 +1473,7 @@ export const deserializeAws_restJson1CreateConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConfigurationSetCommandError(output, context);
   }
   const contents: CreateConfigurationSetCommandOutput = {
@@ -1564,7 +1564,7 @@ export const deserializeAws_restJson1CreateConfigurationSetEventDestinationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConfigurationSetEventDestinationCommandError(output, context);
   }
   const contents: CreateConfigurationSetEventDestinationCommandOutput = {
@@ -1647,7 +1647,7 @@ export const deserializeAws_restJson1CreateDedicatedIpPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDedicatedIpPoolCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDedicatedIpPoolCommandError(output, context);
   }
   const contents: CreateDedicatedIpPoolCommandOutput = {
@@ -1730,7 +1730,7 @@ export const deserializeAws_restJson1CreateDeliverabilityTestReportCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeliverabilityTestReportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeliverabilityTestReportCommandError(output, context);
   }
   const contents: CreateDeliverabilityTestReportCommandOutput = {
@@ -1853,7 +1853,7 @@ export const deserializeAws_restJson1CreateEmailIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEmailIdentityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateEmailIdentityCommandError(output, context);
   }
   const contents: CreateEmailIdentityCommandOutput = {
@@ -1940,7 +1940,7 @@ export const deserializeAws_restJson1DeleteConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteConfigurationSetCommandError(output, context);
   }
   const contents: DeleteConfigurationSetCommandOutput = {
@@ -2015,7 +2015,7 @@ export const deserializeAws_restJson1DeleteConfigurationSetEventDestinationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteConfigurationSetEventDestinationCommandError(output, context);
   }
   const contents: DeleteConfigurationSetEventDestinationCommandOutput = {
@@ -2082,7 +2082,7 @@ export const deserializeAws_restJson1DeleteDedicatedIpPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDedicatedIpPoolCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDedicatedIpPoolCommandError(output, context);
   }
   const contents: DeleteDedicatedIpPoolCommandOutput = {
@@ -2157,7 +2157,7 @@ export const deserializeAws_restJson1DeleteEmailIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEmailIdentityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEmailIdentityCommandError(output, context);
   }
   const contents: DeleteEmailIdentityCommandOutput = {
@@ -2232,7 +2232,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAccountCommandError(output, context);
   }
   const contents: GetAccountCommandOutput = {
@@ -2311,7 +2311,7 @@ export const deserializeAws_restJson1GetBlacklistReportsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBlacklistReportsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBlacklistReportsCommandError(output, context);
   }
   const contents: GetBlacklistReportsCommandOutput = {
@@ -2382,7 +2382,7 @@ export const deserializeAws_restJson1GetConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConfigurationSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConfigurationSetCommandError(output, context);
   }
   const contents: GetConfigurationSetCommandOutput = {
@@ -2473,7 +2473,7 @@ export const deserializeAws_restJson1GetConfigurationSetEventDestinationsCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConfigurationSetEventDestinationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConfigurationSetEventDestinationsCommandError(output, context);
   }
   const contents: GetConfigurationSetEventDestinationsCommandOutput = {
@@ -2544,7 +2544,7 @@ export const deserializeAws_restJson1GetDedicatedIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDedicatedIpCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDedicatedIpCommandError(output, context);
   }
   const contents: GetDedicatedIpCommandOutput = {
@@ -2615,7 +2615,7 @@ export const deserializeAws_restJson1GetDedicatedIpsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDedicatedIpsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDedicatedIpsCommandError(output, context);
   }
   const contents: GetDedicatedIpsCommandOutput = {
@@ -2690,7 +2690,7 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeliverabilityDashboardOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommandError(output, context);
   }
   const contents: GetDeliverabilityDashboardOptionsCommandOutput = {
@@ -2783,7 +2783,7 @@ export const deserializeAws_restJson1GetDeliverabilityTestReportCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeliverabilityTestReportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeliverabilityTestReportCommandError(output, context);
   }
   const contents: GetDeliverabilityTestReportCommandOutput = {
@@ -2873,7 +2873,7 @@ export const deserializeAws_restJson1GetDomainDeliverabilityCampaignCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainDeliverabilityCampaignCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDomainDeliverabilityCampaignCommandError(output, context);
   }
   const contents: GetDomainDeliverabilityCampaignCommandOutput = {
@@ -2947,7 +2947,7 @@ export const deserializeAws_restJson1GetDomainStatisticsReportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainStatisticsReportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDomainStatisticsReportCommandError(output, context);
   }
   const contents: GetDomainStatisticsReportCommandOutput = {
@@ -3022,7 +3022,7 @@ export const deserializeAws_restJson1GetEmailIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEmailIdentityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEmailIdentityCommandError(output, context);
   }
   const contents: GetEmailIdentityCommandOutput = {
@@ -3113,7 +3113,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConfigurationSetsCommandError(output, context);
   }
   const contents: ListConfigurationSetsCommandOutput = {
@@ -3180,7 +3180,7 @@ export const deserializeAws_restJson1ListDedicatedIpPoolsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDedicatedIpPoolsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDedicatedIpPoolsCommandError(output, context);
   }
   const contents: ListDedicatedIpPoolsCommandOutput = {
@@ -3247,7 +3247,7 @@ export const deserializeAws_restJson1ListDeliverabilityTestReportsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeliverabilityTestReportsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDeliverabilityTestReportsCommandError(output, context);
   }
   const contents: ListDeliverabilityTestReportsCommandOutput = {
@@ -3325,7 +3325,7 @@ export const deserializeAws_restJson1ListDomainDeliverabilityCampaignsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainDeliverabilityCampaignsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDomainDeliverabilityCampaignsCommandError(output, context);
   }
   const contents: ListDomainDeliverabilityCampaignsCommandOutput = {
@@ -3403,7 +3403,7 @@ export const deserializeAws_restJson1ListEmailIdentitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEmailIdentitiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListEmailIdentitiesCommandError(output, context);
   }
   const contents: ListEmailIdentitiesCommandOutput = {
@@ -3470,7 +3470,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -3541,7 +3541,7 @@ export const deserializeAws_restJson1PutAccountDedicatedIpWarmupAttributesComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAccountDedicatedIpWarmupAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutAccountDedicatedIpWarmupAttributesCommandError(output, context);
   }
   const contents: PutAccountDedicatedIpWarmupAttributesCommandOutput = {
@@ -3600,7 +3600,7 @@ export const deserializeAws_restJson1PutAccountSendingAttributesCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAccountSendingAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutAccountSendingAttributesCommandError(output, context);
   }
   const contents: PutAccountSendingAttributesCommandOutput = {
@@ -3659,7 +3659,7 @@ export const deserializeAws_restJson1PutConfigurationSetDeliveryOptionsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationSetDeliveryOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutConfigurationSetDeliveryOptionsCommandError(output, context);
   }
   const contents: PutConfigurationSetDeliveryOptionsCommandOutput = {
@@ -3726,7 +3726,7 @@ export const deserializeAws_restJson1PutConfigurationSetReputationOptionsCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationSetReputationOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutConfigurationSetReputationOptionsCommandError(output, context);
   }
   const contents: PutConfigurationSetReputationOptionsCommandOutput = {
@@ -3793,7 +3793,7 @@ export const deserializeAws_restJson1PutConfigurationSetSendingOptionsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationSetSendingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutConfigurationSetSendingOptionsCommandError(output, context);
   }
   const contents: PutConfigurationSetSendingOptionsCommandOutput = {
@@ -3860,7 +3860,7 @@ export const deserializeAws_restJson1PutConfigurationSetTrackingOptionsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationSetTrackingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutConfigurationSetTrackingOptionsCommandError(output, context);
   }
   const contents: PutConfigurationSetTrackingOptionsCommandOutput = {
@@ -3927,7 +3927,7 @@ export const deserializeAws_restJson1PutDedicatedIpInPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDedicatedIpInPoolCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutDedicatedIpInPoolCommandError(output, context);
   }
   const contents: PutDedicatedIpInPoolCommandOutput = {
@@ -3994,7 +3994,7 @@ export const deserializeAws_restJson1PutDedicatedIpWarmupAttributesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDedicatedIpWarmupAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutDedicatedIpWarmupAttributesCommandError(output, context);
   }
   const contents: PutDedicatedIpWarmupAttributesCommandOutput = {
@@ -4061,7 +4061,7 @@ export const deserializeAws_restJson1PutDeliverabilityDashboardOptionCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDeliverabilityDashboardOptionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutDeliverabilityDashboardOptionCommandError(output, context);
   }
   const contents: PutDeliverabilityDashboardOptionCommandOutput = {
@@ -4144,7 +4144,7 @@ export const deserializeAws_restJson1PutEmailIdentityDkimAttributesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEmailIdentityDkimAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEmailIdentityDkimAttributesCommandError(output, context);
   }
   const contents: PutEmailIdentityDkimAttributesCommandOutput = {
@@ -4211,7 +4211,7 @@ export const deserializeAws_restJson1PutEmailIdentityFeedbackAttributesCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEmailIdentityFeedbackAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEmailIdentityFeedbackAttributesCommandError(output, context);
   }
   const contents: PutEmailIdentityFeedbackAttributesCommandOutput = {
@@ -4278,7 +4278,7 @@ export const deserializeAws_restJson1PutEmailIdentityMailFromAttributesCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEmailIdentityMailFromAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEmailIdentityMailFromAttributesCommandError(output, context);
   }
   const contents: PutEmailIdentityMailFromAttributesCommandOutput = {
@@ -4345,7 +4345,7 @@ export const deserializeAws_restJson1SendEmailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendEmailCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SendEmailCommandError(output, context);
   }
   const contents: SendEmailCommandOutput = {
@@ -4456,7 +4456,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -4531,7 +4531,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -4606,7 +4606,7 @@ export const deserializeAws_restJson1UpdateConfigurationSetEventDestinationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateConfigurationSetEventDestinationCommandError(output, context);
   }
   const contents: UpdateConfigurationSetEventDestinationCommandOutput = {

--- a/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1.ts
@@ -320,7 +320,7 @@ export const deserializeAws_restJson1CreateConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConfigurationSetCommandError(output, context);
   }
   const contents: CreateConfigurationSetCommandOutput = {
@@ -403,7 +403,7 @@ export const deserializeAws_restJson1CreateConfigurationSetEventDestinationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConfigurationSetEventDestinationCommandError(output, context);
   }
   const contents: CreateConfigurationSetEventDestinationCommandOutput = {
@@ -494,7 +494,7 @@ export const deserializeAws_restJson1DeleteConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteConfigurationSetCommandError(output, context);
   }
   const contents: DeleteConfigurationSetCommandOutput = {
@@ -569,7 +569,7 @@ export const deserializeAws_restJson1DeleteConfigurationSetEventDestinationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteConfigurationSetEventDestinationCommandError(output, context);
   }
   const contents: DeleteConfigurationSetEventDestinationCommandOutput = {
@@ -644,7 +644,7 @@ export const deserializeAws_restJson1GetConfigurationSetEventDestinationsCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConfigurationSetEventDestinationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConfigurationSetEventDestinationsCommandError(output, context);
   }
   const contents: GetConfigurationSetEventDestinationsCommandOutput = {
@@ -723,7 +723,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConfigurationSetsCommandError(output, context);
   }
   const contents: ListConfigurationSetsCommandOutput = {
@@ -798,7 +798,7 @@ export const deserializeAws_restJson1SendVoiceMessageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendVoiceMessageCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SendVoiceMessageCommandError(output, context);
   }
   const contents: SendVoiceMessageCommandOutput = {
@@ -869,7 +869,7 @@ export const deserializeAws_restJson1UpdateConfigurationSetEventDestinationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateConfigurationSetEventDestinationCommandError(output, context);
   }
   const contents: UpdateConfigurationSetEventDestinationCommandOutput = {

--- a/clients/client-pinpoint/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/protocols/Aws_restJson1.ts
@@ -4514,7 +4514,7 @@ export const deserializeAws_restJson1CreateAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAppCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAppCommandError(output, context);
   }
   const contents: CreateAppCommandOutput = {
@@ -4615,7 +4615,7 @@ export const deserializeAws_restJson1CreateCampaignCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCampaignCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCampaignCommandError(output, context);
   }
   const contents: CreateCampaignCommandOutput = {
@@ -4716,7 +4716,7 @@ export const deserializeAws_restJson1CreateEmailTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateEmailTemplateCommandError(output, context);
   }
   const contents: CreateEmailTemplateCommandOutput = {
@@ -4801,7 +4801,7 @@ export const deserializeAws_restJson1CreateExportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateExportJobCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateExportJobCommandError(output, context);
   }
   const contents: CreateExportJobCommandOutput = {
@@ -4902,7 +4902,7 @@ export const deserializeAws_restJson1CreateImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateImportJobCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateImportJobCommandError(output, context);
   }
   const contents: CreateImportJobCommandOutput = {
@@ -5003,7 +5003,7 @@ export const deserializeAws_restJson1CreateJourneyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateJourneyCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateJourneyCommandError(output, context);
   }
   const contents: CreateJourneyCommandOutput = {
@@ -5104,7 +5104,7 @@ export const deserializeAws_restJson1CreatePushTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePushTemplateCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreatePushTemplateCommandError(output, context);
   }
   const contents: CreatePushTemplateCommandOutput = {
@@ -5189,7 +5189,7 @@ export const deserializeAws_restJson1CreateRecommenderConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRecommenderConfigurationCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRecommenderConfigurationCommandError(output, context);
   }
   const contents: CreateRecommenderConfigurationCommandOutput = {
@@ -5290,7 +5290,7 @@ export const deserializeAws_restJson1CreateSegmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSegmentCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSegmentCommandError(output, context);
   }
   const contents: CreateSegmentCommandOutput = {
@@ -5391,7 +5391,7 @@ export const deserializeAws_restJson1CreateSmsTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSmsTemplateCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSmsTemplateCommandError(output, context);
   }
   const contents: CreateSmsTemplateCommandOutput = {
@@ -5476,7 +5476,7 @@ export const deserializeAws_restJson1CreateVoiceTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVoiceTemplateCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateVoiceTemplateCommandError(output, context);
   }
   const contents: CreateVoiceTemplateCommandOutput = {
@@ -5561,7 +5561,7 @@ export const deserializeAws_restJson1DeleteAdmChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAdmChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAdmChannelCommandError(output, context);
   }
   const contents: DeleteAdmChannelCommandOutput = {
@@ -5662,7 +5662,7 @@ export const deserializeAws_restJson1DeleteApnsChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApnsChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApnsChannelCommandError(output, context);
   }
   const contents: DeleteApnsChannelCommandOutput = {
@@ -5763,7 +5763,7 @@ export const deserializeAws_restJson1DeleteApnsSandboxChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApnsSandboxChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApnsSandboxChannelCommandError(output, context);
   }
   const contents: DeleteApnsSandboxChannelCommandOutput = {
@@ -5864,7 +5864,7 @@ export const deserializeAws_restJson1DeleteApnsVoipChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApnsVoipChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApnsVoipChannelCommandError(output, context);
   }
   const contents: DeleteApnsVoipChannelCommandOutput = {
@@ -5965,7 +5965,7 @@ export const deserializeAws_restJson1DeleteApnsVoipSandboxChannelCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApnsVoipSandboxChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApnsVoipSandboxChannelCommandError(output, context);
   }
   const contents: DeleteApnsVoipSandboxChannelCommandOutput = {
@@ -6066,7 +6066,7 @@ export const deserializeAws_restJson1DeleteAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAppCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAppCommandError(output, context);
   }
   const contents: DeleteAppCommandOutput = {
@@ -6167,7 +6167,7 @@ export const deserializeAws_restJson1DeleteBaiduChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBaiduChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteBaiduChannelCommandError(output, context);
   }
   const contents: DeleteBaiduChannelCommandOutput = {
@@ -6268,7 +6268,7 @@ export const deserializeAws_restJson1DeleteCampaignCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCampaignCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteCampaignCommandError(output, context);
   }
   const contents: DeleteCampaignCommandOutput = {
@@ -6369,7 +6369,7 @@ export const deserializeAws_restJson1DeleteEmailChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEmailChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEmailChannelCommandError(output, context);
   }
   const contents: DeleteEmailChannelCommandOutput = {
@@ -6470,7 +6470,7 @@ export const deserializeAws_restJson1DeleteEmailTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEmailTemplateCommandError(output, context);
   }
   const contents: DeleteEmailTemplateCommandOutput = {
@@ -6571,7 +6571,7 @@ export const deserializeAws_restJson1DeleteEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEndpointCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEndpointCommandError(output, context);
   }
   const contents: DeleteEndpointCommandOutput = {
@@ -6672,7 +6672,7 @@ export const deserializeAws_restJson1DeleteEventStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEventStreamCommandError(output, context);
   }
   const contents: DeleteEventStreamCommandOutput = {
@@ -6773,7 +6773,7 @@ export const deserializeAws_restJson1DeleteGcmChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGcmChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGcmChannelCommandError(output, context);
   }
   const contents: DeleteGcmChannelCommandOutput = {
@@ -6874,7 +6874,7 @@ export const deserializeAws_restJson1DeleteJourneyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteJourneyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteJourneyCommandError(output, context);
   }
   const contents: DeleteJourneyCommandOutput = {
@@ -6975,7 +6975,7 @@ export const deserializeAws_restJson1DeletePushTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePushTemplateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeletePushTemplateCommandError(output, context);
   }
   const contents: DeletePushTemplateCommandOutput = {
@@ -7076,7 +7076,7 @@ export const deserializeAws_restJson1DeleteRecommenderConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRecommenderConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRecommenderConfigurationCommandError(output, context);
   }
   const contents: DeleteRecommenderConfigurationCommandOutput = {
@@ -7177,7 +7177,7 @@ export const deserializeAws_restJson1DeleteSegmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSegmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSegmentCommandError(output, context);
   }
   const contents: DeleteSegmentCommandOutput = {
@@ -7278,7 +7278,7 @@ export const deserializeAws_restJson1DeleteSmsChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSmsChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSmsChannelCommandError(output, context);
   }
   const contents: DeleteSmsChannelCommandOutput = {
@@ -7379,7 +7379,7 @@ export const deserializeAws_restJson1DeleteSmsTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSmsTemplateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSmsTemplateCommandError(output, context);
   }
   const contents: DeleteSmsTemplateCommandOutput = {
@@ -7480,7 +7480,7 @@ export const deserializeAws_restJson1DeleteUserEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserEndpointsCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteUserEndpointsCommandError(output, context);
   }
   const contents: DeleteUserEndpointsCommandOutput = {
@@ -7581,7 +7581,7 @@ export const deserializeAws_restJson1DeleteVoiceChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVoiceChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVoiceChannelCommandError(output, context);
   }
   const contents: DeleteVoiceChannelCommandOutput = {
@@ -7682,7 +7682,7 @@ export const deserializeAws_restJson1DeleteVoiceTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVoiceTemplateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteVoiceTemplateCommandError(output, context);
   }
   const contents: DeleteVoiceTemplateCommandOutput = {
@@ -7783,7 +7783,7 @@ export const deserializeAws_restJson1GetAdmChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAdmChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAdmChannelCommandError(output, context);
   }
   const contents: GetAdmChannelCommandOutput = {
@@ -7884,7 +7884,7 @@ export const deserializeAws_restJson1GetApnsChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApnsChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApnsChannelCommandError(output, context);
   }
   const contents: GetApnsChannelCommandOutput = {
@@ -7985,7 +7985,7 @@ export const deserializeAws_restJson1GetApnsSandboxChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApnsSandboxChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApnsSandboxChannelCommandError(output, context);
   }
   const contents: GetApnsSandboxChannelCommandOutput = {
@@ -8086,7 +8086,7 @@ export const deserializeAws_restJson1GetApnsVoipChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApnsVoipChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApnsVoipChannelCommandError(output, context);
   }
   const contents: GetApnsVoipChannelCommandOutput = {
@@ -8187,7 +8187,7 @@ export const deserializeAws_restJson1GetApnsVoipSandboxChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApnsVoipSandboxChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApnsVoipSandboxChannelCommandError(output, context);
   }
   const contents: GetApnsVoipSandboxChannelCommandOutput = {
@@ -8288,7 +8288,7 @@ export const deserializeAws_restJson1GetAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAppCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAppCommandError(output, context);
   }
   const contents: GetAppCommandOutput = {
@@ -8389,7 +8389,7 @@ export const deserializeAws_restJson1GetApplicationDateRangeKpiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApplicationDateRangeKpiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApplicationDateRangeKpiCommandError(output, context);
   }
   const contents: GetApplicationDateRangeKpiCommandOutput = {
@@ -8490,7 +8490,7 @@ export const deserializeAws_restJson1GetApplicationSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApplicationSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApplicationSettingsCommandError(output, context);
   }
   const contents: GetApplicationSettingsCommandOutput = {
@@ -8591,7 +8591,7 @@ export const deserializeAws_restJson1GetAppsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAppsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAppsCommandError(output, context);
   }
   const contents: GetAppsCommandOutput = {
@@ -8692,7 +8692,7 @@ export const deserializeAws_restJson1GetBaiduChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBaiduChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBaiduChannelCommandError(output, context);
   }
   const contents: GetBaiduChannelCommandOutput = {
@@ -8793,7 +8793,7 @@ export const deserializeAws_restJson1GetCampaignCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCampaignCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCampaignCommandError(output, context);
   }
   const contents: GetCampaignCommandOutput = {
@@ -8894,7 +8894,7 @@ export const deserializeAws_restJson1GetCampaignActivitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCampaignActivitiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCampaignActivitiesCommandError(output, context);
   }
   const contents: GetCampaignActivitiesCommandOutput = {
@@ -8995,7 +8995,7 @@ export const deserializeAws_restJson1GetCampaignDateRangeKpiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCampaignDateRangeKpiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCampaignDateRangeKpiCommandError(output, context);
   }
   const contents: GetCampaignDateRangeKpiCommandOutput = {
@@ -9096,7 +9096,7 @@ export const deserializeAws_restJson1GetCampaignsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCampaignsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCampaignsCommandError(output, context);
   }
   const contents: GetCampaignsCommandOutput = {
@@ -9197,7 +9197,7 @@ export const deserializeAws_restJson1GetCampaignVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCampaignVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCampaignVersionCommandError(output, context);
   }
   const contents: GetCampaignVersionCommandOutput = {
@@ -9298,7 +9298,7 @@ export const deserializeAws_restJson1GetCampaignVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCampaignVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCampaignVersionsCommandError(output, context);
   }
   const contents: GetCampaignVersionsCommandOutput = {
@@ -9399,7 +9399,7 @@ export const deserializeAws_restJson1GetChannelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetChannelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetChannelsCommandError(output, context);
   }
   const contents: GetChannelsCommandOutput = {
@@ -9500,7 +9500,7 @@ export const deserializeAws_restJson1GetEmailChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEmailChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEmailChannelCommandError(output, context);
   }
   const contents: GetEmailChannelCommandOutput = {
@@ -9601,7 +9601,7 @@ export const deserializeAws_restJson1GetEmailTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEmailTemplateCommandError(output, context);
   }
   const contents: GetEmailTemplateCommandOutput = {
@@ -9702,7 +9702,7 @@ export const deserializeAws_restJson1GetEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEndpointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEndpointCommandError(output, context);
   }
   const contents: GetEndpointCommandOutput = {
@@ -9803,7 +9803,7 @@ export const deserializeAws_restJson1GetEventStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEventStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEventStreamCommandError(output, context);
   }
   const contents: GetEventStreamCommandOutput = {
@@ -9904,7 +9904,7 @@ export const deserializeAws_restJson1GetExportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetExportJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetExportJobCommandError(output, context);
   }
   const contents: GetExportJobCommandOutput = {
@@ -10005,7 +10005,7 @@ export const deserializeAws_restJson1GetExportJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetExportJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetExportJobsCommandError(output, context);
   }
   const contents: GetExportJobsCommandOutput = {
@@ -10106,7 +10106,7 @@ export const deserializeAws_restJson1GetGcmChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGcmChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGcmChannelCommandError(output, context);
   }
   const contents: GetGcmChannelCommandOutput = {
@@ -10207,7 +10207,7 @@ export const deserializeAws_restJson1GetImportJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetImportJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetImportJobCommandError(output, context);
   }
   const contents: GetImportJobCommandOutput = {
@@ -10308,7 +10308,7 @@ export const deserializeAws_restJson1GetImportJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetImportJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetImportJobsCommandError(output, context);
   }
   const contents: GetImportJobsCommandOutput = {
@@ -10409,7 +10409,7 @@ export const deserializeAws_restJson1GetJourneyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJourneyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJourneyCommandError(output, context);
   }
   const contents: GetJourneyCommandOutput = {
@@ -10510,7 +10510,7 @@ export const deserializeAws_restJson1GetJourneyDateRangeKpiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJourneyDateRangeKpiCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJourneyDateRangeKpiCommandError(output, context);
   }
   const contents: GetJourneyDateRangeKpiCommandOutput = {
@@ -10611,7 +10611,7 @@ export const deserializeAws_restJson1GetJourneyExecutionActivityMetricsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJourneyExecutionActivityMetricsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJourneyExecutionActivityMetricsCommandError(output, context);
   }
   const contents: GetJourneyExecutionActivityMetricsCommandOutput = {
@@ -10715,7 +10715,7 @@ export const deserializeAws_restJson1GetJourneyExecutionMetricsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJourneyExecutionMetricsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetJourneyExecutionMetricsCommandError(output, context);
   }
   const contents: GetJourneyExecutionMetricsCommandOutput = {
@@ -10816,7 +10816,7 @@ export const deserializeAws_restJson1GetPushTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPushTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPushTemplateCommandError(output, context);
   }
   const contents: GetPushTemplateCommandOutput = {
@@ -10917,7 +10917,7 @@ export const deserializeAws_restJson1GetRecommenderConfigurationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRecommenderConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRecommenderConfigurationCommandError(output, context);
   }
   const contents: GetRecommenderConfigurationCommandOutput = {
@@ -11018,7 +11018,7 @@ export const deserializeAws_restJson1GetRecommenderConfigurationsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRecommenderConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRecommenderConfigurationsCommandError(output, context);
   }
   const contents: GetRecommenderConfigurationsCommandOutput = {
@@ -11122,7 +11122,7 @@ export const deserializeAws_restJson1GetSegmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSegmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSegmentCommandError(output, context);
   }
   const contents: GetSegmentCommandOutput = {
@@ -11223,7 +11223,7 @@ export const deserializeAws_restJson1GetSegmentExportJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSegmentExportJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSegmentExportJobsCommandError(output, context);
   }
   const contents: GetSegmentExportJobsCommandOutput = {
@@ -11324,7 +11324,7 @@ export const deserializeAws_restJson1GetSegmentImportJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSegmentImportJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSegmentImportJobsCommandError(output, context);
   }
   const contents: GetSegmentImportJobsCommandOutput = {
@@ -11425,7 +11425,7 @@ export const deserializeAws_restJson1GetSegmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSegmentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSegmentsCommandError(output, context);
   }
   const contents: GetSegmentsCommandOutput = {
@@ -11526,7 +11526,7 @@ export const deserializeAws_restJson1GetSegmentVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSegmentVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSegmentVersionCommandError(output, context);
   }
   const contents: GetSegmentVersionCommandOutput = {
@@ -11627,7 +11627,7 @@ export const deserializeAws_restJson1GetSegmentVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSegmentVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSegmentVersionsCommandError(output, context);
   }
   const contents: GetSegmentVersionsCommandOutput = {
@@ -11728,7 +11728,7 @@ export const deserializeAws_restJson1GetSmsChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSmsChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSmsChannelCommandError(output, context);
   }
   const contents: GetSmsChannelCommandOutput = {
@@ -11829,7 +11829,7 @@ export const deserializeAws_restJson1GetSmsTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSmsTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSmsTemplateCommandError(output, context);
   }
   const contents: GetSmsTemplateCommandOutput = {
@@ -11930,7 +11930,7 @@ export const deserializeAws_restJson1GetUserEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetUserEndpointsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetUserEndpointsCommandError(output, context);
   }
   const contents: GetUserEndpointsCommandOutput = {
@@ -12031,7 +12031,7 @@ export const deserializeAws_restJson1GetVoiceChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceChannelCommandError(output, context);
   }
   const contents: GetVoiceChannelCommandOutput = {
@@ -12132,7 +12132,7 @@ export const deserializeAws_restJson1GetVoiceTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVoiceTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetVoiceTemplateCommandError(output, context);
   }
   const contents: GetVoiceTemplateCommandOutput = {
@@ -12233,7 +12233,7 @@ export const deserializeAws_restJson1ListJourneysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJourneysCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJourneysCommandError(output, context);
   }
   const contents: ListJourneysCommandOutput = {
@@ -12334,7 +12334,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -12379,7 +12379,7 @@ export const deserializeAws_restJson1ListTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTemplatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTemplatesCommandError(output, context);
   }
   const contents: ListTemplatesCommandOutput = {
@@ -12464,7 +12464,7 @@ export const deserializeAws_restJson1ListTemplateVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTemplateVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTemplateVersionsCommandError(output, context);
   }
   const contents: ListTemplateVersionsCommandOutput = {
@@ -12565,7 +12565,7 @@ export const deserializeAws_restJson1PhoneNumberValidateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PhoneNumberValidateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PhoneNumberValidateCommandError(output, context);
   }
   const contents: PhoneNumberValidateCommandOutput = {
@@ -12666,7 +12666,7 @@ export const deserializeAws_restJson1PutEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEventsCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEventsCommandError(output, context);
   }
   const contents: PutEventsCommandOutput = {
@@ -12767,7 +12767,7 @@ export const deserializeAws_restJson1PutEventStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEventStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEventStreamCommandError(output, context);
   }
   const contents: PutEventStreamCommandOutput = {
@@ -12868,7 +12868,7 @@ export const deserializeAws_restJson1RemoveAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveAttributesCommandError(output, context);
   }
   const contents: RemoveAttributesCommandOutput = {
@@ -12969,7 +12969,7 @@ export const deserializeAws_restJson1SendMessagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendMessagesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SendMessagesCommandError(output, context);
   }
   const contents: SendMessagesCommandOutput = {
@@ -13070,7 +13070,7 @@ export const deserializeAws_restJson1SendUsersMessagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendUsersMessagesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SendUsersMessagesCommandError(output, context);
   }
   const contents: SendUsersMessagesCommandOutput = {
@@ -13171,7 +13171,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -13214,7 +13214,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -13257,7 +13257,7 @@ export const deserializeAws_restJson1UpdateAdmChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAdmChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAdmChannelCommandError(output, context);
   }
   const contents: UpdateAdmChannelCommandOutput = {
@@ -13358,7 +13358,7 @@ export const deserializeAws_restJson1UpdateApnsChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApnsChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApnsChannelCommandError(output, context);
   }
   const contents: UpdateApnsChannelCommandOutput = {
@@ -13459,7 +13459,7 @@ export const deserializeAws_restJson1UpdateApnsSandboxChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApnsSandboxChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApnsSandboxChannelCommandError(output, context);
   }
   const contents: UpdateApnsSandboxChannelCommandOutput = {
@@ -13560,7 +13560,7 @@ export const deserializeAws_restJson1UpdateApnsVoipChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApnsVoipChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApnsVoipChannelCommandError(output, context);
   }
   const contents: UpdateApnsVoipChannelCommandOutput = {
@@ -13661,7 +13661,7 @@ export const deserializeAws_restJson1UpdateApnsVoipSandboxChannelCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApnsVoipSandboxChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApnsVoipSandboxChannelCommandError(output, context);
   }
   const contents: UpdateApnsVoipSandboxChannelCommandOutput = {
@@ -13762,7 +13762,7 @@ export const deserializeAws_restJson1UpdateApplicationSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApplicationSettingsCommandError(output, context);
   }
   const contents: UpdateApplicationSettingsCommandOutput = {
@@ -13863,7 +13863,7 @@ export const deserializeAws_restJson1UpdateBaiduChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBaiduChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateBaiduChannelCommandError(output, context);
   }
   const contents: UpdateBaiduChannelCommandOutput = {
@@ -13964,7 +13964,7 @@ export const deserializeAws_restJson1UpdateCampaignCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCampaignCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateCampaignCommandError(output, context);
   }
   const contents: UpdateCampaignCommandOutput = {
@@ -14065,7 +14065,7 @@ export const deserializeAws_restJson1UpdateEmailChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEmailChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateEmailChannelCommandError(output, context);
   }
   const contents: UpdateEmailChannelCommandOutput = {
@@ -14166,7 +14166,7 @@ export const deserializeAws_restJson1UpdateEmailTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateEmailTemplateCommandError(output, context);
   }
   const contents: UpdateEmailTemplateCommandOutput = {
@@ -14267,7 +14267,7 @@ export const deserializeAws_restJson1UpdateEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEndpointCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateEndpointCommandError(output, context);
   }
   const contents: UpdateEndpointCommandOutput = {
@@ -14368,7 +14368,7 @@ export const deserializeAws_restJson1UpdateEndpointsBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEndpointsBatchCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateEndpointsBatchCommandError(output, context);
   }
   const contents: UpdateEndpointsBatchCommandOutput = {
@@ -14469,7 +14469,7 @@ export const deserializeAws_restJson1UpdateGcmChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGcmChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGcmChannelCommandError(output, context);
   }
   const contents: UpdateGcmChannelCommandOutput = {
@@ -14570,7 +14570,7 @@ export const deserializeAws_restJson1UpdateJourneyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateJourneyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateJourneyCommandError(output, context);
   }
   const contents: UpdateJourneyCommandOutput = {
@@ -14671,7 +14671,7 @@ export const deserializeAws_restJson1UpdateJourneyStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateJourneyStateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateJourneyStateCommandError(output, context);
   }
   const contents: UpdateJourneyStateCommandOutput = {
@@ -14772,7 +14772,7 @@ export const deserializeAws_restJson1UpdatePushTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePushTemplateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdatePushTemplateCommandError(output, context);
   }
   const contents: UpdatePushTemplateCommandOutput = {
@@ -14873,7 +14873,7 @@ export const deserializeAws_restJson1UpdateRecommenderConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRecommenderConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRecommenderConfigurationCommandError(output, context);
   }
   const contents: UpdateRecommenderConfigurationCommandOutput = {
@@ -14974,7 +14974,7 @@ export const deserializeAws_restJson1UpdateSegmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSegmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSegmentCommandError(output, context);
   }
   const contents: UpdateSegmentCommandOutput = {
@@ -15075,7 +15075,7 @@ export const deserializeAws_restJson1UpdateSmsChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSmsChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSmsChannelCommandError(output, context);
   }
   const contents: UpdateSmsChannelCommandOutput = {
@@ -15176,7 +15176,7 @@ export const deserializeAws_restJson1UpdateSmsTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSmsTemplateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSmsTemplateCommandError(output, context);
   }
   const contents: UpdateSmsTemplateCommandOutput = {
@@ -15277,7 +15277,7 @@ export const deserializeAws_restJson1UpdateTemplateActiveVersionCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTemplateActiveVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateTemplateActiveVersionCommandError(output, context);
   }
   const contents: UpdateTemplateActiveVersionCommandOutput = {
@@ -15378,7 +15378,7 @@ export const deserializeAws_restJson1UpdateVoiceChannelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVoiceChannelCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateVoiceChannelCommandError(output, context);
   }
   const contents: UpdateVoiceChannelCommandOutput = {
@@ -15479,7 +15479,7 @@ export const deserializeAws_restJson1UpdateVoiceTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVoiceTemplateCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateVoiceTemplateCommandError(output, context);
   }
   const contents: UpdateVoiceTemplateCommandOutput = {

--- a/clients/client-polly/protocols/Aws_restJson1.ts
+++ b/clients/client-polly/protocols/Aws_restJson1.ts
@@ -343,7 +343,7 @@ export const deserializeAws_restJson1DeleteLexiconCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLexiconCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteLexiconCommandError(output, context);
   }
   const contents: DeleteLexiconCommandOutput = {
@@ -402,7 +402,7 @@ export const deserializeAws_restJson1DescribeVoicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVoicesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeVoicesCommandError(output, context);
   }
   const contents: DescribeVoicesCommandOutput = {
@@ -469,7 +469,7 @@ export const deserializeAws_restJson1GetLexiconCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLexiconCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetLexiconCommandError(output, context);
   }
   const contents: GetLexiconCommandOutput = {
@@ -536,7 +536,7 @@ export const deserializeAws_restJson1GetSpeechSynthesisTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSpeechSynthesisTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSpeechSynthesisTaskCommandError(output, context);
   }
   const contents: GetSpeechSynthesisTaskCommandOutput = {
@@ -607,7 +607,7 @@ export const deserializeAws_restJson1ListLexiconsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLexiconsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListLexiconsCommandError(output, context);
   }
   const contents: ListLexiconsCommandOutput = {
@@ -674,7 +674,7 @@ export const deserializeAws_restJson1ListSpeechSynthesisTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSpeechSynthesisTasksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSpeechSynthesisTasksCommandError(output, context);
   }
   const contents: ListSpeechSynthesisTasksCommandOutput = {
@@ -741,7 +741,7 @@ export const deserializeAws_restJson1PutLexiconCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLexiconCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutLexiconCommandError(output, context);
   }
   const contents: PutLexiconCommandOutput = {
@@ -840,7 +840,7 @@ export const deserializeAws_restJson1StartSpeechSynthesisTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSpeechSynthesisTaskCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartSpeechSynthesisTaskCommandError(output, context);
   }
   const contents: StartSpeechSynthesisTaskCommandOutput = {
@@ -983,7 +983,7 @@ export const deserializeAws_restJson1SynthesizeSpeechCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SynthesizeSpeechCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SynthesizeSpeechCommandError(output, context);
   }
   const contents: SynthesizeSpeechCommandOutput = {

--- a/clients/client-pricing/protocols/Aws_json1_1.ts
+++ b/clients/client-pricing/protocols/Aws_json1_1.ts
@@ -70,7 +70,7 @@ export const deserializeAws_json1_1DescribeServicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeServicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeServicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -157,7 +157,7 @@ export const deserializeAws_json1_1GetAttributeValuesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAttributeValuesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAttributeValuesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -244,7 +244,7 @@ export const deserializeAws_json1_1GetProductsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetProductsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetProductsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-qldb-session/protocols/Aws_json1_0.ts
+++ b/clients/client-qldb-session/protocols/Aws_json1_0.ts
@@ -51,7 +51,7 @@ export const deserializeAws_json1_0SendCommandCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendCommandCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0SendCommandCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-qldb/protocols/Aws_restJson1.ts
+++ b/clients/client-qldb/protocols/Aws_restJson1.ts
@@ -721,7 +721,7 @@ export const deserializeAws_restJson1CancelJournalKinesisStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelJournalKinesisStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelJournalKinesisStreamCommandError(output, context);
   }
   const contents: CancelJournalKinesisStreamCommandOutput = {
@@ -792,7 +792,7 @@ export const deserializeAws_restJson1CreateLedgerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLedgerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateLedgerCommandError(output, context);
   }
   const contents: CreateLedgerCommandOutput = {
@@ -887,7 +887,7 @@ export const deserializeAws_restJson1DeleteLedgerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLedgerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteLedgerCommandError(output, context);
   }
   const contents: DeleteLedgerCommandOutput = {
@@ -962,7 +962,7 @@ export const deserializeAws_restJson1DescribeJournalKinesisStreamCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJournalKinesisStreamCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeJournalKinesisStreamCommandError(output, context);
   }
   const contents: DescribeJournalKinesisStreamCommandOutput = {
@@ -1033,7 +1033,7 @@ export const deserializeAws_restJson1DescribeJournalS3ExportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJournalS3ExportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeJournalS3ExportCommandError(output, context);
   }
   const contents: DescribeJournalS3ExportCommandOutput = {
@@ -1088,7 +1088,7 @@ export const deserializeAws_restJson1DescribeLedgerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLedgerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeLedgerCommandError(output, context);
   }
   const contents: DescribeLedgerCommandOutput = {
@@ -1167,7 +1167,7 @@ export const deserializeAws_restJson1ExportJournalToS3Command = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExportJournalToS3CommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ExportJournalToS3CommandError(output, context);
   }
   const contents: ExportJournalToS3CommandOutput = {
@@ -1230,7 +1230,7 @@ export const deserializeAws_restJson1GetBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBlockCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBlockCommandError(output, context);
   }
   const contents: GetBlockCommandOutput = {
@@ -1305,7 +1305,7 @@ export const deserializeAws_restJson1GetDigestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDigestCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDigestCommandError(output, context);
   }
   const contents: GetDigestCommandOutput = {
@@ -1380,7 +1380,7 @@ export const deserializeAws_restJson1GetRevisionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRevisionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRevisionCommandError(output, context);
   }
   const contents: GetRevisionCommandOutput = {
@@ -1455,7 +1455,7 @@ export const deserializeAws_restJson1ListJournalKinesisStreamsForLedgerCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJournalKinesisStreamsForLedgerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJournalKinesisStreamsForLedgerCommandError(output, context);
   }
   const contents: ListJournalKinesisStreamsForLedgerCommandOutput = {
@@ -1530,7 +1530,7 @@ export const deserializeAws_restJson1ListJournalS3ExportsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJournalS3ExportsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJournalS3ExportsCommandError(output, context);
   }
   const contents: ListJournalS3ExportsCommandOutput = {
@@ -1581,7 +1581,7 @@ export const deserializeAws_restJson1ListJournalS3ExportsForLedgerCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJournalS3ExportsForLedgerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListJournalS3ExportsForLedgerCommandError(output, context);
   }
   const contents: ListJournalS3ExportsForLedgerCommandOutput = {
@@ -1632,7 +1632,7 @@ export const deserializeAws_restJson1ListLedgersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLedgersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListLedgersCommandError(output, context);
   }
   const contents: ListLedgersCommandOutput = {
@@ -1683,7 +1683,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1746,7 +1746,7 @@ export const deserializeAws_restJson1StreamJournalToKinesisCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StreamJournalToKinesisCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StreamJournalToKinesisCommandError(output, context);
   }
   const contents: StreamJournalToKinesisCommandOutput = {
@@ -1817,7 +1817,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1876,7 +1876,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -1935,7 +1935,7 @@ export const deserializeAws_restJson1UpdateLedgerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateLedgerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateLedgerCommandError(output, context);
   }
   const contents: UpdateLedgerCommandOutput = {

--- a/clients/client-quicksight/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1.ts
@@ -4355,7 +4355,7 @@ export const deserializeAws_restJson1CancelIngestionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelIngestionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelIngestionCommandError(output, context);
   }
   const contents: CancelIngestionCommandOutput = {
@@ -4458,7 +4458,7 @@ export const deserializeAws_restJson1CreateAccountCustomizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAccountCustomizationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateAccountCustomizationCommandError(output, context);
   }
   const contents: CreateAccountCustomizationCommandOutput = {
@@ -4573,7 +4573,7 @@ export const deserializeAws_restJson1CreateDashboardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDashboardCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDashboardCommandError(output, context);
   }
   const contents: CreateDashboardCommandOutput = {
@@ -4692,7 +4692,7 @@ export const deserializeAws_restJson1CreateDataSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDataSetCommandError(output, context);
   }
   const contents: CreateDataSetCommandOutput = {
@@ -4827,7 +4827,7 @@ export const deserializeAws_restJson1CreateDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDataSourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDataSourceCommandError(output, context);
   }
   const contents: CreateDataSourceCommandOutput = {
@@ -4950,7 +4950,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGroupCommandError(output, context);
   }
   const contents: CreateGroupCommandOutput = {
@@ -5073,7 +5073,7 @@ export const deserializeAws_restJson1CreateGroupMembershipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGroupMembershipCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGroupMembershipCommandError(output, context);
   }
   const contents: CreateGroupMembershipCommandOutput = {
@@ -5180,7 +5180,7 @@ export const deserializeAws_restJson1CreateIAMPolicyAssignmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIAMPolicyAssignmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateIAMPolicyAssignmentCommandError(output, context);
   }
   const contents: CreateIAMPolicyAssignmentCommandOutput = {
@@ -5303,7 +5303,7 @@ export const deserializeAws_restJson1CreateIngestionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIngestionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateIngestionCommandError(output, context);
   }
   const contents: CreateIngestionCommandOutput = {
@@ -5418,7 +5418,7 @@ export const deserializeAws_restJson1CreateNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNamespaceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateNamespaceCommandError(output, context);
   }
   const contents: CreateNamespaceCommandOutput = {
@@ -5565,7 +5565,7 @@ export const deserializeAws_restJson1CreateTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateTemplateCommandError(output, context);
   }
   const contents: CreateTemplateCommandOutput = {
@@ -5700,7 +5700,7 @@ export const deserializeAws_restJson1CreateTemplateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTemplateAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateTemplateAliasCommandError(output, context);
   }
   const contents: CreateTemplateAliasCommandOutput = {
@@ -5807,7 +5807,7 @@ export const deserializeAws_restJson1CreateThemeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateThemeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateThemeCommandError(output, context);
   }
   const contents: CreateThemeCommandOutput = {
@@ -5934,7 +5934,7 @@ export const deserializeAws_restJson1CreateThemeAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateThemeAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateThemeAliasCommandError(output, context);
   }
   const contents: CreateThemeAliasCommandOutput = {
@@ -6049,7 +6049,7 @@ export const deserializeAws_restJson1DeleteAccountCustomizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccountCustomizationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteAccountCustomizationCommandError(output, context);
   }
   const contents: DeleteAccountCustomizationCommandOutput = {
@@ -6144,7 +6144,7 @@ export const deserializeAws_restJson1DeleteDashboardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDashboardCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDashboardCommandError(output, context);
   }
   const contents: DeleteDashboardCommandOutput = {
@@ -6247,7 +6247,7 @@ export const deserializeAws_restJson1DeleteDataSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDataSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDataSetCommandError(output, context);
   }
   const contents: DeleteDataSetCommandOutput = {
@@ -6342,7 +6342,7 @@ export const deserializeAws_restJson1DeleteDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDataSourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDataSourceCommandError(output, context);
   }
   const contents: DeleteDataSourceCommandOutput = {
@@ -6437,7 +6437,7 @@ export const deserializeAws_restJson1DeleteGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGroupCommandError(output, context);
   }
   const contents: DeleteGroupCommandOutput = {
@@ -6540,7 +6540,7 @@ export const deserializeAws_restJson1DeleteGroupMembershipCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGroupMembershipCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGroupMembershipCommandError(output, context);
   }
   const contents: DeleteGroupMembershipCommandOutput = {
@@ -6643,7 +6643,7 @@ export const deserializeAws_restJson1DeleteIAMPolicyAssignmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIAMPolicyAssignmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteIAMPolicyAssignmentCommandError(output, context);
   }
   const contents: DeleteIAMPolicyAssignmentCommandOutput = {
@@ -6750,7 +6750,7 @@ export const deserializeAws_restJson1DeleteNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNamespaceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteNamespaceCommandError(output, context);
   }
   const contents: DeleteNamespaceCommandOutput = {
@@ -6853,7 +6853,7 @@ export const deserializeAws_restJson1DeleteTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteTemplateCommandError(output, context);
   }
   const contents: DeleteTemplateCommandOutput = {
@@ -6964,7 +6964,7 @@ export const deserializeAws_restJson1DeleteTemplateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTemplateAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteTemplateAliasCommandError(output, context);
   }
   const contents: DeleteTemplateAliasCommandOutput = {
@@ -7063,7 +7063,7 @@ export const deserializeAws_restJson1DeleteThemeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteThemeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteThemeCommandError(output, context);
   }
   const contents: DeleteThemeCommandOutput = {
@@ -7174,7 +7174,7 @@ export const deserializeAws_restJson1DeleteThemeAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteThemeAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteThemeAliasCommandError(output, context);
   }
   const contents: DeleteThemeAliasCommandOutput = {
@@ -7281,7 +7281,7 @@ export const deserializeAws_restJson1DeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteUserCommandError(output, context);
   }
   const contents: DeleteUserCommandOutput = {
@@ -7384,7 +7384,7 @@ export const deserializeAws_restJson1DeleteUserByPrincipalIdCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserByPrincipalIdCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteUserByPrincipalIdCommandError(output, context);
   }
   const contents: DeleteUserByPrincipalIdCommandOutput = {
@@ -7487,7 +7487,7 @@ export const deserializeAws_restJson1DescribeAccountCustomizationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountCustomizationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAccountCustomizationCommandError(output, context);
   }
   const contents: DescribeAccountCustomizationCommandOutput = {
@@ -7594,7 +7594,7 @@ export const deserializeAws_restJson1DescribeAccountSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAccountSettingsCommandError(output, context);
   }
   const contents: DescribeAccountSettingsCommandOutput = {
@@ -7693,7 +7693,7 @@ export const deserializeAws_restJson1DescribeDashboardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDashboardCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDashboardCommandError(output, context);
   }
   const contents: DescribeDashboardCommandOutput = {
@@ -7792,7 +7792,7 @@ export const deserializeAws_restJson1DescribeDashboardPermissionsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDashboardPermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDashboardPermissionsCommandError(output, context);
   }
   const contents: DescribeDashboardPermissionsCommandOutput = {
@@ -7891,7 +7891,7 @@ export const deserializeAws_restJson1DescribeDataSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDataSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDataSetCommandError(output, context);
   }
   const contents: DescribeDataSetCommandOutput = {
@@ -7982,7 +7982,7 @@ export const deserializeAws_restJson1DescribeDataSetPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDataSetPermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDataSetPermissionsCommandError(output, context);
   }
   const contents: DescribeDataSetPermissionsCommandOutput = {
@@ -8081,7 +8081,7 @@ export const deserializeAws_restJson1DescribeDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDataSourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDataSourceCommandError(output, context);
   }
   const contents: DescribeDataSourceCommandOutput = {
@@ -8172,7 +8172,7 @@ export const deserializeAws_restJson1DescribeDataSourcePermissionsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDataSourcePermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDataSourcePermissionsCommandError(output, context);
   }
   const contents: DescribeDataSourcePermissionsCommandOutput = {
@@ -8271,7 +8271,7 @@ export const deserializeAws_restJson1DescribeGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeGroupCommandError(output, context);
   }
   const contents: DescribeGroupCommandOutput = {
@@ -8378,7 +8378,7 @@ export const deserializeAws_restJson1DescribeIAMPolicyAssignmentCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIAMPolicyAssignmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeIAMPolicyAssignmentCommandError(output, context);
   }
   const contents: DescribeIAMPolicyAssignmentCommandOutput = {
@@ -8477,7 +8477,7 @@ export const deserializeAws_restJson1DescribeIngestionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIngestionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeIngestionCommandError(output, context);
   }
   const contents: DescribeIngestionCommandOutput = {
@@ -8576,7 +8576,7 @@ export const deserializeAws_restJson1DescribeNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNamespaceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeNamespaceCommandError(output, context);
   }
   const contents: DescribeNamespaceCommandOutput = {
@@ -8675,7 +8675,7 @@ export const deserializeAws_restJson1DescribeTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeTemplateCommandError(output, context);
   }
   const contents: DescribeTemplateCommandOutput = {
@@ -8790,7 +8790,7 @@ export const deserializeAws_restJson1DescribeTemplateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTemplateAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeTemplateAliasCommandError(output, context);
   }
   const contents: DescribeTemplateAliasCommandOutput = {
@@ -8873,7 +8873,7 @@ export const deserializeAws_restJson1DescribeTemplatePermissionsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTemplatePermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeTemplatePermissionsCommandError(output, context);
   }
   const contents: DescribeTemplatePermissionsCommandOutput = {
@@ -8980,7 +8980,7 @@ export const deserializeAws_restJson1DescribeThemeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeThemeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeThemeCommandError(output, context);
   }
   const contents: DescribeThemeCommandOutput = {
@@ -9087,7 +9087,7 @@ export const deserializeAws_restJson1DescribeThemeAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeThemeAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeThemeAliasCommandError(output, context);
   }
   const contents: DescribeThemeAliasCommandOutput = {
@@ -9186,7 +9186,7 @@ export const deserializeAws_restJson1DescribeThemePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeThemePermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeThemePermissionsCommandError(output, context);
   }
   const contents: DescribeThemePermissionsCommandOutput = {
@@ -9293,7 +9293,7 @@ export const deserializeAws_restJson1DescribeUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeUserCommandError(output, context);
   }
   const contents: DescribeUserCommandOutput = {
@@ -9400,7 +9400,7 @@ export const deserializeAws_restJson1GetDashboardEmbedUrlCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDashboardEmbedUrlCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDashboardEmbedUrlCommandError(output, context);
   }
   const contents: GetDashboardEmbedUrlCommandOutput = {
@@ -9539,7 +9539,7 @@ export const deserializeAws_restJson1GetSessionEmbedUrlCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSessionEmbedUrlCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSessionEmbedUrlCommandError(output, context);
   }
   const contents: GetSessionEmbedUrlCommandOutput = {
@@ -9662,7 +9662,7 @@ export const deserializeAws_restJson1ListDashboardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDashboardsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDashboardsCommandError(output, context);
   }
   const contents: ListDashboardsCommandOutput = {
@@ -9749,7 +9749,7 @@ export const deserializeAws_restJson1ListDashboardVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDashboardVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDashboardVersionsCommandError(output, context);
   }
   const contents: ListDashboardVersionsCommandOutput = {
@@ -9855,7 +9855,7 @@ export const deserializeAws_restJson1ListDataSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDataSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDataSetsCommandError(output, context);
   }
   const contents: ListDataSetsCommandOutput = {
@@ -9950,7 +9950,7 @@ export const deserializeAws_restJson1ListDataSourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDataSourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDataSourcesCommandError(output, context);
   }
   const contents: ListDataSourcesCommandOutput = {
@@ -10045,7 +10045,7 @@ export const deserializeAws_restJson1ListGroupMembershipsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupMembershipsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGroupMembershipsCommandError(output, context);
   }
   const contents: ListGroupMembershipsCommandOutput = {
@@ -10164,7 +10164,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGroupsCommandError(output, context);
   }
   const contents: ListGroupsCommandOutput = {
@@ -10283,7 +10283,7 @@ export const deserializeAws_restJson1ListIAMPolicyAssignmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIAMPolicyAssignmentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListIAMPolicyAssignmentsCommandError(output, context);
   }
   const contents: ListIAMPolicyAssignmentsCommandOutput = {
@@ -10389,7 +10389,7 @@ export const deserializeAws_restJson1ListIAMPolicyAssignmentsForUserCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIAMPolicyAssignmentsForUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListIAMPolicyAssignmentsForUserCommandError(output, context);
   }
   const contents: ListIAMPolicyAssignmentsForUserCommandOutput = {
@@ -10500,7 +10500,7 @@ export const deserializeAws_restJson1ListIngestionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIngestionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListIngestionsCommandError(output, context);
   }
   const contents: ListIngestionsCommandOutput = {
@@ -10611,7 +10611,7 @@ export const deserializeAws_restJson1ListNamespacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNamespacesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListNamespacesCommandError(output, context);
   }
   const contents: ListNamespacesCommandOutput = {
@@ -10730,7 +10730,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -10821,7 +10821,7 @@ export const deserializeAws_restJson1ListTemplateAliasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTemplateAliasesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTemplateAliasesCommandError(output, context);
   }
   const contents: ListTemplateAliasesCommandOutput = {
@@ -10916,7 +10916,7 @@ export const deserializeAws_restJson1ListTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTemplatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTemplatesCommandError(output, context);
   }
   const contents: ListTemplatesCommandOutput = {
@@ -11019,7 +11019,7 @@ export const deserializeAws_restJson1ListTemplateVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTemplateVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTemplateVersionsCommandError(output, context);
   }
   const contents: ListTemplateVersionsCommandOutput = {
@@ -11125,7 +11125,7 @@ export const deserializeAws_restJson1ListThemeAliasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThemeAliasesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThemeAliasesCommandError(output, context);
   }
   const contents: ListThemeAliasesCommandOutput = {
@@ -11236,7 +11236,7 @@ export const deserializeAws_restJson1ListThemesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThemesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThemesCommandError(output, context);
   }
   const contents: ListThemesCommandOutput = {
@@ -11347,7 +11347,7 @@ export const deserializeAws_restJson1ListThemeVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListThemeVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListThemeVersionsCommandError(output, context);
   }
   const contents: ListThemeVersionsCommandOutput = {
@@ -11461,7 +11461,7 @@ export const deserializeAws_restJson1ListUserGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUserGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListUserGroupsCommandError(output, context);
   }
   const contents: ListUserGroupsCommandOutput = {
@@ -11572,7 +11572,7 @@ export const deserializeAws_restJson1ListUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUsersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListUsersCommandError(output, context);
   }
   const contents: ListUsersCommandOutput = {
@@ -11691,7 +11691,7 @@ export const deserializeAws_restJson1RegisterUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegisterUserCommandError(output, context);
   }
   const contents: RegisterUserCommandOutput = {
@@ -11818,7 +11818,7 @@ export const deserializeAws_restJson1SearchDashboardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchDashboardsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SearchDashboardsCommandError(output, context);
   }
   const contents: SearchDashboardsCommandOutput = {
@@ -11921,7 +11921,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -12016,7 +12016,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -12103,7 +12103,7 @@ export const deserializeAws_restJson1UpdateAccountCustomizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAccountCustomizationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAccountCustomizationCommandError(output, context);
   }
   const contents: UpdateAccountCustomizationCommandOutput = {
@@ -12210,7 +12210,7 @@ export const deserializeAws_restJson1UpdateAccountSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAccountSettingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAccountSettingsCommandError(output, context);
   }
   const contents: UpdateAccountSettingsCommandOutput = {
@@ -12305,7 +12305,7 @@ export const deserializeAws_restJson1UpdateDashboardCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDashboardCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDashboardCommandError(output, context);
   }
   const contents: UpdateDashboardCommandOutput = {
@@ -12428,7 +12428,7 @@ export const deserializeAws_restJson1UpdateDashboardPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDashboardPermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDashboardPermissionsCommandError(output, context);
   }
   const contents: UpdateDashboardPermissionsCommandOutput = {
@@ -12535,7 +12535,7 @@ export const deserializeAws_restJson1UpdateDashboardPublishedVersionCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDashboardPublishedVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDashboardPublishedVersionCommandError(output, context);
   }
   const contents: UpdateDashboardPublishedVersionCommandOutput = {
@@ -12638,7 +12638,7 @@ export const deserializeAws_restJson1UpdateDataSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDataSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDataSetCommandError(output, context);
   }
   const contents: UpdateDataSetCommandOutput = {
@@ -12765,7 +12765,7 @@ export const deserializeAws_restJson1UpdateDataSetPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDataSetPermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDataSetPermissionsCommandError(output, context);
   }
   const contents: UpdateDataSetPermissionsCommandOutput = {
@@ -12868,7 +12868,7 @@ export const deserializeAws_restJson1UpdateDataSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDataSourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDataSourceCommandError(output, context);
   }
   const contents: UpdateDataSourceCommandOutput = {
@@ -12975,7 +12975,7 @@ export const deserializeAws_restJson1UpdateDataSourcePermissionsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDataSourcePermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDataSourcePermissionsCommandError(output, context);
   }
   const contents: UpdateDataSourcePermissionsCommandOutput = {
@@ -13078,7 +13078,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGroupCommandError(output, context);
   }
   const contents: UpdateGroupCommandOutput = {
@@ -13185,7 +13185,7 @@ export const deserializeAws_restJson1UpdateIAMPolicyAssignmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIAMPolicyAssignmentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateIAMPolicyAssignmentCommandError(output, context);
   }
   const contents: UpdateIAMPolicyAssignmentCommandOutput = {
@@ -13308,7 +13308,7 @@ export const deserializeAws_restJson1UpdateTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateTemplateCommandError(output, context);
   }
   const contents: UpdateTemplateCommandOutput = {
@@ -13435,7 +13435,7 @@ export const deserializeAws_restJson1UpdateTemplateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTemplateAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateTemplateAliasCommandError(output, context);
   }
   const contents: UpdateTemplateAliasCommandOutput = {
@@ -13526,7 +13526,7 @@ export const deserializeAws_restJson1UpdateTemplatePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTemplatePermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateTemplatePermissionsCommandError(output, context);
   }
   const contents: UpdateTemplatePermissionsCommandOutput = {
@@ -13633,7 +13633,7 @@ export const deserializeAws_restJson1UpdateThemeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateThemeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateThemeCommandError(output, context);
   }
   const contents: UpdateThemeCommandOutput = {
@@ -13760,7 +13760,7 @@ export const deserializeAws_restJson1UpdateThemeAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateThemeAliasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateThemeAliasCommandError(output, context);
   }
   const contents: UpdateThemeAliasCommandOutput = {
@@ -13867,7 +13867,7 @@ export const deserializeAws_restJson1UpdateThemePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateThemePermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateThemePermissionsCommandError(output, context);
   }
   const contents: UpdateThemePermissionsCommandOutput = {
@@ -13974,7 +13974,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUserCommandError(output, context);
   }
   const contents: UpdateUserCommandOutput = {

--- a/clients/client-ram/protocols/Aws_restJson1.ts
+++ b/clients/client-ram/protocols/Aws_restJson1.ts
@@ -799,7 +799,7 @@ export const deserializeAws_restJson1AcceptResourceShareInvitationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptResourceShareInvitationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AcceptResourceShareInvitationCommandError(output, context);
   }
   const contents: AcceptResourceShareInvitationCommandOutput = {
@@ -939,7 +939,7 @@ export const deserializeAws_restJson1AssociateResourceShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateResourceShareCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateResourceShareCommandError(output, context);
   }
   const contents: AssociateResourceShareCommandOutput = {
@@ -1073,7 +1073,7 @@ export const deserializeAws_restJson1AssociateResourceSharePermissionCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateResourceSharePermissionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateResourceSharePermissionCommandError(output, context);
   }
   const contents: AssociateResourceSharePermissionCommandOutput = {
@@ -1180,7 +1180,7 @@ export const deserializeAws_restJson1CreateResourceShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResourceShareCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateResourceShareCommandError(output, context);
   }
   const contents: CreateResourceShareCommandOutput = {
@@ -1319,7 +1319,7 @@ export const deserializeAws_restJson1DeleteResourceShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourceShareCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteResourceShareCommandError(output, context);
   }
   const contents: DeleteResourceShareCommandOutput = {
@@ -1442,7 +1442,7 @@ export const deserializeAws_restJson1DisassociateResourceShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateResourceShareCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateResourceShareCommandError(output, context);
   }
   const contents: DisassociateResourceShareCommandOutput = {
@@ -1576,7 +1576,7 @@ export const deserializeAws_restJson1DisassociateResourceSharePermissionCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateResourceSharePermissionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateResourceSharePermissionCommandError(output, context);
   }
   const contents: DisassociateResourceSharePermissionCommandOutput = {
@@ -1683,7 +1683,7 @@ export const deserializeAws_restJson1EnableSharingWithAwsOrganizationCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableSharingWithAwsOrganizationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1EnableSharingWithAwsOrganizationCommandError(output, context);
   }
   const contents: EnableSharingWithAwsOrganizationCommandOutput = {
@@ -1754,7 +1754,7 @@ export const deserializeAws_restJson1GetPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPermissionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetPermissionCommandError(output, context);
   }
   const contents: GetPermissionCommandOutput = {
@@ -1849,7 +1849,7 @@ export const deserializeAws_restJson1GetResourcePoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourcePoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResourcePoliciesCommandError(output, context);
   }
   const contents: GetResourcePoliciesCommandOutput = {
@@ -1948,7 +1948,7 @@ export const deserializeAws_restJson1GetResourceShareAssociationsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourceShareAssociationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResourceShareAssociationsCommandError(output, context);
   }
   const contents: GetResourceShareAssociationsCommandOutput = {
@@ -2058,7 +2058,7 @@ export const deserializeAws_restJson1GetResourceShareInvitationsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourceShareInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResourceShareInvitationsCommandError(output, context);
   }
   const contents: GetResourceShareInvitationsCommandOutput = {
@@ -2176,7 +2176,7 @@ export const deserializeAws_restJson1GetResourceSharesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourceSharesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResourceSharesCommandError(output, context);
   }
   const contents: GetResourceSharesCommandOutput = {
@@ -2275,7 +2275,7 @@ export const deserializeAws_restJson1ListPendingInvitationResourcesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPendingInvitationResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPendingInvitationResourcesCommandError(output, context);
   }
   const contents: ListPendingInvitationResourcesCommandOutput = {
@@ -2401,7 +2401,7 @@ export const deserializeAws_restJson1ListPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPermissionsCommandError(output, context);
   }
   const contents: ListPermissionsCommandOutput = {
@@ -2492,7 +2492,7 @@ export const deserializeAws_restJson1ListPrincipalsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPrincipalsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListPrincipalsCommandError(output, context);
   }
   const contents: ListPrincipalsCommandOutput = {
@@ -2591,7 +2591,7 @@ export const deserializeAws_restJson1ListResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListResourcesCommandError(output, context);
   }
   const contents: ListResourcesCommandOutput = {
@@ -2698,7 +2698,7 @@ export const deserializeAws_restJson1ListResourceSharePermissionsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceSharePermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListResourceSharePermissionsCommandError(output, context);
   }
   const contents: ListResourceSharePermissionsCommandOutput = {
@@ -2805,7 +2805,7 @@ export const deserializeAws_restJson1ListResourceTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListResourceTypesCommandError(output, context);
   }
   const contents: ListResourceTypesCommandOutput = {
@@ -2888,7 +2888,7 @@ export const deserializeAws_restJson1PromoteResourceShareCreatedFromPolicyComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PromoteResourceShareCreatedFromPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PromoteResourceShareCreatedFromPolicyCommandError(output, context);
   }
   const contents: PromoteResourceShareCreatedFromPolicyCommandOutput = {
@@ -2991,7 +2991,7 @@ export const deserializeAws_restJson1RejectResourceShareInvitationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectResourceShareInvitationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RejectResourceShareInvitationCommandError(output, context);
   }
   const contents: RejectResourceShareInvitationCommandOutput = {
@@ -3131,7 +3131,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -3230,7 +3230,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -3297,7 +3297,7 @@ export const deserializeAws_restJson1UpdateResourceShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateResourceShareCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateResourceShareCommandError(output, context);
   }
   const contents: UpdateResourceShareCommandOutput = {

--- a/clients/client-rds-data/protocols/Aws_restJson1.ts
+++ b/clients/client-rds-data/protocols/Aws_restJson1.ts
@@ -219,7 +219,7 @@ export const deserializeAws_restJson1BatchExecuteStatementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchExecuteStatementCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchExecuteStatementCommandError(output, context);
   }
   const contents: BatchExecuteStatementCommandOutput = {
@@ -306,7 +306,7 @@ export const deserializeAws_restJson1BeginTransactionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BeginTransactionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BeginTransactionCommandError(output, context);
   }
   const contents: BeginTransactionCommandOutput = {
@@ -393,7 +393,7 @@ export const deserializeAws_restJson1CommitTransactionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CommitTransactionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CommitTransactionCommandError(output, context);
   }
   const contents: CommitTransactionCommandOutput = {
@@ -488,7 +488,7 @@ export const deserializeAws_restJson1ExecuteSqlCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExecuteSqlCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ExecuteSqlCommandError(output, context);
   }
   const contents: ExecuteSqlCommandOutput = {
@@ -567,7 +567,7 @@ export const deserializeAws_restJson1ExecuteStatementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExecuteStatementCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ExecuteStatementCommandError(output, context);
   }
   const contents: ExecuteStatementCommandOutput = {
@@ -666,7 +666,7 @@ export const deserializeAws_restJson1RollbackTransactionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RollbackTransactionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RollbackTransactionCommandError(output, context);
   }
   const contents: RollbackTransactionCommandOutput = {

--- a/clients/client-rds/protocols/Aws_query.ts
+++ b/clients/client-rds/protocols/Aws_query.ts
@@ -2955,7 +2955,7 @@ export const deserializeAws_queryAddRoleToDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddRoleToDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddRoleToDBClusterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3030,7 +3030,7 @@ export const deserializeAws_queryAddRoleToDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddRoleToDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddRoleToDBInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3105,7 +3105,7 @@ export const deserializeAws_queryAddSourceIdentifierToSubscriptionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddSourceIdentifierToSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddSourceIdentifierToSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3170,7 +3170,7 @@ export const deserializeAws_queryAddTagsToResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddTagsToResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3253,7 +3253,7 @@ export const deserializeAws_queryApplyPendingMaintenanceActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ApplyPendingMaintenanceActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryApplyPendingMaintenanceActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3323,7 +3323,7 @@ export const deserializeAws_queryAuthorizeDBSecurityGroupIngressCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AuthorizeDBSecurityGroupIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAuthorizeDBSecurityGroupIngressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3404,7 +3404,7 @@ export const deserializeAws_queryBacktrackDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BacktrackDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryBacktrackDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3466,7 +3466,7 @@ export const deserializeAws_queryCancelExportTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelExportTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCancelExportTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3528,7 +3528,7 @@ export const deserializeAws_queryCopyDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3598,7 +3598,7 @@ export const deserializeAws_queryCopyDBClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyDBClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyDBClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3692,7 +3692,7 @@ export const deserializeAws_queryCopyDBParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyDBParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyDBParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3762,7 +3762,7 @@ export const deserializeAws_queryCopyDBSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyDBSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyDBSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3848,7 +3848,7 @@ export const deserializeAws_queryCopyOptionGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyOptionGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyOptionGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3918,7 +3918,7 @@ export const deserializeAws_queryCreateCustomAvailabilityZoneCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCustomAvailabilityZoneCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateCustomAvailabilityZoneCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3988,7 +3988,7 @@ export const deserializeAws_queryCreateDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4178,7 +4178,7 @@ export const deserializeAws_queryCreateDBClusterEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBClusterEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBClusterEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4272,7 +4272,7 @@ export const deserializeAws_queryCreateDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4334,7 +4334,7 @@ export const deserializeAws_queryCreateDBClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4420,7 +4420,7 @@ export const deserializeAws_queryCreateDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4618,7 +4618,7 @@ export const deserializeAws_queryCreateDBInstanceReadReplicaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBInstanceReadReplicaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBInstanceReadReplicaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4816,7 +4816,7 @@ export const deserializeAws_queryCreateDBParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4878,7 +4878,7 @@ export const deserializeAws_queryCreateDBProxyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBProxyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBProxyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4948,7 +4948,7 @@ export const deserializeAws_queryCreateDBSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBSecurityGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBSecurityGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5018,7 +5018,7 @@ export const deserializeAws_queryCreateDBSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5096,7 +5096,7 @@ export const deserializeAws_queryCreateDBSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDBSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateDBSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5182,7 +5182,7 @@ export const deserializeAws_queryCreateEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5284,7 +5284,7 @@ export const deserializeAws_queryCreateGlobalClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGlobalClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateGlobalClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5362,7 +5362,7 @@ export const deserializeAws_queryCreateOptionGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOptionGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateOptionGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5424,7 +5424,7 @@ export const deserializeAws_queryDeleteCustomAvailabilityZoneCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCustomAvailabilityZoneCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteCustomAvailabilityZoneCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5486,7 +5486,7 @@ export const deserializeAws_queryDeleteDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5572,7 +5572,7 @@ export const deserializeAws_queryDeleteDBClusterEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBClusterEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBClusterEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5642,7 +5642,7 @@ export const deserializeAws_queryDeleteDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBClusterParameterGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5701,7 +5701,7 @@ export const deserializeAws_queryDeleteDBClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5763,7 +5763,7 @@ export const deserializeAws_queryDeleteDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5857,7 +5857,7 @@ export const deserializeAws_queryDeleteDBInstanceAutomatedBackupCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBInstanceAutomatedBackupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBInstanceAutomatedBackupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5922,7 +5922,7 @@ export const deserializeAws_queryDeleteDBParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBParameterGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5981,7 +5981,7 @@ export const deserializeAws_queryDeleteDBProxyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBProxyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBProxyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6043,7 +6043,7 @@ export const deserializeAws_queryDeleteDBSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBSecurityGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBSecurityGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6102,7 +6102,7 @@ export const deserializeAws_queryDeleteDBSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6164,7 +6164,7 @@ export const deserializeAws_queryDeleteDBSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDBSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteDBSubnetGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6231,7 +6231,7 @@ export const deserializeAws_queryDeleteEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6293,7 +6293,7 @@ export const deserializeAws_queryDeleteGlobalClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGlobalClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteGlobalClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6355,7 +6355,7 @@ export const deserializeAws_queryDeleteInstallationMediaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInstallationMediaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteInstallationMediaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6409,7 +6409,7 @@ export const deserializeAws_queryDeleteOptionGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteOptionGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteOptionGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -6468,7 +6468,7 @@ export const deserializeAws_queryDeregisterDBProxyTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterDBProxyTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeregisterDBProxyTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6546,7 +6546,7 @@ export const deserializeAws_queryDescribeAccountAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAccountAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6592,7 +6592,7 @@ export const deserializeAws_queryDescribeCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6646,7 +6646,7 @@ export const deserializeAws_queryDescribeCustomAvailabilityZonesCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCustomAvailabilityZonesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeCustomAvailabilityZonesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6700,7 +6700,7 @@ export const deserializeAws_queryDescribeDBClusterBacktracksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterBacktracksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterBacktracksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6762,7 +6762,7 @@ export const deserializeAws_queryDescribeDBClusterEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6816,7 +6816,7 @@ export const deserializeAws_queryDescribeDBClusterParameterGroupsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterParameterGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterParameterGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6870,7 +6870,7 @@ export const deserializeAws_queryDescribeDBClusterParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6924,7 +6924,7 @@ export const deserializeAws_queryDescribeDBClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6978,7 +6978,7 @@ export const deserializeAws_queryDescribeDBClusterSnapshotAttributesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterSnapshotAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterSnapshotAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7035,7 +7035,7 @@ export const deserializeAws_queryDescribeDBClusterSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBClusterSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBClusterSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7089,7 +7089,7 @@ export const deserializeAws_queryDescribeDBEngineVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBEngineVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBEngineVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7135,7 +7135,7 @@ export const deserializeAws_queryDescribeDBInstanceAutomatedBackupsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBInstanceAutomatedBackupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBInstanceAutomatedBackupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7192,7 +7192,7 @@ export const deserializeAws_queryDescribeDBInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7246,7 +7246,7 @@ export const deserializeAws_queryDescribeDBLogFilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBLogFilesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBLogFilesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7300,7 +7300,7 @@ export const deserializeAws_queryDescribeDBParameterGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBParameterGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBParameterGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7354,7 +7354,7 @@ export const deserializeAws_queryDescribeDBParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7408,7 +7408,7 @@ export const deserializeAws_queryDescribeDBProxiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBProxiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBProxiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7462,7 +7462,7 @@ export const deserializeAws_queryDescribeDBProxyTargetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBProxyTargetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBProxyTargetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7532,7 +7532,7 @@ export const deserializeAws_queryDescribeDBProxyTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBProxyTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBProxyTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7610,7 +7610,7 @@ export const deserializeAws_queryDescribeDBSecurityGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBSecurityGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBSecurityGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7664,7 +7664,7 @@ export const deserializeAws_queryDescribeDBSnapshotAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBSnapshotAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBSnapshotAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7718,7 +7718,7 @@ export const deserializeAws_queryDescribeDBSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7772,7 +7772,7 @@ export const deserializeAws_queryDescribeDBSubnetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDBSubnetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDBSubnetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7826,7 +7826,7 @@ export const deserializeAws_queryDescribeEngineDefaultClusterParametersCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEngineDefaultClusterParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEngineDefaultClusterParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7875,7 +7875,7 @@ export const deserializeAws_queryDescribeEngineDefaultParametersCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEngineDefaultParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEngineDefaultParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7924,7 +7924,7 @@ export const deserializeAws_queryDescribeEventCategoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventCategoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventCategoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7970,7 +7970,7 @@ export const deserializeAws_queryDescribeEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8016,7 +8016,7 @@ export const deserializeAws_queryDescribeEventSubscriptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventSubscriptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventSubscriptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8070,7 +8070,7 @@ export const deserializeAws_queryDescribeExportTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeExportTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeExportTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8124,7 +8124,7 @@ export const deserializeAws_queryDescribeGlobalClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGlobalClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeGlobalClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8178,7 +8178,7 @@ export const deserializeAws_queryDescribeInstallationMediaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstallationMediaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeInstallationMediaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8232,7 +8232,7 @@ export const deserializeAws_queryDescribeOptionGroupOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOptionGroupOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeOptionGroupOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8278,7 +8278,7 @@ export const deserializeAws_queryDescribeOptionGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOptionGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeOptionGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8332,7 +8332,7 @@ export const deserializeAws_queryDescribeOrderableDBInstanceOptionsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrderableDBInstanceOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeOrderableDBInstanceOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8381,7 +8381,7 @@ export const deserializeAws_queryDescribePendingMaintenanceActionsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePendingMaintenanceActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribePendingMaintenanceActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8438,7 +8438,7 @@ export const deserializeAws_queryDescribeReservedDBInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedDBInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeReservedDBInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8492,7 +8492,7 @@ export const deserializeAws_queryDescribeReservedDBInstancesOfferingsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedDBInstancesOfferingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeReservedDBInstancesOfferingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8549,7 +8549,7 @@ export const deserializeAws_queryDescribeSourceRegionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSourceRegionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeSourceRegionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8595,7 +8595,7 @@ export const deserializeAws_queryDescribeValidDBInstanceModificationsCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeValidDBInstanceModificationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeValidDBInstanceModificationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8660,7 +8660,7 @@ export const deserializeAws_queryDownloadDBLogFilePortionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DownloadDBLogFilePortionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDownloadDBLogFilePortionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8722,7 +8722,7 @@ export const deserializeAws_queryFailoverDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FailoverDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryFailoverDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8792,7 +8792,7 @@ export const deserializeAws_queryImportInstallationMediaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportInstallationMediaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryImportInstallationMediaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8854,7 +8854,7 @@ export const deserializeAws_queryListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8940,7 +8940,7 @@ export const deserializeAws_queryModifyCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8994,7 +8994,7 @@ export const deserializeAws_queryModifyCurrentDBClusterCapacityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyCurrentDBClusterCapacityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyCurrentDBClusterCapacityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9064,7 +9064,7 @@ export const deserializeAws_queryModifyDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9206,7 +9206,7 @@ export const deserializeAws_queryModifyDBClusterEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBClusterEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBClusterEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9292,7 +9292,7 @@ export const deserializeAws_queryModifyDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9354,7 +9354,7 @@ export const deserializeAws_queryModifyDBClusterSnapshotAttributeCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBClusterSnapshotAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBClusterSnapshotAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9427,7 +9427,7 @@ export const deserializeAws_queryModifyDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9625,7 +9625,7 @@ export const deserializeAws_queryModifyDBParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9687,7 +9687,7 @@ export const deserializeAws_queryModifyDBProxyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBProxyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBProxyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9757,7 +9757,7 @@ export const deserializeAws_queryModifyDBProxyTargetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBProxyTargetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBProxyTargetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9827,7 +9827,7 @@ export const deserializeAws_queryModifyDBSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9881,7 +9881,7 @@ export const deserializeAws_queryModifyDBSnapshotAttributeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBSnapshotAttributeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBSnapshotAttributeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9951,7 +9951,7 @@ export const deserializeAws_queryModifyDBSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDBSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyDBSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10037,7 +10037,7 @@ export const deserializeAws_queryModifyEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10131,7 +10131,7 @@ export const deserializeAws_queryModifyGlobalClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyGlobalClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyGlobalClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10193,7 +10193,7 @@ export const deserializeAws_queryModifyOptionGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyOptionGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyOptionGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10255,7 +10255,7 @@ export const deserializeAws_queryPromoteReadReplicaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PromoteReadReplicaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPromoteReadReplicaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10317,7 +10317,7 @@ export const deserializeAws_queryPromoteReadReplicaDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PromoteReadReplicaDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPromoteReadReplicaDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10379,7 +10379,7 @@ export const deserializeAws_queryPurchaseReservedDBInstancesOfferingCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurchaseReservedDBInstancesOfferingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPurchaseReservedDBInstancesOfferingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10452,7 +10452,7 @@ export const deserializeAws_queryRebootDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRebootDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10514,7 +10514,7 @@ export const deserializeAws_queryRegisterDBProxyTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterDBProxyTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRegisterDBProxyTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10624,7 +10624,7 @@ export const deserializeAws_queryRemoveFromGlobalClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveFromGlobalClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveFromGlobalClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10694,7 +10694,7 @@ export const deserializeAws_queryRemoveRoleFromDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveRoleFromDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveRoleFromDBClusterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10761,7 +10761,7 @@ export const deserializeAws_queryRemoveRoleFromDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveRoleFromDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveRoleFromDBInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10828,7 +10828,7 @@ export const deserializeAws_queryRemoveSourceIdentifierFromSubscriptionCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveSourceIdentifierFromSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveSourceIdentifierFromSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10893,7 +10893,7 @@ export const deserializeAws_queryRemoveTagsFromResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemoveTagsFromResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -10976,7 +10976,7 @@ export const deserializeAws_queryResetDBClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetDBClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResetDBClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11038,7 +11038,7 @@ export const deserializeAws_queryResetDBParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetDBParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResetDBParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11100,7 +11100,7 @@ export const deserializeAws_queryRestoreDBClusterFromS3Command = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDBClusterFromS3CommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreDBClusterFromS3CommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11258,7 +11258,7 @@ export const deserializeAws_queryRestoreDBClusterFromSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDBClusterFromSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreDBClusterFromSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11440,7 +11440,7 @@ export const deserializeAws_queryRestoreDBClusterToPointInTimeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDBClusterToPointInTimeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreDBClusterToPointInTimeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11630,7 +11630,7 @@ export const deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDBInstanceFromDBSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreDBInstanceFromDBSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11839,7 +11839,7 @@ export const deserializeAws_queryRestoreDBInstanceFromS3Command = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDBInstanceFromS3CommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreDBInstanceFromS3CommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12021,7 +12021,7 @@ export const deserializeAws_queryRestoreDBInstanceToPointInTimeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDBInstanceToPointInTimeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreDBInstanceToPointInTimeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12246,7 +12246,7 @@ export const deserializeAws_queryRevokeDBSecurityGroupIngressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeDBSecurityGroupIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRevokeDBSecurityGroupIngressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12316,7 +12316,7 @@ export const deserializeAws_queryStartActivityStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartActivityStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStartActivityStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12410,7 +12410,7 @@ export const deserializeAws_queryStartDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStartDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12480,7 +12480,7 @@ export const deserializeAws_queryStartDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStartDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12614,7 +12614,7 @@ export const deserializeAws_queryStartExportTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartExportTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStartExportTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12732,7 +12732,7 @@ export const deserializeAws_queryStopActivityStreamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopActivityStreamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStopActivityStreamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12818,7 +12818,7 @@ export const deserializeAws_queryStopDBClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDBClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStopDBClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -12888,7 +12888,7 @@ export const deserializeAws_queryStopDBInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDBInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryStopDBInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-redshift/protocols/Aws_query.ts
+++ b/clients/client-redshift/protocols/Aws_query.ts
@@ -2124,7 +2124,7 @@ export const deserializeAws_queryAcceptReservedNodeExchangeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptReservedNodeExchangeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAcceptReservedNodeExchangeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2229,7 +2229,7 @@ export const deserializeAws_queryAuthorizeClusterSecurityGroupIngressCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AuthorizeClusterSecurityGroupIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAuthorizeClusterSecurityGroupIngressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2310,7 +2310,7 @@ export const deserializeAws_queryAuthorizeSnapshotAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AuthorizeSnapshotAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAuthorizeSnapshotAccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2404,7 +2404,7 @@ export const deserializeAws_queryBatchDeleteClusterSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDeleteClusterSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryBatchDeleteClusterSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2458,7 +2458,7 @@ export const deserializeAws_queryBatchModifyClusterSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchModifyClusterSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryBatchModifyClusterSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2523,7 +2523,7 @@ export const deserializeAws_queryCancelResizeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelResizeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCancelResizeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2601,7 +2601,7 @@ export const deserializeAws_queryCopyClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCopyClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2687,7 +2687,7 @@ export const deserializeAws_queryCreateClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2909,7 +2909,7 @@ export const deserializeAws_queryCreateClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2987,7 +2987,7 @@ export const deserializeAws_queryCreateClusterSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterSecurityGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateClusterSecurityGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3065,7 +3065,7 @@ export const deserializeAws_queryCreateClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3167,7 +3167,7 @@ export const deserializeAws_queryCreateClusterSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateClusterSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3277,7 +3277,7 @@ export const deserializeAws_queryCreateEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3411,7 +3411,7 @@ export const deserializeAws_queryCreateHsmClientCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHsmClientCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateHsmClientCertificateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3489,7 +3489,7 @@ export const deserializeAws_queryCreateHsmConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHsmConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateHsmConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3567,7 +3567,7 @@ export const deserializeAws_queryCreateScheduledActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateScheduledActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateScheduledActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3661,7 +3661,7 @@ export const deserializeAws_queryCreateSnapshotCopyGrantCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSnapshotCopyGrantCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateSnapshotCopyGrantCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3755,7 +3755,7 @@ export const deserializeAws_queryCreateSnapshotScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSnapshotScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateSnapshotScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3841,7 +3841,7 @@ export const deserializeAws_queryCreateTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateTagsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3908,7 +3908,7 @@ export const deserializeAws_queryCreateUsageLimitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUsageLimitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateUsageLimitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4010,7 +4010,7 @@ export const deserializeAws_queryDeleteClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4096,7 +4096,7 @@ export const deserializeAws_queryDeleteClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteClusterParameterGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4155,7 +4155,7 @@ export const deserializeAws_queryDeleteClusterSecurityGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClusterSecurityGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteClusterSecurityGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4214,7 +4214,7 @@ export const deserializeAws_queryDeleteClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4276,7 +4276,7 @@ export const deserializeAws_queryDeleteClusterSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteClusterSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteClusterSubnetGroupCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4343,7 +4343,7 @@ export const deserializeAws_queryDeleteEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteEventSubscriptionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4402,7 +4402,7 @@ export const deserializeAws_queryDeleteHsmClientCertificateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHsmClientCertificateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteHsmClientCertificateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4461,7 +4461,7 @@ export const deserializeAws_queryDeleteHsmConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHsmConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteHsmConfigurationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4520,7 +4520,7 @@ export const deserializeAws_queryDeleteScheduledActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteScheduledActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteScheduledActionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4579,7 +4579,7 @@ export const deserializeAws_queryDeleteSnapshotCopyGrantCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSnapshotCopyGrantCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteSnapshotCopyGrantCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4638,7 +4638,7 @@ export const deserializeAws_queryDeleteSnapshotScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSnapshotScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteSnapshotScheduleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4697,7 +4697,7 @@ export const deserializeAws_queryDeleteTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteTagsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4756,7 +4756,7 @@ export const deserializeAws_queryDeleteUsageLimitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUsageLimitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteUsageLimitCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4815,7 +4815,7 @@ export const deserializeAws_queryDescribeAccountAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeAccountAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4861,7 +4861,7 @@ export const deserializeAws_queryDescribeClusterDbRevisionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterDbRevisionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeClusterDbRevisionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4923,7 +4923,7 @@ export const deserializeAws_queryDescribeClusterParameterGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterParameterGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeClusterParameterGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4985,7 +4985,7 @@ export const deserializeAws_queryDescribeClusterParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeClusterParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5039,7 +5039,7 @@ export const deserializeAws_queryDescribeClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5101,7 +5101,7 @@ export const deserializeAws_queryDescribeClusterSecurityGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterSecurityGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeClusterSecurityGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5163,7 +5163,7 @@ export const deserializeAws_queryDescribeClusterSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeClusterSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5233,7 +5233,7 @@ export const deserializeAws_queryDescribeClusterSubnetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterSubnetGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeClusterSubnetGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5295,7 +5295,7 @@ export const deserializeAws_queryDescribeClusterTracksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterTracksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeClusterTracksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5357,7 +5357,7 @@ export const deserializeAws_queryDescribeClusterVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeClusterVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5403,7 +5403,7 @@ export const deserializeAws_queryDescribeDefaultClusterParametersCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDefaultClusterParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeDefaultClusterParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5452,7 +5452,7 @@ export const deserializeAws_queryDescribeEventCategoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventCategoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventCategoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5498,7 +5498,7 @@ export const deserializeAws_queryDescribeEventsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5544,7 +5544,7 @@ export const deserializeAws_queryDescribeEventSubscriptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEventSubscriptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeEventSubscriptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5606,7 +5606,7 @@ export const deserializeAws_queryDescribeHsmClientCertificatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHsmClientCertificatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeHsmClientCertificatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5668,7 +5668,7 @@ export const deserializeAws_queryDescribeHsmConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHsmConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeHsmConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5730,7 +5730,7 @@ export const deserializeAws_queryDescribeLoggingStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLoggingStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeLoggingStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5784,7 +5784,7 @@ export const deserializeAws_queryDescribeNodeConfigurationOptionsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNodeConfigurationOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeNodeConfigurationOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5862,7 +5862,7 @@ export const deserializeAws_queryDescribeOrderableClusterOptionsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrderableClusterOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeOrderableClusterOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5908,7 +5908,7 @@ export const deserializeAws_queryDescribeReservedNodeOfferingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedNodeOfferingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeReservedNodeOfferingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5978,7 +5978,7 @@ export const deserializeAws_queryDescribeReservedNodesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReservedNodesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeReservedNodesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6040,7 +6040,7 @@ export const deserializeAws_queryDescribeResizeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeResizeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeResizeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6102,7 +6102,7 @@ export const deserializeAws_queryDescribeScheduledActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeScheduledActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeScheduledActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6164,7 +6164,7 @@ export const deserializeAws_queryDescribeSnapshotCopyGrantsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSnapshotCopyGrantsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeSnapshotCopyGrantsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6226,7 +6226,7 @@ export const deserializeAws_queryDescribeSnapshotSchedulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSnapshotSchedulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeSnapshotSchedulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6272,7 +6272,7 @@ export const deserializeAws_queryDescribeStorageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStorageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeStorageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6318,7 +6318,7 @@ export const deserializeAws_queryDescribeTableRestoreStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTableRestoreStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTableRestoreStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6380,7 +6380,7 @@ export const deserializeAws_queryDescribeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6442,7 +6442,7 @@ export const deserializeAws_queryDescribeUsageLimitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUsageLimitsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeUsageLimitsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6504,7 +6504,7 @@ export const deserializeAws_queryDisableLoggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableLoggingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDisableLoggingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6558,7 +6558,7 @@ export const deserializeAws_queryDisableSnapshotCopyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableSnapshotCopyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDisableSnapshotCopyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6636,7 +6636,7 @@ export const deserializeAws_queryEnableLoggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableLoggingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryEnableLoggingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6730,7 +6730,7 @@ export const deserializeAws_queryEnableSnapshotCopyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableSnapshotCopyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryEnableSnapshotCopyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6864,7 +6864,7 @@ export const deserializeAws_queryGetClusterCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetClusterCredentialsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetClusterCredentialsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6926,7 +6926,7 @@ export const deserializeAws_queryGetReservedNodeExchangeOfferingsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetReservedNodeExchangeOfferingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetReservedNodeExchangeOfferingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7023,7 +7023,7 @@ export const deserializeAws_queryModifyClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7221,7 +7221,7 @@ export const deserializeAws_queryModifyClusterDbRevisionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClusterDbRevisionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyClusterDbRevisionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7291,7 +7291,7 @@ export const deserializeAws_queryModifyClusterIamRolesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClusterIamRolesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyClusterIamRolesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7353,7 +7353,7 @@ export const deserializeAws_queryModifyClusterMaintenanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClusterMaintenanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyClusterMaintenanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7415,7 +7415,7 @@ export const deserializeAws_queryModifyClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7477,7 +7477,7 @@ export const deserializeAws_queryModifyClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7547,7 +7547,7 @@ export const deserializeAws_queryModifyClusterSnapshotScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClusterSnapshotScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyClusterSnapshotScheduleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -7614,7 +7614,7 @@ export const deserializeAws_queryModifyClusterSubnetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClusterSubnetGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyClusterSubnetGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7708,7 +7708,7 @@ export const deserializeAws_queryModifyEventSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyEventSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyEventSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7826,7 +7826,7 @@ export const deserializeAws_queryModifyScheduledActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyScheduledActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyScheduledActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7912,7 +7912,7 @@ export const deserializeAws_queryModifySnapshotCopyRetentionPeriodCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifySnapshotCopyRetentionPeriodCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifySnapshotCopyRetentionPeriodCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8001,7 +8001,7 @@ export const deserializeAws_queryModifySnapshotScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifySnapshotScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifySnapshotScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8071,7 +8071,7 @@ export const deserializeAws_queryModifyUsageLimitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyUsageLimitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryModifyUsageLimitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8141,7 +8141,7 @@ export const deserializeAws_queryPauseClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PauseClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPauseClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8203,7 +8203,7 @@ export const deserializeAws_queryPurchaseReservedNodeOfferingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurchaseReservedNodeOfferingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPurchaseReservedNodeOfferingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8281,7 +8281,7 @@ export const deserializeAws_queryRebootClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRebootClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8343,7 +8343,7 @@ export const deserializeAws_queryResetClusterParameterGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetClusterParameterGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResetClusterParameterGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8405,7 +8405,7 @@ export const deserializeAws_queryResizeClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResizeClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResizeClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8523,7 +8523,7 @@ export const deserializeAws_queryRestoreFromClusterSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreFromClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreFromClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8769,7 +8769,7 @@ export const deserializeAws_queryRestoreTableFromClusterSnapshotCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreTableFromClusterSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRestoreTableFromClusterSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8874,7 +8874,7 @@ export const deserializeAws_queryResumeClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResumeClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryResumeClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8936,7 +8936,7 @@ export const deserializeAws_queryRevokeClusterSecurityGroupIngressCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeClusterSecurityGroupIngressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRevokeClusterSecurityGroupIngressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9009,7 +9009,7 @@ export const deserializeAws_queryRevokeSnapshotAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeSnapshotAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRevokeSnapshotAccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9079,7 +9079,7 @@ export const deserializeAws_queryRotateEncryptionKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RotateEncryptionKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRotateEncryptionKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-rekognition/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/protocols/Aws_json1_1.ts
@@ -925,7 +925,7 @@ export const deserializeAws_json1_1CompareFacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CompareFacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CompareFacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1036,7 +1036,7 @@ export const deserializeAws_json1_1CreateCollectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCollectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCollectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1131,7 +1131,7 @@ export const deserializeAws_json1_1CreateProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1234,7 +1234,7 @@ export const deserializeAws_json1_1CreateProjectVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProjectVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProjectVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1345,7 +1345,7 @@ export const deserializeAws_json1_1CreateStreamProcessorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStreamProcessorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateStreamProcessorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1448,7 +1448,7 @@ export const deserializeAws_json1_1DeleteCollectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCollectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCollectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1543,7 +1543,7 @@ export const deserializeAws_json1_1DeleteFacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1638,7 +1638,7 @@ export const deserializeAws_json1_1DeleteProjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProjectCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProjectCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1741,7 +1741,7 @@ export const deserializeAws_json1_1DeleteProjectVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProjectVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProjectVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1844,7 +1844,7 @@ export const deserializeAws_json1_1DeleteStreamProcessorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStreamProcessorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteStreamProcessorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1947,7 +1947,7 @@ export const deserializeAws_json1_1DescribeCollectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCollectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCollectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2042,7 +2042,7 @@ export const deserializeAws_json1_1DescribeProjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProjectsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProjectsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2137,7 +2137,7 @@ export const deserializeAws_json1_1DescribeProjectVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProjectVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProjectVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2240,7 +2240,7 @@ export const deserializeAws_json1_1DescribeStreamProcessorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStreamProcessorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeStreamProcessorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2335,7 +2335,7 @@ export const deserializeAws_json1_1DetectCustomLabelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectCustomLabelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectCustomLabelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2470,7 +2470,7 @@ export const deserializeAws_json1_1DetectFacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectFacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectFacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2581,7 +2581,7 @@ export const deserializeAws_json1_1DetectLabelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectLabelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectLabelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2692,7 +2692,7 @@ export const deserializeAws_json1_1DetectModerationLabelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectModerationLabelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectModerationLabelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2811,7 +2811,7 @@ export const deserializeAws_json1_1DetectTextCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectTextCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectTextCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2922,7 +2922,7 @@ export const deserializeAws_json1_1GetCelebrityInfoCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCelebrityInfoCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCelebrityInfoCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3017,7 +3017,7 @@ export const deserializeAws_json1_1GetCelebrityRecognitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCelebrityRecognitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCelebrityRecognitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3120,7 +3120,7 @@ export const deserializeAws_json1_1GetContentModerationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetContentModerationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetContentModerationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3223,7 +3223,7 @@ export const deserializeAws_json1_1GetFaceDetectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFaceDetectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetFaceDetectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3326,7 +3326,7 @@ export const deserializeAws_json1_1GetFaceSearchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFaceSearchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetFaceSearchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3429,7 +3429,7 @@ export const deserializeAws_json1_1GetLabelDetectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLabelDetectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLabelDetectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3532,7 +3532,7 @@ export const deserializeAws_json1_1GetPersonTrackingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPersonTrackingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPersonTrackingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3635,7 +3635,7 @@ export const deserializeAws_json1_1GetSegmentDetectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSegmentDetectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSegmentDetectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3738,7 +3738,7 @@ export const deserializeAws_json1_1GetTextDetectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTextDetectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTextDetectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3841,7 +3841,7 @@ export const deserializeAws_json1_1IndexFacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IndexFacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1IndexFacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3960,7 +3960,7 @@ export const deserializeAws_json1_1ListCollectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCollectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCollectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4063,7 +4063,7 @@ export const deserializeAws_json1_1ListFacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListFacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4166,7 +4166,7 @@ export const deserializeAws_json1_1ListStreamProcessorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStreamProcessorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListStreamProcessorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4261,7 +4261,7 @@ export const deserializeAws_json1_1RecognizeCelebritiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RecognizeCelebritiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RecognizeCelebritiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4372,7 +4372,7 @@ export const deserializeAws_json1_1SearchFacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchFacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchFacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4467,7 +4467,7 @@ export const deserializeAws_json1_1SearchFacesByImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchFacesByImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchFacesByImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4586,7 +4586,7 @@ export const deserializeAws_json1_1StartCelebrityRecognitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartCelebrityRecognitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartCelebrityRecognitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4705,7 +4705,7 @@ export const deserializeAws_json1_1StartContentModerationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartContentModerationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartContentModerationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4824,7 +4824,7 @@ export const deserializeAws_json1_1StartFaceDetectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartFaceDetectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartFaceDetectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4943,7 +4943,7 @@ export const deserializeAws_json1_1StartFaceSearchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartFaceSearchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartFaceSearchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5070,7 +5070,7 @@ export const deserializeAws_json1_1StartLabelDetectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartLabelDetectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartLabelDetectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5189,7 +5189,7 @@ export const deserializeAws_json1_1StartPersonTrackingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartPersonTrackingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartPersonTrackingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5308,7 +5308,7 @@ export const deserializeAws_json1_1StartProjectVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartProjectVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartProjectVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5419,7 +5419,7 @@ export const deserializeAws_json1_1StartSegmentDetectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSegmentDetectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartSegmentDetectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5538,7 +5538,7 @@ export const deserializeAws_json1_1StartStreamProcessorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartStreamProcessorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartStreamProcessorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5641,7 +5641,7 @@ export const deserializeAws_json1_1StartTextDetectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartTextDetectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartTextDetectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5760,7 +5760,7 @@ export const deserializeAws_json1_1StopProjectVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopProjectVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopProjectVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5863,7 +5863,7 @@ export const deserializeAws_json1_1StopStreamProcessorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopStreamProcessorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopStreamProcessorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
+++ b/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
@@ -164,7 +164,7 @@ export const deserializeAws_json1_1DescribeReportCreationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReportCreationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeReportCreationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -243,7 +243,7 @@ export const deserializeAws_json1_1GetComplianceSummaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetComplianceSummaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetComplianceSummaryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -322,7 +322,7 @@ export const deserializeAws_json1_1GetResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -401,7 +401,7 @@ export const deserializeAws_json1_1GetTagKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTagKeysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTagKeysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -480,7 +480,7 @@ export const deserializeAws_json1_1GetTagValuesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTagValuesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTagValuesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -559,7 +559,7 @@ export const deserializeAws_json1_1StartReportCreationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartReportCreationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartReportCreationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -646,7 +646,7 @@ export const deserializeAws_json1_1TagResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -717,7 +717,7 @@ export const deserializeAws_json1_1UntagResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-resource-groups/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-groups/protocols/Aws_restJson1.ts
@@ -473,7 +473,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGroupCommandError(output, context);
   }
   const contents: CreateGroupCommandOutput = {
@@ -572,7 +572,7 @@ export const deserializeAws_restJson1DeleteGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGroupCommandError(output, context);
   }
   const contents: DeleteGroupCommandOutput = {
@@ -667,7 +667,7 @@ export const deserializeAws_restJson1GetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGroupCommandError(output, context);
   }
   const contents: GetGroupCommandOutput = {
@@ -762,7 +762,7 @@ export const deserializeAws_restJson1GetGroupConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGroupConfigurationCommandError(output, context);
   }
   const contents: GetGroupConfigurationCommandOutput = {
@@ -857,7 +857,7 @@ export const deserializeAws_restJson1GetGroupQueryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupQueryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGroupQueryCommandError(output, context);
   }
   const contents: GetGroupQueryCommandOutput = {
@@ -952,7 +952,7 @@ export const deserializeAws_restJson1GetTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTagsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTagsCommandError(output, context);
   }
   const contents: GetTagsCommandOutput = {
@@ -1051,7 +1051,7 @@ export const deserializeAws_restJson1GroupResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GroupResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GroupResourcesCommandError(output, context);
   }
   const contents: GroupResourcesCommandOutput = {
@@ -1150,7 +1150,7 @@ export const deserializeAws_restJson1ListGroupResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGroupResourcesCommandError(output, context);
   }
   const contents: ListGroupResourcesCommandOutput = {
@@ -1261,7 +1261,7 @@ export const deserializeAws_restJson1ListGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListGroupsCommandError(output, context);
   }
   const contents: ListGroupsCommandOutput = {
@@ -1356,7 +1356,7 @@ export const deserializeAws_restJson1SearchResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SearchResourcesCommandError(output, context);
   }
   const contents: SearchResourcesCommandOutput = {
@@ -1459,7 +1459,7 @@ export const deserializeAws_restJson1TagCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagCommandError(output, context);
   }
   const contents: TagCommandOutput = {
@@ -1558,7 +1558,7 @@ export const deserializeAws_restJson1UngroupResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UngroupResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UngroupResourcesCommandError(output, context);
   }
   const contents: UngroupResourcesCommandOutput = {
@@ -1657,7 +1657,7 @@ export const deserializeAws_restJson1UntagCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagCommandError(output, context);
   }
   const contents: UntagCommandOutput = {
@@ -1756,7 +1756,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGroupCommandError(output, context);
   }
   const contents: UpdateGroupCommandOutput = {
@@ -1851,7 +1851,7 @@ export const deserializeAws_restJson1UpdateGroupQueryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGroupQueryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGroupQueryCommandError(output, context);
   }
   const contents: UpdateGroupQueryCommandOutput = {

--- a/clients/client-robomaker/protocols/Aws_restJson1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1.ts
@@ -1267,7 +1267,7 @@ export const deserializeAws_restJson1BatchDescribeSimulationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDescribeSimulationJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchDescribeSimulationJobCommandError(output, context);
   }
   const contents: BatchDescribeSimulationJobCommandOutput = {
@@ -1350,7 +1350,7 @@ export const deserializeAws_restJson1CancelDeploymentJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelDeploymentJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelDeploymentJobCommandError(output, context);
   }
   const contents: CancelDeploymentJobCommandOutput = {
@@ -1425,7 +1425,7 @@ export const deserializeAws_restJson1CancelSimulationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelSimulationJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelSimulationJobCommandError(output, context);
   }
   const contents: CancelSimulationJobCommandOutput = {
@@ -1500,7 +1500,7 @@ export const deserializeAws_restJson1CancelSimulationJobBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelSimulationJobBatchCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelSimulationJobBatchCommandError(output, context);
   }
   const contents: CancelSimulationJobBatchCommandOutput = {
@@ -1575,7 +1575,7 @@ export const deserializeAws_restJson1CreateDeploymentJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeploymentJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeploymentJobCommandError(output, context);
   }
   const contents: CreateDeploymentJobCommandOutput = {
@@ -1713,7 +1713,7 @@ export const deserializeAws_restJson1CreateFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFleetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFleetCommandError(output, context);
   }
   const contents: CreateFleetCommandOutput = {
@@ -1804,7 +1804,7 @@ export const deserializeAws_restJson1CreateRobotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRobotCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRobotCommandError(output, context);
   }
   const contents: CreateRobotCommandOutput = {
@@ -1911,7 +1911,7 @@ export const deserializeAws_restJson1CreateRobotApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRobotApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRobotApplicationCommandError(output, context);
   }
   const contents: CreateRobotApplicationCommandOutput = {
@@ -2034,7 +2034,7 @@ export const deserializeAws_restJson1CreateRobotApplicationVersionCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRobotApplicationVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRobotApplicationVersionCommandError(output, context);
   }
   const contents: CreateRobotApplicationVersionCommandOutput = {
@@ -2145,7 +2145,7 @@ export const deserializeAws_restJson1CreateSimulationApplicationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSimulationApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSimulationApplicationCommandError(output, context);
   }
   const contents: CreateSimulationApplicationCommandOutput = {
@@ -2279,7 +2279,7 @@ export const deserializeAws_restJson1CreateSimulationApplicationVersionCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSimulationApplicationVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSimulationApplicationVersionCommandError(output, context);
   }
   const contents: CreateSimulationApplicationVersionCommandOutput = {
@@ -2401,7 +2401,7 @@ export const deserializeAws_restJson1CreateSimulationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSimulationJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSimulationJobCommandError(output, context);
   }
   const contents: CreateSimulationJobCommandOutput = {
@@ -2575,7 +2575,7 @@ export const deserializeAws_restJson1DeleteFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFleetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFleetCommandError(output, context);
   }
   const contents: DeleteFleetCommandOutput = {
@@ -2642,7 +2642,7 @@ export const deserializeAws_restJson1DeleteRobotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRobotCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRobotCommandError(output, context);
   }
   const contents: DeleteRobotCommandOutput = {
@@ -2709,7 +2709,7 @@ export const deserializeAws_restJson1DeleteRobotApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRobotApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRobotApplicationCommandError(output, context);
   }
   const contents: DeleteRobotApplicationCommandOutput = {
@@ -2776,7 +2776,7 @@ export const deserializeAws_restJson1DeleteSimulationApplicationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSimulationApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSimulationApplicationCommandError(output, context);
   }
   const contents: DeleteSimulationApplicationCommandOutput = {
@@ -2843,7 +2843,7 @@ export const deserializeAws_restJson1DeregisterRobotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterRobotCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeregisterRobotCommandError(output, context);
   }
   const contents: DeregisterRobotCommandOutput = {
@@ -2926,7 +2926,7 @@ export const deserializeAws_restJson1DescribeDeploymentJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDeploymentJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDeploymentJobCommandError(output, context);
   }
   const contents: DescribeDeploymentJobCommandOutput = {
@@ -3047,7 +3047,7 @@ export const deserializeAws_restJson1DescribeFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeFleetCommandError(output, context);
   }
   const contents: DescribeFleetCommandOutput = {
@@ -3154,7 +3154,7 @@ export const deserializeAws_restJson1DescribeRobotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRobotCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRobotCommandError(output, context);
   }
   const contents: DescribeRobotCommandOutput = {
@@ -3269,7 +3269,7 @@ export const deserializeAws_restJson1DescribeRobotApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRobotApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRobotApplicationCommandError(output, context);
   }
   const contents: DescribeRobotApplicationCommandOutput = {
@@ -3376,7 +3376,7 @@ export const deserializeAws_restJson1DescribeSimulationApplicationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSimulationApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSimulationApplicationCommandError(output, context);
   }
   const contents: DescribeSimulationApplicationCommandOutput = {
@@ -3494,7 +3494,7 @@ export const deserializeAws_restJson1DescribeSimulationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSimulationJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSimulationJobCommandError(output, context);
   }
   const contents: DescribeSimulationJobCommandOutput = {
@@ -3656,7 +3656,7 @@ export const deserializeAws_restJson1DescribeSimulationJobBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSimulationJobBatchCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSimulationJobBatchCommandError(output, context);
   }
   const contents: DescribeSimulationJobBatchCommandOutput = {
@@ -3771,7 +3771,7 @@ export const deserializeAws_restJson1ListDeploymentJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeploymentJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDeploymentJobsCommandError(output, context);
   }
   const contents: ListDeploymentJobsCommandOutput = {
@@ -3854,7 +3854,7 @@ export const deserializeAws_restJson1ListFleetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFleetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFleetsCommandError(output, context);
   }
   const contents: ListFleetsCommandOutput = {
@@ -3937,7 +3937,7 @@ export const deserializeAws_restJson1ListRobotApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRobotApplicationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRobotApplicationsCommandError(output, context);
   }
   const contents: ListRobotApplicationsCommandOutput = {
@@ -4015,7 +4015,7 @@ export const deserializeAws_restJson1ListRobotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRobotsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRobotsCommandError(output, context);
   }
   const contents: ListRobotsCommandOutput = {
@@ -4098,7 +4098,7 @@ export const deserializeAws_restJson1ListSimulationApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSimulationApplicationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSimulationApplicationsCommandError(output, context);
   }
   const contents: ListSimulationApplicationsCommandOutput = {
@@ -4176,7 +4176,7 @@ export const deserializeAws_restJson1ListSimulationJobBatchesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSimulationJobBatchesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSimulationJobBatchesCommandError(output, context);
   }
   const contents: ListSimulationJobBatchesCommandOutput = {
@@ -4246,7 +4246,7 @@ export const deserializeAws_restJson1ListSimulationJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSimulationJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSimulationJobsCommandError(output, context);
   }
   const contents: ListSimulationJobsCommandOutput = {
@@ -4324,7 +4324,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -4403,7 +4403,7 @@ export const deserializeAws_restJson1RegisterRobotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterRobotCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegisterRobotCommandError(output, context);
   }
   const contents: RegisterRobotCommandOutput = {
@@ -4494,7 +4494,7 @@ export const deserializeAws_restJson1RestartSimulationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestartSimulationJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RestartSimulationJobCommandError(output, context);
   }
   const contents: RestartSimulationJobCommandOutput = {
@@ -4577,7 +4577,7 @@ export const deserializeAws_restJson1StartSimulationJobBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSimulationJobBatchCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartSimulationJobBatchCommandError(output, context);
   }
   const contents: StartSimulationJobBatchCommandOutput = {
@@ -4704,7 +4704,7 @@ export const deserializeAws_restJson1SyncDeploymentJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SyncDeploymentJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SyncDeploymentJobCommandError(output, context);
   }
   const contents: SyncDeploymentJobCommandOutput = {
@@ -4838,7 +4838,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -4913,7 +4913,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -4988,7 +4988,7 @@ export const deserializeAws_restJson1UpdateRobotApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRobotApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRobotApplicationCommandError(output, context);
   }
   const contents: UpdateRobotApplicationCommandOutput = {
@@ -5099,7 +5099,7 @@ export const deserializeAws_restJson1UpdateSimulationApplicationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSimulationApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSimulationApplicationCommandError(output, context);
   }
   const contents: UpdateSimulationApplicationCommandOutput = {

--- a/clients/client-route-53-domains/protocols/Aws_json1_1.ts
+++ b/clients/client-route-53-domains/protocols/Aws_json1_1.ts
@@ -534,7 +534,7 @@ export const deserializeAws_json1_1AcceptDomainTransferFromAnotherAwsAccountComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptDomainTransferFromAnotherAwsAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AcceptDomainTransferFromAnotherAwsAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -605,7 +605,7 @@ export const deserializeAws_json1_1CancelDomainTransferToAnotherAwsAccountComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelDomainTransferToAnotherAwsAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelDomainTransferToAnotherAwsAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -668,7 +668,7 @@ export const deserializeAws_json1_1CheckDomainAvailabilityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CheckDomainAvailabilityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CheckDomainAvailabilityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -731,7 +731,7 @@ export const deserializeAws_json1_1CheckDomainTransferabilityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CheckDomainTransferabilityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CheckDomainTransferabilityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -794,7 +794,7 @@ export const deserializeAws_json1_1DeleteTagsForDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsForDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTagsForDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -865,7 +865,7 @@ export const deserializeAws_json1_1DisableDomainAutoRenewCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableDomainAutoRenewCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableDomainAutoRenewCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -928,7 +928,7 @@ export const deserializeAws_json1_1DisableDomainTransferLockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableDomainTransferLockCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableDomainTransferLockCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1015,7 +1015,7 @@ export const deserializeAws_json1_1EnableDomainAutoRenewCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableDomainAutoRenewCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableDomainAutoRenewCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1086,7 +1086,7 @@ export const deserializeAws_json1_1EnableDomainTransferLockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableDomainTransferLockCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableDomainTransferLockCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1173,7 +1173,7 @@ export const deserializeAws_json1_1GetContactReachabilityStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetContactReachabilityStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetContactReachabilityStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1244,7 +1244,7 @@ export const deserializeAws_json1_1GetDomainDetailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainDetailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDomainDetailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1307,7 +1307,7 @@ export const deserializeAws_json1_1GetDomainSuggestionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainSuggestionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDomainSuggestionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1370,7 +1370,7 @@ export const deserializeAws_json1_1GetOperationDetailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOperationDetailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOperationDetailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1425,7 +1425,7 @@ export const deserializeAws_json1_1ListDomainsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDomainsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1480,7 +1480,7 @@ export const deserializeAws_json1_1ListOperationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOperationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListOperationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1535,7 +1535,7 @@ export const deserializeAws_json1_1ListTagsForDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1606,7 +1606,7 @@ export const deserializeAws_json1_1RegisterDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1701,7 +1701,7 @@ export const deserializeAws_json1_1RejectDomainTransferFromAnotherAwsAccountComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectDomainTransferFromAnotherAwsAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RejectDomainTransferFromAnotherAwsAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1764,7 +1764,7 @@ export const deserializeAws_json1_1RenewDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RenewDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RenewDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1851,7 +1851,7 @@ export const deserializeAws_json1_1ResendContactReachabilityEmailCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResendContactReachabilityEmailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResendContactReachabilityEmailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1922,7 +1922,7 @@ export const deserializeAws_json1_1RetrieveDomainAuthCodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RetrieveDomainAuthCodeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RetrieveDomainAuthCodeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1985,7 +1985,7 @@ export const deserializeAws_json1_1TransferDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TransferDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TransferDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2080,7 +2080,7 @@ export const deserializeAws_json1_1TransferDomainToAnotherAwsAccountCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TransferDomainToAnotherAwsAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TransferDomainToAnotherAwsAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2151,7 +2151,7 @@ export const deserializeAws_json1_1UpdateDomainContactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainContactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDomainContactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2238,7 +2238,7 @@ export const deserializeAws_json1_1UpdateDomainContactPrivacyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainContactPrivacyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDomainContactPrivacyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2325,7 +2325,7 @@ export const deserializeAws_json1_1UpdateDomainNameserversCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainNameserversCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDomainNameserversCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2412,7 +2412,7 @@ export const deserializeAws_json1_1UpdateTagsForDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTagsForDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTagsForDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2483,7 +2483,7 @@ export const deserializeAws_json1_1ViewBillingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ViewBillingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ViewBillingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -2294,7 +2294,7 @@ export const deserializeAws_restXmlAssociateVPCWithHostedZoneCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateVPCWithHostedZoneCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlAssociateVPCWithHostedZoneCommandError(output, context);
   }
   const contents: AssociateVPCWithHostedZoneCommandOutput = {
@@ -2405,7 +2405,7 @@ export const deserializeAws_restXmlChangeResourceRecordSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ChangeResourceRecordSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlChangeResourceRecordSetsCommandError(output, context);
   }
   const contents: ChangeResourceRecordSetsCommandOutput = {
@@ -2492,7 +2492,7 @@ export const deserializeAws_restXmlChangeTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ChangeTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlChangeTagsForResourceCommandError(output, context);
   }
   const contents: ChangeTagsForResourceCommandOutput = {
@@ -2575,7 +2575,7 @@ export const deserializeAws_restXmlCreateHealthCheckCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHealthCheckCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateHealthCheckCommandError(output, context);
   }
   const contents: CreateHealthCheckCommandOutput = {
@@ -2650,7 +2650,7 @@ export const deserializeAws_restXmlCreateHostedZoneCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHostedZoneCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateHostedZoneCommandError(output, context);
   }
   const contents: CreateHostedZoneCommandOutput = {
@@ -2785,7 +2785,7 @@ export const deserializeAws_restXmlCreateQueryLoggingConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateQueryLoggingConfigCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateQueryLoggingConfigCommandError(output, context);
   }
   const contents: CreateQueryLoggingConfigCommandOutput = {
@@ -2884,7 +2884,7 @@ export const deserializeAws_restXmlCreateReusableDelegationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReusableDelegationSetCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateReusableDelegationSetCommandError(output, context);
   }
   const contents: CreateReusableDelegationSetCommandOutput = {
@@ -2991,7 +2991,7 @@ export const deserializeAws_restXmlCreateTrafficPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrafficPolicyCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateTrafficPolicyCommandError(output, context);
   }
   const contents: CreateTrafficPolicyCommandOutput = {
@@ -3074,7 +3074,7 @@ export const deserializeAws_restXmlCreateTrafficPolicyInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrafficPolicyInstanceCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateTrafficPolicyInstanceCommandError(output, context);
   }
   const contents: CreateTrafficPolicyInstanceCommandOutput = {
@@ -3168,7 +3168,7 @@ export const deserializeAws_restXmlCreateTrafficPolicyVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrafficPolicyVersionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateTrafficPolicyVersionCommandError(output, context);
   }
   const contents: CreateTrafficPolicyVersionCommandOutput = {
@@ -3259,7 +3259,7 @@ export const deserializeAws_restXmlCreateVPCAssociationAuthorizationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVPCAssociationAuthorizationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateVPCAssociationAuthorizationCommandError(output, context);
   }
   const contents: CreateVPCAssociationAuthorizationCommandOutput = {
@@ -3350,7 +3350,7 @@ export const deserializeAws_restXmlDeleteHealthCheckCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHealthCheckCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteHealthCheckCommandError(output, context);
   }
   const contents: DeleteHealthCheckCommandOutput = {
@@ -3417,7 +3417,7 @@ export const deserializeAws_restXmlDeleteHostedZoneCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHostedZoneCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteHostedZoneCommandError(output, context);
   }
   const contents: DeleteHostedZoneCommandOutput = {
@@ -3504,7 +3504,7 @@ export const deserializeAws_restXmlDeleteQueryLoggingConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteQueryLoggingConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteQueryLoggingConfigCommandError(output, context);
   }
   const contents: DeleteQueryLoggingConfigCommandOutput = {
@@ -3571,7 +3571,7 @@ export const deserializeAws_restXmlDeleteReusableDelegationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReusableDelegationSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteReusableDelegationSetCommandError(output, context);
   }
   const contents: DeleteReusableDelegationSetCommandOutput = {
@@ -3646,7 +3646,7 @@ export const deserializeAws_restXmlDeleteTrafficPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTrafficPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteTrafficPolicyCommandError(output, context);
   }
   const contents: DeleteTrafficPolicyCommandOutput = {
@@ -3721,7 +3721,7 @@ export const deserializeAws_restXmlDeleteTrafficPolicyInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTrafficPolicyInstanceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteTrafficPolicyInstanceCommandError(output, context);
   }
   const contents: DeleteTrafficPolicyInstanceCommandOutput = {
@@ -3788,7 +3788,7 @@ export const deserializeAws_restXmlDeleteVPCAssociationAuthorizationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVPCAssociationAuthorizationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteVPCAssociationAuthorizationCommandError(output, context);
   }
   const contents: DeleteVPCAssociationAuthorizationCommandOutput = {
@@ -3871,7 +3871,7 @@ export const deserializeAws_restXmlDisassociateVPCFromHostedZoneCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateVPCFromHostedZoneCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDisassociateVPCFromHostedZoneCommandError(output, context);
   }
   const contents: DisassociateVPCFromHostedZoneCommandOutput = {
@@ -3958,7 +3958,7 @@ export const deserializeAws_restXmlGetAccountLimitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountLimitCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetAccountLimitCommandError(output, context);
   }
   const contents: GetAccountLimitCommandOutput = {
@@ -4017,7 +4017,7 @@ export const deserializeAws_restXmlGetChangeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetChangeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetChangeCommandError(output, context);
   }
   const contents: GetChangeCommandOutput = {
@@ -4080,7 +4080,7 @@ export const deserializeAws_restXmlGetCheckerIpRangesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCheckerIpRangesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetCheckerIpRangesCommandError(output, context);
   }
   const contents: GetCheckerIpRangesCommandOutput = {
@@ -4133,7 +4133,7 @@ export const deserializeAws_restXmlGetGeoLocationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGeoLocationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetGeoLocationCommandError(output, context);
   }
   const contents: GetGeoLocationCommandOutput = {
@@ -4196,7 +4196,7 @@ export const deserializeAws_restXmlGetHealthCheckCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHealthCheckCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetHealthCheckCommandError(output, context);
   }
   const contents: GetHealthCheckCommandOutput = {
@@ -4267,7 +4267,7 @@ export const deserializeAws_restXmlGetHealthCheckCountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHealthCheckCountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetHealthCheckCountCommandError(output, context);
   }
   const contents: GetHealthCheckCountCommandOutput = {
@@ -4314,7 +4314,7 @@ export const deserializeAws_restXmlGetHealthCheckLastFailureReasonCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHealthCheckLastFailureReasonCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetHealthCheckLastFailureReasonCommandError(output, context);
   }
   const contents: GetHealthCheckLastFailureReasonCommandOutput = {
@@ -4386,7 +4386,7 @@ export const deserializeAws_restXmlGetHealthCheckStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHealthCheckStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetHealthCheckStatusCommandError(output, context);
   }
   const contents: GetHealthCheckStatusCommandOutput = {
@@ -4458,7 +4458,7 @@ export const deserializeAws_restXmlGetHostedZoneCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHostedZoneCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetHostedZoneCommandError(output, context);
   }
   const contents: GetHostedZoneCommandOutput = {
@@ -4532,7 +4532,7 @@ export const deserializeAws_restXmlGetHostedZoneCountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHostedZoneCountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetHostedZoneCountCommandError(output, context);
   }
   const contents: GetHostedZoneCountCommandOutput = {
@@ -4587,7 +4587,7 @@ export const deserializeAws_restXmlGetHostedZoneLimitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetHostedZoneLimitCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetHostedZoneLimitCommandError(output, context);
   }
   const contents: GetHostedZoneLimitCommandOutput = {
@@ -4662,7 +4662,7 @@ export const deserializeAws_restXmlGetQueryLoggingConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetQueryLoggingConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetQueryLoggingConfigCommandError(output, context);
   }
   const contents: GetQueryLoggingConfigCommandOutput = {
@@ -4725,7 +4725,7 @@ export const deserializeAws_restXmlGetReusableDelegationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetReusableDelegationSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetReusableDelegationSetCommandError(output, context);
   }
   const contents: GetReusableDelegationSetCommandOutput = {
@@ -4796,7 +4796,7 @@ export const deserializeAws_restXmlGetReusableDelegationSetLimitCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetReusableDelegationSetLimitCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetReusableDelegationSetLimitCommandError(output, context);
   }
   const contents: GetReusableDelegationSetLimitCommandOutput = {
@@ -4863,7 +4863,7 @@ export const deserializeAws_restXmlGetTrafficPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTrafficPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetTrafficPolicyCommandError(output, context);
   }
   const contents: GetTrafficPolicyCommandOutput = {
@@ -4926,7 +4926,7 @@ export const deserializeAws_restXmlGetTrafficPolicyInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTrafficPolicyInstanceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetTrafficPolicyInstanceCommandError(output, context);
   }
   const contents: GetTrafficPolicyInstanceCommandOutput = {
@@ -4992,7 +4992,7 @@ export const deserializeAws_restXmlGetTrafficPolicyInstanceCountCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTrafficPolicyInstanceCountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetTrafficPolicyInstanceCountCommandError(output, context);
   }
   const contents: GetTrafficPolicyInstanceCountCommandOutput = {
@@ -5039,7 +5039,7 @@ export const deserializeAws_restXmlListGeoLocationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGeoLocationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListGeoLocationsCommandError(output, context);
   }
   const contents: ListGeoLocationsCommandOutput = {
@@ -5123,7 +5123,7 @@ export const deserializeAws_restXmlListHealthChecksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHealthChecksCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListHealthChecksCommandError(output, context);
   }
   const contents: ListHealthChecksCommandOutput = {
@@ -5208,7 +5208,7 @@ export const deserializeAws_restXmlListHostedZonesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHostedZonesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListHostedZonesCommandError(output, context);
   }
   const contents: ListHostedZonesCommandOutput = {
@@ -5301,7 +5301,7 @@ export const deserializeAws_restXmlListHostedZonesByNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHostedZonesByNameCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListHostedZonesByNameCommandError(output, context);
   }
   const contents: ListHostedZonesByNameCommandOutput = {
@@ -5394,7 +5394,7 @@ export const deserializeAws_restXmlListHostedZonesByVPCCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHostedZonesByVPCCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListHostedZonesByVPCCommandError(output, context);
   }
   const contents: ListHostedZonesByVPCCommandOutput = {
@@ -5471,7 +5471,7 @@ export const deserializeAws_restXmlListQueryLoggingConfigsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListQueryLoggingConfigsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListQueryLoggingConfigsCommandError(output, context);
   }
   const contents: ListQueryLoggingConfigsCommandOutput = {
@@ -5552,7 +5552,7 @@ export const deserializeAws_restXmlListResourceRecordSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceRecordSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListResourceRecordSetsCommandError(output, context);
   }
   const contents: ListResourceRecordSetsCommandOutput = {
@@ -5641,7 +5641,7 @@ export const deserializeAws_restXmlListReusableDelegationSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListReusableDelegationSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListReusableDelegationSetsCommandError(output, context);
   }
   const contents: ListReusableDelegationSetsCommandOutput = {
@@ -5718,7 +5718,7 @@ export const deserializeAws_restXmlListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -5805,7 +5805,7 @@ export const deserializeAws_restXmlListTagsForResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListTagsForResourcesCommandError(output, context);
   }
   const contents: ListTagsForResourcesCommandOutput = {
@@ -5898,7 +5898,7 @@ export const deserializeAws_restXmlListTrafficPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTrafficPoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListTrafficPoliciesCommandError(output, context);
   }
   const contents: ListTrafficPoliciesCommandOutput = {
@@ -5974,7 +5974,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTrafficPolicyInstancesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListTrafficPolicyInstancesCommandError(output, context);
   }
   const contents: ListTrafficPolicyInstancesCommandOutput = {
@@ -6066,7 +6066,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByHostedZoneCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTrafficPolicyInstancesByHostedZoneCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListTrafficPolicyInstancesByHostedZoneCommandError(output, context);
   }
   const contents: ListTrafficPolicyInstancesByHostedZoneCommandOutput = {
@@ -6162,7 +6162,7 @@ export const deserializeAws_restXmlListTrafficPolicyInstancesByPolicyCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTrafficPolicyInstancesByPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListTrafficPolicyInstancesByPolicyCommandError(output, context);
   }
   const contents: ListTrafficPolicyInstancesByPolicyCommandOutput = {
@@ -6262,7 +6262,7 @@ export const deserializeAws_restXmlListTrafficPolicyVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTrafficPolicyVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListTrafficPolicyVersionsCommandError(output, context);
   }
   const contents: ListTrafficPolicyVersionsCommandOutput = {
@@ -6343,7 +6343,7 @@ export const deserializeAws_restXmlListVPCAssociationAuthorizationsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVPCAssociationAuthorizationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListVPCAssociationAuthorizationsCommandError(output, context);
   }
   const contents: ListVPCAssociationAuthorizationsCommandOutput = {
@@ -6425,7 +6425,7 @@ export const deserializeAws_restXmlTestDNSAnswerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestDNSAnswerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlTestDNSAnswerCommandError(output, context);
   }
   const contents: TestDNSAnswerCommandOutput = {
@@ -6514,7 +6514,7 @@ export const deserializeAws_restXmlUpdateHealthCheckCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateHealthCheckCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateHealthCheckCommandError(output, context);
   }
   const contents: UpdateHealthCheckCommandOutput = {
@@ -6585,7 +6585,7 @@ export const deserializeAws_restXmlUpdateHostedZoneCommentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateHostedZoneCommentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateHostedZoneCommentCommandError(output, context);
   }
   const contents: UpdateHostedZoneCommentCommandOutput = {
@@ -6648,7 +6648,7 @@ export const deserializeAws_restXmlUpdateTrafficPolicyCommentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTrafficPolicyCommentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateTrafficPolicyCommentCommandError(output, context);
   }
   const contents: UpdateTrafficPolicyCommentCommandOutput = {
@@ -6719,7 +6719,7 @@ export const deserializeAws_restXmlUpdateTrafficPolicyInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTrafficPolicyInstanceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateTrafficPolicyInstanceCommandError(output, context);
   }
   const contents: UpdateTrafficPolicyInstanceCommandOutput = {

--- a/clients/client-route53resolver/protocols/Aws_json1_1.ts
+++ b/clients/client-route53resolver/protocols/Aws_json1_1.ts
@@ -434,7 +434,7 @@ export const deserializeAws_json1_1AssociateResolverEndpointIpAddressCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateResolverEndpointIpAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateResolverEndpointIpAddressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -537,7 +537,7 @@ export const deserializeAws_json1_1AssociateResolverRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateResolverRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateResolverRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -640,7 +640,7 @@ export const deserializeAws_json1_1CreateResolverEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResolverEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateResolverEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -743,7 +743,7 @@ export const deserializeAws_json1_1CreateResolverRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResolverRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateResolverRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -854,7 +854,7 @@ export const deserializeAws_json1_1DeleteResolverEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResolverEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResolverEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -941,7 +941,7 @@ export const deserializeAws_json1_1DeleteResolverRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResolverRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResolverRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1028,7 +1028,7 @@ export const deserializeAws_json1_1DisassociateResolverEndpointIpAddressCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateResolverEndpointIpAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateResolverEndpointIpAddressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1123,7 +1123,7 @@ export const deserializeAws_json1_1DisassociateResolverRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateResolverRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateResolverRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1202,7 +1202,7 @@ export const deserializeAws_json1_1GetResolverEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResolverEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResolverEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1281,7 +1281,7 @@ export const deserializeAws_json1_1GetResolverRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResolverRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResolverRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1360,7 +1360,7 @@ export const deserializeAws_json1_1GetResolverRuleAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResolverRuleAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResolverRuleAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1439,7 +1439,7 @@ export const deserializeAws_json1_1GetResolverRulePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResolverRulePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResolverRulePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1510,7 +1510,7 @@ export const deserializeAws_json1_1ListResolverEndpointIpAddressesCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResolverEndpointIpAddressesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResolverEndpointIpAddressesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1597,7 +1597,7 @@ export const deserializeAws_json1_1ListResolverEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResolverEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResolverEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1684,7 +1684,7 @@ export const deserializeAws_json1_1ListResolverRuleAssociationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResolverRuleAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResolverRuleAssociationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1771,7 +1771,7 @@ export const deserializeAws_json1_1ListResolverRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResolverRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResolverRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1858,7 +1858,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1953,7 +1953,7 @@ export const deserializeAws_json1_1PutResolverRulePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutResolverRulePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutResolverRulePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2032,7 +2032,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2127,7 +2127,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2206,7 +2206,7 @@ export const deserializeAws_json1_1UpdateResolverEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateResolverEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateResolverEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2293,7 +2293,7 @@ export const deserializeAws_json1_1UpdateResolverRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateResolverRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateResolverRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -1496,7 +1496,7 @@ export const deserializeAws_restXmlCreateAccessPointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAccessPointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateAccessPointCommandError(output, context);
   }
   const contents: CreateAccessPointCommandOutput = {
@@ -1543,7 +1543,7 @@ export const deserializeAws_restXmlCreateBucketCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBucketCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateBucketCommandError(output, context);
   }
   const contents: CreateBucketCommandOutput = {
@@ -1610,7 +1610,7 @@ export const deserializeAws_restXmlCreateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateJobCommandError(output, context);
   }
   const contents: CreateJobCommandOutput = {
@@ -1689,7 +1689,7 @@ export const deserializeAws_restXmlDeleteAccessPointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccessPointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteAccessPointCommandError(output, context);
   }
   const contents: DeleteAccessPointCommandOutput = {
@@ -1732,7 +1732,7 @@ export const deserializeAws_restXmlDeleteAccessPointPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAccessPointPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteAccessPointPolicyCommandError(output, context);
   }
   const contents: DeleteAccessPointPolicyCommandOutput = {
@@ -1775,7 +1775,7 @@ export const deserializeAws_restXmlDeleteBucketCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketCommandError(output, context);
   }
   const contents: DeleteBucketCommandOutput = {
@@ -1818,7 +1818,7 @@ export const deserializeAws_restXmlDeleteBucketLifecycleConfigurationCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketLifecycleConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketLifecycleConfigurationCommandError(output, context);
   }
   const contents: DeleteBucketLifecycleConfigurationCommandOutput = {
@@ -1861,7 +1861,7 @@ export const deserializeAws_restXmlDeleteBucketPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketPolicyCommandError(output, context);
   }
   const contents: DeleteBucketPolicyCommandOutput = {
@@ -1904,7 +1904,7 @@ export const deserializeAws_restXmlDeleteBucketTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketTaggingCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketTaggingCommandError(output, context);
   }
   const contents: DeleteBucketTaggingCommandOutput = {
@@ -1947,7 +1947,7 @@ export const deserializeAws_restXmlDeleteJobTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteJobTaggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteJobTaggingCommandError(output, context);
   }
   const contents: DeleteJobTaggingCommandOutput = {
@@ -2014,7 +2014,7 @@ export const deserializeAws_restXmlDeletePublicAccessBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePublicAccessBlockCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeletePublicAccessBlockCommandError(output, context);
   }
   const contents: DeletePublicAccessBlockCommandOutput = {
@@ -2057,7 +2057,7 @@ export const deserializeAws_restXmlDescribeJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDescribeJobCommandError(output, context);
   }
   const contents: DescribeJobCommandOutput = {
@@ -2136,7 +2136,7 @@ export const deserializeAws_restXmlGetAccessPointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccessPointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetAccessPointCommandError(output, context);
   }
   const contents: GetAccessPointCommandOutput = {
@@ -2206,7 +2206,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccessPointPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetAccessPointPolicyCommandError(output, context);
   }
   const contents: GetAccessPointPolicyCommandOutput = {
@@ -2253,7 +2253,7 @@ export const deserializeAws_restXmlGetAccessPointPolicyStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccessPointPolicyStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetAccessPointPolicyStatusCommandError(output, context);
   }
   const contents: GetAccessPointPolicyStatusCommandOutput = {
@@ -2300,7 +2300,7 @@ export const deserializeAws_restXmlGetBucketCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketCommandError(output, context);
   }
   const contents: GetBucketCommandOutput = {
@@ -2355,7 +2355,7 @@ export const deserializeAws_restXmlGetBucketLifecycleConfigurationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketLifecycleConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketLifecycleConfigurationCommandError(output, context);
   }
   const contents: GetBucketLifecycleConfigurationCommandOutput = {
@@ -2405,7 +2405,7 @@ export const deserializeAws_restXmlGetBucketPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketPolicyCommandError(output, context);
   }
   const contents: GetBucketPolicyCommandOutput = {
@@ -2452,7 +2452,7 @@ export const deserializeAws_restXmlGetBucketTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketTaggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketTaggingCommandError(output, context);
   }
   const contents: GetBucketTaggingCommandOutput = {
@@ -2502,7 +2502,7 @@ export const deserializeAws_restXmlGetJobTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobTaggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetJobTaggingCommandError(output, context);
   }
   const contents: GetJobTaggingCommandOutput = {
@@ -2576,7 +2576,7 @@ export const deserializeAws_restXmlGetPublicAccessBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPublicAccessBlockCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetPublicAccessBlockCommandError(output, context);
   }
   const contents: GetPublicAccessBlockCommandOutput = {
@@ -2629,7 +2629,7 @@ export const deserializeAws_restXmlListAccessPointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAccessPointsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListAccessPointsCommandError(output, context);
   }
   const contents: ListAccessPointsCommandOutput = {
@@ -2686,7 +2686,7 @@ export const deserializeAws_restXmlListJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListJobsCommandError(output, context);
   }
   const contents: ListJobsCommandOutput = {
@@ -2767,7 +2767,7 @@ export const deserializeAws_restXmlListRegionalBucketsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRegionalBucketsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListRegionalBucketsCommandError(output, context);
   }
   const contents: ListRegionalBucketsCommandOutput = {
@@ -2824,7 +2824,7 @@ export const deserializeAws_restXmlPutAccessPointPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAccessPointPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutAccessPointPolicyCommandError(output, context);
   }
   const contents: PutAccessPointPolicyCommandOutput = {
@@ -2867,7 +2867,7 @@ export const deserializeAws_restXmlPutBucketLifecycleConfigurationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketLifecycleConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketLifecycleConfigurationCommandError(output, context);
   }
   const contents: PutBucketLifecycleConfigurationCommandOutput = {
@@ -2910,7 +2910,7 @@ export const deserializeAws_restXmlPutBucketPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketPolicyCommandError(output, context);
   }
   const contents: PutBucketPolicyCommandOutput = {
@@ -2953,7 +2953,7 @@ export const deserializeAws_restXmlPutBucketTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketTaggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketTaggingCommandError(output, context);
   }
   const contents: PutBucketTaggingCommandOutput = {
@@ -2996,7 +2996,7 @@ export const deserializeAws_restXmlPutJobTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutJobTaggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutJobTaggingCommandError(output, context);
   }
   const contents: PutJobTaggingCommandOutput = {
@@ -3071,7 +3071,7 @@ export const deserializeAws_restXmlPutPublicAccessBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPublicAccessBlockCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutPublicAccessBlockCommandError(output, context);
   }
   const contents: PutPublicAccessBlockCommandOutput = {
@@ -3114,7 +3114,7 @@ export const deserializeAws_restXmlUpdateJobPriorityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateJobPriorityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateJobPriorityCommandError(output, context);
   }
   const contents: UpdateJobPriorityCommandOutput = {
@@ -3197,7 +3197,7 @@ export const deserializeAws_restXmlUpdateJobStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateJobStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUpdateJobStatusCommandError(output, context);
   }
   const contents: UpdateJobStatusCommandOutput = {

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -4177,7 +4177,7 @@ export const deserializeAws_restXmlAbortMultipartUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AbortMultipartUploadCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlAbortMultipartUploadCommandError(output, context);
   }
   const contents: AbortMultipartUploadCommandOutput = {
@@ -4232,7 +4232,7 @@ export const deserializeAws_restXmlCompleteMultipartUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CompleteMultipartUploadCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlCompleteMultipartUploadCommandError(output, context);
   }
   const contents: CompleteMultipartUploadCommandOutput = {
@@ -4311,7 +4311,7 @@ export const deserializeAws_restXmlCopyObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlCopyObjectCommandError(output, context);
   }
   const contents: CopyObjectCommandOutput = {
@@ -4400,7 +4400,7 @@ export const deserializeAws_restXmlCreateBucketCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateBucketCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateBucketCommandError(output, context);
   }
   const contents: CreateBucketCommandOutput = {
@@ -4463,7 +4463,7 @@ export const deserializeAws_restXmlCreateMultipartUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMultipartUploadCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlCreateMultipartUploadCommandError(output, context);
   }
   const contents: CreateMultipartUploadCommandOutput = {
@@ -4550,7 +4550,7 @@ export const deserializeAws_restXmlDeleteBucketCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketCommandError(output, context);
   }
   const contents: DeleteBucketCommandOutput = {
@@ -4593,7 +4593,7 @@ export const deserializeAws_restXmlDeleteBucketAnalyticsConfigurationCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketAnalyticsConfigurationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketAnalyticsConfigurationCommandError(output, context);
   }
   const contents: DeleteBucketAnalyticsConfigurationCommandOutput = {
@@ -4636,7 +4636,7 @@ export const deserializeAws_restXmlDeleteBucketCorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketCorsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketCorsCommandError(output, context);
   }
   const contents: DeleteBucketCorsCommandOutput = {
@@ -4679,7 +4679,7 @@ export const deserializeAws_restXmlDeleteBucketEncryptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketEncryptionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketEncryptionCommandError(output, context);
   }
   const contents: DeleteBucketEncryptionCommandOutput = {
@@ -4722,7 +4722,7 @@ export const deserializeAws_restXmlDeleteBucketInventoryConfigurationCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketInventoryConfigurationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketInventoryConfigurationCommandError(output, context);
   }
   const contents: DeleteBucketInventoryConfigurationCommandOutput = {
@@ -4765,7 +4765,7 @@ export const deserializeAws_restXmlDeleteBucketLifecycleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketLifecycleCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketLifecycleCommandError(output, context);
   }
   const contents: DeleteBucketLifecycleCommandOutput = {
@@ -4808,7 +4808,7 @@ export const deserializeAws_restXmlDeleteBucketMetricsConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketMetricsConfigurationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketMetricsConfigurationCommandError(output, context);
   }
   const contents: DeleteBucketMetricsConfigurationCommandOutput = {
@@ -4851,7 +4851,7 @@ export const deserializeAws_restXmlDeleteBucketPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketPolicyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketPolicyCommandError(output, context);
   }
   const contents: DeleteBucketPolicyCommandOutput = {
@@ -4894,7 +4894,7 @@ export const deserializeAws_restXmlDeleteBucketReplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketReplicationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketReplicationCommandError(output, context);
   }
   const contents: DeleteBucketReplicationCommandOutput = {
@@ -4937,7 +4937,7 @@ export const deserializeAws_restXmlDeleteBucketTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketTaggingCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketTaggingCommandError(output, context);
   }
   const contents: DeleteBucketTaggingCommandOutput = {
@@ -4980,7 +4980,7 @@ export const deserializeAws_restXmlDeleteBucketWebsiteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBucketWebsiteCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteBucketWebsiteCommandError(output, context);
   }
   const contents: DeleteBucketWebsiteCommandOutput = {
@@ -5023,7 +5023,7 @@ export const deserializeAws_restXmlDeleteObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteObjectCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteObjectCommandError(output, context);
   }
   const contents: DeleteObjectCommandOutput = {
@@ -5078,7 +5078,7 @@ export const deserializeAws_restXmlDeleteObjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteObjectsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteObjectsCommandError(output, context);
   }
   const contents: DeleteObjectsCommandOutput = {
@@ -5139,7 +5139,7 @@ export const deserializeAws_restXmlDeleteObjectTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteObjectTaggingCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeleteObjectTaggingCommandError(output, context);
   }
   const contents: DeleteObjectTaggingCommandOutput = {
@@ -5186,7 +5186,7 @@ export const deserializeAws_restXmlDeletePublicAccessBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePublicAccessBlockCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restXmlDeletePublicAccessBlockCommandError(output, context);
   }
   const contents: DeletePublicAccessBlockCommandOutput = {
@@ -5229,7 +5229,7 @@ export const deserializeAws_restXmlGetBucketAccelerateConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketAccelerateConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketAccelerateConfigurationCommandError(output, context);
   }
   const contents: GetBucketAccelerateConfigurationCommandOutput = {
@@ -5276,7 +5276,7 @@ export const deserializeAws_restXmlGetBucketAclCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketAclCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketAclCommandError(output, context);
   }
   const contents: GetBucketAclCommandOutput = {
@@ -5330,7 +5330,7 @@ export const deserializeAws_restXmlGetBucketAnalyticsConfigurationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketAnalyticsConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketAnalyticsConfigurationCommandError(output, context);
   }
   const contents: GetBucketAnalyticsConfigurationCommandOutput = {
@@ -5375,7 +5375,7 @@ export const deserializeAws_restXmlGetBucketCorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketCorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketCorsCommandError(output, context);
   }
   const contents: GetBucketCorsCommandOutput = {
@@ -5425,7 +5425,7 @@ export const deserializeAws_restXmlGetBucketEncryptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketEncryptionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketEncryptionCommandError(output, context);
   }
   const contents: GetBucketEncryptionCommandOutput = {
@@ -5470,7 +5470,7 @@ export const deserializeAws_restXmlGetBucketInventoryConfigurationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketInventoryConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketInventoryConfigurationCommandError(output, context);
   }
   const contents: GetBucketInventoryConfigurationCommandOutput = {
@@ -5515,7 +5515,7 @@ export const deserializeAws_restXmlGetBucketLifecycleConfigurationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketLifecycleConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketLifecycleConfigurationCommandError(output, context);
   }
   const contents: GetBucketLifecycleConfigurationCommandOutput = {
@@ -5565,7 +5565,7 @@ export const deserializeAws_restXmlGetBucketLocationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketLocationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketLocationCommandError(output, context);
   }
   const contents: GetBucketLocationCommandOutput = {
@@ -5612,7 +5612,7 @@ export const deserializeAws_restXmlGetBucketLoggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketLoggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketLoggingCommandError(output, context);
   }
   const contents: GetBucketLoggingCommandOutput = {
@@ -5659,7 +5659,7 @@ export const deserializeAws_restXmlGetBucketMetricsConfigurationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketMetricsConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketMetricsConfigurationCommandError(output, context);
   }
   const contents: GetBucketMetricsConfigurationCommandOutput = {
@@ -5704,7 +5704,7 @@ export const deserializeAws_restXmlGetBucketNotificationConfigurationCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketNotificationConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketNotificationConfigurationCommandError(output, context);
   }
   const contents: GetBucketNotificationConfigurationCommandOutput = {
@@ -5777,7 +5777,7 @@ export const deserializeAws_restXmlGetBucketPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketPolicyCommandError(output, context);
   }
   const contents: GetBucketPolicyCommandOutput = {
@@ -5824,7 +5824,7 @@ export const deserializeAws_restXmlGetBucketPolicyStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketPolicyStatusCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketPolicyStatusCommandError(output, context);
   }
   const contents: GetBucketPolicyStatusCommandOutput = {
@@ -5869,7 +5869,7 @@ export const deserializeAws_restXmlGetBucketReplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketReplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketReplicationCommandError(output, context);
   }
   const contents: GetBucketReplicationCommandOutput = {
@@ -5914,7 +5914,7 @@ export const deserializeAws_restXmlGetBucketRequestPaymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketRequestPaymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketRequestPaymentCommandError(output, context);
   }
   const contents: GetBucketRequestPaymentCommandOutput = {
@@ -5961,7 +5961,7 @@ export const deserializeAws_restXmlGetBucketTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketTaggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketTaggingCommandError(output, context);
   }
   const contents: GetBucketTaggingCommandOutput = {
@@ -6011,7 +6011,7 @@ export const deserializeAws_restXmlGetBucketVersioningCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketVersioningCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketVersioningCommandError(output, context);
   }
   const contents: GetBucketVersioningCommandOutput = {
@@ -6062,7 +6062,7 @@ export const deserializeAws_restXmlGetBucketWebsiteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBucketWebsiteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetBucketWebsiteCommandError(output, context);
   }
   const contents: GetBucketWebsiteCommandOutput = {
@@ -6130,7 +6130,7 @@ export const deserializeAws_restXmlGetObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetObjectCommandError(output, context);
   }
   const contents: GetObjectCommandOutput = {
@@ -6308,7 +6308,7 @@ export const deserializeAws_restXmlGetObjectAclCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetObjectAclCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetObjectAclCommandError(output, context);
   }
   const contents: GetObjectAclCommandOutput = {
@@ -6374,7 +6374,7 @@ export const deserializeAws_restXmlGetObjectLegalHoldCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetObjectLegalHoldCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetObjectLegalHoldCommandError(output, context);
   }
   const contents: GetObjectLegalHoldCommandOutput = {
@@ -6419,7 +6419,7 @@ export const deserializeAws_restXmlGetObjectLockConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetObjectLockConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetObjectLockConfigurationCommandError(output, context);
   }
   const contents: GetObjectLockConfigurationCommandOutput = {
@@ -6464,7 +6464,7 @@ export const deserializeAws_restXmlGetObjectRetentionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetObjectRetentionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetObjectRetentionCommandError(output, context);
   }
   const contents: GetObjectRetentionCommandOutput = {
@@ -6509,7 +6509,7 @@ export const deserializeAws_restXmlGetObjectTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetObjectTaggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetObjectTaggingCommandError(output, context);
   }
   const contents: GetObjectTaggingCommandOutput = {
@@ -6563,7 +6563,7 @@ export const deserializeAws_restXmlGetObjectTorrentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetObjectTorrentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetObjectTorrentCommandError(output, context);
   }
   const contents: GetObjectTorrentCommandOutput = {
@@ -6612,7 +6612,7 @@ export const deserializeAws_restXmlGetPublicAccessBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPublicAccessBlockCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGetPublicAccessBlockCommandError(output, context);
   }
   const contents: GetPublicAccessBlockCommandOutput = {
@@ -6657,7 +6657,7 @@ export const deserializeAws_restXmlHeadBucketCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HeadBucketCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHeadBucketCommandError(output, context);
   }
   const contents: HeadBucketCommandOutput = {
@@ -6708,7 +6708,7 @@ export const deserializeAws_restXmlHeadObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HeadObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHeadObjectCommandError(output, context);
   }
   const contents: HeadObjectCommandOutput = {
@@ -6876,7 +6876,7 @@ export const deserializeAws_restXmlListBucketAnalyticsConfigurationsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBucketAnalyticsConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListBucketAnalyticsConfigurationsCommandError(output, context);
   }
   const contents: ListBucketAnalyticsConfigurationsCommandOutput = {
@@ -6941,7 +6941,7 @@ export const deserializeAws_restXmlListBucketInventoryConfigurationsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBucketInventoryConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListBucketInventoryConfigurationsCommandError(output, context);
   }
   const contents: ListBucketInventoryConfigurationsCommandOutput = {
@@ -7006,7 +7006,7 @@ export const deserializeAws_restXmlListBucketMetricsConfigurationsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBucketMetricsConfigurationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListBucketMetricsConfigurationsCommandError(output, context);
   }
   const contents: ListBucketMetricsConfigurationsCommandOutput = {
@@ -7071,7 +7071,7 @@ export const deserializeAws_restXmlListBucketsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBucketsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListBucketsCommandError(output, context);
   }
   const contents: ListBucketsCommandOutput = {
@@ -7125,7 +7125,7 @@ export const deserializeAws_restXmlListMultipartUploadsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMultipartUploadsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListMultipartUploadsCommandError(output, context);
   }
   const contents: ListMultipartUploadsCommandOutput = {
@@ -7225,7 +7225,7 @@ export const deserializeAws_restXmlListObjectsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListObjectsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListObjectsCommandError(output, context);
   }
   const contents: ListObjectsCommandOutput = {
@@ -7325,7 +7325,7 @@ export const deserializeAws_restXmlListObjectsV2Command = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListObjectsV2CommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListObjectsV2CommandError(output, context);
   }
   const contents: ListObjectsV2CommandOutput = {
@@ -7433,7 +7433,7 @@ export const deserializeAws_restXmlListObjectVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListObjectVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListObjectVersionsCommandError(output, context);
   }
   const contents: ListObjectVersionsCommandOutput = {
@@ -7540,7 +7540,7 @@ export const deserializeAws_restXmlListPartsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPartsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlListPartsCommandError(output, context);
   }
   const contents: ListPartsCommandOutput = {
@@ -7642,7 +7642,7 @@ export const deserializeAws_restXmlPutBucketAccelerateConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketAccelerateConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketAccelerateConfigurationCommandError(output, context);
   }
   const contents: PutBucketAccelerateConfigurationCommandOutput = {
@@ -7685,7 +7685,7 @@ export const deserializeAws_restXmlPutBucketAclCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketAclCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketAclCommandError(output, context);
   }
   const contents: PutBucketAclCommandOutput = {
@@ -7728,7 +7728,7 @@ export const deserializeAws_restXmlPutBucketAnalyticsConfigurationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketAnalyticsConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketAnalyticsConfigurationCommandError(output, context);
   }
   const contents: PutBucketAnalyticsConfigurationCommandOutput = {
@@ -7771,7 +7771,7 @@ export const deserializeAws_restXmlPutBucketCorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketCorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketCorsCommandError(output, context);
   }
   const contents: PutBucketCorsCommandOutput = {
@@ -7814,7 +7814,7 @@ export const deserializeAws_restXmlPutBucketEncryptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketEncryptionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketEncryptionCommandError(output, context);
   }
   const contents: PutBucketEncryptionCommandOutput = {
@@ -7857,7 +7857,7 @@ export const deserializeAws_restXmlPutBucketInventoryConfigurationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketInventoryConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketInventoryConfigurationCommandError(output, context);
   }
   const contents: PutBucketInventoryConfigurationCommandOutput = {
@@ -7900,7 +7900,7 @@ export const deserializeAws_restXmlPutBucketLifecycleConfigurationCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketLifecycleConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketLifecycleConfigurationCommandError(output, context);
   }
   const contents: PutBucketLifecycleConfigurationCommandOutput = {
@@ -7943,7 +7943,7 @@ export const deserializeAws_restXmlPutBucketLoggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketLoggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketLoggingCommandError(output, context);
   }
   const contents: PutBucketLoggingCommandOutput = {
@@ -7986,7 +7986,7 @@ export const deserializeAws_restXmlPutBucketMetricsConfigurationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketMetricsConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketMetricsConfigurationCommandError(output, context);
   }
   const contents: PutBucketMetricsConfigurationCommandOutput = {
@@ -8029,7 +8029,7 @@ export const deserializeAws_restXmlPutBucketNotificationConfigurationCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketNotificationConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketNotificationConfigurationCommandError(output, context);
   }
   const contents: PutBucketNotificationConfigurationCommandOutput = {
@@ -8072,7 +8072,7 @@ export const deserializeAws_restXmlPutBucketPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketPolicyCommandError(output, context);
   }
   const contents: PutBucketPolicyCommandOutput = {
@@ -8115,7 +8115,7 @@ export const deserializeAws_restXmlPutBucketReplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketReplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketReplicationCommandError(output, context);
   }
   const contents: PutBucketReplicationCommandOutput = {
@@ -8158,7 +8158,7 @@ export const deserializeAws_restXmlPutBucketRequestPaymentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketRequestPaymentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketRequestPaymentCommandError(output, context);
   }
   const contents: PutBucketRequestPaymentCommandOutput = {
@@ -8201,7 +8201,7 @@ export const deserializeAws_restXmlPutBucketTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketTaggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketTaggingCommandError(output, context);
   }
   const contents: PutBucketTaggingCommandOutput = {
@@ -8244,7 +8244,7 @@ export const deserializeAws_restXmlPutBucketVersioningCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketVersioningCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketVersioningCommandError(output, context);
   }
   const contents: PutBucketVersioningCommandOutput = {
@@ -8287,7 +8287,7 @@ export const deserializeAws_restXmlPutBucketWebsiteCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutBucketWebsiteCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutBucketWebsiteCommandError(output, context);
   }
   const contents: PutBucketWebsiteCommandOutput = {
@@ -8330,7 +8330,7 @@ export const deserializeAws_restXmlPutObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutObjectCommandError(output, context);
   }
   const contents: PutObjectCommandOutput = {
@@ -8409,7 +8409,7 @@ export const deserializeAws_restXmlPutObjectAclCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutObjectAclCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutObjectAclCommandError(output, context);
   }
   const contents: PutObjectAclCommandOutput = {
@@ -8464,7 +8464,7 @@ export const deserializeAws_restXmlPutObjectLegalHoldCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutObjectLegalHoldCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutObjectLegalHoldCommandError(output, context);
   }
   const contents: PutObjectLegalHoldCommandOutput = {
@@ -8511,7 +8511,7 @@ export const deserializeAws_restXmlPutObjectLockConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutObjectLockConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutObjectLockConfigurationCommandError(output, context);
   }
   const contents: PutObjectLockConfigurationCommandOutput = {
@@ -8558,7 +8558,7 @@ export const deserializeAws_restXmlPutObjectRetentionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutObjectRetentionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutObjectRetentionCommandError(output, context);
   }
   const contents: PutObjectRetentionCommandOutput = {
@@ -8605,7 +8605,7 @@ export const deserializeAws_restXmlPutObjectTaggingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutObjectTaggingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutObjectTaggingCommandError(output, context);
   }
   const contents: PutObjectTaggingCommandOutput = {
@@ -8652,7 +8652,7 @@ export const deserializeAws_restXmlPutPublicAccessBlockCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPublicAccessBlockCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlPutPublicAccessBlockCommandError(output, context);
   }
   const contents: PutPublicAccessBlockCommandOutput = {
@@ -8695,7 +8695,7 @@ export const deserializeAws_restXmlRestoreObjectCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreObjectCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlRestoreObjectCommandError(output, context);
   }
   const contents: RestoreObjectCommandOutput = {
@@ -8754,7 +8754,7 @@ export const deserializeAws_restXmlSelectObjectContentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext & __EventStreamSerdeContext
 ): Promise<SelectObjectContentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlSelectObjectContentCommandError(output, context);
   }
   const contents: SelectObjectContentCommandOutput = {
@@ -8813,7 +8813,7 @@ export const deserializeAws_restXmlUploadPartCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UploadPartCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUploadPartCommandError(output, context);
   }
   const contents: UploadPartCommandOutput = {
@@ -8880,7 +8880,7 @@ export const deserializeAws_restXmlUploadPartCopyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UploadPartCopyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlUploadPartCopyCommandError(output, context);
   }
   const contents: UploadPartCopyCommandOutput = {

--- a/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1.ts
@@ -181,7 +181,7 @@ export const deserializeAws_restJson1DeleteHumanLoopCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHumanLoopCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteHumanLoopCommandError(output, context);
   }
   const contents: DeleteHumanLoopCommandOutput = {
@@ -256,7 +256,7 @@ export const deserializeAws_restJson1DescribeHumanLoopCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHumanLoopCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeHumanLoopCommandError(output, context);
   }
   const contents: DescribeHumanLoopCommandOutput = {
@@ -363,7 +363,7 @@ export const deserializeAws_restJson1ListHumanLoopsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHumanLoopsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListHumanLoopsCommandError(output, context);
   }
   const contents: ListHumanLoopsCommandOutput = {
@@ -446,7 +446,7 @@ export const deserializeAws_restJson1StartHumanLoopCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartHumanLoopCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartHumanLoopCommandError(output, context);
   }
   const contents: StartHumanLoopCommandOutput = {
@@ -533,7 +533,7 @@ export const deserializeAws_restJson1StopHumanLoopCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopHumanLoopCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopHumanLoopCommandError(output, context);
   }
   const contents: StopHumanLoopCommandOutput = {

--- a/clients/client-sagemaker-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-runtime/protocols/Aws_restJson1.ts
@@ -51,7 +51,7 @@ export const deserializeAws_restJson1InvokeEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InvokeEndpointCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1InvokeEndpointCommandError(output, context);
   }
   const contents: InvokeEndpointCommandOutput = {

--- a/clients/client-sagemaker/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/protocols/Aws_json1_1.ts
@@ -2602,7 +2602,7 @@ export const deserializeAws_json1_1AddTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2649,7 +2649,7 @@ export const deserializeAws_json1_1AssociateTrialComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateTrialComponentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateTrialComponentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2712,7 +2712,7 @@ export const deserializeAws_json1_1CreateAlgorithmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAlgorithmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAlgorithmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2759,7 +2759,7 @@ export const deserializeAws_json1_1CreateAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAppCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2822,7 +2822,7 @@ export const deserializeAws_json1_1CreateAutoMLJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAutoMLJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAutoMLJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2885,7 +2885,7 @@ export const deserializeAws_json1_1CreateCodeRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCodeRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCodeRepositoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2932,7 +2932,7 @@ export const deserializeAws_json1_1CreateCompilationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCompilationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCompilationJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2995,7 +2995,7 @@ export const deserializeAws_json1_1CreateDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3058,7 +3058,7 @@ export const deserializeAws_json1_1CreateEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3113,7 +3113,7 @@ export const deserializeAws_json1_1CreateEndpointConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEndpointConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateEndpointConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3168,7 +3168,7 @@ export const deserializeAws_json1_1CreateExperimentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateExperimentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateExperimentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3223,7 +3223,7 @@ export const deserializeAws_json1_1CreateFlowDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFlowDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateFlowDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3286,7 +3286,7 @@ export const deserializeAws_json1_1CreateHumanTaskUiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHumanTaskUiCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateHumanTaskUiCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3349,7 +3349,7 @@ export const deserializeAws_json1_1CreateHyperParameterTuningJobCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHyperParameterTuningJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateHyperParameterTuningJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3412,7 +3412,7 @@ export const deserializeAws_json1_1CreateLabelingJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLabelingJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateLabelingJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3475,7 +3475,7 @@ export const deserializeAws_json1_1CreateModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateModelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateModelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3530,7 +3530,7 @@ export const deserializeAws_json1_1CreateModelPackageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateModelPackageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateModelPackageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3577,7 +3577,7 @@ export const deserializeAws_json1_1CreateMonitoringScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMonitoringScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateMonitoringScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3640,7 +3640,7 @@ export const deserializeAws_json1_1CreateNotebookInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNotebookInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateNotebookInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3695,7 +3695,7 @@ export const deserializeAws_json1_1CreateNotebookInstanceLifecycleConfigCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNotebookInstanceLifecycleConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateNotebookInstanceLifecycleConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3750,7 +3750,7 @@ export const deserializeAws_json1_1CreatePresignedDomainUrlCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePresignedDomainUrlCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePresignedDomainUrlCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3805,7 +3805,7 @@ export const deserializeAws_json1_1CreatePresignedNotebookInstanceUrlCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePresignedNotebookInstanceUrlCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePresignedNotebookInstanceUrlCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3852,7 +3852,7 @@ export const deserializeAws_json1_1CreateProcessingJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProcessingJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProcessingJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3923,7 +3923,7 @@ export const deserializeAws_json1_1CreateTrainingJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrainingJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTrainingJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3994,7 +3994,7 @@ export const deserializeAws_json1_1CreateTransformJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTransformJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTransformJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4065,7 +4065,7 @@ export const deserializeAws_json1_1CreateTrialCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrialCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTrialCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4128,7 +4128,7 @@ export const deserializeAws_json1_1CreateTrialComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTrialComponentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTrialComponentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4183,7 +4183,7 @@ export const deserializeAws_json1_1CreateUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4246,7 +4246,7 @@ export const deserializeAws_json1_1CreateWorkforceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWorkforceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWorkforceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4293,7 +4293,7 @@ export const deserializeAws_json1_1CreateWorkteamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWorkteamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWorkteamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4356,7 +4356,7 @@ export const deserializeAws_json1_1DeleteAlgorithmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAlgorithmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAlgorithmCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4400,7 +4400,7 @@ export const deserializeAws_json1_1DeleteAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAppCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4460,7 +4460,7 @@ export const deserializeAws_json1_1DeleteCodeRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCodeRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteCodeRepositoryCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4504,7 +4504,7 @@ export const deserializeAws_json1_1DeleteDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDomainCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4564,7 +4564,7 @@ export const deserializeAws_json1_1DeleteEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEndpointCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4608,7 +4608,7 @@ export const deserializeAws_json1_1DeleteEndpointConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEndpointConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteEndpointConfigCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4652,7 +4652,7 @@ export const deserializeAws_json1_1DeleteExperimentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteExperimentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteExperimentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4707,7 +4707,7 @@ export const deserializeAws_json1_1DeleteFlowDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFlowDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFlowDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4770,7 +4770,7 @@ export const deserializeAws_json1_1DeleteHumanTaskUiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteHumanTaskUiCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteHumanTaskUiCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4825,7 +4825,7 @@ export const deserializeAws_json1_1DeleteModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteModelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteModelCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4869,7 +4869,7 @@ export const deserializeAws_json1_1DeleteModelPackageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteModelPackageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteModelPackageCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4913,7 +4913,7 @@ export const deserializeAws_json1_1DeleteMonitoringScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMonitoringScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMonitoringScheduleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -4965,7 +4965,7 @@ export const deserializeAws_json1_1DeleteNotebookInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNotebookInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteNotebookInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5009,7 +5009,7 @@ export const deserializeAws_json1_1DeleteNotebookInstanceLifecycleConfigCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNotebookInstanceLifecycleConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteNotebookInstanceLifecycleConfigCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5053,7 +5053,7 @@ export const deserializeAws_json1_1DeleteTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5100,7 +5100,7 @@ export const deserializeAws_json1_1DeleteTrialCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTrialCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTrialCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5155,7 +5155,7 @@ export const deserializeAws_json1_1DeleteTrialComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTrialComponentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTrialComponentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5210,7 +5210,7 @@ export const deserializeAws_json1_1DeleteUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserProfileCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5270,7 +5270,7 @@ export const deserializeAws_json1_1DeleteWorkforceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWorkforceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWorkforceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5317,7 +5317,7 @@ export const deserializeAws_json1_1DeleteWorkteamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWorkteamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWorkteamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5372,7 +5372,7 @@ export const deserializeAws_json1_1DescribeAlgorithmCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAlgorithmCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAlgorithmCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5419,7 +5419,7 @@ export const deserializeAws_json1_1DescribeAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAppCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5474,7 +5474,7 @@ export const deserializeAws_json1_1DescribeAutoMLJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAutoMLJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAutoMLJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5529,7 +5529,7 @@ export const deserializeAws_json1_1DescribeCodeRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCodeRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCodeRepositoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5576,7 +5576,7 @@ export const deserializeAws_json1_1DescribeCompilationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCompilationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCompilationJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5631,7 +5631,7 @@ export const deserializeAws_json1_1DescribeDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5686,7 +5686,7 @@ export const deserializeAws_json1_1DescribeEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5733,7 +5733,7 @@ export const deserializeAws_json1_1DescribeEndpointConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEndpointConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEndpointConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5780,7 +5780,7 @@ export const deserializeAws_json1_1DescribeExperimentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeExperimentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeExperimentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5835,7 +5835,7 @@ export const deserializeAws_json1_1DescribeFlowDefinitionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFlowDefinitionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeFlowDefinitionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5890,7 +5890,7 @@ export const deserializeAws_json1_1DescribeHumanTaskUiCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHumanTaskUiCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeHumanTaskUiCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5945,7 +5945,7 @@ export const deserializeAws_json1_1DescribeHyperParameterTuningJobCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHyperParameterTuningJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeHyperParameterTuningJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6000,7 +6000,7 @@ export const deserializeAws_json1_1DescribeLabelingJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeLabelingJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeLabelingJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6055,7 +6055,7 @@ export const deserializeAws_json1_1DescribeModelCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeModelCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeModelCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6102,7 +6102,7 @@ export const deserializeAws_json1_1DescribeModelPackageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeModelPackageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeModelPackageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6149,7 +6149,7 @@ export const deserializeAws_json1_1DescribeMonitoringScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMonitoringScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMonitoringScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6204,7 +6204,7 @@ export const deserializeAws_json1_1DescribeNotebookInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNotebookInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeNotebookInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6251,7 +6251,7 @@ export const deserializeAws_json1_1DescribeNotebookInstanceLifecycleConfigComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNotebookInstanceLifecycleConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeNotebookInstanceLifecycleConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6298,7 +6298,7 @@ export const deserializeAws_json1_1DescribeProcessingJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProcessingJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProcessingJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6353,7 +6353,7 @@ export const deserializeAws_json1_1DescribeSubscribedWorkteamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSubscribedWorkteamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSubscribedWorkteamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6400,7 +6400,7 @@ export const deserializeAws_json1_1DescribeTrainingJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrainingJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTrainingJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6455,7 +6455,7 @@ export const deserializeAws_json1_1DescribeTransformJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTransformJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTransformJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6510,7 +6510,7 @@ export const deserializeAws_json1_1DescribeTrialCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrialCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTrialCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6565,7 +6565,7 @@ export const deserializeAws_json1_1DescribeTrialComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrialComponentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTrialComponentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6620,7 +6620,7 @@ export const deserializeAws_json1_1DescribeUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUserProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6675,7 +6675,7 @@ export const deserializeAws_json1_1DescribeWorkforceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkforceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeWorkforceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6722,7 +6722,7 @@ export const deserializeAws_json1_1DescribeWorkteamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkteamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeWorkteamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6769,7 +6769,7 @@ export const deserializeAws_json1_1DisassociateTrialComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateTrialComponentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateTrialComponentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6824,7 +6824,7 @@ export const deserializeAws_json1_1GetSearchSuggestionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSearchSuggestionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSearchSuggestionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6871,7 +6871,7 @@ export const deserializeAws_json1_1ListAlgorithmsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAlgorithmsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAlgorithmsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6918,7 +6918,7 @@ export const deserializeAws_json1_1ListAppsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAppsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAppsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6965,7 +6965,7 @@ export const deserializeAws_json1_1ListAutoMLJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAutoMLJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAutoMLJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7012,7 +7012,7 @@ export const deserializeAws_json1_1ListCandidatesForAutoMLJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCandidatesForAutoMLJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCandidatesForAutoMLJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7067,7 +7067,7 @@ export const deserializeAws_json1_1ListCodeRepositoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCodeRepositoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCodeRepositoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7114,7 +7114,7 @@ export const deserializeAws_json1_1ListCompilationJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCompilationJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCompilationJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7161,7 +7161,7 @@ export const deserializeAws_json1_1ListDomainsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDomainsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7208,7 +7208,7 @@ export const deserializeAws_json1_1ListEndpointConfigsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEndpointConfigsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEndpointConfigsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7255,7 +7255,7 @@ export const deserializeAws_json1_1ListEndpointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEndpointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListEndpointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7302,7 +7302,7 @@ export const deserializeAws_json1_1ListExperimentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListExperimentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListExperimentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7349,7 +7349,7 @@ export const deserializeAws_json1_1ListFlowDefinitionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFlowDefinitionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListFlowDefinitionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7396,7 +7396,7 @@ export const deserializeAws_json1_1ListHumanTaskUisCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHumanTaskUisCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListHumanTaskUisCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7443,7 +7443,7 @@ export const deserializeAws_json1_1ListHyperParameterTuningJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListHyperParameterTuningJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListHyperParameterTuningJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7490,7 +7490,7 @@ export const deserializeAws_json1_1ListLabelingJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLabelingJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLabelingJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7537,7 +7537,7 @@ export const deserializeAws_json1_1ListLabelingJobsForWorkteamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLabelingJobsForWorkteamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLabelingJobsForWorkteamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7592,7 +7592,7 @@ export const deserializeAws_json1_1ListModelPackagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListModelPackagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListModelPackagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7639,7 +7639,7 @@ export const deserializeAws_json1_1ListModelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListModelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListModelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7686,7 +7686,7 @@ export const deserializeAws_json1_1ListMonitoringExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMonitoringExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListMonitoringExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7733,7 +7733,7 @@ export const deserializeAws_json1_1ListMonitoringSchedulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMonitoringSchedulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListMonitoringSchedulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7780,7 +7780,7 @@ export const deserializeAws_json1_1ListNotebookInstanceLifecycleConfigsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNotebookInstanceLifecycleConfigsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListNotebookInstanceLifecycleConfigsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7827,7 +7827,7 @@ export const deserializeAws_json1_1ListNotebookInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNotebookInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListNotebookInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7874,7 +7874,7 @@ export const deserializeAws_json1_1ListProcessingJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProcessingJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProcessingJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7921,7 +7921,7 @@ export const deserializeAws_json1_1ListSubscribedWorkteamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSubscribedWorkteamsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSubscribedWorkteamsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7968,7 +7968,7 @@ export const deserializeAws_json1_1ListTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8015,7 +8015,7 @@ export const deserializeAws_json1_1ListTrainingJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTrainingJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTrainingJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8062,7 +8062,7 @@ export const deserializeAws_json1_1ListTrainingJobsForHyperParameterTuningJobCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTrainingJobsForHyperParameterTuningJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTrainingJobsForHyperParameterTuningJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8117,7 +8117,7 @@ export const deserializeAws_json1_1ListTransformJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTransformJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTransformJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8164,7 +8164,7 @@ export const deserializeAws_json1_1ListTrialComponentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTrialComponentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTrialComponentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8219,7 +8219,7 @@ export const deserializeAws_json1_1ListTrialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTrialsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTrialsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8274,7 +8274,7 @@ export const deserializeAws_json1_1ListUserProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUserProfilesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUserProfilesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8321,7 +8321,7 @@ export const deserializeAws_json1_1ListWorkforcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWorkforcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListWorkforcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8368,7 +8368,7 @@ export const deserializeAws_json1_1ListWorkteamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWorkteamsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListWorkteamsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8415,7 +8415,7 @@ export const deserializeAws_json1_1RenderUiTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RenderUiTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RenderUiTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8470,7 +8470,7 @@ export const deserializeAws_json1_1SearchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8517,7 +8517,7 @@ export const deserializeAws_json1_1StartMonitoringScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMonitoringScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartMonitoringScheduleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -8569,7 +8569,7 @@ export const deserializeAws_json1_1StartNotebookInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartNotebookInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartNotebookInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -8621,7 +8621,7 @@ export const deserializeAws_json1_1StopAutoMLJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopAutoMLJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopAutoMLJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -8673,7 +8673,7 @@ export const deserializeAws_json1_1StopCompilationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopCompilationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopCompilationJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -8725,7 +8725,7 @@ export const deserializeAws_json1_1StopHyperParameterTuningJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopHyperParameterTuningJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopHyperParameterTuningJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -8777,7 +8777,7 @@ export const deserializeAws_json1_1StopLabelingJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopLabelingJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopLabelingJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -8829,7 +8829,7 @@ export const deserializeAws_json1_1StopMonitoringScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopMonitoringScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopMonitoringScheduleCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -8881,7 +8881,7 @@ export const deserializeAws_json1_1StopNotebookInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopNotebookInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopNotebookInstanceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -8925,7 +8925,7 @@ export const deserializeAws_json1_1StopProcessingJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopProcessingJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopProcessingJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -8977,7 +8977,7 @@ export const deserializeAws_json1_1StopTrainingJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopTrainingJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopTrainingJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -9029,7 +9029,7 @@ export const deserializeAws_json1_1StopTransformJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopTransformJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopTransformJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -9081,7 +9081,7 @@ export const deserializeAws_json1_1UpdateCodeRepositoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCodeRepositoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateCodeRepositoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9128,7 +9128,7 @@ export const deserializeAws_json1_1UpdateDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9199,7 +9199,7 @@ export const deserializeAws_json1_1UpdateEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9254,7 +9254,7 @@ export const deserializeAws_json1_1UpdateEndpointWeightsAndCapacitiesCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEndpointWeightsAndCapacitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateEndpointWeightsAndCapacitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9309,7 +9309,7 @@ export const deserializeAws_json1_1UpdateExperimentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateExperimentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateExperimentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9372,7 +9372,7 @@ export const deserializeAws_json1_1UpdateMonitoringScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMonitoringScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMonitoringScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9435,7 +9435,7 @@ export const deserializeAws_json1_1UpdateNotebookInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNotebookInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateNotebookInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9490,7 +9490,7 @@ export const deserializeAws_json1_1UpdateNotebookInstanceLifecycleConfigCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNotebookInstanceLifecycleConfigCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateNotebookInstanceLifecycleConfigCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9545,7 +9545,7 @@ export const deserializeAws_json1_1UpdateTrialCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTrialCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTrialCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9608,7 +9608,7 @@ export const deserializeAws_json1_1UpdateTrialComponentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTrialComponentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTrialComponentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9671,7 +9671,7 @@ export const deserializeAws_json1_1UpdateUserProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserProfileCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateUserProfileCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9742,7 +9742,7 @@ export const deserializeAws_json1_1UpdateWorkforceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateWorkforceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateWorkforceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9789,7 +9789,7 @@ export const deserializeAws_json1_1UpdateWorkteamCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateWorkteamCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateWorkteamCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-savingsplans/protocols/Aws_restJson1.ts
+++ b/clients/client-savingsplans/protocols/Aws_restJson1.ts
@@ -329,7 +329,7 @@ export const deserializeAws_restJson1CreateSavingsPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSavingsPlanCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSavingsPlanCommandError(output, context);
   }
   const contents: CreateSavingsPlanCommandOutput = {
@@ -408,7 +408,7 @@ export const deserializeAws_restJson1DescribeSavingsPlanRatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSavingsPlanRatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSavingsPlanRatesCommandError(output, context);
   }
   const contents: DescribeSavingsPlanRatesCommandOutput = {
@@ -479,7 +479,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSavingsPlansCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSavingsPlansCommandError(output, context);
   }
   const contents: DescribeSavingsPlansCommandOutput = {
@@ -546,7 +546,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansOfferingRatesCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSavingsPlansOfferingRatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSavingsPlansOfferingRatesCommandError(output, context);
   }
   const contents: DescribeSavingsPlansOfferingRatesCommandOutput = {
@@ -613,7 +613,7 @@ export const deserializeAws_restJson1DescribeSavingsPlansOfferingsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSavingsPlansOfferingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSavingsPlansOfferingsCommandError(output, context);
   }
   const contents: DescribeSavingsPlansOfferingsCommandOutput = {
@@ -680,7 +680,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -751,7 +751,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -826,7 +826,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {

--- a/clients/client-schemas/protocols/Aws_restJson1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1.ts
@@ -1139,7 +1139,7 @@ export const deserializeAws_restJson1CreateDiscovererCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDiscovererCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDiscovererCommandError(output, context);
   }
   const contents: CreateDiscovererCommandOutput = {
@@ -1254,7 +1254,7 @@ export const deserializeAws_restJson1CreateRegistryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRegistryCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateRegistryCommandError(output, context);
   }
   const contents: CreateRegistryCommandOutput = {
@@ -1361,7 +1361,7 @@ export const deserializeAws_restJson1CreateSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSchemaCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSchemaCommandError(output, context);
   }
   const contents: CreateSchemaCommandOutput = {
@@ -1468,7 +1468,7 @@ export const deserializeAws_restJson1DeleteDiscovererCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDiscovererCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDiscovererCommandError(output, context);
   }
   const contents: DeleteDiscovererCommandOutput = {
@@ -1559,7 +1559,7 @@ export const deserializeAws_restJson1DeleteRegistryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRegistryCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteRegistryCommandError(output, context);
   }
   const contents: DeleteRegistryCommandOutput = {
@@ -1650,7 +1650,7 @@ export const deserializeAws_restJson1DeleteResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourcePolicyCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteResourcePolicyCommandError(output, context);
   }
   const contents: DeleteResourcePolicyCommandOutput = {
@@ -1741,7 +1741,7 @@ export const deserializeAws_restJson1DeleteSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSchemaCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSchemaCommandError(output, context);
   }
   const contents: DeleteSchemaCommandOutput = {
@@ -1832,7 +1832,7 @@ export const deserializeAws_restJson1DeleteSchemaVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSchemaVersionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSchemaVersionCommandError(output, context);
   }
   const contents: DeleteSchemaVersionCommandOutput = {
@@ -1923,7 +1923,7 @@ export const deserializeAws_restJson1DescribeCodeBindingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCodeBindingCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeCodeBindingCommandError(output, context);
   }
   const contents: DescribeCodeBindingCommandOutput = {
@@ -2030,7 +2030,7 @@ export const deserializeAws_restJson1DescribeDiscovererCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDiscovererCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDiscovererCommandError(output, context);
   }
   const contents: DescribeDiscovererCommandOutput = {
@@ -2145,7 +2145,7 @@ export const deserializeAws_restJson1DescribeRegistryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRegistryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRegistryCommandError(output, context);
   }
   const contents: DescribeRegistryCommandOutput = {
@@ -2252,7 +2252,7 @@ export const deserializeAws_restJson1DescribeSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSchemaCommandError(output, context);
   }
   const contents: DescribeSchemaCommandOutput = {
@@ -2379,7 +2379,7 @@ export const deserializeAws_restJson1GetCodeBindingSourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCodeBindingSourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCodeBindingSourceCommandError(output, context);
   }
   const contents: GetCodeBindingSourceCommandOutput = {
@@ -2472,7 +2472,7 @@ export const deserializeAws_restJson1GetDiscoveredSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDiscoveredSchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDiscoveredSchemaCommandError(output, context);
   }
   const contents: GetDiscoveredSchemaCommandOutput = {
@@ -2559,7 +2559,7 @@ export const deserializeAws_restJson1GetResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourcePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResourcePolicyCommandError(output, context);
   }
   const contents: GetResourcePolicyCommandOutput = {
@@ -2658,7 +2658,7 @@ export const deserializeAws_restJson1ListDiscoverersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDiscoverersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDiscoverersCommandError(output, context);
   }
   const contents: ListDiscoverersCommandOutput = {
@@ -2749,7 +2749,7 @@ export const deserializeAws_restJson1ListRegistriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRegistriesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListRegistriesCommandError(output, context);
   }
   const contents: ListRegistriesCommandOutput = {
@@ -2840,7 +2840,7 @@ export const deserializeAws_restJson1ListSchemasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSchemasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSchemasCommandError(output, context);
   }
   const contents: ListSchemasCommandOutput = {
@@ -2931,7 +2931,7 @@ export const deserializeAws_restJson1ListSchemaVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSchemaVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSchemaVersionsCommandError(output, context);
   }
   const contents: ListSchemaVersionsCommandOutput = {
@@ -3030,7 +3030,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -3109,7 +3109,7 @@ export const deserializeAws_restJson1PutCodeBindingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutCodeBindingCommandOutput> => {
-  if (output.statusCode !== 202 && output.statusCode >= 400) {
+  if (output.statusCode !== 202 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutCodeBindingCommandError(output, context);
   }
   const contents: PutCodeBindingCommandOutput = {
@@ -3224,7 +3224,7 @@ export const deserializeAws_restJson1PutResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutResourcePolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutResourcePolicyCommandError(output, context);
   }
   const contents: PutResourcePolicyCommandOutput = {
@@ -3331,7 +3331,7 @@ export const deserializeAws_restJson1SearchSchemasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchSchemasCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SearchSchemasCommandError(output, context);
   }
   const contents: SearchSchemasCommandOutput = {
@@ -3422,7 +3422,7 @@ export const deserializeAws_restJson1StartDiscovererCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDiscovererCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartDiscovererCommandError(output, context);
   }
   const contents: StartDiscovererCommandOutput = {
@@ -3521,7 +3521,7 @@ export const deserializeAws_restJson1StopDiscovererCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopDiscovererCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopDiscovererCommandError(output, context);
   }
   const contents: StopDiscovererCommandOutput = {
@@ -3620,7 +3620,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -3695,7 +3695,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -3770,7 +3770,7 @@ export const deserializeAws_restJson1UpdateDiscovererCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDiscovererCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDiscovererCommandError(output, context);
   }
   const contents: UpdateDiscovererCommandOutput = {
@@ -3885,7 +3885,7 @@ export const deserializeAws_restJson1UpdateRegistryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRegistryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateRegistryCommandError(output, context);
   }
   const contents: UpdateRegistryCommandOutput = {
@@ -3992,7 +3992,7 @@ export const deserializeAws_restJson1UpdateSchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSchemaCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSchemaCommandError(output, context);
   }
   const contents: UpdateSchemaCommandOutput = {

--- a/clients/client-secrets-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/protocols/Aws_json1_1.ts
@@ -347,7 +347,7 @@ export const deserializeAws_json1_1CancelRotateSecretCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelRotateSecretCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelRotateSecretCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -426,7 +426,7 @@ export const deserializeAws_json1_1CreateSecretCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSecretCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSecretCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -545,7 +545,7 @@ export const deserializeAws_json1_1DeleteResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -616,7 +616,7 @@ export const deserializeAws_json1_1DeleteSecretCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSecretCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSecretCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -695,7 +695,7 @@ export const deserializeAws_json1_1DescribeSecretCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSecretCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSecretCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -758,7 +758,7 @@ export const deserializeAws_json1_1GetRandomPasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRandomPasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRandomPasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -829,7 +829,7 @@ export const deserializeAws_json1_1GetResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -900,7 +900,7 @@ export const deserializeAws_json1_1GetSecretValueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSecretValueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSecretValueCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -987,7 +987,7 @@ export const deserializeAws_json1_1ListSecretsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSecretsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSecretsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1058,7 +1058,7 @@ export const deserializeAws_json1_1ListSecretVersionIdsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSecretVersionIdsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSecretVersionIdsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1129,7 +1129,7 @@ export const deserializeAws_json1_1PutResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1224,7 +1224,7 @@ export const deserializeAws_json1_1PutSecretValueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutSecretValueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutSecretValueCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1327,7 +1327,7 @@ export const deserializeAws_json1_1RestoreSecretCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreSecretCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RestoreSecretCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1406,7 +1406,7 @@ export const deserializeAws_json1_1RotateSecretCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RotateSecretCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RotateSecretCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1485,7 +1485,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1561,7 +1561,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1637,7 +1637,7 @@ export const deserializeAws_json1_1UpdateSecretCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSecretCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSecretCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1756,7 +1756,7 @@ export const deserializeAws_json1_1UpdateSecretVersionStageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSecretVersionStageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSecretVersionStageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1843,7 +1843,7 @@ export const deserializeAws_json1_1ValidateResourcePolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ValidateResourcePolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ValidateResourcePolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-securityhub/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1.ts
@@ -1479,7 +1479,7 @@ export const deserializeAws_restJson1AcceptInvitationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptInvitationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AcceptInvitationCommandError(output, context);
   }
   const contents: AcceptInvitationCommandOutput = {
@@ -1562,7 +1562,7 @@ export const deserializeAws_restJson1BatchDisableStandardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDisableStandardsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchDisableStandardsCommandError(output, context);
   }
   const contents: BatchDisableStandardsCommandOutput = {
@@ -1644,7 +1644,7 @@ export const deserializeAws_restJson1BatchEnableStandardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchEnableStandardsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchEnableStandardsCommandError(output, context);
   }
   const contents: BatchEnableStandardsCommandOutput = {
@@ -1726,7 +1726,7 @@ export const deserializeAws_restJson1BatchImportFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchImportFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchImportFindingsCommandError(output, context);
   }
   const contents: BatchImportFindingsCommandOutput = {
@@ -1813,7 +1813,7 @@ export const deserializeAws_restJson1BatchUpdateFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchUpdateFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchUpdateFindingsCommandError(output, context);
   }
   const contents: BatchUpdateFindingsCommandOutput = {
@@ -1902,7 +1902,7 @@ export const deserializeAws_restJson1CreateActionTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateActionTargetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateActionTargetCommandError(output, context);
   }
   const contents: CreateActionTargetCommandOutput = {
@@ -1989,7 +1989,7 @@ export const deserializeAws_restJson1CreateInsightCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateInsightCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateInsightCommandError(output, context);
   }
   const contents: CreateInsightCommandOutput = {
@@ -2076,7 +2076,7 @@ export const deserializeAws_restJson1CreateMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateMembersCommandError(output, context);
   }
   const contents: CreateMembersCommandOutput = {
@@ -2163,7 +2163,7 @@ export const deserializeAws_restJson1DeclineInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeclineInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeclineInvitationsCommandError(output, context);
   }
   const contents: DeclineInvitationsCommandOutput = {
@@ -2242,7 +2242,7 @@ export const deserializeAws_restJson1DeleteActionTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteActionTargetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteActionTargetCommandError(output, context);
   }
   const contents: DeleteActionTargetCommandOutput = {
@@ -2321,7 +2321,7 @@ export const deserializeAws_restJson1DeleteInsightCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInsightCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteInsightCommandError(output, context);
   }
   const contents: DeleteInsightCommandOutput = {
@@ -2408,7 +2408,7 @@ export const deserializeAws_restJson1DeleteInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteInvitationsCommandError(output, context);
   }
   const contents: DeleteInvitationsCommandOutput = {
@@ -2495,7 +2495,7 @@ export const deserializeAws_restJson1DeleteMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteMembersCommandError(output, context);
   }
   const contents: DeleteMembersCommandOutput = {
@@ -2582,7 +2582,7 @@ export const deserializeAws_restJson1DescribeActionTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeActionTargetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeActionTargetsCommandError(output, context);
   }
   const contents: DescribeActionTargetsCommandOutput = {
@@ -2665,7 +2665,7 @@ export const deserializeAws_restJson1DescribeHubCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeHubCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeHubCommandError(output, context);
   }
   const contents: DescribeHubCommandOutput = {
@@ -2760,7 +2760,7 @@ export const deserializeAws_restJson1DescribeProductsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProductsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeProductsCommandError(output, context);
   }
   const contents: DescribeProductsCommandOutput = {
@@ -2843,7 +2843,7 @@ export const deserializeAws_restJson1DescribeStandardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStandardsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeStandardsCommandError(output, context);
   }
   const contents: DescribeStandardsCommandOutput = {
@@ -2918,7 +2918,7 @@ export const deserializeAws_restJson1DescribeStandardsControlsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStandardsControlsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeStandardsControlsCommandError(output, context);
   }
   const contents: DescribeStandardsControlsCommandOutput = {
@@ -3001,7 +3001,7 @@ export const deserializeAws_restJson1DisableImportFindingsForProductCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableImportFindingsForProductCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisableImportFindingsForProductCommandError(output, context);
   }
   const contents: DisableImportFindingsForProductCommandOutput = {
@@ -3084,7 +3084,7 @@ export const deserializeAws_restJson1DisableSecurityHubCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableSecurityHubCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisableSecurityHubCommandError(output, context);
   }
   const contents: DisableSecurityHubCommandOutput = {
@@ -3159,7 +3159,7 @@ export const deserializeAws_restJson1DisassociateFromMasterAccountCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateFromMasterAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateFromMasterAccountCommandError(output, context);
   }
   const contents: DisassociateFromMasterAccountCommandOutput = {
@@ -3242,7 +3242,7 @@ export const deserializeAws_restJson1DisassociateMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateMembersCommandError(output, context);
   }
   const contents: DisassociateMembersCommandOutput = {
@@ -3325,7 +3325,7 @@ export const deserializeAws_restJson1EnableImportFindingsForProductCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableImportFindingsForProductCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1EnableImportFindingsForProductCommandError(output, context);
   }
   const contents: EnableImportFindingsForProductCommandOutput = {
@@ -3412,7 +3412,7 @@ export const deserializeAws_restJson1EnableSecurityHubCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableSecurityHubCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1EnableSecurityHubCommandError(output, context);
   }
   const contents: EnableSecurityHubCommandOutput = {
@@ -3495,7 +3495,7 @@ export const deserializeAws_restJson1GetEnabledStandardsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEnabledStandardsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEnabledStandardsCommandError(output, context);
   }
   const contents: GetEnabledStandardsCommandOutput = {
@@ -3581,7 +3581,7 @@ export const deserializeAws_restJson1GetFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFindingsCommandError(output, context);
   }
   const contents: GetFindingsCommandOutput = {
@@ -3664,7 +3664,7 @@ export const deserializeAws_restJson1GetInsightResultsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInsightResultsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetInsightResultsCommandError(output, context);
   }
   const contents: GetInsightResultsCommandOutput = {
@@ -3751,7 +3751,7 @@ export const deserializeAws_restJson1GetInsightsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInsightsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetInsightsCommandError(output, context);
   }
   const contents: GetInsightsCommandOutput = {
@@ -3842,7 +3842,7 @@ export const deserializeAws_restJson1GetInvitationsCountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInvitationsCountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetInvitationsCountCommandError(output, context);
   }
   const contents: GetInvitationsCountCommandOutput = {
@@ -3921,7 +3921,7 @@ export const deserializeAws_restJson1GetMasterAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMasterAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMasterAccountCommandError(output, context);
   }
   const contents: GetMasterAccountCommandOutput = {
@@ -4008,7 +4008,7 @@ export const deserializeAws_restJson1GetMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetMembersCommandError(output, context);
   }
   const contents: GetMembersCommandOutput = {
@@ -4099,7 +4099,7 @@ export const deserializeAws_restJson1InviteMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InviteMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1InviteMembersCommandError(output, context);
   }
   const contents: InviteMembersCommandOutput = {
@@ -4186,7 +4186,7 @@ export const deserializeAws_restJson1ListEnabledProductsForImportCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEnabledProductsForImportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListEnabledProductsForImportCommandError(output, context);
   }
   const contents: ListEnabledProductsForImportCommandOutput = {
@@ -4264,7 +4264,7 @@ export const deserializeAws_restJson1ListInvitationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInvitationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListInvitationsCommandError(output, context);
   }
   const contents: ListInvitationsCommandOutput = {
@@ -4347,7 +4347,7 @@ export const deserializeAws_restJson1ListMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMembersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListMembersCommandError(output, context);
   }
   const contents: ListMembersCommandOutput = {
@@ -4430,7 +4430,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -4501,7 +4501,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -4568,7 +4568,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -4635,7 +4635,7 @@ export const deserializeAws_restJson1UpdateActionTargetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateActionTargetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateActionTargetCommandError(output, context);
   }
   const contents: UpdateActionTargetCommandOutput = {
@@ -4710,7 +4710,7 @@ export const deserializeAws_restJson1UpdateFindingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFindingsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFindingsCommandError(output, context);
   }
   const contents: UpdateFindingsCommandOutput = {
@@ -4793,7 +4793,7 @@ export const deserializeAws_restJson1UpdateInsightCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateInsightCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateInsightCommandError(output, context);
   }
   const contents: UpdateInsightCommandOutput = {
@@ -4876,7 +4876,7 @@ export const deserializeAws_restJson1UpdateSecurityHubConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSecurityHubConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSecurityHubConfigurationCommandError(output, context);
   }
   const contents: UpdateSecurityHubConfigurationCommandOutput = {
@@ -4959,7 +4959,7 @@ export const deserializeAws_restJson1UpdateStandardsControlCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStandardsControlCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateStandardsControlCommandError(output, context);
   }
   const contents: UpdateStandardsControlCommandOutput = {

--- a/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1.ts
+++ b/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1.ts
@@ -577,7 +577,7 @@ export const deserializeAws_restJson1CreateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateApplicationCommandError(output, context);
   }
   const contents: CreateApplicationCommandOutput = {
@@ -712,7 +712,7 @@ export const deserializeAws_restJson1CreateApplicationVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateApplicationVersionCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateApplicationVersionCommandError(output, context);
   }
   const contents: CreateApplicationVersionCommandOutput = {
@@ -834,7 +834,7 @@ export const deserializeAws_restJson1CreateCloudFormationChangeSetCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCloudFormationChangeSetCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCloudFormationChangeSetCommandError(output, context);
   }
   const contents: CreateCloudFormationChangeSetCommandOutput = {
@@ -925,7 +925,7 @@ export const deserializeAws_restJson1CreateCloudFormationTemplateCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCloudFormationTemplateCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCloudFormationTemplateCommandError(output, context);
   }
   const contents: CreateCloudFormationTemplateCommandOutput = {
@@ -1036,7 +1036,7 @@ export const deserializeAws_restJson1DeleteApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteApplicationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteApplicationCommandError(output, context);
   }
   const contents: DeleteApplicationCommandOutput = {
@@ -1127,7 +1127,7 @@ export const deserializeAws_restJson1GetApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApplicationCommandError(output, context);
   }
   const contents: GetApplicationCommandOutput = {
@@ -1262,7 +1262,7 @@ export const deserializeAws_restJson1GetApplicationPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetApplicationPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetApplicationPolicyCommandError(output, context);
   }
   const contents: GetApplicationPolicyCommandOutput = {
@@ -1349,7 +1349,7 @@ export const deserializeAws_restJson1GetCloudFormationTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCloudFormationTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCloudFormationTemplateCommandError(output, context);
   }
   const contents: GetCloudFormationTemplateCommandOutput = {
@@ -1460,7 +1460,7 @@ export const deserializeAws_restJson1ListApplicationDependenciesCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationDependenciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListApplicationDependenciesCommandError(output, context);
   }
   const contents: ListApplicationDependenciesCommandOutput = {
@@ -1551,7 +1551,7 @@ export const deserializeAws_restJson1ListApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListApplicationsCommandError(output, context);
   }
   const contents: ListApplicationsCommandOutput = {
@@ -1634,7 +1634,7 @@ export const deserializeAws_restJson1ListApplicationVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListApplicationVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListApplicationVersionsCommandError(output, context);
   }
   const contents: ListApplicationVersionsCommandOutput = {
@@ -1725,7 +1725,7 @@ export const deserializeAws_restJson1PutApplicationPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutApplicationPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutApplicationPolicyCommandError(output, context);
   }
   const contents: PutApplicationPolicyCommandOutput = {
@@ -1812,7 +1812,7 @@ export const deserializeAws_restJson1UnshareApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnshareApplicationCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1UnshareApplicationCommandError(output, context);
   }
   const contents: UnshareApplicationCommandOutput = {
@@ -1895,7 +1895,7 @@ export const deserializeAws_restJson1UpdateApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateApplicationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateApplicationCommandError(output, context);
   }
   const contents: UpdateApplicationCommandOutput = {

--- a/clients/client-service-catalog/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/protocols/Aws_json1_1.ts
@@ -1586,7 +1586,7 @@ export const deserializeAws_json1_1AcceptPortfolioShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AcceptPortfolioShareCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AcceptPortfolioShareCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1657,7 +1657,7 @@ export const deserializeAws_json1_1AssociateBudgetWithResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateBudgetWithResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateBudgetWithResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1736,7 +1736,7 @@ export const deserializeAws_json1_1AssociatePrincipalWithPortfolioCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociatePrincipalWithPortfolioCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociatePrincipalWithPortfolioCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1807,7 +1807,7 @@ export const deserializeAws_json1_1AssociateProductWithPortfolioCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateProductWithPortfolioCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateProductWithPortfolioCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1878,7 +1878,7 @@ export const deserializeAws_json1_1AssociateServiceActionWithProvisioningArtifac
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateServiceActionWithProvisioningArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateServiceActionWithProvisioningArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1949,7 +1949,7 @@ export const deserializeAws_json1_1AssociateTagOptionWithResourceCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateTagOptionWithResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateTagOptionWithResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2044,7 +2044,7 @@ export const deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningAr
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchAssociateServiceActionWithProvisioningArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchAssociateServiceActionWithProvisioningArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2099,7 +2099,7 @@ export const deserializeAws_json1_1BatchDisassociateServiceActionFromProvisionin
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchDisassociateServiceActionFromProvisioningArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1BatchDisassociateServiceActionFromProvisioningArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2154,7 +2154,7 @@ export const deserializeAws_json1_1CopyProductCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CopyProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2217,7 +2217,7 @@ export const deserializeAws_json1_1CreateConstraintCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConstraintCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateConstraintCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2296,7 +2296,7 @@ export const deserializeAws_json1_1CreatePortfolioCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePortfolioCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePortfolioCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2367,7 +2367,7 @@ export const deserializeAws_json1_1CreatePortfolioShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePortfolioShareCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePortfolioShareCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2454,7 +2454,7 @@ export const deserializeAws_json1_1CreateProductCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2525,7 +2525,7 @@ export const deserializeAws_json1_1CreateProvisionedProductPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProvisionedProductPlanCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProvisionedProductPlanCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2596,7 +2596,7 @@ export const deserializeAws_json1_1CreateProvisioningArtifactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProvisioningArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProvisioningArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2667,7 +2667,7 @@ export const deserializeAws_json1_1CreateServiceActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateServiceActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateServiceActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2730,7 +2730,7 @@ export const deserializeAws_json1_1CreateTagOptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTagOptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTagOptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2801,7 +2801,7 @@ export const deserializeAws_json1_1DeleteConstraintCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConstraintCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteConstraintCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2864,7 +2864,7 @@ export const deserializeAws_json1_1DeletePortfolioCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePortfolioCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePortfolioCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2943,7 +2943,7 @@ export const deserializeAws_json1_1DeletePortfolioShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePortfolioShareCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePortfolioShareCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3022,7 +3022,7 @@ export const deserializeAws_json1_1DeleteProductCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3101,7 +3101,7 @@ export const deserializeAws_json1_1DeleteProvisionedProductPlanCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProvisionedProductPlanCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProvisionedProductPlanCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3164,7 +3164,7 @@ export const deserializeAws_json1_1DeleteProvisioningArtifactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProvisioningArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProvisioningArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3235,7 +3235,7 @@ export const deserializeAws_json1_1DeleteServiceActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteServiceActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteServiceActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3298,7 +3298,7 @@ export const deserializeAws_json1_1DeleteTagOptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagOptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTagOptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3369,7 +3369,7 @@ export const deserializeAws_json1_1DescribeConstraintCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConstraintCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeConstraintCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3424,7 +3424,7 @@ export const deserializeAws_json1_1DescribeCopyProductStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCopyProductStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCopyProductStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3479,7 +3479,7 @@ export const deserializeAws_json1_1DescribePortfolioCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePortfolioCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePortfolioCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3534,7 +3534,7 @@ export const deserializeAws_json1_1DescribePortfolioShareStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePortfolioShareStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePortfolioShareStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3605,7 +3605,7 @@ export const deserializeAws_json1_1DescribeProductCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3668,7 +3668,7 @@ export const deserializeAws_json1_1DescribeProductAsAdminCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProductAsAdminCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProductAsAdminCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3731,7 +3731,7 @@ export const deserializeAws_json1_1DescribeProductViewCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProductViewCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProductViewCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3794,7 +3794,7 @@ export const deserializeAws_json1_1DescribeProvisionedProductCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProvisionedProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProvisionedProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3849,7 +3849,7 @@ export const deserializeAws_json1_1DescribeProvisionedProductPlanCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProvisionedProductPlanCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProvisionedProductPlanCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3912,7 +3912,7 @@ export const deserializeAws_json1_1DescribeProvisioningArtifactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProvisioningArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProvisioningArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3975,7 +3975,7 @@ export const deserializeAws_json1_1DescribeProvisioningParametersCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProvisioningParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProvisioningParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4038,7 +4038,7 @@ export const deserializeAws_json1_1DescribeRecordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRecordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeRecordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4093,7 +4093,7 @@ export const deserializeAws_json1_1DescribeServiceActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeServiceActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeServiceActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4148,7 +4148,7 @@ export const deserializeAws_json1_1DescribeServiceActionExecutionParametersComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeServiceActionExecutionParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeServiceActionExecutionParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4211,7 +4211,7 @@ export const deserializeAws_json1_1DescribeTagOptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagOptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTagOptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4274,7 +4274,7 @@ export const deserializeAws_json1_1DisableAWSOrganizationsAccessCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableAWSOrganizationsAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableAWSOrganizationsAccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4345,7 +4345,7 @@ export const deserializeAws_json1_1DisassociateBudgetFromResourceCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateBudgetFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateBudgetFromResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4400,7 +4400,7 @@ export const deserializeAws_json1_1DisassociatePrincipalFromPortfolioCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociatePrincipalFromPortfolioCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociatePrincipalFromPortfolioCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4463,7 +4463,7 @@ export const deserializeAws_json1_1DisassociateProductFromPortfolioCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateProductFromPortfolioCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateProductFromPortfolioCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4534,7 +4534,7 @@ export const deserializeAws_json1_1DisassociateServiceActionFromProvisioningArti
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateServiceActionFromProvisioningArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateServiceActionFromProvisioningArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4589,7 +4589,7 @@ export const deserializeAws_json1_1DisassociateTagOptionFromResourceCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateTagOptionFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateTagOptionFromResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4652,7 +4652,7 @@ export const deserializeAws_json1_1EnableAWSOrganizationsAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableAWSOrganizationsAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableAWSOrganizationsAccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4723,7 +4723,7 @@ export const deserializeAws_json1_1ExecuteProvisionedProductPlanCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExecuteProvisionedProductPlanCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ExecuteProvisionedProductPlanCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4794,7 +4794,7 @@ export const deserializeAws_json1_1ExecuteProvisionedProductServiceActionCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ExecuteProvisionedProductServiceActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ExecuteProvisionedProductServiceActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4865,7 +4865,7 @@ export const deserializeAws_json1_1GetAWSOrganizationsAccessStatusCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAWSOrganizationsAccessStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAWSOrganizationsAccessStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4928,7 +4928,7 @@ export const deserializeAws_json1_1ListAcceptedPortfolioSharesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAcceptedPortfolioSharesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAcceptedPortfolioSharesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4991,7 +4991,7 @@ export const deserializeAws_json1_1ListBudgetsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListBudgetsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListBudgetsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5054,7 +5054,7 @@ export const deserializeAws_json1_1ListConstraintsForPortfolioCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConstraintsForPortfolioCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListConstraintsForPortfolioCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5117,7 +5117,7 @@ export const deserializeAws_json1_1ListLaunchPathsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLaunchPathsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLaunchPathsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5180,7 +5180,7 @@ export const deserializeAws_json1_1ListOrganizationPortfolioAccessCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOrganizationPortfolioAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListOrganizationPortfolioAccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5251,7 +5251,7 @@ export const deserializeAws_json1_1ListPortfolioAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPortfolioAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPortfolioAccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5314,7 +5314,7 @@ export const deserializeAws_json1_1ListPortfoliosCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPortfoliosCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPortfoliosCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5369,7 +5369,7 @@ export const deserializeAws_json1_1ListPortfoliosForProductCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPortfoliosForProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPortfoliosForProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5432,7 +5432,7 @@ export const deserializeAws_json1_1ListPrincipalsForPortfolioCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPrincipalsForPortfolioCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListPrincipalsForPortfolioCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5495,7 +5495,7 @@ export const deserializeAws_json1_1ListProvisionedProductPlansCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProvisionedProductPlansCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProvisionedProductPlansCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5558,7 +5558,7 @@ export const deserializeAws_json1_1ListProvisioningArtifactsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProvisioningArtifactsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProvisioningArtifactsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5621,7 +5621,7 @@ export const deserializeAws_json1_1ListProvisioningArtifactsForServiceActionComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProvisioningArtifactsForServiceActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProvisioningArtifactsForServiceActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5684,7 +5684,7 @@ export const deserializeAws_json1_1ListRecordHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRecordHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRecordHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5739,7 +5739,7 @@ export const deserializeAws_json1_1ListResourcesForTagOptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourcesForTagOptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourcesForTagOptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5810,7 +5810,7 @@ export const deserializeAws_json1_1ListServiceActionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServiceActionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListServiceActionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5865,7 +5865,7 @@ export const deserializeAws_json1_1ListServiceActionsForProvisioningArtifactComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServiceActionsForProvisioningArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListServiceActionsForProvisioningArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5928,7 +5928,7 @@ export const deserializeAws_json1_1ListStackInstancesForProvisionedProductComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStackInstancesForProvisionedProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListStackInstancesForProvisionedProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5991,7 +5991,7 @@ export const deserializeAws_json1_1ListTagOptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6054,7 +6054,7 @@ export const deserializeAws_json1_1ProvisionProductCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ProvisionProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ProvisionProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6125,7 +6125,7 @@ export const deserializeAws_json1_1RejectPortfolioShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RejectPortfolioShareCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RejectPortfolioShareCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6180,7 +6180,7 @@ export const deserializeAws_json1_1ScanProvisionedProductsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ScanProvisionedProductsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ScanProvisionedProductsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6235,7 +6235,7 @@ export const deserializeAws_json1_1SearchProductsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchProductsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchProductsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6290,7 +6290,7 @@ export const deserializeAws_json1_1SearchProductsAsAdminCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchProductsAsAdminCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchProductsAsAdminCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6353,7 +6353,7 @@ export const deserializeAws_json1_1SearchProvisionedProductsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SearchProvisionedProductsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SearchProvisionedProductsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6408,7 +6408,7 @@ export const deserializeAws_json1_1TerminateProvisionedProductCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateProvisionedProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TerminateProvisionedProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6463,7 +6463,7 @@ export const deserializeAws_json1_1UpdateConstraintCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConstraintCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateConstraintCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6526,7 +6526,7 @@ export const deserializeAws_json1_1UpdatePortfolioCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePortfolioCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePortfolioCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6605,7 +6605,7 @@ export const deserializeAws_json1_1UpdateProductCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6676,7 +6676,7 @@ export const deserializeAws_json1_1UpdateProvisionedProductCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProvisionedProductCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateProvisionedProductCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6739,7 +6739,7 @@ export const deserializeAws_json1_1UpdateProvisionedProductPropertiesCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProvisionedProductPropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateProvisionedProductPropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6810,7 +6810,7 @@ export const deserializeAws_json1_1UpdateProvisioningArtifactCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateProvisioningArtifactCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateProvisioningArtifactCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6873,7 +6873,7 @@ export const deserializeAws_json1_1UpdateServiceActionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServiceActionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateServiceActionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6936,7 +6936,7 @@ export const deserializeAws_json1_1UpdateTagOptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTagOptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateTagOptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-service-quotas/protocols/Aws_json1_1.ts
+++ b/clients/client-service-quotas/protocols/Aws_json1_1.ts
@@ -331,7 +331,7 @@ export const deserializeAws_json1_1AssociateServiceQuotaTemplateCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateServiceQuotaTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateServiceQuotaTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -442,7 +442,7 @@ export const deserializeAws_json1_1DeleteServiceQuotaIncreaseRequestFromTemplate
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteServiceQuotaIncreaseRequestFromTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteServiceQuotaIncreaseRequestFromTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -561,7 +561,7 @@ export const deserializeAws_json1_1DisassociateServiceQuotaTemplateCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateServiceQuotaTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateServiceQuotaTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -672,7 +672,7 @@ export const deserializeAws_json1_1GetAssociationForServiceQuotaTemplateCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAssociationForServiceQuotaTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAssociationForServiceQuotaTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -783,7 +783,7 @@ export const deserializeAws_json1_1GetAWSDefaultServiceQuotaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAWSDefaultServiceQuotaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAWSDefaultServiceQuotaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -870,7 +870,7 @@ export const deserializeAws_json1_1GetRequestedServiceQuotaChangeCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRequestedServiceQuotaChangeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRequestedServiceQuotaChangeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -957,7 +957,7 @@ export const deserializeAws_json1_1GetServiceQuotaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServiceQuotaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetServiceQuotaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1044,7 +1044,7 @@ export const deserializeAws_json1_1GetServiceQuotaIncreaseRequestFromTemplateCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServiceQuotaIncreaseRequestFromTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetServiceQuotaIncreaseRequestFromTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1163,7 +1163,7 @@ export const deserializeAws_json1_1ListAWSDefaultServiceQuotasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAWSDefaultServiceQuotasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAWSDefaultServiceQuotasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1258,7 +1258,7 @@ export const deserializeAws_json1_1ListRequestedServiceQuotaChangeHistoryCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRequestedServiceQuotaChangeHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRequestedServiceQuotaChangeHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1353,7 +1353,7 @@ export const deserializeAws_json1_1ListRequestedServiceQuotaChangeHistoryByQuota
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRequestedServiceQuotaChangeHistoryByQuotaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRequestedServiceQuotaChangeHistoryByQuotaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1448,7 +1448,7 @@ export const deserializeAws_json1_1ListServiceQuotaIncreaseRequestsInTemplateCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServiceQuotaIncreaseRequestsInTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListServiceQuotaIncreaseRequestsInTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1559,7 +1559,7 @@ export const deserializeAws_json1_1ListServiceQuotasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServiceQuotasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListServiceQuotasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1654,7 +1654,7 @@ export const deserializeAws_json1_1ListServicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListServicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1741,7 +1741,7 @@ export const deserializeAws_json1_1PutServiceQuotaIncreaseRequestIntoTemplateCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutServiceQuotaIncreaseRequestIntoTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutServiceQuotaIncreaseRequestIntoTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1868,7 +1868,7 @@ export const deserializeAws_json1_1RequestServiceQuotaIncreaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RequestServiceQuotaIncreaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RequestServiceQuotaIncreaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-servicediscovery/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/protocols/Aws_json1_1.ts
@@ -449,7 +449,7 @@ export const deserializeAws_json1_1CreateHttpNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateHttpNamespaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateHttpNamespaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -536,7 +536,7 @@ export const deserializeAws_json1_1CreatePrivateDnsNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePrivateDnsNamespaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePrivateDnsNamespaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -623,7 +623,7 @@ export const deserializeAws_json1_1CreatePublicDnsNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePublicDnsNamespaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePublicDnsNamespaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -710,7 +710,7 @@ export const deserializeAws_json1_1CreateServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateServiceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateServiceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -797,7 +797,7 @@ export const deserializeAws_json1_1DeleteNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNamespaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteNamespaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -876,7 +876,7 @@ export const deserializeAws_json1_1DeleteServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteServiceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteServiceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -947,7 +947,7 @@ export const deserializeAws_json1_1DeregisterInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1034,7 +1034,7 @@ export const deserializeAws_json1_1DiscoverInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DiscoverInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DiscoverInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1113,7 +1113,7 @@ export const deserializeAws_json1_1GetInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1184,7 +1184,7 @@ export const deserializeAws_json1_1GetInstancesHealthStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInstancesHealthStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInstancesHealthStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1255,7 +1255,7 @@ export const deserializeAws_json1_1GetNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetNamespaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetNamespaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1318,7 +1318,7 @@ export const deserializeAws_json1_1GetOperationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOperationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOperationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1381,7 +1381,7 @@ export const deserializeAws_json1_1GetServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServiceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetServiceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1444,7 +1444,7 @@ export const deserializeAws_json1_1ListInstancesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInstancesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListInstancesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1507,7 +1507,7 @@ export const deserializeAws_json1_1ListNamespacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListNamespacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListNamespacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1562,7 +1562,7 @@ export const deserializeAws_json1_1ListOperationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOperationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListOperationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1617,7 +1617,7 @@ export const deserializeAws_json1_1ListServicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListServicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1672,7 +1672,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1735,7 +1735,7 @@ export const deserializeAws_json1_1RegisterInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1822,7 +1822,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1893,7 +1893,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1956,7 +1956,7 @@ export const deserializeAws_json1_1UpdateInstanceCustomHealthStatusCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateInstanceCustomHealthStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateInstanceCustomHealthStatusCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2032,7 +2032,7 @@ export const deserializeAws_json1_1UpdateServiceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServiceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateServiceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -1576,7 +1576,7 @@ export const deserializeAws_queryCloneReceiptRuleSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CloneReceiptRuleSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCloneReceiptRuleSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1646,7 +1646,7 @@ export const deserializeAws_queryCreateConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateConfigurationSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1716,7 +1716,7 @@ export const deserializeAws_queryCreateConfigurationSetEventDestinationCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateConfigurationSetEventDestinationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1813,7 +1813,7 @@ export const deserializeAws_queryCreateConfigurationSetTrackingOptionsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationSetTrackingOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateConfigurationSetTrackingOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1886,7 +1886,7 @@ export const deserializeAws_queryCreateCustomVerificationEmailTemplateCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCustomVerificationEmailTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateCustomVerificationEmailTemplateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1964,7 +1964,7 @@ export const deserializeAws_queryCreateReceiptFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReceiptFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateReceiptFilterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2026,7 +2026,7 @@ export const deserializeAws_queryCreateReceiptRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReceiptRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateReceiptRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2128,7 +2128,7 @@ export const deserializeAws_queryCreateReceiptRuleSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReceiptRuleSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateReceiptRuleSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2190,7 +2190,7 @@ export const deserializeAws_queryCreateTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2260,7 +2260,7 @@ export const deserializeAws_queryDeleteConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteConfigurationSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2314,7 +2314,7 @@ export const deserializeAws_queryDeleteConfigurationSetEventDestinationCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteConfigurationSetEventDestinationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2379,7 +2379,7 @@ export const deserializeAws_queryDeleteConfigurationSetTrackingOptionsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationSetTrackingOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteConfigurationSetTrackingOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2444,7 +2444,7 @@ export const deserializeAws_queryDeleteCustomVerificationEmailTemplateCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCustomVerificationEmailTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteCustomVerificationEmailTemplateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2487,7 +2487,7 @@ export const deserializeAws_queryDeleteIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteIdentityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2533,7 +2533,7 @@ export const deserializeAws_queryDeleteIdentityPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIdentityPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteIdentityPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2579,7 +2579,7 @@ export const deserializeAws_queryDeleteReceiptFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReceiptFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteReceiptFilterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2625,7 +2625,7 @@ export const deserializeAws_queryDeleteReceiptRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReceiptRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteReceiptRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2679,7 +2679,7 @@ export const deserializeAws_queryDeleteReceiptRuleSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReceiptRuleSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteReceiptRuleSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2733,7 +2733,7 @@ export const deserializeAws_queryDeleteTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2779,7 +2779,7 @@ export const deserializeAws_queryDeleteVerifiedEmailAddressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVerifiedEmailAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteVerifiedEmailAddressCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2822,7 +2822,7 @@ export const deserializeAws_queryDescribeActiveReceiptRuleSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeActiveReceiptRuleSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeActiveReceiptRuleSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2868,7 +2868,7 @@ export const deserializeAws_queryDescribeConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeConfigurationSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeConfigurationSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2922,7 +2922,7 @@ export const deserializeAws_queryDescribeReceiptRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReceiptRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeReceiptRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2984,7 +2984,7 @@ export const deserializeAws_queryDescribeReceiptRuleSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeReceiptRuleSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDescribeReceiptRuleSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3038,7 +3038,7 @@ export const deserializeAws_queryGetAccountSendingEnabledCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountSendingEnabledCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetAccountSendingEnabledCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3084,7 +3084,7 @@ export const deserializeAws_queryGetCustomVerificationEmailTemplateCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCustomVerificationEmailTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetCustomVerificationEmailTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3144,7 +3144,7 @@ export const deserializeAws_queryGetIdentityDkimAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIdentityDkimAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetIdentityDkimAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3190,7 +3190,7 @@ export const deserializeAws_queryGetIdentityMailFromDomainAttributesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIdentityMailFromDomainAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetIdentityMailFromDomainAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3239,7 +3239,7 @@ export const deserializeAws_queryGetIdentityNotificationAttributesCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIdentityNotificationAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetIdentityNotificationAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3288,7 +3288,7 @@ export const deserializeAws_queryGetIdentityPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIdentityPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetIdentityPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3334,7 +3334,7 @@ export const deserializeAws_queryGetIdentityVerificationAttributesCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIdentityVerificationAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetIdentityVerificationAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3383,7 +3383,7 @@ export const deserializeAws_queryGetSendQuotaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSendQuotaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetSendQuotaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3429,7 +3429,7 @@ export const deserializeAws_queryGetSendStatisticsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSendStatisticsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetSendStatisticsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3475,7 +3475,7 @@ export const deserializeAws_queryGetTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3529,7 +3529,7 @@ export const deserializeAws_queryListConfigurationSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListConfigurationSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3575,7 +3575,7 @@ export const deserializeAws_queryListCustomVerificationEmailTemplatesCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCustomVerificationEmailTemplatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListCustomVerificationEmailTemplatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3624,7 +3624,7 @@ export const deserializeAws_queryListIdentitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIdentitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListIdentitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3670,7 +3670,7 @@ export const deserializeAws_queryListIdentityPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIdentityPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListIdentityPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3716,7 +3716,7 @@ export const deserializeAws_queryListReceiptFiltersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListReceiptFiltersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListReceiptFiltersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3762,7 +3762,7 @@ export const deserializeAws_queryListReceiptRuleSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListReceiptRuleSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListReceiptRuleSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3808,7 +3808,7 @@ export const deserializeAws_queryListTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTemplatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTemplatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3854,7 +3854,7 @@ export const deserializeAws_queryListVerifiedEmailAddressesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVerifiedEmailAddressesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListVerifiedEmailAddressesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3900,7 +3900,7 @@ export const deserializeAws_queryPutConfigurationSetDeliveryOptionsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationSetDeliveryOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutConfigurationSetDeliveryOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3965,7 +3965,7 @@ export const deserializeAws_queryPutIdentityPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutIdentityPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPutIdentityPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4019,7 +4019,7 @@ export const deserializeAws_queryReorderReceiptRuleSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReorderReceiptRuleSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryReorderReceiptRuleSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4081,7 +4081,7 @@ export const deserializeAws_querySendBounceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendBounceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySendBounceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4135,7 +4135,7 @@ export const deserializeAws_querySendBulkTemplatedEmailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendBulkTemplatedEmailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySendBulkTemplatedEmailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4229,7 +4229,7 @@ export const deserializeAws_querySendCustomVerificationEmailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendCustomVerificationEmailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySendCustomVerificationEmailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4318,7 +4318,7 @@ export const deserializeAws_querySendEmailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendEmailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySendEmailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4404,7 +4404,7 @@ export const deserializeAws_querySendRawEmailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendRawEmailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySendRawEmailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4490,7 +4490,7 @@ export const deserializeAws_querySendTemplatedEmailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendTemplatedEmailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySendTemplatedEmailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4584,7 +4584,7 @@ export const deserializeAws_querySetActiveReceiptRuleSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetActiveReceiptRuleSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetActiveReceiptRuleSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4638,7 +4638,7 @@ export const deserializeAws_querySetIdentityDkimEnabledCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetIdentityDkimEnabledCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetIdentityDkimEnabledCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4684,7 +4684,7 @@ export const deserializeAws_querySetIdentityFeedbackForwardingEnabledCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetIdentityFeedbackForwardingEnabledCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetIdentityFeedbackForwardingEnabledCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4733,7 +4733,7 @@ export const deserializeAws_querySetIdentityHeadersInNotificationsEnabledCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetIdentityHeadersInNotificationsEnabledCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetIdentityHeadersInNotificationsEnabledCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4782,7 +4782,7 @@ export const deserializeAws_querySetIdentityMailFromDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetIdentityMailFromDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetIdentityMailFromDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4828,7 +4828,7 @@ export const deserializeAws_querySetIdentityNotificationTopicCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetIdentityNotificationTopicCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetIdentityNotificationTopicCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4874,7 +4874,7 @@ export const deserializeAws_querySetReceiptRulePositionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetReceiptRulePositionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetReceiptRulePositionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4936,7 +4936,7 @@ export const deserializeAws_queryTestRenderTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestRenderTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryTestRenderTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5006,7 +5006,7 @@ export const deserializeAws_queryUpdateAccountSendingEnabledCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAccountSendingEnabledCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateAccountSendingEnabledCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5049,7 +5049,7 @@ export const deserializeAws_queryUpdateConfigurationSetEventDestinationCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateConfigurationSetEventDestinationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5138,7 +5138,7 @@ export const deserializeAws_queryUpdateConfigurationSetReputationMetricsEnabledC
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigurationSetReputationMetricsEnabledCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateConfigurationSetReputationMetricsEnabledCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5189,7 +5189,7 @@ export const deserializeAws_queryUpdateConfigurationSetSendingEnabledCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigurationSetSendingEnabledCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateConfigurationSetSendingEnabledCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5240,7 +5240,7 @@ export const deserializeAws_queryUpdateConfigurationSetTrackingOptionsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigurationSetTrackingOptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateConfigurationSetTrackingOptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5313,7 +5313,7 @@ export const deserializeAws_queryUpdateCustomVerificationEmailTemplateCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCustomVerificationEmailTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateCustomVerificationEmailTemplateCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5383,7 +5383,7 @@ export const deserializeAws_queryUpdateReceiptRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateReceiptRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateReceiptRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5477,7 +5477,7 @@ export const deserializeAws_queryUpdateTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUpdateTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5539,7 +5539,7 @@ export const deserializeAws_queryVerifyDomainDkimCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<VerifyDomainDkimCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryVerifyDomainDkimCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5585,7 +5585,7 @@ export const deserializeAws_queryVerifyDomainIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<VerifyDomainIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryVerifyDomainIdentityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5631,7 +5631,7 @@ export const deserializeAws_queryVerifyEmailAddressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<VerifyEmailAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryVerifyEmailAddressCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -5674,7 +5674,7 @@ export const deserializeAws_queryVerifyEmailIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<VerifyEmailIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryVerifyEmailIdentityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-sesv2/protocols/Aws_restJson1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1.ts
@@ -2395,7 +2395,7 @@ export const deserializeAws_restJson1CreateConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConfigurationSetCommandError(output, context);
   }
   const contents: CreateConfigurationSetCommandOutput = {
@@ -2486,7 +2486,7 @@ export const deserializeAws_restJson1CreateConfigurationSetEventDestinationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateConfigurationSetEventDestinationCommandError(output, context);
   }
   const contents: CreateConfigurationSetEventDestinationCommandOutput = {
@@ -2569,7 +2569,7 @@ export const deserializeAws_restJson1CreateCustomVerificationEmailTemplateComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCustomVerificationEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCustomVerificationEmailTemplateCommandError(output, context);
   }
   const contents: CreateCustomVerificationEmailTemplateCommandOutput = {
@@ -2652,7 +2652,7 @@ export const deserializeAws_restJson1CreateDedicatedIpPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDedicatedIpPoolCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDedicatedIpPoolCommandError(output, context);
   }
   const contents: CreateDedicatedIpPoolCommandOutput = {
@@ -2735,7 +2735,7 @@ export const deserializeAws_restJson1CreateDeliverabilityTestReportCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDeliverabilityTestReportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateDeliverabilityTestReportCommandError(output, context);
   }
   const contents: CreateDeliverabilityTestReportCommandOutput = {
@@ -2858,7 +2858,7 @@ export const deserializeAws_restJson1CreateEmailIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEmailIdentityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateEmailIdentityCommandError(output, context);
   }
   const contents: CreateEmailIdentityCommandOutput = {
@@ -2953,7 +2953,7 @@ export const deserializeAws_restJson1CreateEmailIdentityPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEmailIdentityPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateEmailIdentityPolicyCommandError(output, context);
   }
   const contents: CreateEmailIdentityPolicyCommandOutput = {
@@ -3036,7 +3036,7 @@ export const deserializeAws_restJson1CreateEmailTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateEmailTemplateCommandError(output, context);
   }
   const contents: CreateEmailTemplateCommandOutput = {
@@ -3111,7 +3111,7 @@ export const deserializeAws_restJson1DeleteConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteConfigurationSetCommandError(output, context);
   }
   const contents: DeleteConfigurationSetCommandOutput = {
@@ -3186,7 +3186,7 @@ export const deserializeAws_restJson1DeleteConfigurationSetEventDestinationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteConfigurationSetEventDestinationCommandError(output, context);
   }
   const contents: DeleteConfigurationSetEventDestinationCommandOutput = {
@@ -3253,7 +3253,7 @@ export const deserializeAws_restJson1DeleteCustomVerificationEmailTemplateComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCustomVerificationEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteCustomVerificationEmailTemplateCommandError(output, context);
   }
   const contents: DeleteCustomVerificationEmailTemplateCommandOutput = {
@@ -3320,7 +3320,7 @@ export const deserializeAws_restJson1DeleteDedicatedIpPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDedicatedIpPoolCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDedicatedIpPoolCommandError(output, context);
   }
   const contents: DeleteDedicatedIpPoolCommandOutput = {
@@ -3395,7 +3395,7 @@ export const deserializeAws_restJson1DeleteEmailIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEmailIdentityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEmailIdentityCommandError(output, context);
   }
   const contents: DeleteEmailIdentityCommandOutput = {
@@ -3470,7 +3470,7 @@ export const deserializeAws_restJson1DeleteEmailIdentityPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEmailIdentityPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEmailIdentityPolicyCommandError(output, context);
   }
   const contents: DeleteEmailIdentityPolicyCommandOutput = {
@@ -3537,7 +3537,7 @@ export const deserializeAws_restJson1DeleteEmailTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteEmailTemplateCommandError(output, context);
   }
   const contents: DeleteEmailTemplateCommandOutput = {
@@ -3604,7 +3604,7 @@ export const deserializeAws_restJson1DeleteSuppressedDestinationCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSuppressedDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSuppressedDestinationCommandError(output, context);
   }
   const contents: DeleteSuppressedDestinationCommandOutput = {
@@ -3671,7 +3671,7 @@ export const deserializeAws_restJson1GetAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccountCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetAccountCommandError(output, context);
   }
   const contents: GetAccountCommandOutput = {
@@ -3758,7 +3758,7 @@ export const deserializeAws_restJson1GetBlacklistReportsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetBlacklistReportsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetBlacklistReportsCommandError(output, context);
   }
   const contents: GetBlacklistReportsCommandOutput = {
@@ -3829,7 +3829,7 @@ export const deserializeAws_restJson1GetConfigurationSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConfigurationSetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConfigurationSetCommandError(output, context);
   }
   const contents: GetConfigurationSetCommandOutput = {
@@ -3924,7 +3924,7 @@ export const deserializeAws_restJson1GetConfigurationSetEventDestinationsCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConfigurationSetEventDestinationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetConfigurationSetEventDestinationsCommandError(output, context);
   }
   const contents: GetConfigurationSetEventDestinationsCommandOutput = {
@@ -3995,7 +3995,7 @@ export const deserializeAws_restJson1GetCustomVerificationEmailTemplateCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCustomVerificationEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCustomVerificationEmailTemplateCommandError(output, context);
   }
   const contents: GetCustomVerificationEmailTemplateCommandOutput = {
@@ -4086,7 +4086,7 @@ export const deserializeAws_restJson1GetDedicatedIpCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDedicatedIpCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDedicatedIpCommandError(output, context);
   }
   const contents: GetDedicatedIpCommandOutput = {
@@ -4157,7 +4157,7 @@ export const deserializeAws_restJson1GetDedicatedIpsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDedicatedIpsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDedicatedIpsCommandError(output, context);
   }
   const contents: GetDedicatedIpsCommandOutput = {
@@ -4232,7 +4232,7 @@ export const deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeliverabilityDashboardOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeliverabilityDashboardOptionsCommandError(output, context);
   }
   const contents: GetDeliverabilityDashboardOptionsCommandOutput = {
@@ -4325,7 +4325,7 @@ export const deserializeAws_restJson1GetDeliverabilityTestReportCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeliverabilityTestReportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDeliverabilityTestReportCommandError(output, context);
   }
   const contents: GetDeliverabilityTestReportCommandOutput = {
@@ -4415,7 +4415,7 @@ export const deserializeAws_restJson1GetDomainDeliverabilityCampaignCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainDeliverabilityCampaignCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDomainDeliverabilityCampaignCommandError(output, context);
   }
   const contents: GetDomainDeliverabilityCampaignCommandOutput = {
@@ -4489,7 +4489,7 @@ export const deserializeAws_restJson1GetDomainStatisticsReportCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDomainStatisticsReportCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDomainStatisticsReportCommandError(output, context);
   }
   const contents: GetDomainStatisticsReportCommandOutput = {
@@ -4564,7 +4564,7 @@ export const deserializeAws_restJson1GetEmailIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEmailIdentityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEmailIdentityCommandError(output, context);
   }
   const contents: GetEmailIdentityCommandOutput = {
@@ -4659,7 +4659,7 @@ export const deserializeAws_restJson1GetEmailIdentityPoliciesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEmailIdentityPoliciesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEmailIdentityPoliciesCommandError(output, context);
   }
   const contents: GetEmailIdentityPoliciesCommandOutput = {
@@ -4730,7 +4730,7 @@ export const deserializeAws_restJson1GetEmailTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEmailTemplateCommandError(output, context);
   }
   const contents: GetEmailTemplateCommandOutput = {
@@ -4805,7 +4805,7 @@ export const deserializeAws_restJson1GetSuppressedDestinationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSuppressedDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSuppressedDestinationCommandError(output, context);
   }
   const contents: GetSuppressedDestinationCommandOutput = {
@@ -4876,7 +4876,7 @@ export const deserializeAws_restJson1ListConfigurationSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListConfigurationSetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListConfigurationSetsCommandError(output, context);
   }
   const contents: ListConfigurationSetsCommandOutput = {
@@ -4943,7 +4943,7 @@ export const deserializeAws_restJson1ListCustomVerificationEmailTemplatesCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCustomVerificationEmailTemplatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListCustomVerificationEmailTemplatesCommandError(output, context);
   }
   const contents: ListCustomVerificationEmailTemplatesCommandOutput = {
@@ -5013,7 +5013,7 @@ export const deserializeAws_restJson1ListDedicatedIpPoolsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDedicatedIpPoolsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDedicatedIpPoolsCommandError(output, context);
   }
   const contents: ListDedicatedIpPoolsCommandOutput = {
@@ -5080,7 +5080,7 @@ export const deserializeAws_restJson1ListDeliverabilityTestReportsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeliverabilityTestReportsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDeliverabilityTestReportsCommandError(output, context);
   }
   const contents: ListDeliverabilityTestReportsCommandOutput = {
@@ -5158,7 +5158,7 @@ export const deserializeAws_restJson1ListDomainDeliverabilityCampaignsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainDeliverabilityCampaignsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDomainDeliverabilityCampaignsCommandError(output, context);
   }
   const contents: ListDomainDeliverabilityCampaignsCommandOutput = {
@@ -5236,7 +5236,7 @@ export const deserializeAws_restJson1ListEmailIdentitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEmailIdentitiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListEmailIdentitiesCommandError(output, context);
   }
   const contents: ListEmailIdentitiesCommandOutput = {
@@ -5303,7 +5303,7 @@ export const deserializeAws_restJson1ListEmailTemplatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEmailTemplatesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListEmailTemplatesCommandError(output, context);
   }
   const contents: ListEmailTemplatesCommandOutput = {
@@ -5370,7 +5370,7 @@ export const deserializeAws_restJson1ListSuppressedDestinationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSuppressedDestinationsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSuppressedDestinationsCommandError(output, context);
   }
   const contents: ListSuppressedDestinationsCommandOutput = {
@@ -5448,7 +5448,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -5519,7 +5519,7 @@ export const deserializeAws_restJson1PutAccountDedicatedIpWarmupAttributesComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAccountDedicatedIpWarmupAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutAccountDedicatedIpWarmupAttributesCommandError(output, context);
   }
   const contents: PutAccountDedicatedIpWarmupAttributesCommandOutput = {
@@ -5578,7 +5578,7 @@ export const deserializeAws_restJson1PutAccountDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAccountDetailsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutAccountDetailsCommandError(output, context);
   }
   const contents: PutAccountDetailsCommandOutput = {
@@ -5645,7 +5645,7 @@ export const deserializeAws_restJson1PutAccountSendingAttributesCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAccountSendingAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutAccountSendingAttributesCommandError(output, context);
   }
   const contents: PutAccountSendingAttributesCommandOutput = {
@@ -5704,7 +5704,7 @@ export const deserializeAws_restJson1PutAccountSuppressionAttributesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAccountSuppressionAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutAccountSuppressionAttributesCommandError(output, context);
   }
   const contents: PutAccountSuppressionAttributesCommandOutput = {
@@ -5763,7 +5763,7 @@ export const deserializeAws_restJson1PutConfigurationSetDeliveryOptionsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationSetDeliveryOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutConfigurationSetDeliveryOptionsCommandError(output, context);
   }
   const contents: PutConfigurationSetDeliveryOptionsCommandOutput = {
@@ -5830,7 +5830,7 @@ export const deserializeAws_restJson1PutConfigurationSetReputationOptionsCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationSetReputationOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutConfigurationSetReputationOptionsCommandError(output, context);
   }
   const contents: PutConfigurationSetReputationOptionsCommandOutput = {
@@ -5897,7 +5897,7 @@ export const deserializeAws_restJson1PutConfigurationSetSendingOptionsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationSetSendingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutConfigurationSetSendingOptionsCommandError(output, context);
   }
   const contents: PutConfigurationSetSendingOptionsCommandOutput = {
@@ -5964,7 +5964,7 @@ export const deserializeAws_restJson1PutConfigurationSetSuppressionOptionsComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationSetSuppressionOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutConfigurationSetSuppressionOptionsCommandError(output, context);
   }
   const contents: PutConfigurationSetSuppressionOptionsCommandOutput = {
@@ -6031,7 +6031,7 @@ export const deserializeAws_restJson1PutConfigurationSetTrackingOptionsCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutConfigurationSetTrackingOptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutConfigurationSetTrackingOptionsCommandError(output, context);
   }
   const contents: PutConfigurationSetTrackingOptionsCommandOutput = {
@@ -6098,7 +6098,7 @@ export const deserializeAws_restJson1PutDedicatedIpInPoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDedicatedIpInPoolCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutDedicatedIpInPoolCommandError(output, context);
   }
   const contents: PutDedicatedIpInPoolCommandOutput = {
@@ -6165,7 +6165,7 @@ export const deserializeAws_restJson1PutDedicatedIpWarmupAttributesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDedicatedIpWarmupAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutDedicatedIpWarmupAttributesCommandError(output, context);
   }
   const contents: PutDedicatedIpWarmupAttributesCommandOutput = {
@@ -6232,7 +6232,7 @@ export const deserializeAws_restJson1PutDeliverabilityDashboardOptionCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutDeliverabilityDashboardOptionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutDeliverabilityDashboardOptionCommandError(output, context);
   }
   const contents: PutDeliverabilityDashboardOptionCommandOutput = {
@@ -6315,7 +6315,7 @@ export const deserializeAws_restJson1PutEmailIdentityDkimAttributesCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEmailIdentityDkimAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEmailIdentityDkimAttributesCommandError(output, context);
   }
   const contents: PutEmailIdentityDkimAttributesCommandOutput = {
@@ -6382,7 +6382,7 @@ export const deserializeAws_restJson1PutEmailIdentityDkimSigningAttributesComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEmailIdentityDkimSigningAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEmailIdentityDkimSigningAttributesCommandError(output, context);
   }
   const contents: PutEmailIdentityDkimSigningAttributesCommandOutput = {
@@ -6457,7 +6457,7 @@ export const deserializeAws_restJson1PutEmailIdentityFeedbackAttributesCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEmailIdentityFeedbackAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEmailIdentityFeedbackAttributesCommandError(output, context);
   }
   const contents: PutEmailIdentityFeedbackAttributesCommandOutput = {
@@ -6524,7 +6524,7 @@ export const deserializeAws_restJson1PutEmailIdentityMailFromAttributesCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEmailIdentityMailFromAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEmailIdentityMailFromAttributesCommandError(output, context);
   }
   const contents: PutEmailIdentityMailFromAttributesCommandOutput = {
@@ -6591,7 +6591,7 @@ export const deserializeAws_restJson1PutSuppressedDestinationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutSuppressedDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutSuppressedDestinationCommandError(output, context);
   }
   const contents: PutSuppressedDestinationCommandOutput = {
@@ -6650,7 +6650,7 @@ export const deserializeAws_restJson1SendBulkEmailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendBulkEmailCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SendBulkEmailCommandError(output, context);
   }
   const contents: SendBulkEmailCommandOutput = {
@@ -6764,7 +6764,7 @@ export const deserializeAws_restJson1SendCustomVerificationEmailCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendCustomVerificationEmailCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SendCustomVerificationEmailCommandError(output, context);
   }
   const contents: SendCustomVerificationEmailCommandOutput = {
@@ -6867,7 +6867,7 @@ export const deserializeAws_restJson1SendEmailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendEmailCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SendEmailCommandError(output, context);
   }
   const contents: SendEmailCommandOutput = {
@@ -6978,7 +6978,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -7053,7 +7053,7 @@ export const deserializeAws_restJson1TestRenderEmailTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestRenderEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TestRenderEmailTemplateCommandError(output, context);
   }
   const contents: TestRenderEmailTemplateCommandOutput = {
@@ -7124,7 +7124,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -7199,7 +7199,7 @@ export const deserializeAws_restJson1UpdateConfigurationSetEventDestinationComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateConfigurationSetEventDestinationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateConfigurationSetEventDestinationCommandError(output, context);
   }
   const contents: UpdateConfigurationSetEventDestinationCommandOutput = {
@@ -7266,7 +7266,7 @@ export const deserializeAws_restJson1UpdateCustomVerificationEmailTemplateComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCustomVerificationEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateCustomVerificationEmailTemplateCommandError(output, context);
   }
   const contents: UpdateCustomVerificationEmailTemplateCommandOutput = {
@@ -7333,7 +7333,7 @@ export const deserializeAws_restJson1UpdateEmailIdentityPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEmailIdentityPolicyCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateEmailIdentityPolicyCommandError(output, context);
   }
   const contents: UpdateEmailIdentityPolicyCommandOutput = {
@@ -7400,7 +7400,7 @@ export const deserializeAws_restJson1UpdateEmailTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEmailTemplateCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateEmailTemplateCommandError(output, context);
   }
   const contents: UpdateEmailTemplateCommandOutput = {

--- a/clients/client-sfn/protocols/Aws_json1_0.ts
+++ b/clients/client-sfn/protocols/Aws_json1_0.ts
@@ -438,7 +438,7 @@ export const deserializeAws_json1_0CreateActivityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateActivityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CreateActivityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -509,7 +509,7 @@ export const deserializeAws_json1_0CreateStateMachineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStateMachineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CreateStateMachineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -628,7 +628,7 @@ export const deserializeAws_json1_0DeleteActivityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteActivityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DeleteActivityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -683,7 +683,7 @@ export const deserializeAws_json1_0DeleteStateMachineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteStateMachineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DeleteStateMachineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -738,7 +738,7 @@ export const deserializeAws_json1_0DescribeActivityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeActivityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeActivityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -801,7 +801,7 @@ export const deserializeAws_json1_0DescribeExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -864,7 +864,7 @@ export const deserializeAws_json1_0DescribeStateMachineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStateMachineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeStateMachineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -927,7 +927,7 @@ export const deserializeAws_json1_0DescribeStateMachineForExecutionCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStateMachineForExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeStateMachineForExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -990,7 +990,7 @@ export const deserializeAws_json1_0GetActivityTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetActivityTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetActivityTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1061,7 +1061,7 @@ export const deserializeAws_json1_0GetExecutionHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetExecutionHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetExecutionHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1132,7 +1132,7 @@ export const deserializeAws_json1_0ListActivitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListActivitiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListActivitiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1187,7 +1187,7 @@ export const deserializeAws_json1_0ListExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1266,7 +1266,7 @@ export const deserializeAws_json1_0ListStateMachinesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListStateMachinesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListStateMachinesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1321,7 +1321,7 @@ export const deserializeAws_json1_0ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1384,7 +1384,7 @@ export const deserializeAws_json1_0SendTaskFailureCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendTaskFailureCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0SendTaskFailureCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1455,7 +1455,7 @@ export const deserializeAws_json1_0SendTaskHeartbeatCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendTaskHeartbeatCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0SendTaskHeartbeatCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1526,7 +1526,7 @@ export const deserializeAws_json1_0SendTaskSuccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendTaskSuccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0SendTaskSuccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1605,7 +1605,7 @@ export const deserializeAws_json1_0StartExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0StartExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1708,7 +1708,7 @@ export const deserializeAws_json1_0StopExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0StopExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1771,7 +1771,7 @@ export const deserializeAws_json1_0TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1842,7 +1842,7 @@ export const deserializeAws_json1_0UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1905,7 +1905,7 @@ export const deserializeAws_json1_0UpdateStateMachineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateStateMachineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UpdateStateMachineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-shield/protocols/Aws_json1_1.ts
+++ b/clients/client-shield/protocols/Aws_json1_1.ts
@@ -445,7 +445,7 @@ export const deserializeAws_json1_1AssociateDRTLogBucketCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateDRTLogBucketCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateDRTLogBucketCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -556,7 +556,7 @@ export const deserializeAws_json1_1AssociateDRTRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateDRTRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateDRTRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -651,7 +651,7 @@ export const deserializeAws_json1_1AssociateHealthCheckCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateHealthCheckCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateHealthCheckCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -738,7 +738,7 @@ export const deserializeAws_json1_1AssociateProactiveEngagementDetailsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateProactiveEngagementDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateProactiveEngagementDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -825,7 +825,7 @@ export const deserializeAws_json1_1CreateProtectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateProtectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateProtectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -928,7 +928,7 @@ export const deserializeAws_json1_1CreateSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -991,7 +991,7 @@ export const deserializeAws_json1_1DeleteProtectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteProtectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteProtectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1062,7 +1062,7 @@ export const deserializeAws_json1_1DeleteSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1133,7 +1133,7 @@ export const deserializeAws_json1_1DescribeAttackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAttackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAttackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1196,7 +1196,7 @@ export const deserializeAws_json1_1DescribeDRTAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDRTAccessCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDRTAccessCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1259,7 +1259,7 @@ export const deserializeAws_json1_1DescribeEmergencyContactSettingsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEmergencyContactSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEmergencyContactSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1322,7 +1322,7 @@ export const deserializeAws_json1_1DescribeProtectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeProtectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeProtectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1393,7 +1393,7 @@ export const deserializeAws_json1_1DescribeSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1456,7 +1456,7 @@ export const deserializeAws_json1_1DisableProactiveEngagementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableProactiveEngagementCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableProactiveEngagementCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1543,7 +1543,7 @@ export const deserializeAws_json1_1DisassociateDRTLogBucketCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateDRTLogBucketCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateDRTLogBucketCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1638,7 +1638,7 @@ export const deserializeAws_json1_1DisassociateDRTRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateDRTRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateDRTRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1717,7 +1717,7 @@ export const deserializeAws_json1_1DisassociateHealthCheckCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateHealthCheckCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateHealthCheckCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1796,7 +1796,7 @@ export const deserializeAws_json1_1EnableProactiveEngagementCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EnableProactiveEngagementCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EnableProactiveEngagementCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1883,7 +1883,7 @@ export const deserializeAws_json1_1GetSubscriptionStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSubscriptionStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSubscriptionStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1938,7 +1938,7 @@ export const deserializeAws_json1_1ListAttacksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAttacksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAttacksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2009,7 +2009,7 @@ export const deserializeAws_json1_1ListProtectionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListProtectionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListProtectionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2080,7 +2080,7 @@ export const deserializeAws_json1_1UpdateEmergencyContactSettingsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateEmergencyContactSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateEmergencyContactSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2159,7 +2159,7 @@ export const deserializeAws_json1_1UpdateSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-signer/protocols/Aws_restJson1.ts
+++ b/clients/client-signer/protocols/Aws_restJson1.ts
@@ -441,7 +441,7 @@ export const deserializeAws_restJson1CancelSigningProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelSigningProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CancelSigningProfileCommandError(output, context);
   }
   const contents: CancelSigningProfileCommandOutput = {
@@ -516,7 +516,7 @@ export const deserializeAws_restJson1DescribeSigningJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSigningJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeSigningJobCommandError(output, context);
   }
   const contents: DescribeSigningJobCommandOutput = {
@@ -635,7 +635,7 @@ export const deserializeAws_restJson1GetSigningPlatformCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSigningPlatformCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSigningPlatformCommandError(output, context);
   }
   const contents: GetSigningPlatformCommandOutput = {
@@ -734,7 +734,7 @@ export const deserializeAws_restJson1GetSigningProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSigningProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSigningProfileCommandError(output, context);
   }
   const contents: GetSigningProfileCommandOutput = {
@@ -841,7 +841,7 @@ export const deserializeAws_restJson1ListSigningJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSigningJobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSigningJobsCommandError(output, context);
   }
   const contents: ListSigningJobsCommandOutput = {
@@ -924,7 +924,7 @@ export const deserializeAws_restJson1ListSigningPlatformsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSigningPlatformsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSigningPlatformsCommandError(output, context);
   }
   const contents: ListSigningPlatformsCommandOutput = {
@@ -1007,7 +1007,7 @@ export const deserializeAws_restJson1ListSigningProfilesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSigningProfilesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListSigningProfilesCommandError(output, context);
   }
   const contents: ListSigningProfilesCommandOutput = {
@@ -1082,7 +1082,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1153,7 +1153,7 @@ export const deserializeAws_restJson1PutSigningProfileCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutSigningProfileCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutSigningProfileCommandError(output, context);
   }
   const contents: PutSigningProfileCommandOutput = {
@@ -1240,7 +1240,7 @@ export const deserializeAws_restJson1StartSigningJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSigningJobCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartSigningJobCommandError(output, context);
   }
   const contents: StartSigningJobCommandOutput = {
@@ -1327,7 +1327,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1394,7 +1394,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {

--- a/clients/client-sms/protocols/Aws_json1_1.ts
+++ b/clients/client-sms/protocols/Aws_json1_1.ts
@@ -534,7 +534,7 @@ export const deserializeAws_json1_1CreateAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAppCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -621,7 +621,7 @@ export const deserializeAws_json1_1CreateReplicationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateReplicationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateReplicationJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -740,7 +740,7 @@ export const deserializeAws_json1_1DeleteAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAppCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -827,7 +827,7 @@ export const deserializeAws_json1_1DeleteAppLaunchConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAppLaunchConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAppLaunchConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -914,7 +914,7 @@ export const deserializeAws_json1_1DeleteAppReplicationConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAppReplicationConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAppReplicationConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1001,7 +1001,7 @@ export const deserializeAws_json1_1DeleteReplicationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteReplicationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteReplicationJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1088,7 +1088,7 @@ export const deserializeAws_json1_1DeleteServerCatalogCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteServerCatalogCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteServerCatalogCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1167,7 +1167,7 @@ export const deserializeAws_json1_1DisassociateConnectorCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateConnectorCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateConnectorCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1246,7 +1246,7 @@ export const deserializeAws_json1_1GenerateChangeSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateChangeSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GenerateChangeSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1333,7 +1333,7 @@ export const deserializeAws_json1_1GenerateTemplateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GenerateTemplateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GenerateTemplateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1420,7 +1420,7 @@ export const deserializeAws_json1_1GetAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAppCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1507,7 +1507,7 @@ export const deserializeAws_json1_1GetAppLaunchConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAppLaunchConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAppLaunchConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1594,7 +1594,7 @@ export const deserializeAws_json1_1GetAppReplicationConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAppReplicationConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAppReplicationConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1681,7 +1681,7 @@ export const deserializeAws_json1_1GetConnectorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConnectorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetConnectorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1736,7 +1736,7 @@ export const deserializeAws_json1_1GetReplicationJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetReplicationJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetReplicationJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1807,7 +1807,7 @@ export const deserializeAws_json1_1GetReplicationRunsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetReplicationRunsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetReplicationRunsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1878,7 +1878,7 @@ export const deserializeAws_json1_1GetServersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetServersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1933,7 +1933,7 @@ export const deserializeAws_json1_1ImportServerCatalogCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportServerCatalogCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportServerCatalogCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2020,7 +2020,7 @@ export const deserializeAws_json1_1LaunchAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<LaunchAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1LaunchAppCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2107,7 +2107,7 @@ export const deserializeAws_json1_1ListAppsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAppsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAppsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2194,7 +2194,7 @@ export const deserializeAws_json1_1PutAppLaunchConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAppLaunchConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutAppLaunchConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2281,7 +2281,7 @@ export const deserializeAws_json1_1PutAppReplicationConfigurationCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutAppReplicationConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutAppReplicationConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2368,7 +2368,7 @@ export const deserializeAws_json1_1StartAppReplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartAppReplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartAppReplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2455,7 +2455,7 @@ export const deserializeAws_json1_1StartOnDemandReplicationRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartOnDemandReplicationRunCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartOnDemandReplicationRunCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2542,7 +2542,7 @@ export const deserializeAws_json1_1StopAppReplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopAppReplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopAppReplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2629,7 +2629,7 @@ export const deserializeAws_json1_1TerminateAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TerminateAppCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2716,7 +2716,7 @@ export const deserializeAws_json1_1UpdateAppCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAppCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAppCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2803,7 +2803,7 @@ export const deserializeAws_json1_1UpdateReplicationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateReplicationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateReplicationJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-snowball/protocols/Aws_json1_1.ts
+++ b/clients/client-snowball/protocols/Aws_json1_1.ts
@@ -353,7 +353,7 @@ export const deserializeAws_json1_1CancelClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -424,7 +424,7 @@ export const deserializeAws_json1_1CancelJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -495,7 +495,7 @@ export const deserializeAws_json1_1CreateAddressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAddressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -558,7 +558,7 @@ export const deserializeAws_json1_1CreateClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -637,7 +637,7 @@ export const deserializeAws_json1_1CreateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -724,7 +724,7 @@ export const deserializeAws_json1_1DescribeAddressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAddressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -779,7 +779,7 @@ export const deserializeAws_json1_1DescribeAddressesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAddressesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAddressesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -842,7 +842,7 @@ export const deserializeAws_json1_1DescribeClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -897,7 +897,7 @@ export const deserializeAws_json1_1DescribeJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -952,7 +952,7 @@ export const deserializeAws_json1_1GetJobManifestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobManifestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetJobManifestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1015,7 +1015,7 @@ export const deserializeAws_json1_1GetJobUnlockCodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetJobUnlockCodeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetJobUnlockCodeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1078,7 +1078,7 @@ export const deserializeAws_json1_1GetSnowballUsageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSnowballUsageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSnowballUsageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1125,7 +1125,7 @@ export const deserializeAws_json1_1GetSoftwareUpdatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSoftwareUpdatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSoftwareUpdatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1188,7 +1188,7 @@ export const deserializeAws_json1_1ListClusterJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListClusterJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListClusterJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1251,7 +1251,7 @@ export const deserializeAws_json1_1ListClustersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListClustersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListClustersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1306,7 +1306,7 @@ export const deserializeAws_json1_1ListCompatibleImagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCompatibleImagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCompatibleImagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1369,7 +1369,7 @@ export const deserializeAws_json1_1ListJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1424,7 +1424,7 @@ export const deserializeAws_json1_1UpdateClusterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateClusterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateClusterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1511,7 +1511,7 @@ export const deserializeAws_json1_1UpdateJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -714,7 +714,7 @@ export const deserializeAws_queryAddPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddPermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddPermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -789,7 +789,7 @@ export const deserializeAws_queryCheckIfPhoneNumberIsOptedOutCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CheckIfPhoneNumberIsOptedOutCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCheckIfPhoneNumberIsOptedOutCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -867,7 +867,7 @@ export const deserializeAws_queryConfirmSubscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConfirmSubscriptionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryConfirmSubscriptionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -961,7 +961,7 @@ export const deserializeAws_queryCreatePlatformApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePlatformApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreatePlatformApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1031,7 +1031,7 @@ export const deserializeAws_queryCreatePlatformEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePlatformEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreatePlatformEndpointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1109,7 +1109,7 @@ export const deserializeAws_queryCreateTopicCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTopicCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateTopicCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1227,7 +1227,7 @@ export const deserializeAws_queryDeleteEndpointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteEndpointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteEndpointCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1294,7 +1294,7 @@ export const deserializeAws_queryDeletePlatformApplicationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePlatformApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeletePlatformApplicationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1361,7 +1361,7 @@ export const deserializeAws_queryDeleteTopicCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTopicCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteTopicCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1460,7 +1460,7 @@ export const deserializeAws_queryGetEndpointAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEndpointAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetEndpointAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1538,7 +1538,7 @@ export const deserializeAws_queryGetPlatformApplicationAttributesCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPlatformApplicationAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetPlatformApplicationAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1619,7 +1619,7 @@ export const deserializeAws_queryGetSMSAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSMSAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetSMSAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1697,7 +1697,7 @@ export const deserializeAws_queryGetSubscriptionAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSubscriptionAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetSubscriptionAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1775,7 +1775,7 @@ export const deserializeAws_queryGetTopicAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTopicAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetTopicAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1861,7 +1861,7 @@ export const deserializeAws_queryListEndpointsByPlatformApplicationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListEndpointsByPlatformApplicationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListEndpointsByPlatformApplicationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1942,7 +1942,7 @@ export const deserializeAws_queryListPhoneNumbersOptedOutCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPhoneNumbersOptedOutCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListPhoneNumbersOptedOutCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2020,7 +2020,7 @@ export const deserializeAws_queryListPlatformApplicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListPlatformApplicationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListPlatformApplicationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2090,7 +2090,7 @@ export const deserializeAws_queryListSubscriptionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSubscriptionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListSubscriptionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2160,7 +2160,7 @@ export const deserializeAws_queryListSubscriptionsByTopicCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSubscriptionsByTopicCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListSubscriptionsByTopicCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2238,7 +2238,7 @@ export const deserializeAws_queryListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2324,7 +2324,7 @@ export const deserializeAws_queryListTopicsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTopicsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListTopicsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2394,7 +2394,7 @@ export const deserializeAws_queryOptInPhoneNumberCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<OptInPhoneNumberCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryOptInPhoneNumberCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2472,7 +2472,7 @@ export const deserializeAws_queryPublishCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PublishCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPublishCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2630,7 +2630,7 @@ export const deserializeAws_queryRemovePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemovePermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemovePermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2705,7 +2705,7 @@ export const deserializeAws_querySetEndpointAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetEndpointAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetEndpointAttributesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2780,7 +2780,7 @@ export const deserializeAws_querySetPlatformApplicationAttributesCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetPlatformApplicationAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetPlatformApplicationAttributesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2855,7 +2855,7 @@ export const deserializeAws_querySetSMSAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetSMSAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetSMSAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2933,7 +2933,7 @@ export const deserializeAws_querySetSubscriptionAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetSubscriptionAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetSubscriptionAttributesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3016,7 +3016,7 @@ export const deserializeAws_querySetTopicAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetTopicAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetTopicAttributesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3099,7 +3099,7 @@ export const deserializeAws_querySubscribeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SubscribeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySubscribeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3201,7 +3201,7 @@ export const deserializeAws_queryTagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryTagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3303,7 +3303,7 @@ export const deserializeAws_queryUnsubscribeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UnsubscribeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUnsubscribeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3386,7 +3386,7 @@ export const deserializeAws_queryUntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-sqs/protocols/Aws_query.ts
+++ b/clients/client-sqs/protocols/Aws_query.ts
@@ -427,7 +427,7 @@ export const deserializeAws_queryAddPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddPermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAddPermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -478,7 +478,7 @@ export const deserializeAws_queryChangeMessageVisibilityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ChangeMessageVisibilityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryChangeMessageVisibilityCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -537,7 +537,7 @@ export const deserializeAws_queryChangeMessageVisibilityBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ChangeMessageVisibilityBatchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryChangeMessageVisibilityBatchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -615,7 +615,7 @@ export const deserializeAws_queryCreateQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateQueueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryCreateQueueCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -677,7 +677,7 @@ export const deserializeAws_queryDeleteMessageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMessageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteMessageCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -736,7 +736,7 @@ export const deserializeAws_queryDeleteMessageBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMessageBatchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteMessageBatchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -814,7 +814,7 @@ export const deserializeAws_queryDeleteQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteQueueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDeleteQueueCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -857,7 +857,7 @@ export const deserializeAws_queryGetQueueAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetQueueAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetQueueAttributesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -911,7 +911,7 @@ export const deserializeAws_queryGetQueueUrlCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetQueueUrlCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetQueueUrlCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -965,7 +965,7 @@ export const deserializeAws_queryListDeadLetterSourceQueuesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDeadLetterSourceQueuesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListDeadLetterSourceQueuesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1019,7 +1019,7 @@ export const deserializeAws_queryListQueuesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListQueuesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListQueuesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1065,7 +1065,7 @@ export const deserializeAws_queryListQueueTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListQueueTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryListQueueTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1111,7 +1111,7 @@ export const deserializeAws_queryPurgeQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PurgeQueueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryPurgeQueueCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1170,7 +1170,7 @@ export const deserializeAws_queryReceiveMessageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ReceiveMessageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryReceiveMessageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1224,7 +1224,7 @@ export const deserializeAws_queryRemovePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemovePermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRemovePermissionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1267,7 +1267,7 @@ export const deserializeAws_querySendMessageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendMessageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySendMessageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1329,7 +1329,7 @@ export const deserializeAws_querySendMessageBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendMessageBatchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySendMessageBatchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1423,7 +1423,7 @@ export const deserializeAws_querySetQueueAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetQueueAttributesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySetQueueAttributesCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1474,7 +1474,7 @@ export const deserializeAws_queryTagQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagQueueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryTagQueueCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1517,7 +1517,7 @@ export const deserializeAws_queryUntagQueueCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagQueueCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryUntagQueueCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-ssm/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/protocols/Aws_json1_1.ts
@@ -2466,7 +2466,7 @@ export const deserializeAws_json1_1AddTagsToResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsToResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2553,7 +2553,7 @@ export const deserializeAws_json1_1CancelCommandCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelCommandCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelCommandCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2632,7 +2632,7 @@ export const deserializeAws_json1_1CancelMaintenanceWindowExecutionCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelMaintenanceWindowExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelMaintenanceWindowExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2695,7 +2695,7 @@ export const deserializeAws_json1_1CreateActivationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateActivationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateActivationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2750,7 +2750,7 @@ export const deserializeAws_json1_1CreateAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2885,7 +2885,7 @@ export const deserializeAws_json1_1CreateAssociationBatchCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAssociationBatchCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAssociationBatchCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3020,7 +3020,7 @@ export const deserializeAws_json1_1CreateDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateDocumentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateDocumentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3115,7 +3115,7 @@ export const deserializeAws_json1_1CreateMaintenanceWindowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMaintenanceWindowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateMaintenanceWindowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3186,7 +3186,7 @@ export const deserializeAws_json1_1CreateOpsItemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateOpsItemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateOpsItemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3265,7 +3265,7 @@ export const deserializeAws_json1_1CreatePatchBaselineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreatePatchBaselineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreatePatchBaselineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3336,7 +3336,7 @@ export const deserializeAws_json1_1CreateResourceDataSyncCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResourceDataSyncCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateResourceDataSyncCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3415,7 +3415,7 @@ export const deserializeAws_json1_1DeleteActivationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteActivationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteActivationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3494,7 +3494,7 @@ export const deserializeAws_json1_1DeleteAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3581,7 +3581,7 @@ export const deserializeAws_json1_1DeleteDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDocumentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteDocumentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3660,7 +3660,7 @@ export const deserializeAws_json1_1DeleteInventoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteInventoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteInventoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3747,7 +3747,7 @@ export const deserializeAws_json1_1DeleteMaintenanceWindowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMaintenanceWindowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMaintenanceWindowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3802,7 +3802,7 @@ export const deserializeAws_json1_1DeleteParameterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteParameterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteParameterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3865,7 +3865,7 @@ export const deserializeAws_json1_1DeleteParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3920,7 +3920,7 @@ export const deserializeAws_json1_1DeletePatchBaselineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePatchBaselineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePatchBaselineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3983,7 +3983,7 @@ export const deserializeAws_json1_1DeleteResourceDataSyncCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourceDataSyncCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResourceDataSyncCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4054,7 +4054,7 @@ export const deserializeAws_json1_1DeregisterManagedInstanceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterManagedInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterManagedInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4117,7 +4117,7 @@ export const deserializeAws_json1_1DeregisterPatchBaselineForPatchGroupCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterPatchBaselineForPatchGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterPatchBaselineForPatchGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4180,7 +4180,7 @@ export const deserializeAws_json1_1DeregisterTargetFromMaintenanceWindowCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterTargetFromMaintenanceWindowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterTargetFromMaintenanceWindowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4251,7 +4251,7 @@ export const deserializeAws_json1_1DeregisterTaskFromMaintenanceWindowCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterTaskFromMaintenanceWindowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterTaskFromMaintenanceWindowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4314,7 +4314,7 @@ export const deserializeAws_json1_1DescribeActivationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeActivationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeActivationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4385,7 +4385,7 @@ export const deserializeAws_json1_1DescribeAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4472,7 +4472,7 @@ export const deserializeAws_json1_1DescribeAssociationExecutionsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAssociationExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAssociationExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4543,7 +4543,7 @@ export const deserializeAws_json1_1DescribeAssociationExecutionTargetsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAssociationExecutionTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAssociationExecutionTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4622,7 +4622,7 @@ export const deserializeAws_json1_1DescribeAutomationExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAutomationExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAutomationExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4701,7 +4701,7 @@ export const deserializeAws_json1_1DescribeAutomationStepExecutionsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAutomationStepExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAutomationStepExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4788,7 +4788,7 @@ export const deserializeAws_json1_1DescribeAvailablePatchesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAvailablePatchesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAvailablePatchesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4843,7 +4843,7 @@ export const deserializeAws_json1_1DescribeDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDocumentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDocumentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4914,7 +4914,7 @@ export const deserializeAws_json1_1DescribeDocumentPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDocumentPermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeDocumentPermissionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4985,7 +4985,7 @@ export const deserializeAws_json1_1DescribeEffectiveInstanceAssociationsCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEffectiveInstanceAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEffectiveInstanceAssociationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5056,7 +5056,7 @@ export const deserializeAws_json1_1DescribeEffectivePatchesForPatchBaselineComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeEffectivePatchesForPatchBaselineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeEffectivePatchesForPatchBaselineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5135,7 +5135,7 @@ export const deserializeAws_json1_1DescribeInstanceAssociationsStatusCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstanceAssociationsStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeInstanceAssociationsStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5206,7 +5206,7 @@ export const deserializeAws_json1_1DescribeInstanceInformationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstanceInformationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeInstanceInformationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5293,7 +5293,7 @@ export const deserializeAws_json1_1DescribeInstancePatchesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstancePatchesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeInstancePatchesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5372,7 +5372,7 @@ export const deserializeAws_json1_1DescribeInstancePatchStatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstancePatchStatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeInstancePatchStatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5435,7 +5435,7 @@ export const deserializeAws_json1_1DescribeInstancePatchStatesForPatchGroupComma
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInstancePatchStatesForPatchGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeInstancePatchStatesForPatchGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5506,7 +5506,7 @@ export const deserializeAws_json1_1DescribeInventoryDeletionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeInventoryDeletionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeInventoryDeletionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5577,7 +5577,7 @@ export const deserializeAws_json1_1DescribeMaintenanceWindowExecutionsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMaintenanceWindowExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMaintenanceWindowExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5632,7 +5632,7 @@ export const deserializeAws_json1_1DescribeMaintenanceWindowExecutionTaskInvocat
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMaintenanceWindowExecutionTaskInvocationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMaintenanceWindowExecutionTaskInvocationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5695,7 +5695,7 @@ export const deserializeAws_json1_1DescribeMaintenanceWindowExecutionTasksComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMaintenanceWindowExecutionTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMaintenanceWindowExecutionTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5758,7 +5758,7 @@ export const deserializeAws_json1_1DescribeMaintenanceWindowsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMaintenanceWindowsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMaintenanceWindowsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5813,7 +5813,7 @@ export const deserializeAws_json1_1DescribeMaintenanceWindowScheduleCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMaintenanceWindowScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMaintenanceWindowScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5876,7 +5876,7 @@ export const deserializeAws_json1_1DescribeMaintenanceWindowsForTargetCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMaintenanceWindowsForTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMaintenanceWindowsForTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5931,7 +5931,7 @@ export const deserializeAws_json1_1DescribeMaintenanceWindowTargetsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMaintenanceWindowTargetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMaintenanceWindowTargetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5994,7 +5994,7 @@ export const deserializeAws_json1_1DescribeMaintenanceWindowTasksCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMaintenanceWindowTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMaintenanceWindowTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6057,7 +6057,7 @@ export const deserializeAws_json1_1DescribeOpsItemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOpsItemsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeOpsItemsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6112,7 +6112,7 @@ export const deserializeAws_json1_1DescribeParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6199,7 +6199,7 @@ export const deserializeAws_json1_1DescribePatchBaselinesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePatchBaselinesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePatchBaselinesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6254,7 +6254,7 @@ export const deserializeAws_json1_1DescribePatchGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePatchGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePatchGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6309,7 +6309,7 @@ export const deserializeAws_json1_1DescribePatchGroupStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePatchGroupStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePatchGroupStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6372,7 +6372,7 @@ export const deserializeAws_json1_1DescribePatchPropertiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribePatchPropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribePatchPropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6427,7 +6427,7 @@ export const deserializeAws_json1_1DescribeSessionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSessionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSessionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6498,7 +6498,7 @@ export const deserializeAws_json1_1GetAutomationExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAutomationExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetAutomationExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6561,7 +6561,7 @@ export const deserializeAws_json1_1GetCalendarStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCalendarStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCalendarStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6640,7 +6640,7 @@ export const deserializeAws_json1_1GetCommandInvocationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCommandInvocationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetCommandInvocationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6727,7 +6727,7 @@ export const deserializeAws_json1_1GetConnectionStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetConnectionStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetConnectionStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6782,7 +6782,7 @@ export const deserializeAws_json1_1GetDefaultPatchBaselineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDefaultPatchBaselineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDefaultPatchBaselineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6837,7 +6837,7 @@ export const deserializeAws_json1_1GetDeployablePatchSnapshotForInstanceCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDeployablePatchSnapshotForInstanceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDeployablePatchSnapshotForInstanceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6908,7 +6908,7 @@ export const deserializeAws_json1_1GetDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDocumentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDocumentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6979,7 +6979,7 @@ export const deserializeAws_json1_1GetInventoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInventoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInventoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7082,7 +7082,7 @@ export const deserializeAws_json1_1GetInventorySchemaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetInventorySchemaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetInventorySchemaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7153,7 +7153,7 @@ export const deserializeAws_json1_1GetMaintenanceWindowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMaintenanceWindowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMaintenanceWindowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7216,7 +7216,7 @@ export const deserializeAws_json1_1GetMaintenanceWindowExecutionCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMaintenanceWindowExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMaintenanceWindowExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7279,7 +7279,7 @@ export const deserializeAws_json1_1GetMaintenanceWindowExecutionTaskCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMaintenanceWindowExecutionTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMaintenanceWindowExecutionTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7342,7 +7342,7 @@ export const deserializeAws_json1_1GetMaintenanceWindowExecutionTaskInvocationCo
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMaintenanceWindowExecutionTaskInvocationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMaintenanceWindowExecutionTaskInvocationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7405,7 +7405,7 @@ export const deserializeAws_json1_1GetMaintenanceWindowTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMaintenanceWindowTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMaintenanceWindowTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7468,7 +7468,7 @@ export const deserializeAws_json1_1GetOpsItemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOpsItemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOpsItemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7531,7 +7531,7 @@ export const deserializeAws_json1_1GetOpsSummaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetOpsSummaryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetOpsSummaryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7626,7 +7626,7 @@ export const deserializeAws_json1_1GetParameterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetParameterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetParameterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7705,7 +7705,7 @@ export const deserializeAws_json1_1GetParameterHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetParameterHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetParameterHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7784,7 +7784,7 @@ export const deserializeAws_json1_1GetParametersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetParametersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetParametersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7847,7 +7847,7 @@ export const deserializeAws_json1_1GetParametersByPathCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetParametersByPathCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetParametersByPathCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7942,7 +7942,7 @@ export const deserializeAws_json1_1GetPatchBaselineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPatchBaselineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPatchBaselineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8013,7 +8013,7 @@ export const deserializeAws_json1_1GetPatchBaselineForPatchGroupCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPatchBaselineForPatchGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPatchBaselineForPatchGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8068,7 +8068,7 @@ export const deserializeAws_json1_1GetServiceSettingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServiceSettingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetServiceSettingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8131,7 +8131,7 @@ export const deserializeAws_json1_1LabelParameterVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<LabelParameterVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1LabelParameterVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8218,7 +8218,7 @@ export const deserializeAws_json1_1ListAssociationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssociationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssociationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8281,7 +8281,7 @@ export const deserializeAws_json1_1ListAssociationVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAssociationVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAssociationVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8352,7 +8352,7 @@ export const deserializeAws_json1_1ListCommandInvocationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCommandInvocationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCommandInvocationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8439,7 +8439,7 @@ export const deserializeAws_json1_1ListCommandsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListCommandsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListCommandsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8526,7 +8526,7 @@ export const deserializeAws_json1_1ListComplianceItemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListComplianceItemsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListComplianceItemsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8613,7 +8613,7 @@ export const deserializeAws_json1_1ListComplianceSummariesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListComplianceSummariesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListComplianceSummariesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8684,7 +8684,7 @@ export const deserializeAws_json1_1ListDocumentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDocumentsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDocumentsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8755,7 +8755,7 @@ export const deserializeAws_json1_1ListDocumentVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDocumentVersionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListDocumentVersionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8826,7 +8826,7 @@ export const deserializeAws_json1_1ListInventoryEntriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListInventoryEntriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListInventoryEntriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8913,7 +8913,7 @@ export const deserializeAws_json1_1ListResourceComplianceSummariesCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceComplianceSummariesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourceComplianceSummariesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8984,7 +8984,7 @@ export const deserializeAws_json1_1ListResourceDataSyncCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceDataSyncCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourceDataSyncCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9055,7 +9055,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9126,7 +9126,7 @@ export const deserializeAws_json1_1ModifyDocumentPermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyDocumentPermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyDocumentPermissionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9213,7 +9213,7 @@ export const deserializeAws_json1_1PutComplianceItemsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutComplianceItemsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutComplianceItemsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9316,7 +9316,7 @@ export const deserializeAws_json1_1PutInventoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutInventoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutInventoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9459,7 +9459,7 @@ export const deserializeAws_json1_1PutParameterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutParameterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutParameterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9626,7 +9626,7 @@ export const deserializeAws_json1_1RegisterDefaultPatchBaselineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterDefaultPatchBaselineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterDefaultPatchBaselineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9697,7 +9697,7 @@ export const deserializeAws_json1_1RegisterPatchBaselineForPatchGroupCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterPatchBaselineForPatchGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterPatchBaselineForPatchGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9784,7 +9784,7 @@ export const deserializeAws_json1_1RegisterTargetWithMaintenanceWindowCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterTargetWithMaintenanceWindowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterTargetWithMaintenanceWindowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9863,7 +9863,7 @@ export const deserializeAws_json1_1RegisterTaskWithMaintenanceWindowCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterTaskWithMaintenanceWindowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterTaskWithMaintenanceWindowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -9950,7 +9950,7 @@ export const deserializeAws_json1_1RemoveTagsFromResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsFromResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10029,7 +10029,7 @@ export const deserializeAws_json1_1ResetServiceSettingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetServiceSettingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResetServiceSettingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10100,7 +10100,7 @@ export const deserializeAws_json1_1ResumeSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResumeSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResumeSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10163,7 +10163,7 @@ export const deserializeAws_json1_1SendAutomationSignalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendAutomationSignalCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SendAutomationSignalCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10242,7 +10242,7 @@ export const deserializeAws_json1_1SendCommandCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SendCommandCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SendCommandCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10377,7 +10377,7 @@ export const deserializeAws_json1_1StartAssociationsOnceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartAssociationsOnceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartAssociationsOnceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10440,7 +10440,7 @@ export const deserializeAws_json1_1StartAutomationExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartAutomationExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartAutomationExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10543,7 +10543,7 @@ export const deserializeAws_json1_1StartSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10614,7 +10614,7 @@ export const deserializeAws_json1_1StopAutomationExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopAutomationExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopAutomationExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10685,7 +10685,7 @@ export const deserializeAws_json1_1TerminateSessionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateSessionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TerminateSessionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10748,7 +10748,7 @@ export const deserializeAws_json1_1UpdateAssociationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAssociationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAssociationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10891,7 +10891,7 @@ export const deserializeAws_json1_1UpdateAssociationStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAssociationStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAssociationStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -10986,7 +10986,7 @@ export const deserializeAws_json1_1UpdateDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDocumentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDocumentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11113,7 +11113,7 @@ export const deserializeAws_json1_1UpdateDocumentDefaultVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDocumentDefaultVersionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateDocumentDefaultVersionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11192,7 +11192,7 @@ export const deserializeAws_json1_1UpdateMaintenanceWindowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMaintenanceWindowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMaintenanceWindowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11255,7 +11255,7 @@ export const deserializeAws_json1_1UpdateMaintenanceWindowTargetCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMaintenanceWindowTargetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMaintenanceWindowTargetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11318,7 +11318,7 @@ export const deserializeAws_json1_1UpdateMaintenanceWindowTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMaintenanceWindowTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMaintenanceWindowTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11381,7 +11381,7 @@ export const deserializeAws_json1_1UpdateManagedInstanceRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateManagedInstanceRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateManagedInstanceRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11444,7 +11444,7 @@ export const deserializeAws_json1_1UpdateOpsItemCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateOpsItemCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateOpsItemCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11531,7 +11531,7 @@ export const deserializeAws_json1_1UpdatePatchBaselineCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePatchBaselineCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePatchBaselineCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11594,7 +11594,7 @@ export const deserializeAws_json1_1UpdateResourceDataSyncCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateResourceDataSyncCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateResourceDataSyncCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -11673,7 +11673,7 @@ export const deserializeAws_json1_1UpdateServiceSettingCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServiceSettingCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateServiceSettingCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-sso-oidc/protocols/Aws_restJson1.ts
+++ b/clients/client-sso-oidc/protocols/Aws_restJson1.ts
@@ -114,7 +114,7 @@ export const deserializeAws_restJson1CreateTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTokenCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateTokenCommandError(output, context);
   }
   const contents: CreateTokenCommandOutput = {
@@ -265,7 +265,7 @@ export const deserializeAws_restJson1RegisterClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterClientCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RegisterClientCommandError(output, context);
   }
   const contents: RegisterClientCommandOutput = {
@@ -364,7 +364,7 @@ export const deserializeAws_restJson1StartDeviceAuthorizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDeviceAuthorizationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartDeviceAuthorizationCommandError(output, context);
   }
   const contents: StartDeviceAuthorizationCommandOutput = {

--- a/clients/client-sso/protocols/Aws_restJson1.ts
+++ b/clients/client-sso/protocols/Aws_restJson1.ts
@@ -131,7 +131,7 @@ export const deserializeAws_restJson1GetRoleCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRoleCredentialsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRoleCredentialsCommandError(output, context);
   }
   const contents: GetRoleCredentialsCommandOutput = {
@@ -210,7 +210,7 @@ export const deserializeAws_restJson1ListAccountRolesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAccountRolesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAccountRolesCommandError(output, context);
   }
   const contents: ListAccountRolesCommandOutput = {
@@ -293,7 +293,7 @@ export const deserializeAws_restJson1ListAccountsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAccountsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListAccountsCommandError(output, context);
   }
   const contents: ListAccountsCommandOutput = {
@@ -376,7 +376,7 @@ export const deserializeAws_restJson1LogoutCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<LogoutCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1LogoutCommandError(output, context);
   }
   const contents: LogoutCommandOutput = {

--- a/clients/client-storage-gateway/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/protocols/Aws_json1_1.ts
@@ -1415,7 +1415,7 @@ export const deserializeAws_json1_1ActivateGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ActivateGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ActivateGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1478,7 +1478,7 @@ export const deserializeAws_json1_1AddCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddCacheCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddCacheCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1541,7 +1541,7 @@ export const deserializeAws_json1_1AddTagsToResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddTagsToResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddTagsToResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1604,7 +1604,7 @@ export const deserializeAws_json1_1AddUploadBufferCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddUploadBufferCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddUploadBufferCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1667,7 +1667,7 @@ export const deserializeAws_json1_1AddWorkingStorageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddWorkingStorageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddWorkingStorageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1730,7 +1730,7 @@ export const deserializeAws_json1_1AssignTapePoolCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssignTapePoolCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssignTapePoolCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1793,7 +1793,7 @@ export const deserializeAws_json1_1AttachVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AttachVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AttachVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1856,7 +1856,7 @@ export const deserializeAws_json1_1CancelArchivalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelArchivalCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelArchivalCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1919,7 +1919,7 @@ export const deserializeAws_json1_1CancelRetrievalCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CancelRetrievalCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CancelRetrievalCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1982,7 +1982,7 @@ export const deserializeAws_json1_1CreateCachediSCSIVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCachediSCSIVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCachediSCSIVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2045,7 +2045,7 @@ export const deserializeAws_json1_1CreateNFSFileShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNFSFileShareCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateNFSFileShareCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2108,7 +2108,7 @@ export const deserializeAws_json1_1CreateSMBFileShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSMBFileShareCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSMBFileShareCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2171,7 +2171,7 @@ export const deserializeAws_json1_1CreateSnapshotCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSnapshotCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSnapshotCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2242,7 +2242,7 @@ export const deserializeAws_json1_1CreateSnapshotFromVolumeRecoveryPointCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSnapshotFromVolumeRecoveryPointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSnapshotFromVolumeRecoveryPointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2313,7 +2313,7 @@ export const deserializeAws_json1_1CreateStorediSCSIVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateStorediSCSIVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateStorediSCSIVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2376,7 +2376,7 @@ export const deserializeAws_json1_1CreateTapesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTapesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTapesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2439,7 +2439,7 @@ export const deserializeAws_json1_1CreateTapeWithBarcodeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTapeWithBarcodeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTapeWithBarcodeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2502,7 +2502,7 @@ export const deserializeAws_json1_1DeleteAutomaticTapeCreationPolicyCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAutomaticTapeCreationPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAutomaticTapeCreationPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2565,7 +2565,7 @@ export const deserializeAws_json1_1DeleteBandwidthRateLimitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteBandwidthRateLimitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteBandwidthRateLimitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2628,7 +2628,7 @@ export const deserializeAws_json1_1DeleteChapCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteChapCredentialsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteChapCredentialsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2691,7 +2691,7 @@ export const deserializeAws_json1_1DeleteFileShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFileShareCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFileShareCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2754,7 +2754,7 @@ export const deserializeAws_json1_1DeleteGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2817,7 +2817,7 @@ export const deserializeAws_json1_1DeleteSnapshotScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSnapshotScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSnapshotScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2880,7 +2880,7 @@ export const deserializeAws_json1_1DeleteTapeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTapeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTapeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2943,7 +2943,7 @@ export const deserializeAws_json1_1DeleteTapeArchiveCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTapeArchiveCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTapeArchiveCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3006,7 +3006,7 @@ export const deserializeAws_json1_1DeleteVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3069,7 +3069,7 @@ export const deserializeAws_json1_1DescribeAvailabilityMonitorTestCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAvailabilityMonitorTestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAvailabilityMonitorTestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3132,7 +3132,7 @@ export const deserializeAws_json1_1DescribeBandwidthRateLimitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeBandwidthRateLimitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeBandwidthRateLimitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3195,7 +3195,7 @@ export const deserializeAws_json1_1DescribeCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCacheCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCacheCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3258,7 +3258,7 @@ export const deserializeAws_json1_1DescribeCachediSCSIVolumesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCachediSCSIVolumesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCachediSCSIVolumesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3321,7 +3321,7 @@ export const deserializeAws_json1_1DescribeChapCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeChapCredentialsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeChapCredentialsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3384,7 +3384,7 @@ export const deserializeAws_json1_1DescribeGatewayInformationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGatewayInformationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeGatewayInformationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3447,7 +3447,7 @@ export const deserializeAws_json1_1DescribeMaintenanceStartTimeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeMaintenanceStartTimeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeMaintenanceStartTimeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3510,7 +3510,7 @@ export const deserializeAws_json1_1DescribeNFSFileSharesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNFSFileSharesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeNFSFileSharesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3573,7 +3573,7 @@ export const deserializeAws_json1_1DescribeSMBFileSharesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSMBFileSharesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSMBFileSharesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3636,7 +3636,7 @@ export const deserializeAws_json1_1DescribeSMBSettingsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSMBSettingsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSMBSettingsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3699,7 +3699,7 @@ export const deserializeAws_json1_1DescribeSnapshotScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSnapshotScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSnapshotScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3762,7 +3762,7 @@ export const deserializeAws_json1_1DescribeStorediSCSIVolumesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeStorediSCSIVolumesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeStorediSCSIVolumesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3825,7 +3825,7 @@ export const deserializeAws_json1_1DescribeTapeArchivesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTapeArchivesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTapeArchivesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3888,7 +3888,7 @@ export const deserializeAws_json1_1DescribeTapeRecoveryPointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTapeRecoveryPointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTapeRecoveryPointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3951,7 +3951,7 @@ export const deserializeAws_json1_1DescribeTapesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTapesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTapesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4014,7 +4014,7 @@ export const deserializeAws_json1_1DescribeUploadBufferCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUploadBufferCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUploadBufferCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4077,7 +4077,7 @@ export const deserializeAws_json1_1DescribeVTLDevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeVTLDevicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeVTLDevicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4140,7 +4140,7 @@ export const deserializeAws_json1_1DescribeWorkingStorageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkingStorageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeWorkingStorageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4203,7 +4203,7 @@ export const deserializeAws_json1_1DetachVolumeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetachVolumeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetachVolumeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4266,7 +4266,7 @@ export const deserializeAws_json1_1DisableGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisableGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisableGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4329,7 +4329,7 @@ export const deserializeAws_json1_1JoinDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<JoinDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1JoinDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4392,7 +4392,7 @@ export const deserializeAws_json1_1ListAutomaticTapeCreationPoliciesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAutomaticTapeCreationPoliciesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAutomaticTapeCreationPoliciesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4455,7 +4455,7 @@ export const deserializeAws_json1_1ListFileSharesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFileSharesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListFileSharesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4518,7 +4518,7 @@ export const deserializeAws_json1_1ListGatewaysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGatewaysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGatewaysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4581,7 +4581,7 @@ export const deserializeAws_json1_1ListLocalDisksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLocalDisksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLocalDisksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4644,7 +4644,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4707,7 +4707,7 @@ export const deserializeAws_json1_1ListTapesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTapesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTapesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4770,7 +4770,7 @@ export const deserializeAws_json1_1ListVolumeInitiatorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVolumeInitiatorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListVolumeInitiatorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4833,7 +4833,7 @@ export const deserializeAws_json1_1ListVolumeRecoveryPointsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVolumeRecoveryPointsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListVolumeRecoveryPointsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4896,7 +4896,7 @@ export const deserializeAws_json1_1ListVolumesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVolumesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListVolumesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4959,7 +4959,7 @@ export const deserializeAws_json1_1NotifyWhenUploadedCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NotifyWhenUploadedCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1NotifyWhenUploadedCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5022,7 +5022,7 @@ export const deserializeAws_json1_1RefreshCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RefreshCacheCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RefreshCacheCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5085,7 +5085,7 @@ export const deserializeAws_json1_1RemoveTagsFromResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveTagsFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RemoveTagsFromResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5148,7 +5148,7 @@ export const deserializeAws_json1_1ResetCacheCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetCacheCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResetCacheCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5211,7 +5211,7 @@ export const deserializeAws_json1_1RetrieveTapeArchiveCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RetrieveTapeArchiveCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RetrieveTapeArchiveCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5274,7 +5274,7 @@ export const deserializeAws_json1_1RetrieveTapeRecoveryPointCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RetrieveTapeRecoveryPointCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RetrieveTapeRecoveryPointCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5337,7 +5337,7 @@ export const deserializeAws_json1_1SetLocalConsolePasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetLocalConsolePasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetLocalConsolePasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5400,7 +5400,7 @@ export const deserializeAws_json1_1SetSMBGuestPasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SetSMBGuestPasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1SetSMBGuestPasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5463,7 +5463,7 @@ export const deserializeAws_json1_1ShutdownGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ShutdownGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ShutdownGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5526,7 +5526,7 @@ export const deserializeAws_json1_1StartAvailabilityMonitorTestCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartAvailabilityMonitorTestCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartAvailabilityMonitorTestCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5589,7 +5589,7 @@ export const deserializeAws_json1_1StartGatewayCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartGatewayCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartGatewayCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5652,7 +5652,7 @@ export const deserializeAws_json1_1UpdateAutomaticTapeCreationPolicyCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAutomaticTapeCreationPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateAutomaticTapeCreationPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5715,7 +5715,7 @@ export const deserializeAws_json1_1UpdateBandwidthRateLimitCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateBandwidthRateLimitCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateBandwidthRateLimitCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5778,7 +5778,7 @@ export const deserializeAws_json1_1UpdateChapCredentialsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateChapCredentialsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateChapCredentialsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5841,7 +5841,7 @@ export const deserializeAws_json1_1UpdateGatewayInformationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGatewayInformationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGatewayInformationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5904,7 +5904,7 @@ export const deserializeAws_json1_1UpdateGatewaySoftwareNowCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGatewaySoftwareNowCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGatewaySoftwareNowCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5967,7 +5967,7 @@ export const deserializeAws_json1_1UpdateMaintenanceStartTimeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMaintenanceStartTimeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMaintenanceStartTimeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6030,7 +6030,7 @@ export const deserializeAws_json1_1UpdateNFSFileShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateNFSFileShareCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateNFSFileShareCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6093,7 +6093,7 @@ export const deserializeAws_json1_1UpdateSMBFileShareCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSMBFileShareCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSMBFileShareCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6156,7 +6156,7 @@ export const deserializeAws_json1_1UpdateSMBSecurityStrategyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSMBSecurityStrategyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSMBSecurityStrategyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6219,7 +6219,7 @@ export const deserializeAws_json1_1UpdateSnapshotScheduleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSnapshotScheduleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSnapshotScheduleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6282,7 +6282,7 @@ export const deserializeAws_json1_1UpdateVTLDeviceTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVTLDeviceTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateVTLDeviceTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-sts/protocols/Aws_query.ts
+++ b/clients/client-sts/protocols/Aws_query.ts
@@ -190,7 +190,7 @@ export const deserializeAws_queryAssumeRoleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssumeRoleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAssumeRoleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -260,7 +260,7 @@ export const deserializeAws_queryAssumeRoleWithSAMLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssumeRoleWithSAMLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAssumeRoleWithSAMLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -354,7 +354,7 @@ export const deserializeAws_queryAssumeRoleWithWebIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssumeRoleWithWebIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryAssumeRoleWithWebIdentityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -456,7 +456,7 @@ export const deserializeAws_queryDecodeAuthorizationMessageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DecodeAuthorizationMessageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryDecodeAuthorizationMessageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -510,7 +510,7 @@ export const deserializeAws_queryGetAccessKeyInfoCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetAccessKeyInfoCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetAccessKeyInfoCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -556,7 +556,7 @@ export const deserializeAws_queryGetCallerIdentityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCallerIdentityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetCallerIdentityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -602,7 +602,7 @@ export const deserializeAws_queryGetFederationTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFederationTokenCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetFederationTokenCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -672,7 +672,7 @@ export const deserializeAws_queryGetSessionTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSessionTokenCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGetSessionTokenCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-support/protocols/Aws_json1_1.ts
+++ b/clients/client-support/protocols/Aws_json1_1.ts
@@ -290,7 +290,7 @@ export const deserializeAws_json1_1AddAttachmentsToSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddAttachmentsToSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddAttachmentsToSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -377,7 +377,7 @@ export const deserializeAws_json1_1AddCommunicationToCaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddCommunicationToCaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AddCommunicationToCaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -456,7 +456,7 @@ export const deserializeAws_json1_1CreateCaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateCaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -535,7 +535,7 @@ export const deserializeAws_json1_1DescribeAttachmentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAttachmentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAttachmentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -606,7 +606,7 @@ export const deserializeAws_json1_1DescribeCasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -669,7 +669,7 @@ export const deserializeAws_json1_1DescribeCommunicationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCommunicationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeCommunicationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -732,7 +732,7 @@ export const deserializeAws_json1_1DescribeServicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeServicesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeServicesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -787,7 +787,7 @@ export const deserializeAws_json1_1DescribeSeverityLevelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeSeverityLevelsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeSeverityLevelsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -842,7 +842,7 @@ export const deserializeAws_json1_1DescribeTrustedAdvisorCheckRefreshStatusesCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrustedAdvisorCheckRefreshStatusesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTrustedAdvisorCheckRefreshStatusesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -897,7 +897,7 @@ export const deserializeAws_json1_1DescribeTrustedAdvisorCheckResultCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrustedAdvisorCheckResultCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTrustedAdvisorCheckResultCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -952,7 +952,7 @@ export const deserializeAws_json1_1DescribeTrustedAdvisorChecksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrustedAdvisorChecksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTrustedAdvisorChecksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1007,7 +1007,7 @@ export const deserializeAws_json1_1DescribeTrustedAdvisorCheckSummariesCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTrustedAdvisorCheckSummariesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTrustedAdvisorCheckSummariesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1062,7 +1062,7 @@ export const deserializeAws_json1_1RefreshTrustedAdvisorCheckCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RefreshTrustedAdvisorCheckCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RefreshTrustedAdvisorCheckCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1117,7 +1117,7 @@ export const deserializeAws_json1_1ResolveCaseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResolveCaseCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResolveCaseCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-swf/protocols/Aws_json1_0.ts
+++ b/clients/client-swf/protocols/Aws_json1_0.ts
@@ -767,7 +767,7 @@ export const deserializeAws_json1_0CountClosedWorkflowExecutionsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CountClosedWorkflowExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CountClosedWorkflowExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -830,7 +830,7 @@ export const deserializeAws_json1_0CountOpenWorkflowExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CountOpenWorkflowExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CountOpenWorkflowExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -893,7 +893,7 @@ export const deserializeAws_json1_0CountPendingActivityTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CountPendingActivityTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CountPendingActivityTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -956,7 +956,7 @@ export const deserializeAws_json1_0CountPendingDecisionTasksCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CountPendingDecisionTasksCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0CountPendingDecisionTasksCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1019,7 +1019,7 @@ export const deserializeAws_json1_0DeprecateActivityTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeprecateActivityTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DeprecateActivityTypeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1087,7 +1087,7 @@ export const deserializeAws_json1_0DeprecateDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeprecateDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DeprecateDomainCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1155,7 +1155,7 @@ export const deserializeAws_json1_0DeprecateWorkflowTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeprecateWorkflowTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DeprecateWorkflowTypeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1223,7 +1223,7 @@ export const deserializeAws_json1_0DescribeActivityTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeActivityTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeActivityTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1286,7 +1286,7 @@ export const deserializeAws_json1_0DescribeDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeDomainCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1349,7 +1349,7 @@ export const deserializeAws_json1_0DescribeWorkflowExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkflowExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeWorkflowExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1412,7 +1412,7 @@ export const deserializeAws_json1_0DescribeWorkflowTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkflowTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0DescribeWorkflowTypeCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1475,7 +1475,7 @@ export const deserializeAws_json1_0GetWorkflowExecutionHistoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWorkflowExecutionHistoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0GetWorkflowExecutionHistoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1538,7 +1538,7 @@ export const deserializeAws_json1_0ListActivityTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListActivityTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListActivityTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1601,7 +1601,7 @@ export const deserializeAws_json1_0ListClosedWorkflowExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListClosedWorkflowExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListClosedWorkflowExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1664,7 +1664,7 @@ export const deserializeAws_json1_0ListDomainsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListDomainsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1719,7 +1719,7 @@ export const deserializeAws_json1_0ListOpenWorkflowExecutionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOpenWorkflowExecutionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListOpenWorkflowExecutionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1782,7 +1782,7 @@ export const deserializeAws_json1_0ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1853,7 +1853,7 @@ export const deserializeAws_json1_0ListWorkflowTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWorkflowTypesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0ListWorkflowTypesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1916,7 +1916,7 @@ export const deserializeAws_json1_0PollForActivityTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PollForActivityTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0PollForActivityTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1987,7 +1987,7 @@ export const deserializeAws_json1_0PollForDecisionTaskCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PollForDecisionTaskCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0PollForDecisionTaskCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2058,7 +2058,7 @@ export const deserializeAws_json1_0RecordActivityTaskHeartbeatCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RecordActivityTaskHeartbeatCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RecordActivityTaskHeartbeatCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2121,7 +2121,7 @@ export const deserializeAws_json1_0RegisterActivityTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterActivityTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RegisterActivityTypeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2197,7 +2197,7 @@ export const deserializeAws_json1_0RegisterDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RegisterDomainCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2273,7 +2273,7 @@ export const deserializeAws_json1_0RegisterWorkflowTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterWorkflowTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RegisterWorkflowTypeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2349,7 +2349,7 @@ export const deserializeAws_json1_0RequestCancelWorkflowExecutionCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RequestCancelWorkflowExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RequestCancelWorkflowExecutionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2409,7 +2409,7 @@ export const deserializeAws_json1_0RespondActivityTaskCanceledCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RespondActivityTaskCanceledCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RespondActivityTaskCanceledCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2469,7 +2469,7 @@ export const deserializeAws_json1_0RespondActivityTaskCompletedCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RespondActivityTaskCompletedCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RespondActivityTaskCompletedCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2529,7 +2529,7 @@ export const deserializeAws_json1_0RespondActivityTaskFailedCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RespondActivityTaskFailedCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RespondActivityTaskFailedCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2589,7 +2589,7 @@ export const deserializeAws_json1_0RespondDecisionTaskCompletedCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RespondDecisionTaskCompletedCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0RespondDecisionTaskCompletedCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2649,7 +2649,7 @@ export const deserializeAws_json1_0SignalWorkflowExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SignalWorkflowExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0SignalWorkflowExecutionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2709,7 +2709,7 @@ export const deserializeAws_json1_0StartWorkflowExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartWorkflowExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0StartWorkflowExecutionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2804,7 +2804,7 @@ export const deserializeAws_json1_0TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0TagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2880,7 +2880,7 @@ export const deserializeAws_json1_0TerminateWorkflowExecutionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateWorkflowExecutionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0TerminateWorkflowExecutionCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -2940,7 +2940,7 @@ export const deserializeAws_json1_0UndeprecateActivityTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UndeprecateActivityTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UndeprecateActivityTypeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3008,7 +3008,7 @@ export const deserializeAws_json1_0UndeprecateDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UndeprecateDomainCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UndeprecateDomainCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3076,7 +3076,7 @@ export const deserializeAws_json1_0UndeprecateWorkflowTypeCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UndeprecateWorkflowTypeCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UndeprecateWorkflowTypeCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -3144,7 +3144,7 @@ export const deserializeAws_json1_0UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_0UntagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);

--- a/clients/client-synthetics/protocols/Aws_restJson1.ts
+++ b/clients/client-synthetics/protocols/Aws_restJson1.ts
@@ -474,7 +474,7 @@ export const deserializeAws_restJson1CreateCanaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCanaryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCanaryCommandError(output, context);
   }
   const contents: CreateCanaryCommandOutput = {
@@ -537,7 +537,7 @@ export const deserializeAws_restJson1DeleteCanaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCanaryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteCanaryCommandError(output, context);
   }
   const contents: DeleteCanaryCommandOutput = {
@@ -612,7 +612,7 @@ export const deserializeAws_restJson1DescribeCanariesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCanariesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeCanariesCommandError(output, context);
   }
   const contents: DescribeCanariesCommandOutput = {
@@ -679,7 +679,7 @@ export const deserializeAws_restJson1DescribeCanariesLastRunCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCanariesLastRunCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeCanariesLastRunCommandError(output, context);
   }
   const contents: DescribeCanariesLastRunCommandOutput = {
@@ -746,7 +746,7 @@ export const deserializeAws_restJson1DescribeRuntimeVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRuntimeVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRuntimeVersionsCommandError(output, context);
   }
   const contents: DescribeRuntimeVersionsCommandOutput = {
@@ -813,7 +813,7 @@ export const deserializeAws_restJson1GetCanaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCanaryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCanaryCommandError(output, context);
   }
   const contents: GetCanaryCommandOutput = {
@@ -876,7 +876,7 @@ export const deserializeAws_restJson1GetCanaryRunsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCanaryRunsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCanaryRunsCommandError(output, context);
   }
   const contents: GetCanaryRunsCommandOutput = {
@@ -951,7 +951,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -1022,7 +1022,7 @@ export const deserializeAws_restJson1StartCanaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartCanaryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartCanaryCommandError(output, context);
   }
   const contents: StartCanaryCommandOutput = {
@@ -1097,7 +1097,7 @@ export const deserializeAws_restJson1StopCanaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopCanaryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StopCanaryCommandError(output, context);
   }
   const contents: StopCanaryCommandOutput = {
@@ -1172,7 +1172,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -1239,7 +1239,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -1306,7 +1306,7 @@ export const deserializeAws_restJson1UpdateCanaryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCanaryCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateCanaryCommandError(output, context);
   }
   const contents: UpdateCanaryCommandOutput = {

--- a/clients/client-textract/protocols/Aws_json1_1.ts
+++ b/clients/client-textract/protocols/Aws_json1_1.ts
@@ -152,7 +152,7 @@ export const deserializeAws_json1_1AnalyzeDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AnalyzeDocumentCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AnalyzeDocumentCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -279,7 +279,7 @@ export const deserializeAws_json1_1DetectDocumentTextCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DetectDocumentTextCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DetectDocumentTextCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -398,7 +398,7 @@ export const deserializeAws_json1_1GetDocumentAnalysisCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDocumentAnalysisCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDocumentAnalysisCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -493,7 +493,7 @@ export const deserializeAws_json1_1GetDocumentTextDetectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDocumentTextDetectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetDocumentTextDetectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -588,7 +588,7 @@ export const deserializeAws_json1_1StartDocumentAnalysisCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDocumentAnalysisCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartDocumentAnalysisCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -723,7 +723,7 @@ export const deserializeAws_json1_1StartDocumentTextDetectionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartDocumentTextDetectionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartDocumentTextDetectionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-transcribe-streaming/protocols/Aws_restJson1.ts
+++ b/clients/client-transcribe-streaming/protocols/Aws_restJson1.ts
@@ -73,7 +73,7 @@ export const deserializeAws_restJson1StartStreamTranscriptionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext & __EventStreamSerdeContext
 ): Promise<StartStreamTranscriptionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1StartStreamTranscriptionCommandError(output, context);
   }
   const contents: StartStreamTranscriptionCommandOutput = {

--- a/clients/client-transcribe/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/protocols/Aws_json1_1.ts
@@ -449,7 +449,7 @@ export const deserializeAws_json1_1CreateMedicalVocabularyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateMedicalVocabularyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateMedicalVocabularyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -528,7 +528,7 @@ export const deserializeAws_json1_1CreateVocabularyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVocabularyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateVocabularyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -607,7 +607,7 @@ export const deserializeAws_json1_1CreateVocabularyFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateVocabularyFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateVocabularyFilterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -686,7 +686,7 @@ export const deserializeAws_json1_1DeleteMedicalTranscriptionJobCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMedicalTranscriptionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMedicalTranscriptionJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -754,7 +754,7 @@ export const deserializeAws_json1_1DeleteMedicalVocabularyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMedicalVocabularyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMedicalVocabularyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -830,7 +830,7 @@ export const deserializeAws_json1_1DeleteTranscriptionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTranscriptionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTranscriptionJobCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -898,7 +898,7 @@ export const deserializeAws_json1_1DeleteVocabularyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVocabularyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteVocabularyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -974,7 +974,7 @@ export const deserializeAws_json1_1DeleteVocabularyFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteVocabularyFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteVocabularyFilterCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1050,7 +1050,7 @@ export const deserializeAws_json1_1GetMedicalTranscriptionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMedicalTranscriptionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMedicalTranscriptionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1129,7 +1129,7 @@ export const deserializeAws_json1_1GetMedicalVocabularyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMedicalVocabularyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMedicalVocabularyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1208,7 +1208,7 @@ export const deserializeAws_json1_1GetTranscriptionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTranscriptionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTranscriptionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1287,7 +1287,7 @@ export const deserializeAws_json1_1GetVocabularyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVocabularyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetVocabularyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1366,7 +1366,7 @@ export const deserializeAws_json1_1GetVocabularyFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetVocabularyFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetVocabularyFilterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1445,7 +1445,7 @@ export const deserializeAws_json1_1ListMedicalTranscriptionJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMedicalTranscriptionJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListMedicalTranscriptionJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1516,7 +1516,7 @@ export const deserializeAws_json1_1ListMedicalVocabulariesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMedicalVocabulariesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListMedicalVocabulariesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1587,7 +1587,7 @@ export const deserializeAws_json1_1ListTranscriptionJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTranscriptionJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTranscriptionJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1658,7 +1658,7 @@ export const deserializeAws_json1_1ListVocabulariesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVocabulariesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListVocabulariesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1729,7 +1729,7 @@ export const deserializeAws_json1_1ListVocabularyFiltersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListVocabularyFiltersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListVocabularyFiltersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1800,7 +1800,7 @@ export const deserializeAws_json1_1StartMedicalTranscriptionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartMedicalTranscriptionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartMedicalTranscriptionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1879,7 +1879,7 @@ export const deserializeAws_json1_1StartTranscriptionJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartTranscriptionJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartTranscriptionJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1958,7 +1958,7 @@ export const deserializeAws_json1_1UpdateMedicalVocabularyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMedicalVocabularyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMedicalVocabularyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2045,7 +2045,7 @@ export const deserializeAws_json1_1UpdateVocabularyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVocabularyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateVocabularyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2132,7 +2132,7 @@ export const deserializeAws_json1_1UpdateVocabularyFilterCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateVocabularyFilterCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateVocabularyFilterCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-transfer/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/protocols/Aws_json1_1.ts
@@ -320,7 +320,7 @@ export const deserializeAws_json1_1CreateServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -415,7 +415,7 @@ export const deserializeAws_json1_1CreateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -502,7 +502,7 @@ export const deserializeAws_json1_1DeleteServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteServerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -586,7 +586,7 @@ export const deserializeAws_json1_1DeleteSshPublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSshPublicKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSshPublicKeyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -670,7 +670,7 @@ export const deserializeAws_json1_1DeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -746,7 +746,7 @@ export const deserializeAws_json1_1DescribeServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -825,7 +825,7 @@ export const deserializeAws_json1_1DescribeUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -904,7 +904,7 @@ export const deserializeAws_json1_1ImportSshPublicKeyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportSshPublicKeyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportSshPublicKeyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -999,7 +999,7 @@ export const deserializeAws_json1_1ListServersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListServersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListServersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1078,7 +1078,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1157,7 +1157,7 @@ export const deserializeAws_json1_1ListUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUsersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUsersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1244,7 +1244,7 @@ export const deserializeAws_json1_1StartServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartServerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1328,7 +1328,7 @@ export const deserializeAws_json1_1StopServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopServerCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1412,7 +1412,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1488,7 +1488,7 @@ export const deserializeAws_json1_1TestIdentityProviderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TestIdentityProviderCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TestIdentityProviderCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1567,7 +1567,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1643,7 +1643,7 @@ export const deserializeAws_json1_1UpdateServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateServerCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateServerCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1754,7 +1754,7 @@ export const deserializeAws_json1_1UpdateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-translate/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/protocols/Aws_json1_1.ts
@@ -192,7 +192,7 @@ export const deserializeAws_json1_1DeleteTerminologyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTerminologyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTerminologyCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -260,7 +260,7 @@ export const deserializeAws_json1_1DescribeTextTranslationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTextTranslationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTextTranslationJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -331,7 +331,7 @@ export const deserializeAws_json1_1GetTerminologyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTerminologyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetTerminologyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -410,7 +410,7 @@ export const deserializeAws_json1_1ImportTerminologyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportTerminologyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportTerminologyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -489,7 +489,7 @@ export const deserializeAws_json1_1ListTerminologiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTerminologiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTerminologiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -560,7 +560,7 @@ export const deserializeAws_json1_1ListTextTranslationJobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTextTranslationJobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTextTranslationJobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -639,7 +639,7 @@ export const deserializeAws_json1_1StartTextTranslationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartTextTranslationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartTextTranslationJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -726,7 +726,7 @@ export const deserializeAws_json1_1StopTextTranslationJobCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopTextTranslationJobCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopTextTranslationJobCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -797,7 +797,7 @@ export const deserializeAws_json1_1TranslateTextCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TranslateTextCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TranslateTextCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-waf-regional/protocols/Aws_json1_1.ts
+++ b/clients/client-waf-regional/protocols/Aws_json1_1.ts
@@ -1490,7 +1490,7 @@ export const deserializeAws_json1_1AssociateWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1577,7 +1577,7 @@ export const deserializeAws_json1_1CreateByteMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateByteMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateByteMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1672,7 +1672,7 @@ export const deserializeAws_json1_1CreateGeoMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGeoMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateGeoMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1767,7 +1767,7 @@ export const deserializeAws_json1_1CreateIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1862,7 +1862,7 @@ export const deserializeAws_json1_1CreateRateBasedRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRateBasedRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRateBasedRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1973,7 +1973,7 @@ export const deserializeAws_json1_1CreateRegexMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRegexMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRegexMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2052,7 +2052,7 @@ export const deserializeAws_json1_1CreateRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2131,7 +2131,7 @@ export const deserializeAws_json1_1CreateRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2242,7 +2242,7 @@ export const deserializeAws_json1_1CreateRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2345,7 +2345,7 @@ export const deserializeAws_json1_1CreateSizeConstraintSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSizeConstraintSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSizeConstraintSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2440,7 +2440,7 @@ export const deserializeAws_json1_1CreateSqlInjectionMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSqlInjectionMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSqlInjectionMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2535,7 +2535,7 @@ export const deserializeAws_json1_1CreateWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2654,7 +2654,7 @@ export const deserializeAws_json1_1CreateWebACLMigrationStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWebACLMigrationStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWebACLMigrationStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2741,7 +2741,7 @@ export const deserializeAws_json1_1CreateXssMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateXssMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateXssMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2836,7 +2836,7 @@ export const deserializeAws_json1_1DeleteByteMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteByteMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteByteMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2931,7 +2931,7 @@ export const deserializeAws_json1_1DeleteGeoMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGeoMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteGeoMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3026,7 +3026,7 @@ export const deserializeAws_json1_1DeleteIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3121,7 +3121,7 @@ export const deserializeAws_json1_1DeleteLoggingConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoggingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLoggingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3192,7 +3192,7 @@ export const deserializeAws_json1_1DeletePermissionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePermissionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePermissionPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3263,7 +3263,7 @@ export const deserializeAws_json1_1DeleteRateBasedRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRateBasedRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRateBasedRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3374,7 +3374,7 @@ export const deserializeAws_json1_1DeleteRegexMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRegexMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRegexMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3469,7 +3469,7 @@ export const deserializeAws_json1_1DeleteRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3564,7 +3564,7 @@ export const deserializeAws_json1_1DeleteRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3675,7 +3675,7 @@ export const deserializeAws_json1_1DeleteRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3786,7 +3786,7 @@ export const deserializeAws_json1_1DeleteSizeConstraintSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSizeConstraintSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSizeConstraintSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3881,7 +3881,7 @@ export const deserializeAws_json1_1DeleteSqlInjectionMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSqlInjectionMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSqlInjectionMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3976,7 +3976,7 @@ export const deserializeAws_json1_1DeleteWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4087,7 +4087,7 @@ export const deserializeAws_json1_1DeleteXssMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteXssMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteXssMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4182,7 +4182,7 @@ export const deserializeAws_json1_1DisassociateWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4261,7 +4261,7 @@ export const deserializeAws_json1_1GetByteMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetByteMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetByteMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4332,7 +4332,7 @@ export const deserializeAws_json1_1GetChangeTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetChangeTokenCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetChangeTokenCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4387,7 +4387,7 @@ export const deserializeAws_json1_1GetChangeTokenStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetChangeTokenStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetChangeTokenStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4450,7 +4450,7 @@ export const deserializeAws_json1_1GetGeoMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGeoMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetGeoMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4521,7 +4521,7 @@ export const deserializeAws_json1_1GetIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4592,7 +4592,7 @@ export const deserializeAws_json1_1GetLoggingConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoggingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLoggingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4655,7 +4655,7 @@ export const deserializeAws_json1_1GetPermissionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPermissionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPermissionPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4718,7 +4718,7 @@ export const deserializeAws_json1_1GetRateBasedRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRateBasedRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRateBasedRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4789,7 +4789,7 @@ export const deserializeAws_json1_1GetRateBasedRuleManagedKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRateBasedRuleManagedKeysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRateBasedRuleManagedKeysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4868,7 +4868,7 @@ export const deserializeAws_json1_1GetRegexMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRegexMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRegexMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4939,7 +4939,7 @@ export const deserializeAws_json1_1GetRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5010,7 +5010,7 @@ export const deserializeAws_json1_1GetRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5081,7 +5081,7 @@ export const deserializeAws_json1_1GetRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5144,7 +5144,7 @@ export const deserializeAws_json1_1GetSampledRequestsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSampledRequestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSampledRequestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5207,7 +5207,7 @@ export const deserializeAws_json1_1GetSizeConstraintSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSizeConstraintSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSizeConstraintSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5278,7 +5278,7 @@ export const deserializeAws_json1_1GetSqlInjectionMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSqlInjectionMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSqlInjectionMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5349,7 +5349,7 @@ export const deserializeAws_json1_1GetWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5420,7 +5420,7 @@ export const deserializeAws_json1_1GetWebACLForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWebACLForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetWebACLForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5507,7 +5507,7 @@ export const deserializeAws_json1_1GetXssMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetXssMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetXssMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5578,7 +5578,7 @@ export const deserializeAws_json1_1ListActivatedRulesInRuleGroupCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListActivatedRulesInRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListActivatedRulesInRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5649,7 +5649,7 @@ export const deserializeAws_json1_1ListByteMatchSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListByteMatchSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListByteMatchSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5712,7 +5712,7 @@ export const deserializeAws_json1_1ListGeoMatchSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGeoMatchSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGeoMatchSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5775,7 +5775,7 @@ export const deserializeAws_json1_1ListIPSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIPSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListIPSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5838,7 +5838,7 @@ export const deserializeAws_json1_1ListLoggingConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLoggingConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLoggingConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5909,7 +5909,7 @@ export const deserializeAws_json1_1ListRateBasedRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRateBasedRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRateBasedRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5972,7 +5972,7 @@ export const deserializeAws_json1_1ListRegexMatchSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRegexMatchSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRegexMatchSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6035,7 +6035,7 @@ export const deserializeAws_json1_1ListRegexPatternSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRegexPatternSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRegexPatternSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6098,7 +6098,7 @@ export const deserializeAws_json1_1ListResourcesForWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourcesForWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourcesForWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6177,7 +6177,7 @@ export const deserializeAws_json1_1ListRuleGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRuleGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRuleGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6232,7 +6232,7 @@ export const deserializeAws_json1_1ListRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6295,7 +6295,7 @@ export const deserializeAws_json1_1ListSizeConstraintSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSizeConstraintSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSizeConstraintSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6358,7 +6358,7 @@ export const deserializeAws_json1_1ListSqlInjectionMatchSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSqlInjectionMatchSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSqlInjectionMatchSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6421,7 +6421,7 @@ export const deserializeAws_json1_1ListSubscribedRuleGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSubscribedRuleGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSubscribedRuleGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6484,7 +6484,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6579,7 +6579,7 @@ export const deserializeAws_json1_1ListWebACLsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWebACLsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListWebACLsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6642,7 +6642,7 @@ export const deserializeAws_json1_1ListXssMatchSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListXssMatchSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListXssMatchSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6705,7 +6705,7 @@ export const deserializeAws_json1_1PutLoggingConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLoggingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutLoggingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6784,7 +6784,7 @@ export const deserializeAws_json1_1PutPermissionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPermissionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutPermissionPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6863,7 +6863,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6966,7 +6966,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7061,7 +7061,7 @@ export const deserializeAws_json1_1UpdateByteMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateByteMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateByteMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7172,7 +7172,7 @@ export const deserializeAws_json1_1UpdateGeoMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGeoMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGeoMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7291,7 +7291,7 @@ export const deserializeAws_json1_1UpdateIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7410,7 +7410,7 @@ export const deserializeAws_json1_1UpdateRateBasedRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRateBasedRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRateBasedRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7529,7 +7529,7 @@ export const deserializeAws_json1_1UpdateRegexMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRegexMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRegexMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7640,7 +7640,7 @@ export const deserializeAws_json1_1UpdateRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7751,7 +7751,7 @@ export const deserializeAws_json1_1UpdateRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7870,7 +7870,7 @@ export const deserializeAws_json1_1UpdateRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7973,7 +7973,7 @@ export const deserializeAws_json1_1UpdateSizeConstraintSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSizeConstraintSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSizeConstraintSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8092,7 +8092,7 @@ export const deserializeAws_json1_1UpdateSqlInjectionMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSqlInjectionMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSqlInjectionMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8203,7 +8203,7 @@ export const deserializeAws_json1_1UpdateWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -8330,7 +8330,7 @@ export const deserializeAws_json1_1UpdateXssMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateXssMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateXssMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-waf/protocols/Aws_json1_1.ts
+++ b/clients/client-waf/protocols/Aws_json1_1.ts
@@ -1419,7 +1419,7 @@ export const deserializeAws_json1_1CreateByteMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateByteMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateByteMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1514,7 +1514,7 @@ export const deserializeAws_json1_1CreateGeoMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGeoMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateGeoMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1609,7 +1609,7 @@ export const deserializeAws_json1_1CreateIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1704,7 +1704,7 @@ export const deserializeAws_json1_1CreateRateBasedRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRateBasedRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRateBasedRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1815,7 +1815,7 @@ export const deserializeAws_json1_1CreateRegexMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRegexMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRegexMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1894,7 +1894,7 @@ export const deserializeAws_json1_1CreateRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1973,7 +1973,7 @@ export const deserializeAws_json1_1CreateRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2084,7 +2084,7 @@ export const deserializeAws_json1_1CreateRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2187,7 +2187,7 @@ export const deserializeAws_json1_1CreateSizeConstraintSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSizeConstraintSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSizeConstraintSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2282,7 +2282,7 @@ export const deserializeAws_json1_1CreateSqlInjectionMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSqlInjectionMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateSqlInjectionMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2377,7 +2377,7 @@ export const deserializeAws_json1_1CreateWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2496,7 +2496,7 @@ export const deserializeAws_json1_1CreateWebACLMigrationStackCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWebACLMigrationStackCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWebACLMigrationStackCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2583,7 +2583,7 @@ export const deserializeAws_json1_1CreateXssMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateXssMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateXssMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2678,7 +2678,7 @@ export const deserializeAws_json1_1DeleteByteMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteByteMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteByteMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2773,7 +2773,7 @@ export const deserializeAws_json1_1DeleteGeoMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGeoMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteGeoMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2868,7 +2868,7 @@ export const deserializeAws_json1_1DeleteIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2963,7 +2963,7 @@ export const deserializeAws_json1_1DeleteLoggingConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoggingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLoggingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3034,7 +3034,7 @@ export const deserializeAws_json1_1DeletePermissionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePermissionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePermissionPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3105,7 +3105,7 @@ export const deserializeAws_json1_1DeleteRateBasedRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRateBasedRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRateBasedRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3216,7 +3216,7 @@ export const deserializeAws_json1_1DeleteRegexMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRegexMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRegexMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3311,7 +3311,7 @@ export const deserializeAws_json1_1DeleteRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3406,7 +3406,7 @@ export const deserializeAws_json1_1DeleteRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3517,7 +3517,7 @@ export const deserializeAws_json1_1DeleteRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3628,7 +3628,7 @@ export const deserializeAws_json1_1DeleteSizeConstraintSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSizeConstraintSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSizeConstraintSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3723,7 +3723,7 @@ export const deserializeAws_json1_1DeleteSqlInjectionMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSqlInjectionMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteSqlInjectionMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3818,7 +3818,7 @@ export const deserializeAws_json1_1DeleteWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3929,7 +3929,7 @@ export const deserializeAws_json1_1DeleteXssMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteXssMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteXssMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4024,7 +4024,7 @@ export const deserializeAws_json1_1GetByteMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetByteMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetByteMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4095,7 +4095,7 @@ export const deserializeAws_json1_1GetChangeTokenCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetChangeTokenCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetChangeTokenCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4150,7 +4150,7 @@ export const deserializeAws_json1_1GetChangeTokenStatusCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetChangeTokenStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetChangeTokenStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4213,7 +4213,7 @@ export const deserializeAws_json1_1GetGeoMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGeoMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetGeoMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4284,7 +4284,7 @@ export const deserializeAws_json1_1GetIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4355,7 +4355,7 @@ export const deserializeAws_json1_1GetLoggingConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoggingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLoggingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4418,7 +4418,7 @@ export const deserializeAws_json1_1GetPermissionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPermissionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPermissionPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4481,7 +4481,7 @@ export const deserializeAws_json1_1GetRateBasedRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRateBasedRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRateBasedRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4552,7 +4552,7 @@ export const deserializeAws_json1_1GetRateBasedRuleManagedKeysCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRateBasedRuleManagedKeysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRateBasedRuleManagedKeysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4631,7 +4631,7 @@ export const deserializeAws_json1_1GetRegexMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRegexMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRegexMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4702,7 +4702,7 @@ export const deserializeAws_json1_1GetRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4773,7 +4773,7 @@ export const deserializeAws_json1_1GetRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4844,7 +4844,7 @@ export const deserializeAws_json1_1GetRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4907,7 +4907,7 @@ export const deserializeAws_json1_1GetSampledRequestsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSampledRequestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSampledRequestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4970,7 +4970,7 @@ export const deserializeAws_json1_1GetSizeConstraintSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSizeConstraintSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSizeConstraintSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5041,7 +5041,7 @@ export const deserializeAws_json1_1GetSqlInjectionMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSqlInjectionMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSqlInjectionMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5112,7 +5112,7 @@ export const deserializeAws_json1_1GetWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5183,7 +5183,7 @@ export const deserializeAws_json1_1GetXssMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetXssMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetXssMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5254,7 +5254,7 @@ export const deserializeAws_json1_1ListActivatedRulesInRuleGroupCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListActivatedRulesInRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListActivatedRulesInRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5325,7 +5325,7 @@ export const deserializeAws_json1_1ListByteMatchSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListByteMatchSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListByteMatchSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5388,7 +5388,7 @@ export const deserializeAws_json1_1ListGeoMatchSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGeoMatchSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGeoMatchSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5451,7 +5451,7 @@ export const deserializeAws_json1_1ListIPSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIPSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListIPSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5514,7 +5514,7 @@ export const deserializeAws_json1_1ListLoggingConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLoggingConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLoggingConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5585,7 +5585,7 @@ export const deserializeAws_json1_1ListRateBasedRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRateBasedRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRateBasedRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5648,7 +5648,7 @@ export const deserializeAws_json1_1ListRegexMatchSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRegexMatchSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRegexMatchSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5711,7 +5711,7 @@ export const deserializeAws_json1_1ListRegexPatternSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRegexPatternSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRegexPatternSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5774,7 +5774,7 @@ export const deserializeAws_json1_1ListRuleGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRuleGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRuleGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5829,7 +5829,7 @@ export const deserializeAws_json1_1ListRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5892,7 +5892,7 @@ export const deserializeAws_json1_1ListSizeConstraintSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSizeConstraintSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSizeConstraintSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -5955,7 +5955,7 @@ export const deserializeAws_json1_1ListSqlInjectionMatchSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSqlInjectionMatchSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSqlInjectionMatchSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6018,7 +6018,7 @@ export const deserializeAws_json1_1ListSubscribedRuleGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListSubscribedRuleGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListSubscribedRuleGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6081,7 +6081,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6176,7 +6176,7 @@ export const deserializeAws_json1_1ListWebACLsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWebACLsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListWebACLsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6239,7 +6239,7 @@ export const deserializeAws_json1_1ListXssMatchSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListXssMatchSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListXssMatchSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6302,7 +6302,7 @@ export const deserializeAws_json1_1PutLoggingConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLoggingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutLoggingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6381,7 +6381,7 @@ export const deserializeAws_json1_1PutPermissionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPermissionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutPermissionPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6460,7 +6460,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6563,7 +6563,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6658,7 +6658,7 @@ export const deserializeAws_json1_1UpdateByteMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateByteMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateByteMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6769,7 +6769,7 @@ export const deserializeAws_json1_1UpdateGeoMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGeoMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateGeoMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -6888,7 +6888,7 @@ export const deserializeAws_json1_1UpdateIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7007,7 +7007,7 @@ export const deserializeAws_json1_1UpdateRateBasedRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRateBasedRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRateBasedRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7126,7 +7126,7 @@ export const deserializeAws_json1_1UpdateRegexMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRegexMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRegexMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7237,7 +7237,7 @@ export const deserializeAws_json1_1UpdateRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7348,7 +7348,7 @@ export const deserializeAws_json1_1UpdateRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRuleCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRuleCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7467,7 +7467,7 @@ export const deserializeAws_json1_1UpdateRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7570,7 +7570,7 @@ export const deserializeAws_json1_1UpdateSizeConstraintSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSizeConstraintSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSizeConstraintSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7689,7 +7689,7 @@ export const deserializeAws_json1_1UpdateSqlInjectionMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSqlInjectionMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateSqlInjectionMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7800,7 +7800,7 @@ export const deserializeAws_json1_1UpdateWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -7927,7 +7927,7 @@ export const deserializeAws_json1_1UpdateXssMatchSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateXssMatchSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateXssMatchSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-wafv2/protocols/Aws_json1_1.ts
+++ b/clients/client-wafv2/protocols/Aws_json1_1.ts
@@ -780,7 +780,7 @@ export const deserializeAws_json1_1AssociateWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -867,7 +867,7 @@ export const deserializeAws_json1_1CheckCapacityCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CheckCapacityCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CheckCapacityCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -970,7 +970,7 @@ export const deserializeAws_json1_1CreateIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1081,7 +1081,7 @@ export const deserializeAws_json1_1CreateRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1192,7 +1192,7 @@ export const deserializeAws_json1_1CreateRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1327,7 +1327,7 @@ export const deserializeAws_json1_1CreateWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1470,7 +1470,7 @@ export const deserializeAws_json1_1DeleteFirewallManagerRuleGroupsCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFirewallManagerRuleGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteFirewallManagerRuleGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1557,7 +1557,7 @@ export const deserializeAws_json1_1DeleteIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1668,7 +1668,7 @@ export const deserializeAws_json1_1DeleteLoggingConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLoggingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteLoggingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1755,7 +1755,7 @@ export const deserializeAws_json1_1DeletePermissionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeletePermissionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeletePermissionPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1826,7 +1826,7 @@ export const deserializeAws_json1_1DeleteRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1937,7 +1937,7 @@ export const deserializeAws_json1_1DeleteRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2048,7 +2048,7 @@ export const deserializeAws_json1_1DeleteWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2159,7 +2159,7 @@ export const deserializeAws_json1_1DescribeManagedRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeManagedRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeManagedRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2246,7 +2246,7 @@ export const deserializeAws_json1_1DisassociateWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2325,7 +2325,7 @@ export const deserializeAws_json1_1GetIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2404,7 +2404,7 @@ export const deserializeAws_json1_1GetLoggingConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetLoggingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetLoggingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2483,7 +2483,7 @@ export const deserializeAws_json1_1GetPermissionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetPermissionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetPermissionPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2554,7 +2554,7 @@ export const deserializeAws_json1_1GetRateBasedStatementManagedKeysCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRateBasedStatementManagedKeysCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRateBasedStatementManagedKeysCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2633,7 +2633,7 @@ export const deserializeAws_json1_1GetRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2712,7 +2712,7 @@ export const deserializeAws_json1_1GetRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2791,7 +2791,7 @@ export const deserializeAws_json1_1GetSampledRequestsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSampledRequestsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetSampledRequestsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2862,7 +2862,7 @@ export const deserializeAws_json1_1GetWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2941,7 +2941,7 @@ export const deserializeAws_json1_1GetWebACLForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetWebACLForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetWebACLForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3028,7 +3028,7 @@ export const deserializeAws_json1_1ListAvailableManagedRuleGroupsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAvailableManagedRuleGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAvailableManagedRuleGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3099,7 +3099,7 @@ export const deserializeAws_json1_1ListIPSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListIPSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListIPSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3170,7 +3170,7 @@ export const deserializeAws_json1_1ListLoggingConfigurationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListLoggingConfigurationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListLoggingConfigurationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3241,7 +3241,7 @@ export const deserializeAws_json1_1ListRegexPatternSetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRegexPatternSetsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRegexPatternSetsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3312,7 +3312,7 @@ export const deserializeAws_json1_1ListResourcesForWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourcesForWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourcesForWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3391,7 +3391,7 @@ export const deserializeAws_json1_1ListRuleGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListRuleGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListRuleGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3462,7 +3462,7 @@ export const deserializeAws_json1_1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListTagsForResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3557,7 +3557,7 @@ export const deserializeAws_json1_1ListWebACLsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWebACLsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListWebACLsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3628,7 +3628,7 @@ export const deserializeAws_json1_1PutLoggingConfigurationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutLoggingConfigurationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutLoggingConfigurationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3731,7 +3731,7 @@ export const deserializeAws_json1_1PutPermissionPolicyCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutPermissionPolicyCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutPermissionPolicyCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3810,7 +3810,7 @@ export const deserializeAws_json1_1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3913,7 +3913,7 @@ export const deserializeAws_json1_1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UntagResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4008,7 +4008,7 @@ export const deserializeAws_json1_1UpdateIPSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIPSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateIPSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4111,7 +4111,7 @@ export const deserializeAws_json1_1UpdateRegexPatternSetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRegexPatternSetCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRegexPatternSetCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4214,7 +4214,7 @@ export const deserializeAws_json1_1UpdateRuleGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRuleGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRuleGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -4333,7 +4333,7 @@ export const deserializeAws_json1_1UpdateWebACLCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateWebACLCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateWebACLCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-workdocs/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1.ts
@@ -1624,7 +1624,7 @@ export const deserializeAws_restJson1AbortDocumentVersionUploadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AbortDocumentVersionUploadCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1AbortDocumentVersionUploadCommandError(output, context);
   }
   const contents: AbortDocumentVersionUploadCommandOutput = {
@@ -1715,7 +1715,7 @@ export const deserializeAws_restJson1ActivateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ActivateUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ActivateUserCommandError(output, context);
   }
   const contents: ActivateUserCommandOutput = {
@@ -1802,7 +1802,7 @@ export const deserializeAws_restJson1AddResourcePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AddResourcePermissionsCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1AddResourcePermissionsCommandError(output, context);
   }
   const contents: AddResourcePermissionsCommandOutput = {
@@ -1881,7 +1881,7 @@ export const deserializeAws_restJson1CreateCommentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCommentCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCommentCommandError(output, context);
   }
   const contents: CreateCommentCommandOutput = {
@@ -1992,7 +1992,7 @@ export const deserializeAws_restJson1CreateCustomMetadataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateCustomMetadataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateCustomMetadataCommandError(output, context);
   }
   const contents: CreateCustomMetadataCommandOutput = {
@@ -2091,7 +2091,7 @@ export const deserializeAws_restJson1CreateFolderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFolderCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFolderCommandError(output, context);
   }
   const contents: CreateFolderCommandOutput = {
@@ -2210,7 +2210,7 @@ export const deserializeAws_restJson1CreateLabelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateLabelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateLabelsCommandError(output, context);
   }
   const contents: CreateLabelsCommandOutput = {
@@ -2301,7 +2301,7 @@ export const deserializeAws_restJson1CreateNotificationSubscriptionCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateNotificationSubscriptionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateNotificationSubscriptionCommandError(output, context);
   }
   const contents: CreateNotificationSubscriptionCommandOutput = {
@@ -2372,7 +2372,7 @@ export const deserializeAws_restJson1CreateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateUserCommandError(output, context);
   }
   const contents: CreateUserCommandOutput = {
@@ -2459,7 +2459,7 @@ export const deserializeAws_restJson1DeactivateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeactivateUserCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeactivateUserCommandError(output, context);
   }
   const contents: DeactivateUserCommandOutput = {
@@ -2542,7 +2542,7 @@ export const deserializeAws_restJson1DeleteCommentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCommentCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteCommentCommandError(output, context);
   }
   const contents: DeleteCommentCommandOutput = {
@@ -2641,7 +2641,7 @@ export const deserializeAws_restJson1DeleteCustomMetadataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteCustomMetadataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteCustomMetadataCommandError(output, context);
   }
   const contents: DeleteCustomMetadataCommandOutput = {
@@ -2732,7 +2732,7 @@ export const deserializeAws_restJson1DeleteDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteDocumentCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteDocumentCommandError(output, context);
   }
   const contents: DeleteDocumentCommandOutput = {
@@ -2839,7 +2839,7 @@ export const deserializeAws_restJson1DeleteFolderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFolderCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFolderCommandError(output, context);
   }
   const contents: DeleteFolderCommandOutput = {
@@ -2946,7 +2946,7 @@ export const deserializeAws_restJson1DeleteFolderContentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFolderContentsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFolderContentsCommandError(output, context);
   }
   const contents: DeleteFolderContentsCommandOutput = {
@@ -3045,7 +3045,7 @@ export const deserializeAws_restJson1DeleteLabelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteLabelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteLabelsCommandError(output, context);
   }
   const contents: DeleteLabelsCommandOutput = {
@@ -3128,7 +3128,7 @@ export const deserializeAws_restJson1DeleteNotificationSubscriptionCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteNotificationSubscriptionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteNotificationSubscriptionCommandError(output, context);
   }
   const contents: DeleteNotificationSubscriptionCommandOutput = {
@@ -3203,7 +3203,7 @@ export const deserializeAws_restJson1DeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteUserCommandError(output, context);
   }
   const contents: DeleteUserCommandOutput = {
@@ -3286,7 +3286,7 @@ export const deserializeAws_restJson1DescribeActivitiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeActivitiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeActivitiesCommandError(output, context);
   }
   const contents: DescribeActivitiesCommandOutput = {
@@ -3377,7 +3377,7 @@ export const deserializeAws_restJson1DescribeCommentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCommentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeCommentsCommandError(output, context);
   }
   const contents: DescribeCommentsCommandOutput = {
@@ -3476,7 +3476,7 @@ export const deserializeAws_restJson1DescribeDocumentVersionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDocumentVersionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDocumentVersionsCommandError(output, context);
   }
   const contents: DescribeDocumentVersionsCommandOutput = {
@@ -3583,7 +3583,7 @@ export const deserializeAws_restJson1DescribeFolderContentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFolderContentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeFolderContentsCommandError(output, context);
   }
   const contents: DescribeFolderContentsCommandOutput = {
@@ -3686,7 +3686,7 @@ export const deserializeAws_restJson1DescribeGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeGroupsCommandError(output, context);
   }
   const contents: DescribeGroupsCommandOutput = {
@@ -3769,7 +3769,7 @@ export const deserializeAws_restJson1DescribeNotificationSubscriptionsCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeNotificationSubscriptionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeNotificationSubscriptionsCommandError(output, context);
   }
   const contents: DescribeNotificationSubscriptionsCommandOutput = {
@@ -3844,7 +3844,7 @@ export const deserializeAws_restJson1DescribeResourcePermissionsCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeResourcePermissionsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeResourcePermissionsCommandError(output, context);
   }
   const contents: DescribeResourcePermissionsCommandOutput = {
@@ -3927,7 +3927,7 @@ export const deserializeAws_restJson1DescribeRootFoldersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeRootFoldersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeRootFoldersCommandError(output, context);
   }
   const contents: DescribeRootFoldersCommandOutput = {
@@ -4018,7 +4018,7 @@ export const deserializeAws_restJson1DescribeUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUsersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeUsersCommandError(output, context);
   }
   const contents: DescribeUsersCommandOutput = {
@@ -4129,7 +4129,7 @@ export const deserializeAws_restJson1GetCurrentUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetCurrentUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetCurrentUserCommandError(output, context);
   }
   const contents: GetCurrentUserCommandOutput = {
@@ -4216,7 +4216,7 @@ export const deserializeAws_restJson1GetDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDocumentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDocumentCommandError(output, context);
   }
   const contents: GetDocumentCommandOutput = {
@@ -4323,7 +4323,7 @@ export const deserializeAws_restJson1GetDocumentPathCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDocumentPathCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDocumentPathCommandError(output, context);
   }
   const contents: GetDocumentPathCommandOutput = {
@@ -4410,7 +4410,7 @@ export const deserializeAws_restJson1GetDocumentVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetDocumentVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetDocumentVersionCommandError(output, context);
   }
   const contents: GetDocumentVersionCommandOutput = {
@@ -4517,7 +4517,7 @@ export const deserializeAws_restJson1GetFolderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFolderCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFolderCommandError(output, context);
   }
   const contents: GetFolderCommandOutput = {
@@ -4624,7 +4624,7 @@ export const deserializeAws_restJson1GetFolderPathCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetFolderPathCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetFolderPathCommandError(output, context);
   }
   const contents: GetFolderPathCommandOutput = {
@@ -4711,7 +4711,7 @@ export const deserializeAws_restJson1GetResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetResourcesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetResourcesCommandError(output, context);
   }
   const contents: GetResourcesCommandOutput = {
@@ -4806,7 +4806,7 @@ export const deserializeAws_restJson1InitiateDocumentVersionUploadCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InitiateDocumentVersionUploadCommandOutput> => {
-  if (output.statusCode !== 201 && output.statusCode >= 400) {
+  if (output.statusCode !== 201 && output.statusCode >= 300) {
     return deserializeAws_restJson1InitiateDocumentVersionUploadCommandError(output, context);
   }
   const contents: InitiateDocumentVersionUploadCommandOutput = {
@@ -4945,7 +4945,7 @@ export const deserializeAws_restJson1RemoveAllResourcePermissionsCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveAllResourcePermissionsCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveAllResourcePermissionsCommandError(output, context);
   }
   const contents: RemoveAllResourcePermissionsCommandOutput = {
@@ -5020,7 +5020,7 @@ export const deserializeAws_restJson1RemoveResourcePermissionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RemoveResourcePermissionCommandOutput> => {
-  if (output.statusCode !== 204 && output.statusCode >= 400) {
+  if (output.statusCode !== 204 && output.statusCode >= 300) {
     return deserializeAws_restJson1RemoveResourcePermissionCommandError(output, context);
   }
   const contents: RemoveResourcePermissionCommandOutput = {
@@ -5095,7 +5095,7 @@ export const deserializeAws_restJson1UpdateDocumentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDocumentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDocumentCommandError(output, context);
   }
   const contents: UpdateDocumentCommandOutput = {
@@ -5218,7 +5218,7 @@ export const deserializeAws_restJson1UpdateDocumentVersionCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDocumentVersionCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDocumentVersionCommandError(output, context);
   }
   const contents: UpdateDocumentVersionCommandOutput = {
@@ -5325,7 +5325,7 @@ export const deserializeAws_restJson1UpdateFolderCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFolderCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFolderCommandError(output, context);
   }
   const contents: UpdateFolderCommandOutput = {
@@ -5448,7 +5448,7 @@ export const deserializeAws_restJson1UpdateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateUserCommandError(output, context);
   }
   const contents: UpdateUserCommandOutput = {

--- a/clients/client-worklink/protocols/Aws_restJson1.ts
+++ b/clients/client-worklink/protocols/Aws_restJson1.ts
@@ -986,7 +986,7 @@ export const deserializeAws_restJson1AssociateDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateDomainCommandError(output, context);
   }
   const contents: AssociateDomainCommandOutput = {
@@ -1077,7 +1077,7 @@ export const deserializeAws_restJson1AssociateWebsiteAuthorizationProviderComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateWebsiteAuthorizationProviderCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateWebsiteAuthorizationProviderCommandError(output, context);
   }
   const contents: AssociateWebsiteAuthorizationProviderCommandOutput = {
@@ -1172,7 +1172,7 @@ export const deserializeAws_restJson1AssociateWebsiteCertificateAuthorityCommand
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateWebsiteCertificateAuthorityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AssociateWebsiteCertificateAuthorityCommandError(output, context);
   }
   const contents: AssociateWebsiteCertificateAuthorityCommandOutput = {
@@ -1267,7 +1267,7 @@ export const deserializeAws_restJson1CreateFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateFleetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateFleetCommandError(output, context);
   }
   const contents: CreateFleetCommandOutput = {
@@ -1362,7 +1362,7 @@ export const deserializeAws_restJson1DeleteFleetCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteFleetCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteFleetCommandError(output, context);
   }
   const contents: DeleteFleetCommandOutput = {
@@ -1445,7 +1445,7 @@ export const deserializeAws_restJson1DescribeAuditStreamConfigurationCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAuditStreamConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeAuditStreamConfigurationCommandError(output, context);
   }
   const contents: DescribeAuditStreamConfigurationCommandOutput = {
@@ -1532,7 +1532,7 @@ export const deserializeAws_restJson1DescribeCompanyNetworkConfigurationCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeCompanyNetworkConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeCompanyNetworkConfigurationCommandError(output, context);
   }
   const contents: DescribeCompanyNetworkConfigurationCommandOutput = {
@@ -1627,7 +1627,7 @@ export const deserializeAws_restJson1DescribeDeviceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDeviceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDeviceCommandError(output, context);
   }
   const contents: DescribeDeviceCommandOutput = {
@@ -1746,7 +1746,7 @@ export const deserializeAws_restJson1DescribeDevicePolicyConfigurationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDevicePolicyConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDevicePolicyConfigurationCommandError(output, context);
   }
   const contents: DescribeDevicePolicyConfigurationCommandOutput = {
@@ -1833,7 +1833,7 @@ export const deserializeAws_restJson1DescribeDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeDomainCommandError(output, context);
   }
   const contents: DescribeDomainCommandOutput = {
@@ -1936,7 +1936,7 @@ export const deserializeAws_restJson1DescribeFleetMetadataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeFleetMetadataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeFleetMetadataCommandError(output, context);
   }
   const contents: DescribeFleetMetadataCommandOutput = {
@@ -2051,7 +2051,7 @@ export const deserializeAws_restJson1DescribeIdentityProviderConfigurationComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIdentityProviderConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeIdentityProviderConfigurationCommandError(output, context);
   }
   const contents: DescribeIdentityProviderConfigurationCommandOutput = {
@@ -2146,7 +2146,7 @@ export const deserializeAws_restJson1DescribeWebsiteCertificateAuthorityCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWebsiteCertificateAuthorityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DescribeWebsiteCertificateAuthorityCommandError(output, context);
   }
   const contents: DescribeWebsiteCertificateAuthorityCommandOutput = {
@@ -2241,7 +2241,7 @@ export const deserializeAws_restJson1DisassociateDomainCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateDomainCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateDomainCommandError(output, context);
   }
   const contents: DisassociateDomainCommandOutput = {
@@ -2324,7 +2324,7 @@ export const deserializeAws_restJson1DisassociateWebsiteAuthorizationProviderCom
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateWebsiteAuthorizationProviderCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateWebsiteAuthorizationProviderCommandError(output, context);
   }
   const contents: DisassociateWebsiteAuthorizationProviderCommandOutput = {
@@ -2415,7 +2415,7 @@ export const deserializeAws_restJson1DisassociateWebsiteCertificateAuthorityComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateWebsiteCertificateAuthorityCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DisassociateWebsiteCertificateAuthorityCommandError(output, context);
   }
   const contents: DisassociateWebsiteCertificateAuthorityCommandOutput = {
@@ -2498,7 +2498,7 @@ export const deserializeAws_restJson1ListDevicesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDevicesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDevicesCommandError(output, context);
   }
   const contents: ListDevicesCommandOutput = {
@@ -2589,7 +2589,7 @@ export const deserializeAws_restJson1ListDomainsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListDomainsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListDomainsCommandError(output, context);
   }
   const contents: ListDomainsCommandOutput = {
@@ -2680,7 +2680,7 @@ export const deserializeAws_restJson1ListFleetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListFleetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListFleetsCommandError(output, context);
   }
   const contents: ListFleetsCommandOutput = {
@@ -2763,7 +2763,7 @@ export const deserializeAws_restJson1ListTagsForResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListTagsForResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListTagsForResourceCommandError(output, context);
   }
   const contents: ListTagsForResourceCommandOutput = {
@@ -2818,7 +2818,7 @@ export const deserializeAws_restJson1ListWebsiteAuthorizationProvidersCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWebsiteAuthorizationProvidersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListWebsiteAuthorizationProvidersCommandError(output, context);
   }
   const contents: ListWebsiteAuthorizationProvidersCommandOutput = {
@@ -2912,7 +2912,7 @@ export const deserializeAws_restJson1ListWebsiteCertificateAuthoritiesCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListWebsiteCertificateAuthoritiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ListWebsiteCertificateAuthoritiesCommandError(output, context);
   }
   const contents: ListWebsiteCertificateAuthoritiesCommandOutput = {
@@ -2998,7 +2998,7 @@ export const deserializeAws_restJson1RestoreDomainAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreDomainAccessCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RestoreDomainAccessCommandError(output, context);
   }
   const contents: RestoreDomainAccessCommandOutput = {
@@ -3081,7 +3081,7 @@ export const deserializeAws_restJson1RevokeDomainAccessCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeDomainAccessCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RevokeDomainAccessCommandError(output, context);
   }
   const contents: RevokeDomainAccessCommandOutput = {
@@ -3164,7 +3164,7 @@ export const deserializeAws_restJson1SignOutUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SignOutUserCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SignOutUserCommandError(output, context);
   }
   const contents: SignOutUserCommandOutput = {
@@ -3247,7 +3247,7 @@ export const deserializeAws_restJson1TagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TagResourceCommandError(output, context);
   }
   const contents: TagResourceCommandOutput = {
@@ -3298,7 +3298,7 @@ export const deserializeAws_restJson1UntagResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UntagResourceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UntagResourceCommandError(output, context);
   }
   const contents: UntagResourceCommandOutput = {
@@ -3349,7 +3349,7 @@ export const deserializeAws_restJson1UpdateAuditStreamConfigurationCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateAuditStreamConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateAuditStreamConfigurationCommandError(output, context);
   }
   const contents: UpdateAuditStreamConfigurationCommandOutput = {
@@ -3432,7 +3432,7 @@ export const deserializeAws_restJson1UpdateCompanyNetworkConfigurationCommand = 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateCompanyNetworkConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateCompanyNetworkConfigurationCommandError(output, context);
   }
   const contents: UpdateCompanyNetworkConfigurationCommandOutput = {
@@ -3515,7 +3515,7 @@ export const deserializeAws_restJson1UpdateDevicePolicyConfigurationCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDevicePolicyConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDevicePolicyConfigurationCommandError(output, context);
   }
   const contents: UpdateDevicePolicyConfigurationCommandOutput = {
@@ -3598,7 +3598,7 @@ export const deserializeAws_restJson1UpdateDomainMetadataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateDomainMetadataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateDomainMetadataCommandError(output, context);
   }
   const contents: UpdateDomainMetadataCommandOutput = {
@@ -3681,7 +3681,7 @@ export const deserializeAws_restJson1UpdateFleetMetadataCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateFleetMetadataCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateFleetMetadataCommandError(output, context);
   }
   const contents: UpdateFleetMetadataCommandOutput = {
@@ -3764,7 +3764,7 @@ export const deserializeAws_restJson1UpdateIdentityProviderConfigurationCommand 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateIdentityProviderConfigurationCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateIdentityProviderConfigurationCommandError(output, context);
   }
   const contents: UpdateIdentityProviderConfigurationCommandOutput = {

--- a/clients/client-workmail/protocols/Aws_json1_1.ts
+++ b/clients/client-workmail/protocols/Aws_json1_1.ts
@@ -600,7 +600,7 @@ export const deserializeAws_json1_1AssociateDelegateToResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateDelegateToResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateDelegateToResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -687,7 +687,7 @@ export const deserializeAws_json1_1AssociateMemberToGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateMemberToGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateMemberToGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -798,7 +798,7 @@ export const deserializeAws_json1_1CreateAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateAliasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -909,7 +909,7 @@ export const deserializeAws_json1_1CreateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1020,7 +1020,7 @@ export const deserializeAws_json1_1CreateResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1123,7 +1123,7 @@ export const deserializeAws_json1_1CreateUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1242,7 +1242,7 @@ export const deserializeAws_json1_1DeleteAliasCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteAliasCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteAliasCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1329,7 +1329,7 @@ export const deserializeAws_json1_1DeleteGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1432,7 +1432,7 @@ export const deserializeAws_json1_1DeleteMailboxPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteMailboxPermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteMailboxPermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1519,7 +1519,7 @@ export const deserializeAws_json1_1DeleteResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1598,7 +1598,7 @@ export const deserializeAws_json1_1DeleteUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1701,7 +1701,7 @@ export const deserializeAws_json1_1DeregisterFromWorkMailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterFromWorkMailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterFromWorkMailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1788,7 +1788,7 @@ export const deserializeAws_json1_1DescribeGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1867,7 +1867,7 @@ export const deserializeAws_json1_1DescribeOrganizationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeOrganizationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeOrganizationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1930,7 +1930,7 @@ export const deserializeAws_json1_1DescribeResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2009,7 +2009,7 @@ export const deserializeAws_json1_1DescribeUserCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeUserCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeUserCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2088,7 +2088,7 @@ export const deserializeAws_json1_1DisassociateDelegateFromResourceCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateDelegateFromResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateDelegateFromResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2175,7 +2175,7 @@ export const deserializeAws_json1_1DisassociateMemberFromGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateMemberFromGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateMemberFromGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2286,7 +2286,7 @@ export const deserializeAws_json1_1GetMailboxDetailsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetMailboxDetailsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1GetMailboxDetailsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2357,7 +2357,7 @@ export const deserializeAws_json1_1ListAliasesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAliasesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAliasesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2444,7 +2444,7 @@ export const deserializeAws_json1_1ListGroupMembersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupMembersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGroupMembersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2531,7 +2531,7 @@ export const deserializeAws_json1_1ListGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2610,7 +2610,7 @@ export const deserializeAws_json1_1ListMailboxPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListMailboxPermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListMailboxPermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2689,7 +2689,7 @@ export const deserializeAws_json1_1ListOrganizationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListOrganizationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListOrganizationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2744,7 +2744,7 @@ export const deserializeAws_json1_1ListResourceDelegatesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourceDelegatesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourceDelegatesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2831,7 +2831,7 @@ export const deserializeAws_json1_1ListResourcesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListResourcesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListResourcesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2902,7 +2902,7 @@ export const deserializeAws_json1_1ListUsersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListUsersCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListUsersCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2973,7 +2973,7 @@ export const deserializeAws_json1_1PutMailboxPermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutMailboxPermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1PutMailboxPermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3060,7 +3060,7 @@ export const deserializeAws_json1_1RegisterToWorkMailCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterToWorkMailCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterToWorkMailCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3195,7 +3195,7 @@ export const deserializeAws_json1_1ResetPasswordCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ResetPasswordCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ResetPasswordCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3314,7 +3314,7 @@ export const deserializeAws_json1_1UpdateMailboxQuotaCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateMailboxQuotaCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateMailboxQuotaCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3401,7 +3401,7 @@ export const deserializeAws_json1_1UpdatePrimaryEmailAddressCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdatePrimaryEmailAddressCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdatePrimaryEmailAddressCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3536,7 +3536,7 @@ export const deserializeAws_json1_1UpdateResourceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateResourceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateResourceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-workmailmessageflow/protocols/Aws_restJson1.ts
+++ b/clients/client-workmailmessageflow/protocols/Aws_restJson1.ts
@@ -49,7 +49,7 @@ export const deserializeAws_restJson1GetRawMessageContentCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetRawMessageContentCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetRawMessageContentCommandError(output, context);
   }
   const contents: GetRawMessageContentCommandOutput = {

--- a/clients/client-workspaces/protocols/Aws_json1_1.ts
+++ b/clients/client-workspaces/protocols/Aws_json1_1.ts
@@ -816,7 +816,7 @@ export const deserializeAws_json1_1AssociateIpGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AssociateIpGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AssociateIpGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -911,7 +911,7 @@ export const deserializeAws_json1_1AuthorizeIpRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AuthorizeIpRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1AuthorizeIpRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -998,7 +998,7 @@ export const deserializeAws_json1_1CopyWorkspaceImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CopyWorkspaceImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CopyWorkspaceImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1101,7 +1101,7 @@ export const deserializeAws_json1_1CreateIpGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateIpGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateIpGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1188,7 +1188,7 @@ export const deserializeAws_json1_1CreateTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1259,7 +1259,7 @@ export const deserializeAws_json1_1CreateWorkspacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateWorkspacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1CreateWorkspacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1322,7 +1322,7 @@ export const deserializeAws_json1_1DeleteIpGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteIpGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteIpGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1401,7 +1401,7 @@ export const deserializeAws_json1_1DeleteTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1464,7 +1464,7 @@ export const deserializeAws_json1_1DeleteWorkspaceImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteWorkspaceImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeleteWorkspaceImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1535,7 +1535,7 @@ export const deserializeAws_json1_1DeregisterWorkspaceDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeregisterWorkspaceDirectoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DeregisterWorkspaceDirectoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1622,7 +1622,7 @@ export const deserializeAws_json1_1DescribeAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1677,7 +1677,7 @@ export const deserializeAws_json1_1DescribeAccountModificationsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeAccountModificationsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeAccountModificationsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1732,7 +1732,7 @@ export const deserializeAws_json1_1DescribeClientPropertiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeClientPropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeClientPropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1803,7 +1803,7 @@ export const deserializeAws_json1_1DescribeIpGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeIpGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeIpGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1866,7 +1866,7 @@ export const deserializeAws_json1_1DescribeTagsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeTagsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeTagsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1921,7 +1921,7 @@ export const deserializeAws_json1_1DescribeWorkspaceBundlesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkspaceBundlesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeWorkspaceBundlesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1976,7 +1976,7 @@ export const deserializeAws_json1_1DescribeWorkspaceDirectoriesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkspaceDirectoriesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeWorkspaceDirectoriesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2031,7 +2031,7 @@ export const deserializeAws_json1_1DescribeWorkspaceImagePermissionsCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkspaceImagePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeWorkspaceImagePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2102,7 +2102,7 @@ export const deserializeAws_json1_1DescribeWorkspaceImagesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkspaceImagesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeWorkspaceImagesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2157,7 +2157,7 @@ export const deserializeAws_json1_1DescribeWorkspacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkspacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeWorkspacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2220,7 +2220,7 @@ export const deserializeAws_json1_1DescribeWorkspacesConnectionStatusCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkspacesConnectionStatusCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeWorkspacesConnectionStatusCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2275,7 +2275,7 @@ export const deserializeAws_json1_1DescribeWorkspaceSnapshotsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DescribeWorkspaceSnapshotsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DescribeWorkspaceSnapshotsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2346,7 +2346,7 @@ export const deserializeAws_json1_1DisassociateIpGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DisassociateIpGroupsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1DisassociateIpGroupsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2425,7 +2425,7 @@ export const deserializeAws_json1_1ImportWorkspaceImageCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ImportWorkspaceImageCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ImportWorkspaceImageCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2520,7 +2520,7 @@ export const deserializeAws_json1_1ListAvailableManagementCidrRangesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ListAvailableManagementCidrRangesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ListAvailableManagementCidrRangesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2583,7 +2583,7 @@ export const deserializeAws_json1_1MigrateWorkspaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<MigrateWorkspaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1MigrateWorkspaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2678,7 +2678,7 @@ export const deserializeAws_json1_1ModifyAccountCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyAccountCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyAccountCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2765,7 +2765,7 @@ export const deserializeAws_json1_1ModifyClientPropertiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyClientPropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyClientPropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2836,7 +2836,7 @@ export const deserializeAws_json1_1ModifySelfservicePermissionsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifySelfservicePermissionsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifySelfservicePermissionsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2907,7 +2907,7 @@ export const deserializeAws_json1_1ModifyWorkspaceAccessPropertiesCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyWorkspaceAccessPropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyWorkspaceAccessPropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -2970,7 +2970,7 @@ export const deserializeAws_json1_1ModifyWorkspaceCreationPropertiesCommand = as
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyWorkspaceCreationPropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyWorkspaceCreationPropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3041,7 +3041,7 @@ export const deserializeAws_json1_1ModifyWorkspacePropertiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyWorkspacePropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyWorkspacePropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3144,7 +3144,7 @@ export const deserializeAws_json1_1ModifyWorkspaceStateCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ModifyWorkspaceStateCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1ModifyWorkspaceStateCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3215,7 +3215,7 @@ export const deserializeAws_json1_1RebootWorkspacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebootWorkspacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RebootWorkspacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3262,7 +3262,7 @@ export const deserializeAws_json1_1RebuildWorkspacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RebuildWorkspacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RebuildWorkspacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3309,7 +3309,7 @@ export const deserializeAws_json1_1RegisterWorkspaceDirectoryCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RegisterWorkspaceDirectoryCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RegisterWorkspaceDirectoryCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3420,7 +3420,7 @@ export const deserializeAws_json1_1RestoreWorkspaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RestoreWorkspaceCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RestoreWorkspaceCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3491,7 +3491,7 @@ export const deserializeAws_json1_1RevokeIpRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RevokeIpRulesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1RevokeIpRulesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3570,7 +3570,7 @@ export const deserializeAws_json1_1StartWorkspacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StartWorkspacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StartWorkspacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3617,7 +3617,7 @@ export const deserializeAws_json1_1StopWorkspacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<StopWorkspacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1StopWorkspacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3664,7 +3664,7 @@ export const deserializeAws_json1_1TerminateWorkspacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TerminateWorkspacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1TerminateWorkspacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3711,7 +3711,7 @@ export const deserializeAws_json1_1UpdateRulesOfIpGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateRulesOfIpGroupCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateRulesOfIpGroupCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -3798,7 +3798,7 @@ export const deserializeAws_json1_1UpdateWorkspaceImagePermissionCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateWorkspaceImagePermissionCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1UpdateWorkspaceImagePermissionCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/clients/client-xray/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1.ts
@@ -616,7 +616,7 @@ export const deserializeAws_restJson1BatchGetTracesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<BatchGetTracesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1BatchGetTracesCommandError(output, context);
   }
   const contents: BatchGetTracesCommandOutput = {
@@ -687,7 +687,7 @@ export const deserializeAws_restJson1CreateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateGroupCommandError(output, context);
   }
   const contents: CreateGroupCommandOutput = {
@@ -750,7 +750,7 @@ export const deserializeAws_restJson1CreateSamplingRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<CreateSamplingRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1CreateSamplingRuleCommandError(output, context);
   }
   const contents: CreateSamplingRuleCommandOutput = {
@@ -821,7 +821,7 @@ export const deserializeAws_restJson1DeleteGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteGroupCommandError(output, context);
   }
   const contents: DeleteGroupCommandOutput = {
@@ -880,7 +880,7 @@ export const deserializeAws_restJson1DeleteSamplingRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<DeleteSamplingRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1DeleteSamplingRuleCommandError(output, context);
   }
   const contents: DeleteSamplingRuleCommandOutput = {
@@ -943,7 +943,7 @@ export const deserializeAws_restJson1GetEncryptionConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetEncryptionConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetEncryptionConfigCommandError(output, context);
   }
   const contents: GetEncryptionConfigCommandOutput = {
@@ -1006,7 +1006,7 @@ export const deserializeAws_restJson1GetGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGroupCommandError(output, context);
   }
   const contents: GetGroupCommandOutput = {
@@ -1069,7 +1069,7 @@ export const deserializeAws_restJson1GetGroupsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetGroupsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetGroupsCommandError(output, context);
   }
   const contents: GetGroupsCommandOutput = {
@@ -1136,7 +1136,7 @@ export const deserializeAws_restJson1GetSamplingRulesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSamplingRulesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSamplingRulesCommandError(output, context);
   }
   const contents: GetSamplingRulesCommandOutput = {
@@ -1203,7 +1203,7 @@ export const deserializeAws_restJson1GetSamplingStatisticSummariesCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSamplingStatisticSummariesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSamplingStatisticSummariesCommandError(output, context);
   }
   const contents: GetSamplingStatisticSummariesCommandOutput = {
@@ -1273,7 +1273,7 @@ export const deserializeAws_restJson1GetSamplingTargetsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetSamplingTargetsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetSamplingTargetsCommandError(output, context);
   }
   const contents: GetSamplingTargetsCommandOutput = {
@@ -1350,7 +1350,7 @@ export const deserializeAws_restJson1GetServiceGraphCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetServiceGraphCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetServiceGraphCommandError(output, context);
   }
   const contents: GetServiceGraphCommandOutput = {
@@ -1429,7 +1429,7 @@ export const deserializeAws_restJson1GetTimeSeriesServiceStatisticsCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTimeSeriesServiceStatisticsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTimeSeriesServiceStatisticsCommandError(output, context);
   }
   const contents: GetTimeSeriesServiceStatisticsCommandOutput = {
@@ -1503,7 +1503,7 @@ export const deserializeAws_restJson1GetTraceGraphCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTraceGraphCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTraceGraphCommandError(output, context);
   }
   const contents: GetTraceGraphCommandOutput = {
@@ -1570,7 +1570,7 @@ export const deserializeAws_restJson1GetTraceSummariesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GetTraceSummariesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GetTraceSummariesCommandError(output, context);
   }
   const contents: GetTraceSummariesCommandOutput = {
@@ -1645,7 +1645,7 @@ export const deserializeAws_restJson1PutEncryptionConfigCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutEncryptionConfigCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutEncryptionConfigCommandError(output, context);
   }
   const contents: PutEncryptionConfigCommandOutput = {
@@ -1708,7 +1708,7 @@ export const deserializeAws_restJson1PutTelemetryRecordsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutTelemetryRecordsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutTelemetryRecordsCommandError(output, context);
   }
   const contents: PutTelemetryRecordsCommandOutput = {
@@ -1767,7 +1767,7 @@ export const deserializeAws_restJson1PutTraceSegmentsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<PutTraceSegmentsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1PutTraceSegmentsCommandError(output, context);
   }
   const contents: PutTraceSegmentsCommandOutput = {
@@ -1833,7 +1833,7 @@ export const deserializeAws_restJson1UpdateGroupCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateGroupCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateGroupCommandError(output, context);
   }
   const contents: UpdateGroupCommandOutput = {
@@ -1896,7 +1896,7 @@ export const deserializeAws_restJson1UpdateSamplingRuleCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<UpdateSamplingRuleCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1UpdateSamplingRuleCommandError(output, context);
   }
   const contents: UpdateSamplingRuleCommandOutput = {

--- a/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
+++ b/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
@@ -312,7 +312,7 @@ export const deserializeAws_ec2EmptyInputAndEmptyOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EmptyInputAndEmptyOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2EmptyInputAndEmptyOutputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -358,7 +358,7 @@ export const deserializeAws_ec2GreetingWithErrorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GreetingWithErrorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2GreetingWithErrorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -420,7 +420,7 @@ export const deserializeAws_ec2IgnoresWrappingXmlNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IgnoresWrappingXmlNameCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2IgnoresWrappingXmlNameCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -466,7 +466,7 @@ export const deserializeAws_ec2NestedStructuresCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NestedStructuresCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2NestedStructuresCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -509,7 +509,7 @@ export const deserializeAws_ec2NoInputAndOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NoInputAndOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2NoInputAndOutputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -555,7 +555,7 @@ export const deserializeAws_ec2QueryIdempotencyTokenAutoFillCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryIdempotencyTokenAutoFillCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2QueryIdempotencyTokenAutoFillCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -598,7 +598,7 @@ export const deserializeAws_ec2QueryListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryListsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2QueryListsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -641,7 +641,7 @@ export const deserializeAws_ec2QueryTimestampsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryTimestampsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2QueryTimestampsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -684,7 +684,7 @@ export const deserializeAws_ec2RecursiveXmlShapesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RecursiveXmlShapesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2RecursiveXmlShapesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -730,7 +730,7 @@ export const deserializeAws_ec2SimpleInputParamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SimpleInputParamsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2SimpleInputParamsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -773,7 +773,7 @@ export const deserializeAws_ec2SimpleScalarXmlPropertiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SimpleScalarXmlPropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2SimpleScalarXmlPropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -819,7 +819,7 @@ export const deserializeAws_ec2XmlBlobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlBlobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2XmlBlobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -865,7 +865,7 @@ export const deserializeAws_ec2XmlEnumsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlEnumsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2XmlEnumsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -911,7 +911,7 @@ export const deserializeAws_ec2XmlListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlListsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2XmlListsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -957,7 +957,7 @@ export const deserializeAws_ec2XmlNamespacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlNamespacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2XmlNamespacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1003,7 +1003,7 @@ export const deserializeAws_ec2XmlTimestampsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlTimestampsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_ec2XmlTimestampsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/protocol_tests/aws-json/protocols/Aws_json1_1.ts
+++ b/protocol_tests/aws-json/protocols/Aws_json1_1.ts
@@ -71,7 +71,7 @@ export const deserializeAws_json1_1EmptyOperationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EmptyOperationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1EmptyOperationCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -115,7 +115,7 @@ export const deserializeAws_json1_1KitchenSinkOperationCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<KitchenSinkOperationCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1KitchenSinkOperationCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -178,7 +178,7 @@ export const deserializeAws_json1_1OperationWithOptionalInputOutputCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<OperationWithOptionalInputOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_json1_1OperationWithOptionalInputOutputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/protocol_tests/aws-query/protocols/Aws_query.ts
+++ b/protocol_tests/aws-query/protocols/Aws_query.ts
@@ -414,7 +414,7 @@ export const deserializeAws_queryEmptyInputAndEmptyOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EmptyInputAndEmptyOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryEmptyInputAndEmptyOutputCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -460,7 +460,7 @@ export const deserializeAws_queryFlattenedXmlMapCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FlattenedXmlMapCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryFlattenedXmlMapCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -506,7 +506,7 @@ export const deserializeAws_queryFlattenedXmlMapWithXmlNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FlattenedXmlMapWithXmlNameCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryFlattenedXmlMapWithXmlNameCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -552,7 +552,7 @@ export const deserializeAws_queryGreetingWithErrorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GreetingWithErrorsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryGreetingWithErrorsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -614,7 +614,7 @@ export const deserializeAws_queryIgnoresWrappingXmlNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IgnoresWrappingXmlNameCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryIgnoresWrappingXmlNameCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -660,7 +660,7 @@ export const deserializeAws_queryNestedStructuresCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NestedStructuresCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryNestedStructuresCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -703,7 +703,7 @@ export const deserializeAws_queryNoInputAndNoOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NoInputAndNoOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryNoInputAndNoOutputCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -746,7 +746,7 @@ export const deserializeAws_queryNoInputAndOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NoInputAndOutputCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryNoInputAndOutputCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -789,7 +789,7 @@ export const deserializeAws_queryQueryIdempotencyTokenAutoFillCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryIdempotencyTokenAutoFillCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryQueryIdempotencyTokenAutoFillCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -832,7 +832,7 @@ export const deserializeAws_queryQueryListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryListsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryQueryListsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -875,7 +875,7 @@ export const deserializeAws_queryQueryMapsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryMapsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryQueryMapsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -918,7 +918,7 @@ export const deserializeAws_queryQueryTimestampsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryTimestampsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryQueryTimestampsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -961,7 +961,7 @@ export const deserializeAws_queryRecursiveXmlShapesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RecursiveXmlShapesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryRecursiveXmlShapesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1007,7 +1007,7 @@ export const deserializeAws_querySimpleInputParamsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SimpleInputParamsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySimpleInputParamsCommandError(output, context);
   }
   await collectBody(output.body, context);
@@ -1050,7 +1050,7 @@ export const deserializeAws_querySimpleScalarXmlPropertiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SimpleScalarXmlPropertiesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_querySimpleScalarXmlPropertiesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1096,7 +1096,7 @@ export const deserializeAws_queryXmlBlobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlBlobsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryXmlBlobsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1142,7 +1142,7 @@ export const deserializeAws_queryXmlEnumsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlEnumsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryXmlEnumsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1188,7 +1188,7 @@ export const deserializeAws_queryXmlListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlListsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryXmlListsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1234,7 +1234,7 @@ export const deserializeAws_queryXmlMapsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlMapsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryXmlMapsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1280,7 +1280,7 @@ export const deserializeAws_queryXmlMapsXmlNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlMapsXmlNameCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryXmlMapsXmlNameCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1326,7 +1326,7 @@ export const deserializeAws_queryXmlNamespacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlNamespacesCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryXmlNamespacesCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);
@@ -1372,7 +1372,7 @@ export const deserializeAws_queryXmlTimestampsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlTimestampsCommandOutput> => {
-  if (output.statusCode >= 400) {
+  if (output.statusCode >= 300) {
     return deserializeAws_queryXmlTimestampsCommandError(output, context);
   }
   const data: any = await parseBody(output.body, context);

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -1072,7 +1072,7 @@ export const deserializeAws_restJson1AllQueryStringTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AllQueryStringTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1AllQueryStringTypesCommandError(output, context);
   }
   const contents: AllQueryStringTypesCommandOutput = {
@@ -1115,7 +1115,7 @@ export const deserializeAws_restJson1ConstantAndVariableQueryStringCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConstantAndVariableQueryStringCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ConstantAndVariableQueryStringCommandError(output, context);
   }
   const contents: ConstantAndVariableQueryStringCommandOutput = {
@@ -1158,7 +1158,7 @@ export const deserializeAws_restJson1ConstantQueryStringCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConstantQueryStringCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1ConstantQueryStringCommandError(output, context);
   }
   const contents: ConstantQueryStringCommandOutput = {
@@ -1201,7 +1201,7 @@ export const deserializeAws_restJson1EmptyInputAndEmptyOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EmptyInputAndEmptyOutputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1EmptyInputAndEmptyOutputCommandError(output, context);
   }
   const contents: EmptyInputAndEmptyOutputCommandOutput = {
@@ -1244,7 +1244,7 @@ export const deserializeAws_restJson1GreetingWithErrorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GreetingWithErrorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1GreetingWithErrorsCommandError(output, context);
   }
   const contents: GreetingWithErrorsCommandOutput = {
@@ -1315,7 +1315,7 @@ export const deserializeAws_restJson1HttpPayloadTraitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPayloadTraitsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1HttpPayloadTraitsCommandError(output, context);
   }
   const contents: HttpPayloadTraitsCommandOutput = {
@@ -1364,7 +1364,7 @@ export const deserializeAws_restJson1HttpPayloadTraitsWithMediaTypeCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPayloadTraitsWithMediaTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1HttpPayloadTraitsWithMediaTypeCommandError(output, context);
   }
   const contents: HttpPayloadTraitsWithMediaTypeCommandOutput = {
@@ -1413,7 +1413,7 @@ export const deserializeAws_restJson1HttpPayloadWithStructureCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPayloadWithStructureCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1HttpPayloadWithStructureCommandError(output, context);
   }
   const contents: HttpPayloadWithStructureCommandOutput = {
@@ -1458,7 +1458,7 @@ export const deserializeAws_restJson1HttpPrefixHeadersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPrefixHeadersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1HttpPrefixHeadersCommandError(output, context);
   }
   const contents: HttpPrefixHeadersCommandOutput = {
@@ -1514,7 +1514,7 @@ export const deserializeAws_restJson1HttpRequestWithGreedyLabelInPathCommand = a
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpRequestWithGreedyLabelInPathCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1HttpRequestWithGreedyLabelInPathCommandError(output, context);
   }
   const contents: HttpRequestWithGreedyLabelInPathCommandOutput = {
@@ -1557,7 +1557,7 @@ export const deserializeAws_restJson1HttpRequestWithLabelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpRequestWithLabelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1HttpRequestWithLabelsCommandError(output, context);
   }
   const contents: HttpRequestWithLabelsCommandOutput = {
@@ -1600,7 +1600,7 @@ export const deserializeAws_restJson1HttpRequestWithLabelsAndTimestampFormatComm
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpRequestWithLabelsAndTimestampFormatCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1HttpRequestWithLabelsAndTimestampFormatCommandError(output, context);
   }
   const contents: HttpRequestWithLabelsAndTimestampFormatCommandOutput = {
@@ -1643,7 +1643,7 @@ export const deserializeAws_restJson1IgnoreQueryParamsInResponseCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IgnoreQueryParamsInResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1IgnoreQueryParamsInResponseCommandError(output, context);
   }
   const contents: IgnoreQueryParamsInResponseCommandOutput = {
@@ -1690,7 +1690,7 @@ export const deserializeAws_restJson1InputAndOutputWithHeadersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InputAndOutputWithHeadersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1InputAndOutputWithHeadersCommandError(output, context);
   }
   const contents: InputAndOutputWithHeadersCommandOutput = {
@@ -1803,7 +1803,7 @@ export const deserializeAws_restJson1JsonBlobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<JsonBlobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1JsonBlobsCommandError(output, context);
   }
   const contents: JsonBlobsCommandOutput = {
@@ -1850,7 +1850,7 @@ export const deserializeAws_restJson1JsonEnumsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<JsonEnumsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1JsonEnumsCommandError(output, context);
   }
   const contents: JsonEnumsCommandOutput = {
@@ -1917,7 +1917,7 @@ export const deserializeAws_restJson1JsonListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<JsonListsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1JsonListsCommandError(output, context);
   }
   const contents: JsonListsCommandOutput = {
@@ -1992,7 +1992,7 @@ export const deserializeAws_restJson1JsonMapsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<JsonMapsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1JsonMapsCommandError(output, context);
   }
   const contents: JsonMapsCommandOutput = {
@@ -2039,7 +2039,7 @@ export const deserializeAws_restJson1JsonTimestampsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<JsonTimestampsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1JsonTimestampsCommandError(output, context);
   }
   const contents: JsonTimestampsCommandOutput = {
@@ -2098,7 +2098,7 @@ export const deserializeAws_restJson1NoInputAndNoOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NoInputAndNoOutputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1NoInputAndNoOutputCommandError(output, context);
   }
   const contents: NoInputAndNoOutputCommandOutput = {
@@ -2141,7 +2141,7 @@ export const deserializeAws_restJson1NoInputAndOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NoInputAndOutputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1NoInputAndOutputCommandError(output, context);
   }
   const contents: NoInputAndOutputCommandOutput = {
@@ -2184,7 +2184,7 @@ export const deserializeAws_restJson1NullAndEmptyHeadersClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NullAndEmptyHeadersClientCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1NullAndEmptyHeadersClientCommandError(output, context);
   }
   const contents: NullAndEmptyHeadersClientCommandOutput = {
@@ -2239,7 +2239,7 @@ export const deserializeAws_restJson1NullAndEmptyHeadersServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NullAndEmptyHeadersServerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1NullAndEmptyHeadersServerCommandError(output, context);
   }
   const contents: NullAndEmptyHeadersServerCommandOutput = {
@@ -2294,7 +2294,7 @@ export const deserializeAws_restJson1OmitsNullSerializesEmptyStringCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<OmitsNullSerializesEmptyStringCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1OmitsNullSerializesEmptyStringCommandError(output, context);
   }
   const contents: OmitsNullSerializesEmptyStringCommandOutput = {
@@ -2337,7 +2337,7 @@ export const deserializeAws_restJson1QueryIdempotencyTokenAutoFillCommand = asyn
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryIdempotencyTokenAutoFillCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1QueryIdempotencyTokenAutoFillCommandError(output, context);
   }
   const contents: QueryIdempotencyTokenAutoFillCommandOutput = {
@@ -2380,7 +2380,7 @@ export const deserializeAws_restJson1RecursiveShapesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RecursiveShapesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1RecursiveShapesCommandError(output, context);
   }
   const contents: RecursiveShapesCommandOutput = {
@@ -2427,7 +2427,7 @@ export const deserializeAws_restJson1SimpleScalarPropertiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SimpleScalarPropertiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1SimpleScalarPropertiesCommandError(output, context);
   }
   const contents: SimpleScalarPropertiesCommandOutput = {
@@ -2510,7 +2510,7 @@ export const deserializeAws_restJson1TimestampFormatHeadersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TimestampFormatHeadersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restJson1TimestampFormatHeadersCommandError(output, context);
   }
   const contents: TimestampFormatHeadersCommandOutput = {

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -1540,7 +1540,7 @@ export const deserializeAws_restXmlAllQueryStringTypesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<AllQueryStringTypesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlAllQueryStringTypesCommandError(output, context);
   }
   const contents: AllQueryStringTypesCommandOutput = {
@@ -1583,7 +1583,7 @@ export const deserializeAws_restXmlConstantAndVariableQueryStringCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConstantAndVariableQueryStringCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlConstantAndVariableQueryStringCommandError(output, context);
   }
   const contents: ConstantAndVariableQueryStringCommandOutput = {
@@ -1626,7 +1626,7 @@ export const deserializeAws_restXmlConstantQueryStringCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<ConstantQueryStringCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlConstantQueryStringCommandError(output, context);
   }
   const contents: ConstantQueryStringCommandOutput = {
@@ -1669,7 +1669,7 @@ export const deserializeAws_restXmlEmptyInputAndEmptyOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<EmptyInputAndEmptyOutputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlEmptyInputAndEmptyOutputCommandError(output, context);
   }
   const contents: EmptyInputAndEmptyOutputCommandOutput = {
@@ -1712,7 +1712,7 @@ export const deserializeAws_restXmlFlattenedXmlMapCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FlattenedXmlMapCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlFlattenedXmlMapCommandError(output, context);
   }
   const contents: FlattenedXmlMapCommandOutput = {
@@ -1762,7 +1762,7 @@ export const deserializeAws_restXmlFlattenedXmlMapWithXmlNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<FlattenedXmlMapWithXmlNameCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlFlattenedXmlMapWithXmlNameCommandError(output, context);
   }
   const contents: FlattenedXmlMapWithXmlNameCommandOutput = {
@@ -1815,7 +1815,7 @@ export const deserializeAws_restXmlGreetingWithErrorsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<GreetingWithErrorsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlGreetingWithErrorsCommandError(output, context);
   }
   const contents: GreetingWithErrorsCommandOutput = {
@@ -1878,7 +1878,7 @@ export const deserializeAws_restXmlHttpPayloadTraitsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPayloadTraitsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHttpPayloadTraitsCommandError(output, context);
   }
   const contents: HttpPayloadTraitsCommandOutput = {
@@ -1927,7 +1927,7 @@ export const deserializeAws_restXmlHttpPayloadTraitsWithMediaTypeCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPayloadTraitsWithMediaTypeCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHttpPayloadTraitsWithMediaTypeCommandError(output, context);
   }
   const contents: HttpPayloadTraitsWithMediaTypeCommandOutput = {
@@ -1976,7 +1976,7 @@ export const deserializeAws_restXmlHttpPayloadWithStructureCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPayloadWithStructureCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHttpPayloadWithStructureCommandError(output, context);
   }
   const contents: HttpPayloadWithStructureCommandOutput = {
@@ -2021,7 +2021,7 @@ export const deserializeAws_restXmlHttpPayloadWithXmlNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPayloadWithXmlNameCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHttpPayloadWithXmlNameCommandError(output, context);
   }
   const contents: HttpPayloadWithXmlNameCommandOutput = {
@@ -2066,7 +2066,7 @@ export const deserializeAws_restXmlHttpPayloadWithXmlNamespaceCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPayloadWithXmlNamespaceCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHttpPayloadWithXmlNamespaceCommandError(output, context);
   }
   const contents: HttpPayloadWithXmlNamespaceCommandOutput = {
@@ -2111,7 +2111,7 @@ export const deserializeAws_restXmlHttpPayloadWithXmlNamespaceAndPrefixCommand =
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPayloadWithXmlNamespaceAndPrefixCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHttpPayloadWithXmlNamespaceAndPrefixCommandError(output, context);
   }
   const contents: HttpPayloadWithXmlNamespaceAndPrefixCommandOutput = {
@@ -2156,7 +2156,7 @@ export const deserializeAws_restXmlHttpPrefixHeadersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpPrefixHeadersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHttpPrefixHeadersCommandError(output, context);
   }
   const contents: HttpPrefixHeadersCommandOutput = {
@@ -2212,7 +2212,7 @@ export const deserializeAws_restXmlHttpRequestWithGreedyLabelInPathCommand = asy
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpRequestWithGreedyLabelInPathCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHttpRequestWithGreedyLabelInPathCommandError(output, context);
   }
   const contents: HttpRequestWithGreedyLabelInPathCommandOutput = {
@@ -2255,7 +2255,7 @@ export const deserializeAws_restXmlHttpRequestWithLabelsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpRequestWithLabelsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHttpRequestWithLabelsCommandError(output, context);
   }
   const contents: HttpRequestWithLabelsCommandOutput = {
@@ -2298,7 +2298,7 @@ export const deserializeAws_restXmlHttpRequestWithLabelsAndTimestampFormatComman
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<HttpRequestWithLabelsAndTimestampFormatCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlHttpRequestWithLabelsAndTimestampFormatCommandError(output, context);
   }
   const contents: HttpRequestWithLabelsAndTimestampFormatCommandOutput = {
@@ -2341,7 +2341,7 @@ export const deserializeAws_restXmlIgnoreQueryParamsInResponseCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<IgnoreQueryParamsInResponseCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlIgnoreQueryParamsInResponseCommandError(output, context);
   }
   const contents: IgnoreQueryParamsInResponseCommandOutput = {
@@ -2388,7 +2388,7 @@ export const deserializeAws_restXmlInputAndOutputWithHeadersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<InputAndOutputWithHeadersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlInputAndOutputWithHeadersCommandError(output, context);
   }
   const contents: InputAndOutputWithHeadersCommandOutput = {
@@ -2501,7 +2501,7 @@ export const deserializeAws_restXmlNoInputAndNoOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NoInputAndNoOutputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlNoInputAndNoOutputCommandError(output, context);
   }
   const contents: NoInputAndNoOutputCommandOutput = {
@@ -2544,7 +2544,7 @@ export const deserializeAws_restXmlNoInputAndOutputCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NoInputAndOutputCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlNoInputAndOutputCommandError(output, context);
   }
   const contents: NoInputAndOutputCommandOutput = {
@@ -2587,7 +2587,7 @@ export const deserializeAws_restXmlNullAndEmptyHeadersClientCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NullAndEmptyHeadersClientCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlNullAndEmptyHeadersClientCommandError(output, context);
   }
   const contents: NullAndEmptyHeadersClientCommandOutput = {
@@ -2642,7 +2642,7 @@ export const deserializeAws_restXmlNullAndEmptyHeadersServerCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<NullAndEmptyHeadersServerCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlNullAndEmptyHeadersServerCommandError(output, context);
   }
   const contents: NullAndEmptyHeadersServerCommandOutput = {
@@ -2697,7 +2697,7 @@ export const deserializeAws_restXmlOmitsNullSerializesEmptyStringCommand = async
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<OmitsNullSerializesEmptyStringCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlOmitsNullSerializesEmptyStringCommandError(output, context);
   }
   const contents: OmitsNullSerializesEmptyStringCommandOutput = {
@@ -2740,7 +2740,7 @@ export const deserializeAws_restXmlQueryIdempotencyTokenAutoFillCommand = async 
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<QueryIdempotencyTokenAutoFillCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlQueryIdempotencyTokenAutoFillCommandError(output, context);
   }
   const contents: QueryIdempotencyTokenAutoFillCommandOutput = {
@@ -2783,7 +2783,7 @@ export const deserializeAws_restXmlRecursiveShapesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<RecursiveShapesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlRecursiveShapesCommandError(output, context);
   }
   const contents: RecursiveShapesCommandOutput = {
@@ -2830,7 +2830,7 @@ export const deserializeAws_restXmlSimpleScalarPropertiesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<SimpleScalarPropertiesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlSimpleScalarPropertiesCommandError(output, context);
   }
   const contents: SimpleScalarPropertiesCommandOutput = {
@@ -2913,7 +2913,7 @@ export const deserializeAws_restXmlTimestampFormatHeadersCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<TimestampFormatHeadersCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlTimestampFormatHeadersCommandError(output, context);
   }
   const contents: TimestampFormatHeadersCommandOutput = {
@@ -2984,7 +2984,7 @@ export const deserializeAws_restXmlXmlAttributesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlAttributesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlXmlAttributesCommandError(output, context);
   }
   const contents: XmlAttributesCommandOutput = {
@@ -3035,7 +3035,7 @@ export const deserializeAws_restXmlXmlAttributesOnPayloadCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlAttributesOnPayloadCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlXmlAttributesOnPayloadCommandError(output, context);
   }
   const contents: XmlAttributesOnPayloadCommandOutput = {
@@ -3080,7 +3080,7 @@ export const deserializeAws_restXmlXmlBlobsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlBlobsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlXmlBlobsCommandError(output, context);
   }
   const contents: XmlBlobsCommandOutput = {
@@ -3127,7 +3127,7 @@ export const deserializeAws_restXmlXmlEnumsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlEnumsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlXmlEnumsCommandError(output, context);
   }
   const contents: XmlEnumsCommandOutput = {
@@ -3212,7 +3212,7 @@ export const deserializeAws_restXmlXmlListsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlListsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlXmlListsCommandError(output, context);
   }
   const contents: XmlListsCommandOutput = {
@@ -3359,7 +3359,7 @@ export const deserializeAws_restXmlXmlMapsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlMapsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlXmlMapsCommandError(output, context);
   }
   const contents: XmlMapsCommandOutput = {
@@ -3412,7 +3412,7 @@ export const deserializeAws_restXmlXmlMapsXmlNameCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlMapsXmlNameCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlXmlMapsXmlNameCommandError(output, context);
   }
   const contents: XmlMapsXmlNameCommandOutput = {
@@ -3465,7 +3465,7 @@ export const deserializeAws_restXmlXmlNamespacesCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlNamespacesCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlXmlNamespacesCommandError(output, context);
   }
   const contents: XmlNamespacesCommandOutput = {
@@ -3512,7 +3512,7 @@ export const deserializeAws_restXmlXmlTimestampsCommand = async (
   output: __HttpResponse,
   context: __SerdeContext
 ): Promise<XmlTimestampsCommandOutput> => {
-  if (output.statusCode !== 200 && output.statusCode >= 400) {
+  if (output.statusCode !== 200 && output.statusCode >= 300) {
     return deserializeAws_restXmlXmlTimestampsCommandError(output, context);
   }
   const contents: XmlTimestampsCommandOutput = {


### PR DESCRIPTION
Codegen change: https://github.com/awslabs/smithy-typescript/pull/222
Resolves: #1446 #1385 

*Description of changes:*
SDK throws 3xx response as exceptions instead of failing silently. This behavior aligns with other Smithy SDK like Go v2


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
