### PR TITLE
fix(codegen): skip awsAuthPlugin when optionalAuth trait is set

### DIFF
--- a/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
+++ b/clients/client-cognito-identity-provider/CognitoIdentityProviderClient.ts
@@ -284,12 +284,7 @@ import {
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
-import {
-  AwsAuthInputConfig,
-  AwsAuthResolvedConfig,
-  getAwsAuthPlugin,
-  resolveAwsAuthConfig,
-} from "@aws-sdk/middleware-signing";
+import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from "@aws-sdk/middleware-signing";
 import {
   UserAgentInputConfig,
   UserAgentResolvedConfig,
@@ -660,7 +655,6 @@ export class CognitoIdentityProviderClient extends __Client<
     let _config_6 = resolveHostHeaderConfig(_config_5);
     super(_config_6);
     this.config = _config_6;
-    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));

--- a/clients/client-cognito-identity-provider/commands/AddCustomAttributesCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AddCustomAttributesCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AddCustomAttributesCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AddCustomAttributesCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AddCustomAttributesCommandInput, AddCustomAttributesCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminAddUserToGroupCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminAddUserToGroupCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminAddUserToGroupCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminAddUserToGroupCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminAddUserToGroupCommandInput, AdminAddUserToGroupCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminConfirmSignUpCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminConfirmSignUpCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminConfirmSignUpCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminConfirmSignUpCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminConfirmSignUpCommandInput, AdminConfirmSignUpCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminCreateUserCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminCreateUserCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminCreateUserCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminCreateUserCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminCreateUserCommandInput, AdminCreateUserCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminDeleteUserAttributesCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminDeleteUserAttributesCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminDeleteUserAttributesCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminDeleteUserAttributesCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminDeleteUserAttributesCommandInput, AdminDeleteUserAttributesCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminDeleteUserCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminDeleteUserCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminDeleteUserCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminDeleteUserCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminDeleteUserCommandInput, AdminDeleteUserCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminDisableProviderForUserCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminDisableProviderForUserCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminDisableProviderForUserCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminDisableProviderForUserCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminDisableProviderForUserCommandInput, AdminDisableProviderForUserCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminDisableUserCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminDisableUserCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminDisableUserCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminDisableUserCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminDisableUserCommandInput, AdminDisableUserCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminEnableUserCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminEnableUserCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminEnableUserCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminEnableUserCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminEnableUserCommandInput, AdminEnableUserCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminForgetDeviceCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminForgetDeviceCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminForgetDeviceCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminForgetDeviceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminForgetDeviceCommandInput, AdminForgetDeviceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminGetDeviceCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminGetDeviceCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminGetDeviceCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminGetDeviceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminGetDeviceCommandInput, AdminGetDeviceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminGetUserCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminGetUserCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminGetUserCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminGetUserCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminGetUserCommandInput, AdminGetUserCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminInitiateAuthCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminInitiateAuthCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminInitiateAuthCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminInitiateAuthCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminInitiateAuthCommandInput, AdminInitiateAuthCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminLinkProviderForUserCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminLinkProviderForUserCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminLinkProviderForUserCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminLinkProviderForUserCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminLinkProviderForUserCommandInput, AdminLinkProviderForUserCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminListDevicesCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminListDevicesCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminListDevicesCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminListDevicesCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminListDevicesCommandInput, AdminListDevicesCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminListGroupsForUserCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminListGroupsForUserCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminListGroupsForUserCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminListGroupsForUserCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminListGroupsForUserCommandInput, AdminListGroupsForUserCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminListUserAuthEventsCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminListUserAuthEventsCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminListUserAuthEventsCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminListUserAuthEventsCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminListUserAuthEventsCommandInput, AdminListUserAuthEventsCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminRemoveUserFromGroupCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminRemoveUserFromGroupCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminRemoveUserFromGroupCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminRemoveUserFromGroupCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminRemoveUserFromGroupCommandInput, AdminRemoveUserFromGroupCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminResetUserPasswordCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminResetUserPasswordCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminResetUserPasswordCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminResetUserPasswordCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminResetUserPasswordCommandInput, AdminResetUserPasswordCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminRespondToAuthChallengeCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminRespondToAuthChallengeCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminRespondToAuthChallengeCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminRespondToAuthChallengeCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminRespondToAuthChallengeCommandInput, AdminRespondToAuthChallengeCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminSetUserMFAPreferenceCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminSetUserMFAPreferenceCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminSetUserMFAPreferenceCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminSetUserMFAPreferenceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminSetUserMFAPreferenceCommandInput, AdminSetUserMFAPreferenceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminSetUserPasswordCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminSetUserPasswordCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminSetUserPasswordCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminSetUserPasswordCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminSetUserPasswordCommandInput, AdminSetUserPasswordCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminSetUserSettingsCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminSetUserSettingsCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminSetUserSettingsCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminSetUserSettingsCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminSetUserSettingsCommandInput, AdminSetUserSettingsCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminUpdateAuthEventFeedbackCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminUpdateAuthEventFeedbackCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminUpdateAuthEventFeedbackCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminUpdateAuthEventFeedbackCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminUpdateAuthEventFeedbackCommandInput, AdminUpdateAuthEventFeedbackCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminUpdateDeviceStatusCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminUpdateDeviceStatusCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminUpdateDeviceStatusCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminUpdateDeviceStatusCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminUpdateDeviceStatusCommandInput, AdminUpdateDeviceStatusCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminUpdateUserAttributesCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminUpdateUserAttributesCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminUpdateUserAttributesCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminUpdateUserAttributesCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminUpdateUserAttributesCommandInput, AdminUpdateUserAttributesCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AdminUserGlobalSignOutCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AdminUserGlobalSignOutCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AdminUserGlobalSignOutCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AdminUserGlobalSignOutCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AdminUserGlobalSignOutCommandInput, AdminUserGlobalSignOutCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/AssociateSoftwareTokenCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/AssociateSoftwareTokenCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1AssociateSoftwareTokenCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class AssociateSoftwareTokenCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AssociateSoftwareTokenCommandInput, AssociateSoftwareTokenCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ConfirmDeviceCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ConfirmDeviceCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ConfirmDeviceCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ConfirmDeviceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ConfirmDeviceCommandInput, ConfirmDeviceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/CreateGroupCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/CreateGroupCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1CreateGroupCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class CreateGroupCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateGroupCommandInput, CreateGroupCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/CreateIdentityProviderCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/CreateIdentityProviderCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1CreateIdentityProviderCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class CreateIdentityProviderCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateIdentityProviderCommandInput, CreateIdentityProviderCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/CreateResourceServerCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/CreateResourceServerCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1CreateResourceServerCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class CreateResourceServerCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateResourceServerCommandInput, CreateResourceServerCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/CreateUserImportJobCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/CreateUserImportJobCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1CreateUserImportJobCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class CreateUserImportJobCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateUserImportJobCommandInput, CreateUserImportJobCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/CreateUserPoolClientCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/CreateUserPoolClientCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1CreateUserPoolClientCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class CreateUserPoolClientCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateUserPoolClientCommandInput, CreateUserPoolClientCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/CreateUserPoolCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/CreateUserPoolCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1CreateUserPoolCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class CreateUserPoolCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateUserPoolCommandInput, CreateUserPoolCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/CreateUserPoolDomainCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/CreateUserPoolDomainCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1CreateUserPoolDomainCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class CreateUserPoolDomainCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<CreateUserPoolDomainCommandInput, CreateUserPoolDomainCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DeleteGroupCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DeleteGroupCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DeleteGroupCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DeleteGroupCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DeleteGroupCommandInput, DeleteGroupCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DeleteIdentityProviderCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DeleteIdentityProviderCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DeleteIdentityProviderCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DeleteIdentityProviderCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DeleteIdentityProviderCommandInput, DeleteIdentityProviderCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DeleteResourceServerCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DeleteResourceServerCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DeleteResourceServerCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DeleteResourceServerCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DeleteResourceServerCommandInput, DeleteResourceServerCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DeleteUserPoolClientCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DeleteUserPoolClientCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DeleteUserPoolClientCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DeleteUserPoolClientCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DeleteUserPoolClientCommandInput, DeleteUserPoolClientCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DeleteUserPoolCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DeleteUserPoolCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DeleteUserPoolCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DeleteUserPoolCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DeleteUserPoolCommandInput, DeleteUserPoolCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DeleteUserPoolDomainCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DeleteUserPoolDomainCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DeleteUserPoolDomainCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DeleteUserPoolDomainCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DeleteUserPoolDomainCommandInput, DeleteUserPoolDomainCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DescribeIdentityProviderCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DescribeIdentityProviderCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DescribeIdentityProviderCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DescribeIdentityProviderCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeIdentityProviderCommandInput, DescribeIdentityProviderCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DescribeResourceServerCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DescribeResourceServerCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DescribeResourceServerCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DescribeResourceServerCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeResourceServerCommandInput, DescribeResourceServerCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DescribeRiskConfigurationCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DescribeRiskConfigurationCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DescribeRiskConfigurationCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DescribeRiskConfigurationCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeRiskConfigurationCommandInput, DescribeRiskConfigurationCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DescribeUserImportJobCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DescribeUserImportJobCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DescribeUserImportJobCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DescribeUserImportJobCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeUserImportJobCommandInput, DescribeUserImportJobCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DescribeUserPoolClientCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DescribeUserPoolClientCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DescribeUserPoolClientCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DescribeUserPoolClientCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeUserPoolClientCommandInput, DescribeUserPoolClientCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DescribeUserPoolCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DescribeUserPoolCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DescribeUserPoolCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DescribeUserPoolCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeUserPoolCommandInput, DescribeUserPoolCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/DescribeUserPoolDomainCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/DescribeUserPoolDomainCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1DescribeUserPoolDomainCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class DescribeUserPoolDomainCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DescribeUserPoolDomainCommandInput, DescribeUserPoolDomainCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ForgetDeviceCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ForgetDeviceCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ForgetDeviceCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ForgetDeviceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ForgetDeviceCommandInput, ForgetDeviceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/GetCSVHeaderCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/GetCSVHeaderCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1GetCSVHeaderCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class GetCSVHeaderCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetCSVHeaderCommandInput, GetCSVHeaderCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/GetDeviceCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/GetDeviceCommand.ts
@@ -6,6 +6,7 @@ import {
 import { GetDeviceRequest, GetDeviceResponse } from "../models/models_0";
 import { deserializeAws_json1_1GetDeviceCommand, serializeAws_json1_1GetDeviceCommand } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -41,6 +42,7 @@ export class GetDeviceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetDeviceCommandInput, GetDeviceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/GetGroupCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/GetGroupCommand.ts
@@ -6,6 +6,7 @@ import {
 import { GetGroupRequest, GetGroupResponse } from "../models/models_0";
 import { deserializeAws_json1_1GetGroupCommand, serializeAws_json1_1GetGroupCommand } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -41,6 +42,7 @@ export class GetGroupCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetGroupCommandInput, GetGroupCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/GetIdentityProviderByIdentifierCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/GetIdentityProviderByIdentifierCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1GetIdentityProviderByIdentifierCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class GetIdentityProviderByIdentifierCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetIdentityProviderByIdentifierCommandInput, GetIdentityProviderByIdentifierCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/GetSigningCertificateCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/GetSigningCertificateCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1GetSigningCertificateCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class GetSigningCertificateCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetSigningCertificateCommandInput, GetSigningCertificateCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/GetUICustomizationCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/GetUICustomizationCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1GetUICustomizationCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class GetUICustomizationCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetUICustomizationCommandInput, GetUICustomizationCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/GetUserPoolMfaConfigCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/GetUserPoolMfaConfigCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1GetUserPoolMfaConfigCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class GetUserPoolMfaConfigCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetUserPoolMfaConfigCommandInput, GetUserPoolMfaConfigCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/GlobalSignOutCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/GlobalSignOutCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1GlobalSignOutCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class GlobalSignOutCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GlobalSignOutCommandInput, GlobalSignOutCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ListDevicesCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ListDevicesCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ListDevicesCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ListDevicesCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListDevicesCommandInput, ListDevicesCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ListGroupsCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ListGroupsCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ListGroupsCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ListGroupsCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListGroupsCommandInput, ListGroupsCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ListIdentityProvidersCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ListIdentityProvidersCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ListIdentityProvidersCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ListIdentityProvidersCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListIdentityProvidersCommandInput, ListIdentityProvidersCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ListResourceServersCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ListResourceServersCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ListResourceServersCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ListResourceServersCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListResourceServersCommandInput, ListResourceServersCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ListTagsForResourceCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ListTagsForResourceCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ListTagsForResourceCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ListTagsForResourceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListTagsForResourceCommandInput, ListTagsForResourceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ListUserImportJobsCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ListUserImportJobsCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ListUserImportJobsCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ListUserImportJobsCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListUserImportJobsCommandInput, ListUserImportJobsCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ListUserPoolClientsCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ListUserPoolClientsCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ListUserPoolClientsCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ListUserPoolClientsCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListUserPoolClientsCommandInput, ListUserPoolClientsCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ListUserPoolsCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ListUserPoolsCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ListUserPoolsCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ListUserPoolsCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListUserPoolsCommandInput, ListUserPoolsCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ListUsersCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ListUsersCommand.ts
@@ -6,6 +6,7 @@ import {
 import { ListUsersRequest, ListUsersResponse } from "../models/models_0";
 import { deserializeAws_json1_1ListUsersCommand, serializeAws_json1_1ListUsersCommand } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -41,6 +42,7 @@ export class ListUsersCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListUsersCommandInput, ListUsersCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/ListUsersInGroupCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/ListUsersInGroupCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1ListUsersInGroupCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class ListUsersInGroupCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<ListUsersInGroupCommandInput, ListUsersInGroupCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/SetRiskConfigurationCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/SetRiskConfigurationCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1SetRiskConfigurationCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class SetRiskConfigurationCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<SetRiskConfigurationCommandInput, SetRiskConfigurationCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/SetUICustomizationCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/SetUICustomizationCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1SetUICustomizationCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class SetUICustomizationCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<SetUICustomizationCommandInput, SetUICustomizationCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/SetUserMFAPreferenceCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/SetUserMFAPreferenceCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1SetUserMFAPreferenceCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class SetUserMFAPreferenceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<SetUserMFAPreferenceCommandInput, SetUserMFAPreferenceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/SetUserPoolMfaConfigCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/SetUserPoolMfaConfigCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1SetUserPoolMfaConfigCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class SetUserPoolMfaConfigCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<SetUserPoolMfaConfigCommandInput, SetUserPoolMfaConfigCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/StartUserImportJobCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/StartUserImportJobCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1StartUserImportJobCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class StartUserImportJobCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<StartUserImportJobCommandInput, StartUserImportJobCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/StopUserImportJobCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/StopUserImportJobCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1StopUserImportJobCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class StopUserImportJobCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<StopUserImportJobCommandInput, StopUserImportJobCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/TagResourceCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/TagResourceCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1TagResourceCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class TagResourceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<TagResourceCommandInput, TagResourceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/UntagResourceCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/UntagResourceCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1UntagResourceCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class UntagResourceCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UntagResourceCommandInput, UntagResourceCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/UpdateAuthEventFeedbackCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/UpdateAuthEventFeedbackCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1UpdateAuthEventFeedbackCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class UpdateAuthEventFeedbackCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateAuthEventFeedbackCommandInput, UpdateAuthEventFeedbackCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/UpdateDeviceStatusCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/UpdateDeviceStatusCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1UpdateDeviceStatusCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class UpdateDeviceStatusCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateDeviceStatusCommandInput, UpdateDeviceStatusCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/UpdateGroupCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/UpdateGroupCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1UpdateGroupCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class UpdateGroupCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateGroupCommandInput, UpdateGroupCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/UpdateIdentityProviderCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/UpdateIdentityProviderCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1UpdateIdentityProviderCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class UpdateIdentityProviderCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateIdentityProviderCommandInput, UpdateIdentityProviderCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/UpdateResourceServerCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/UpdateResourceServerCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1UpdateResourceServerCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class UpdateResourceServerCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateResourceServerCommandInput, UpdateResourceServerCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/UpdateUserPoolClientCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/UpdateUserPoolClientCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1UpdateUserPoolClientCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class UpdateUserPoolClientCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateUserPoolClientCommandInput, UpdateUserPoolClientCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/UpdateUserPoolCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/UpdateUserPoolCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1UpdateUserPoolCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class UpdateUserPoolCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateUserPoolCommandInput, UpdateUserPoolCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/UpdateUserPoolDomainCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/UpdateUserPoolDomainCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1UpdateUserPoolDomainCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class UpdateUserPoolDomainCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<UpdateUserPoolDomainCommandInput, UpdateUserPoolDomainCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-cognito-identity-provider/commands/VerifySoftwareTokenCommand.ts
+++ b/clients/client-cognito-identity-provider/commands/VerifySoftwareTokenCommand.ts
@@ -9,6 +9,7 @@ import {
   serializeAws_json1_1VerifySoftwareTokenCommand,
 } from "../protocols/Aws_json1_1";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -44,6 +45,7 @@ export class VerifySoftwareTokenCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<VerifySoftwareTokenCommandInput, VerifySoftwareTokenCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-sso/SSOClient.ts
+++ b/clients/client-sso/SSOClient.ts
@@ -20,12 +20,7 @@ import {
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
-import {
-  AwsAuthInputConfig,
-  AwsAuthResolvedConfig,
-  getAwsAuthPlugin,
-  resolveAwsAuthConfig,
-} from "@aws-sdk/middleware-signing";
+import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from "@aws-sdk/middleware-signing";
 import {
   UserAgentInputConfig,
   UserAgentResolvedConfig,
@@ -214,7 +209,6 @@ export class SSOClient extends __Client<
     let _config_6 = resolveHostHeaderConfig(_config_5);
     super(_config_6);
     this.config = _config_6;
-    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1414

*Description of changes:*
skip awsAuthPlugin when optionalAuth trait is set for an operation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
