### PR TITLE
fix(util-format-url): remove headers or path from input

### DIFF
--- a/packages/util-format-url/src/index.ts
+++ b/packages/util-format-url/src/index.ts
@@ -1,7 +1,7 @@
 import { buildQueryString } from "@aws-sdk/querystring-builder";
 import { HttpRequest } from "@aws-sdk/types";
 
-export function formatUrl(request: HttpRequest): string {
+export function formatUrl(request: Omit<HttpRequest, "headers"|"method">): string {
   const { port, query } = request;
   let { protocol, path, hostname } = request;
   if (protocol && protocol.substr(-1) !== ":") {


### PR DESCRIPTION
Neither `path` or `headers` is required for generating url string, so remove them from input parameter


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
