### PR TITLE
docs(middleware-stack): remove outdated README content

### DIFF
--- a/packages/middleware-stack/README.md
+++ b/packages/middleware-stack/README.md
@@ -54,29 +54,9 @@ stack.add(middleware, {
   name: "myMiddleware",
 });
 stack.addRelativeTo(anotherMiddleware, {
-  step: "finalizeRequest",
   relation: "before", //or 'after'
   toMiddleware: "myMiddleware",
 });
-```
-
-You need to specify the `step` in `addRelativeTo()`. This is because the middleware function signature of each step is different, middleware for different step should not be mixed. The previous middleware **must** have a unique name, this is the only way to refer a known middleware when adding middleware relatively. Note that if specified `step` doesn't have a middleware named as the value in `toMiddleware`, this middleware will fallback to be added with absolute location.
-
-You can do this:
-
-```javascript
-stack.addRelativeTo(middleware1, {
-  step: "finalizeRequest",
-  name: "Middleware1",
-  relation: 'before',
-  toMiddleware: 'middleware2'
-}); //this will fall back to `add()`
-stack.addRelativeTo(middleware2, {
-  step: "finalizeRequest",
-  name: 'Middleware2'
-  relation: "after",
-  toMiddleware: "Middleware1"
-}); //this will be added after middleware1
 ```
 
 ## Removing Middleware


### PR DESCRIPTION
Follow up to #1393 that removed the `step` parameter from `addRelativeTo()`.
The README should reflect it.

TODO: add blog post link to readme

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
