### PR TITLE
fix(readme): highlight package name as standard

### DIFF
--- a/packages/credential-provider-env/README.md
+++ b/packages/credential-provider-env/README.md
@@ -1,7 +1,9 @@
-# AWS Credential Provider for Node.JS - Environment Variables
+# @aws-sdk/credential-provider-env
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-env/beta.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-env)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-env.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-env)
+
+## AWS Credential Provider for Node.JS - Environment Variables
 
 This module provides a `CredentialProvider` function, `fromEnv`, that reads from
 the following environment variables:

--- a/packages/credential-provider-imds/README.md
+++ b/packages/credential-provider-imds/README.md
@@ -1,7 +1,9 @@
-# AWS Credential Provider for Node.JS - Instance and Container Metadata
+# @aws-sdk/credential-provider-imds
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-imds/beta.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-imds)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-imds.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-imds)
+
+## AWS Credential Provider for Node.JS - Instance and Container Metadata
 
 This module provides two `CredentialProvider` factory functions,
 `fromContainerMetadata` and `fromInstanceMetadata`, that will create

--- a/packages/credential-provider-ini/README.md
+++ b/packages/credential-provider-ini/README.md
@@ -1,7 +1,9 @@
-# AWS Credential Provider for Node.JS - Shared Configuration Files
+# @aws-sdk/credential-provider-ini
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-ini/beta.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-ini)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-ini.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-ini)
+
+## AWS Credential Provider for Node.JS - Shared Configuration Files
 
 This module provides a function, `fromSharedConfigFiles` that will create
 `CredentialProvider` functions that read from a shared credentials file at

--- a/packages/credential-provider-node/README.md
+++ b/packages/credential-provider-node/README.md
@@ -1,7 +1,9 @@
-# AWS Credential Provider for Node.JS
+# @aws-sdk/credential-provider-node
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-node.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-node)
+
+## AWS Credential Provider for Node.JS
 
 This module provides a factory function, `fromEnv`, that will attempt to source
 AWS credentials from a Node.JS environment. It will attempt to find credentials

--- a/packages/credential-provider-process/README.md
+++ b/packages/credential-provider-process/README.md
@@ -1,7 +1,9 @@
-# AWS Credential Provider for Node.JS - Shared Configuration Files
+# @aws-sdk/credential-provider-process
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/credential-provider-process/beta.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-process)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/credential-provider-process.svg)](https://www.npmjs.com/package/@aws-sdk/credential-provider-process)
+
+## AWS Credential Provider for Node.JS - Shared Configuration Files
 
 This module provides a function, `fromSharedConfigFiles` that will create
 `CredentialProvider` functions that read from a shared credentials file at

--- a/packages/eventstream-serde-browser/README.md
+++ b/packages/eventstream-serde-browser/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/eventstream-serde-browser
+# @aws-sdk/eventstream-serde-browser
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-serde-browser/alpha.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-serde-browser.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-browser)

--- a/packages/eventstream-serde-node/README.md
+++ b/packages/eventstream-serde-node/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/eventstream-serde-node
+# @aws-sdk/eventstream-serde-node
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/eventstream-serde-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/eventstream-serde-node.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/eventstream-serde-node)

--- a/packages/hash-blob-browser/README.md
+++ b/packages/hash-blob-browser/README.md
@@ -1,4 +1,4 @@
-# sha256-blob-browser
+# @aws-sdk/sha256-blob-browser
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/hash-blob-browser/beta.svg)](https://www.npmjs.com/package/@aws-sdk/hash-blob-browser)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/hash-blob-browser.svg)](https://www.npmjs.com/package/@aws-sdk/hash-blob-browser)

--- a/packages/hash-node/README.md
+++ b/packages/hash-node/README.md
@@ -1,4 +1,4 @@
-# md5-node
+# @aws-sdk/md5-node
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/hash-node/beta.svg)](https://www.npmjs.com/package/@aws-sdk/hash-node)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/hash-node.svg)](https://www.npmjs.com/package/@aws-sdk/hash-node)

--- a/packages/invalid-dependency/README.md
+++ b/packages/invalid-dependency/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/invalid-dependency
+# @aws-sdk/invalid-dependency
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/invalid-dependency/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/invalid-dependency)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/invalid-dependency.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/invalid-dependency)

--- a/packages/middleware-host-header/README.md
+++ b/packages/middleware-host-header/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/middleware-host-header
+# @aws-sdk/middleware-host-header
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/middleware-host-header/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-host-header)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/middleware-host-header.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-host-header)

--- a/packages/middleware-sdk-api-gateway/README.md
+++ b/packages/middleware-sdk-api-gateway/README.md
@@ -1,4 +1,4 @@
-# middleware-sdk-apigateway
+# @aws-sdk/middleware-sdk-apigateway
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-sdk-api-gateway/beta.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-sdk-api-gateway)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-sdk-api-gateway.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-sdk-api-gateway)

--- a/packages/middleware-sdk-s3-control/README.md
+++ b/packages/middleware-sdk-s3-control/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/middleware-sdk-s3-control
+# @aws-sdk/middleware-sdk-s3-control
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/middleware-sdk-s3-control/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-sdk-s3-control)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/middleware-sdk-s3-control.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-sdk-s3-control)

--- a/packages/middleware-sdk-s3/README.md
+++ b/packages/middleware-sdk-s3/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/middleware-sdk-s3
+# @aws-sdk/middleware-sdk-s3
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/middleware-sdk-s3/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-sdk-s3)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/middleware-sdk-s3.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-sdk-s3)

--- a/packages/middleware-sdk-sqs/README.md
+++ b/packages/middleware-sdk-sqs/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/middleware-sdk-sqs
+# @aws-sdk/middleware-sdk-sqs
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/middleware-sdk-sqs/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-sdk-sqs)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/middleware-sdk-sqs.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-sdk-sqs)

--- a/packages/middleware-serde/README.md
+++ b/packages/middleware-serde/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/middleware-serde
+# @aws-sdk/middleware-serde
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/middleware-serde/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-serde)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/middleware-serde.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-serde)

--- a/packages/middleware-signing/README.md
+++ b/packages/middleware-signing/README.md
@@ -1,4 +1,4 @@
-# signer-middleware
+# @aws-sdk/signer-middleware
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/middleware-signing/beta.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-signing)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/middleware-signing.svg)](https://www.npmjs.com/package/@aws-sdk/middleware-signing)

--- a/packages/middleware-user-agent/README.md
+++ b/packages/middleware-user-agent/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/middleware-user-agent
+# @aws-sdk/middleware-user-agent
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/middleware-user-agent/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-user-agent)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/middleware-user-agent.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/middleware-user-agent)

--- a/packages/protocol-http/README.md
+++ b/packages/protocol-http/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/protocol-http
+# @aws-sdk/protocol-http
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/protocol-http/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/protocol-http)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/protocol-http.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/protocol-http)

--- a/packages/shared-ini-file-loader/README.md
+++ b/packages/shared-ini-file-loader/README.md
@@ -1,7 +1,9 @@
-# AWS Shared Configuration File Loader
+# @aws-sdk/shared-ini-file-loader
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/shared-ini-file-loader/beta.svg)](https://www.npmjs.com/package/@aws-sdk/shared-ini-file-loader)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/shared-ini-file-loader.svg)](https://www.npmjs.com/package/@aws-sdk/shared-ini-file-loader)
+
+## AWS Shared Configuration File Loader
 
 This module provides a function that reads from AWS SDK configuration files and
 returns a promise that will resolve with a hash of the parsed contents of the

--- a/packages/smithy-client/README.md
+++ b/packages/smithy-client/README.md
@@ -1,4 +1,4 @@
-# @aws-sdk/@aws-sdk/smithy-client
+# @aws-sdk/smithy-client
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/@aws-sdk/smithy-client/beta.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/smithy-client)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/@aws-sdk/smithy-client.svg)](https://www.npmjs.com/package/@aws-sdk/@aws-sdk/smithy-client)

--- a/packages/util-uri-escape/README.md
+++ b/packages/util-uri-escape/README.md
@@ -1,4 +1,4 @@
-# util-uri-escape
+# @aws-sdk/util-uri-escape
 
 [![NPM version](https://img.shields.io/npm/v/@aws-sdk/util-uri-escape/beta.svg)](https://www.npmjs.com/package/@aws-sdk/util-uri-escape)
 [![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/util-uri-escape.svg)](https://www.npmjs.com/package/@aws-sdk/util-uri-escape)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Standardizes the title in packages to list package name.
* Moved description title to below the badges if present.
* Removed redundant `@aws-sdk/`
* Added missing `@aws-sdk/`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
