### PR TITLE
chore(codegen): fix checkstyle violations in AddS3ControlDependency.java

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java
@@ -12,34 +12,34 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
+
 package software.amazon.smithy.aws.typescript.codegen;
 
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_CONFIG;
 import static software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin.Convention.HAS_MIDDLEWARE;
 
-import java.util.logging.Logger;
 import java.util.List;
 import java.util.Optional;
-import software.amazon.smithy.build.PluginContext;
+import java.util.logging.Logger;
 import software.amazon.smithy.aws.traits.ServiceTrait;
-
+import software.amazon.smithy.build.PluginContext;
+import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.shapes.MemberShape;
 import software.amazon.smithy.model.shapes.OperationShape;
 import software.amazon.smithy.model.shapes.ServiceShape;
 import software.amazon.smithy.model.shapes.Shape;
 import software.amazon.smithy.model.traits.RequiredTrait;
-import software.amazon.smithy.model.Model;
 import software.amazon.smithy.model.transform.ModelTransformer;
+import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.typescript.codegen.integration.RuntimeClientPlugin;
 import software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration;
-import software.amazon.smithy.typescript.codegen.TypeScriptSettings;
 import software.amazon.smithy.utils.ListUtils;
 
 /**
- * Add S3Control customization
+ * Add S3Control customization.
  */
 public class AddS3ControlDependency implements TypeScriptIntegration {
-    
+
     private static final Logger LOGGER = Logger.getLogger(AddS3ControlDependency.class.getName());
 
     @Override
@@ -50,17 +50,25 @@ public class AddS3ControlDependency implements TypeScriptIntegration {
                         .servicePredicate((m, s) -> isS3Control(s))
                         .build(),
                 RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.S3_CONTROL_MIDDLEWARE.dependency, "ProcessArnables", HAS_MIDDLEWARE)
+                        .withConventions(
+                            AwsDependency.S3_CONTROL_MIDDLEWARE.dependency,
+                            "ProcessArnables",
+                            HAS_MIDDLEWARE
+                        )
                         .operationPredicate((m, s, o) ->  isS3Control(s) && isArnableOperation(o))
                         .build(),
                 RuntimeClientPlugin.builder()
-                        .withConventions(AwsDependency.S3_CONTROL_MIDDLEWARE.dependency, "RedirectFromPostId", HAS_MIDDLEWARE)
+                        .withConventions(
+                            AwsDependency.S3_CONTROL_MIDDLEWARE.dependency,
+                            "RedirectFromPostId",
+                            HAS_MIDDLEWARE
+                        )
                         .operationPredicate((m, s, o) ->  isS3Control(s) && !isArnableOperation(o))
                         .build());
     }
 
     @Override
-    public Model preprocessModel(PluginContext context, TypeScriptSettings settings) {        
+    public Model preprocessModel(PluginContext context, TypeScriptSettings settings) {
         Model model = context.getModel();
         if (!isS3Control(settings.getService(model))) {
             return model;


### PR DESCRIPTION
That changes makes `./grandlew build` pass. Otherwise it fails with checkstyle violations

*Issue #, if available:*

*Description of changes:*

```
> Task :smithy-aws-typescript-codegen:checkstyleMain
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:15: 'package' should be separated from previous statement. [EmptyLineSeparator]
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:21: Wrong lexicographical order for 'java.util.List' import. Should be before 'java.util.logging.Logger'. [CustomImportOrder]
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:22: Wrong lexicographical order for 'java.util.Optional' import. Should be before 'java.util.logging.Logger'. [CustomImportOrder]
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:24: Wrong lexicographical order for 'software.amazon.smithy.aws.traits.ServiceTrait' import. Should be before 'software.amazon.smithy.build.PluginContext'. [CustomImportOrder]
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:31: Wrong lexicographical order for 'software.amazon.smithy.model.Model' import. Should be before 'software.amazon.smithy.model.traits.RequiredTrait'. [CustomImportOrder]
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:35: Wrong lexicographical order for 'software.amazon.smithy.typescript.codegen.TypeScriptSettings' import. Should be before 'software.amazon.smithy.typescript.codegen.integration.TypeScriptIntegration'. [CustomImportOrder]
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:38: First sentence should end with a period. [JavadocStyle]
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:42: Line has trailing spaces. [RegexpSingleline]
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:53: Line is longer than 120 characters (found 123). [LineLength]
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:57: Line is longer than 120 characters (found 126). [LineLength]
[ant:checkstyle] [ERROR] /Volumes/unix/aws-sdk-js-v3/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddS3ControlDependency.java:63: Line has trailing spaces. [RegexpSingleline]

> Task :smithy-aws-typescript-codegen:checkstyleMain FAILED

FAILURE: Build failed with an exception.
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
