### PR TITLE
chore(deps-dev): bump @aws-crypto deps to 1.0.0

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -28,8 +28,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/body-checksum-browser": "1.0.0-rc.2",
     "@aws-sdk/body-checksum-node": "1.0.0-rc.2",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/eventstream-serde-browser": "1.0.0-rc.2",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -27,8 +27,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -27,8 +27,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -27,8 +27,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -28,8 +28,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/eventstream-serde-browser": "1.0.0-rc.2",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -28,8 +28,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/eventstream-handler-node": "1.0.0-rc.2",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -26,7 +26,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/util-utf8-browser": "1.0.0-rc.2",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -27,7 +27,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/util-utf8-node": "1.0.0-rc.2",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -18,7 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-crypto/crc32": "^1.0.0-alpha.0",
+    "@aws-crypto/crc32": "^1.0.0",
     "@aws-sdk/types": "1.0.0-rc.2",
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.2",
     "tslib": "^1.8.0"

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -24,7 +24,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.2",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.2",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -22,7 +22,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.2",
     "@aws-sdk/util-utf8-node": "1.0.0-rc.2",
     "@types/jest": "^26.0.4",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -26,7 +26,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/protocol-http": "1.0.0-rc.2",
     "@aws-sdk/util-buffer-from": "1.0.0-rc.2",
     "@types/jest": "^26.0.4",

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -26,8 +26,8 @@
   },
   "sideEffects": false,
   "dependencies": {
-    "@aws-crypto/sha256-browser": "^1.0.0-alpha.0",
-    "@aws-crypto/sha256-js": "^1.0.0-alpha.0",
+    "@aws-crypto/sha256-browser": "^1.0.0",
+    "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/config-resolver": "1.0.0-rc.2",
     "@aws-sdk/credential-provider-node": "1.0.0-rc.2",
     "@aws-sdk/fetch-http-handler": "1.0.0-rc.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,48 +2,48 @@
 # yarn lockfile v1
 
 
-"@aws-crypto/crc32@^1.0.0-alpha.0":
-  version "1.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-1.0.0-alpha.0.tgz#12e593b60c42352d1942a2fa31122747650dd8f8"
-  integrity sha512-n4OJttn49liBR0CVdK7dAvkTaP8jLiRRekdA0wunTEELIIwjC4c60YODADbqR2Hug4dtzQ6huJTgyFeHIaYPHg==
+"@aws-crypto/crc32@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/crc32/-/crc32-1.0.0.tgz#6a0164fd92bb365860ba6afb5dfef449701eb8ca"
+  integrity sha512-wr4EyCv3ZfLH3Sg7FErV6e/cLhpk9rUP/l5322y8PRgpQsItdieaLbtE4aDOR+dxl8U7BG9FIwWXH4TleTDZ9A==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^1.11.1"
 
-"@aws-crypto/ie11-detection@^1.0.0-alpha.0":
-  version "1.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0-alpha.0.tgz#16ca4a9233ec4a90e1d0b2f1712f4aa2043457bd"
-  integrity sha512-TQ55S96+aD/iZF/VdgbLqCm2um8mQhjNrlFqQEJkXc12L4taF0wz0FfdFSJ9Uuy6EIf4GjgvbLExgJwxmFqL5A==
+"@aws-crypto/ie11-detection@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/ie11-detection/-/ie11-detection-1.0.0.tgz#d3a6af29ba7f15458f79c41d1cd8cac3925e726a"
+  integrity sha512-kCKVhCF1oDxFYgQrxXmIrS5oaWulkvRcPz+QBDMsUr2crbF4VGgGT6+uQhSwJFdUAQ2A//Vq+uT83eJrkzFgXA==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^1.11.1"
 
-"@aws-crypto/sha256-browser@^1.0.0-alpha.0":
-  version "1.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-1.0.0-alpha.0.tgz#f438fb3423aa989814b87e6afbc490e1d17f3122"
-  integrity sha512-ZhULGaJKI/o8KROknqvnmYX3gphPQL5HLoMdVD5yPEsEsFG7rEIu4ORv2s6uaiqkdEkXZcdS+CNC8ekIndr9QA==
+"@aws-crypto/sha256-browser@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-browser/-/sha256-browser-1.0.0.tgz#9c34d3b829d922b2c8e077b30a60db53d6befcb1"
+  integrity sha512-uSufui4ZktC5lYX6bDxgBgNboxGyw9V9V+rlcNsNTxh4YPhOdCslwJMGntiWOBRGAgXhhvWi7FqnTS2SaT3cpg==
   dependencies:
-    "@aws-crypto/ie11-detection" "^1.0.0-alpha.0"
-    "@aws-crypto/sha256-js" "^1.0.0-alpha.0"
-    "@aws-crypto/supports-web-crypto" "^1.0.0-alpha.0"
-    "@aws-sdk/types" "^1.0.0-alpha.0"
-    "@aws-sdk/util-locate-window" "^1.0.0-alpha.0"
-    "@aws-sdk/util-utf8-browser" "^1.0.0-alpha.0"
-    tslib "^1.9.3"
+    "@aws-crypto/ie11-detection" "^1.0.0"
+    "@aws-crypto/sha256-js" "^1.0.0"
+    "@aws-crypto/supports-web-crypto" "^1.0.0"
+    "@aws-sdk/types" "^1.0.0-rc.1"
+    "@aws-sdk/util-locate-window" "^1.0.0-rc.1"
+    "@aws-sdk/util-utf8-browser" "^1.0.0-rc.1"
+    tslib "^1.11.1"
 
-"@aws-crypto/sha256-js@^1.0.0-alpha.0":
-  version "1.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-1.0.0-alpha.0.tgz#1146f6fa823001a9065ce60db5bf1afcc7c1cc3a"
-  integrity sha512-GidX2lccEtHZw8mXDKJQj6tea7qh3pAnsNSp1eZNxsN4MMu2OvSraPSqiB1EihsQkZBMg0IiZPpZHoACUX/QMQ==
+"@aws-crypto/sha256-js@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/sha256-js/-/sha256-js-1.0.0.tgz#ca788a3242a4024c386e6b9985da28f290a79ad7"
+  integrity sha512-89kqtFs/tdHBFHEBXZ4UXlCISswvEor3BVVOriR68Tbk1Qe1zBOZtfbSOt3CDT69z88x5uM558YW9k8I1xei5A==
   dependencies:
-    "@aws-sdk/types" "^1.0.0-alpha.0"
-    "@aws-sdk/util-utf8-browser" "^1.0.0-alpha.0"
-    tslib "^1.9.3"
+    "@aws-sdk/types" "^1.0.0-rc.1"
+    "@aws-sdk/util-utf8-browser" "^1.0.0-rc.1"
+    tslib "^1.11.1"
 
-"@aws-crypto/supports-web-crypto@^1.0.0-alpha.0":
-  version "1.0.0-alpha.0"
-  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0-alpha.0.tgz#f9f2bed724caba3036be73e1f9bf25e01e5f6c42"
-  integrity sha512-jVWjNCoEKY49NIWyU1ia1RvtupEZEzOTkYZ1kRH+Z0RqIg9DZksQ7PbSRvxtAv8rTBdyGSgQdEpbFtQtm/ZiRQ==
+"@aws-crypto/supports-web-crypto@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@aws-crypto/supports-web-crypto/-/supports-web-crypto-1.0.0.tgz#c40901bc17ac1e875e248df16a2b47ad8bfd9a93"
+  integrity sha512-IHLfv+WmVH89EW4n6a5eE8/hUlz6qkWGMn/v4r5ZgzcXdTC5nolii2z3k46y01hWRiC2PPhOdeSLzMUCUMco7g==
   dependencies:
-    tslib "^1.9.3"
+    tslib "^1.11.1"
 
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.3":
   version "7.10.3"
@@ -11801,7 +11801,12 @@ ts-loader@^7.0.5:
     micromatch "^4.0.0"
     semver "^6.0.0"
 
-tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.11.1:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^1.8.0, tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/awslabs/smithy-typescript/pull/226

*Description of changes:*
chore(deps-dev): bump @aws-crypto deps to 1.0.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
