### PR TITLE
fix(codgen): only publish types and dist folder to npm

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/npmignore
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/npmignore
@@ -1,4 +1,12 @@
 /coverage/
 /docs/
-tsconfig.test.json
+tsconfig*.json
 *.tsbuildinfo
+
+# source files
+/*.ts
+/jest.config.js
+/commands
+/models
+/pagination
+/protocols


### PR DESCRIPTION
Before all kind of `.ts` files got published as well, which can cause problems when consuming them because TypeScript would re-compile `.ts` files in `node_modules`. It's better to only publish the `types` and `dist` folder with compiled artifacts.

*Issue #, if available:*

*Description of changes:*

I think it would be better to have an allow-list instead of the deny-list. I tried adding a `files` section:

```
diff --git a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/package.json.template b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/package.json.template
index cb857a66e0..992d26b505 100644
--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/package.json.template
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/package.json.template
@@ -3,5 +3,6 @@
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"
   },
+  "files": ["dist", "types"],
   "license": "Apache-2.0"
 }
```

but the result generated a strange map:

```
+  "files": {
+    "0": "dist",
+    "1": "types"
+  },
```

I'm not sure how to debug it further.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
