### PR TITLE
fix(generate-clients): Invoke prettier relative to client-generation

### DIFF
--- a/scripts/generate-clients/code-prettify.js
+++ b/scripts/generate-clients/code-prettify.js
@@ -1,8 +1,9 @@
 // @ts-check
 const { spawnProcess } = require("./spawn-process");
+const path = require("path");
 
 const prettifyCode = async (dir) => {
-  await spawnProcess("./node_modules/.bin/prettier", ["--write", `${dir}/**/*.{ts,js,md,json}`]);
+  await spawnProcess(path.join(__dirname, "..", "..", "node_modules", ".bin", "prettier"), ["--write", `${dir}/**/*.{ts,js,md,json}`]);
 };
 
 module.exports = {


### PR DESCRIPTION
It allows to run `scripts/generate-clients` outside of the aws-sdk root directory.

Before it was required to run the script always in the root (like with `yarn generate-clients`. By invoking prettier with relative path it can be executed from every directory like `node $HOME/aws-sdk-js-v3/scripts/generate-clients` which is helpful for building private clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
