### PR TITLE
fix: update client readme template

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
@@ -1,6 +1,6 @@
-${packageName}
+# ${packageName}
 
-[![NPM version](https://img.shields.io/npm/v/${packageName}/beta.svg)](https://www.npmjs.com/package/${packageName})
+[![NPM version](https://img.shields.io/npm/v/${packageName}/rc.svg)](https://www.npmjs.com/package/${packageName})
 [![NPM downloads](https://img.shields.io/npm/dm/${packageName}.svg)](https://www.npmjs.com/package/${packageName})
 
 For SDK usage, please step to [SDK readme](https://github.com/aws/aws-sdk-js-v3).


### PR DESCRIPTION
*Issue #, if available:*
This was missed in PRs:
* https://github.com/aws/aws-sdk-js-v3/pull/1600
* https://github.com/aws/aws-sdk-js-v3/pull/1601

The code change was manually done in above to PRs, as the script `copy-to-clients` doesn't override README.md once generated.	

*Description of changes:*
update client readme template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
