### PR TITLE
fix(client-cognito-identity): remove auth for UnlinkIdentity

### DIFF
--- a/clients/client-cognito-identity/commands/UnlinkIdentityCommand.ts
+++ b/clients/client-cognito-identity/commands/UnlinkIdentityCommand.ts
@@ -5,7 +5,6 @@ import {
   serializeAws_json1_1UnlinkIdentityCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
-import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -41,7 +40,6 @@ export class UnlinkIdentityCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UnlinkIdentityCommandInput, UnlinkIdentityCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
-    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -228,9 +228,11 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
     }
 
     private static boolean operationUsesAwsAuth(Model model, ServiceShape service, OperationShape operation) {
-        // Cognito Identity service doesn't need auth for GetId, GetOpenIdToken, GetCredentialsForIdentity.
+        // Cognito Identity doesn't need auth for GetId, GetOpenIdToken, GetCredentialsForIdentity, UnlinkIdentity.
+        // Remove when optionalAuth model update is published in V261331976.
         if (testServiceId(service, "Cognito Identity")) {
-            Boolean isUnsignedCommand = SetUtils.of("GetId", "GetOpenIdToken", "GetCredentialsForIdentity")
+            Boolean isUnsignedCommand = SetUtils
+                    .of("GetId", "GetOpenIdToken", "GetCredentialsForIdentity", "UnlinkIdentity")
                     .contains(operation.getId().getName());
             return !isUnsignedCommand;
         }


### PR DESCRIPTION
*Issue #, if available:*
> This is a public API. You do not need any credentials to call this API.

Cognito unlinkIdentity docs: https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/CognitoIdentity.html#unlinkIdentity-property

*Description of changes:*
fix(cognito): remove auth for UnlinkIdentity

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
