### PR TITLE
fix(credential-provider-cognito-identity): return identityId as part of cognitoIdentityPool

### DIFF
--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.spec.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.spec.ts
@@ -29,6 +29,7 @@ describe("fromCognitoIdentity", () => {
         customRoleArn: "myArn",
       })()
     ).toEqual({
+      identityId: identityId,
       accessKeyId: "foo",
       secretAccessKey: "bar",
       sessionToken: "baz",

--- a/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
+++ b/packages/credential-provider-cognito-identity/src/fromCognitoIdentity.ts
@@ -5,6 +5,13 @@ import { CredentialProvider, Credentials } from "@aws-sdk/types";
 import { CognitoProviderParameters } from "./CognitoProviderParameters";
 import { resolveLogins } from "./resolveLogins";
 
+export interface CognitoIdentityCredentials extends Credentials {
+  /**
+   * The Cognito ID returned by the last call to AWS.CognitoIdentity.getOpenIdToken().
+   */
+  identityId: string;
+}
+
 /**
  * Retrieves temporary AWS credentials using Amazon Cognito's
  * `GetCredentialsForIdentity` operation.
@@ -12,7 +19,7 @@ import { resolveLogins } from "./resolveLogins";
  * Results from this function call are not cached internally.
  */
 export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): CredentialProvider {
-  return async (): Promise<Credentials> => {
+  return async (): Promise<CognitoIdentityCredentials> => {
     const {
       Credentials: {
         AccessKeyId = throwOnMissingAccessKeyId(),
@@ -29,6 +36,7 @@ export function fromCognitoIdentity(parameters: FromCognitoIdentityParameters): 
     );
 
     return {
+      identityId: parameters.identityId,
       accessKeyId: AccessKeyId,
       secretAccessKey: SecretKey,
       sessionToken: SessionToken,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/893

*Description of changes:*
This change is done to preserve parity with V2. Returns identityId from fromCognitoIdentityPool calls 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
