### PR TITLE
feat(s3-presigned-post): support S3 object post

### DIFF
--- a/packages/s3-presigned-post/LICENSE
+++ b/packages/s3-presigned-post/LICENSE
@@ -1,0 +1,201 @@
+                                Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/s3-presigned-post/README.md
+++ b/packages/s3-presigned-post/README.md
@@ -31,13 +31,13 @@ For example:
 const Conditions = [{ acl: "public-read" }, { bucket: "johnsmith" }, ["starts-with", "$key", "user/eric/"]];
 ```
 
-More supported policy elements are documented in [S3 POST documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html).
-Note that if you include a condition, you must specify the valid value in the `Fields` parameter as well. A value will
-not be added automatically to the fields dictionary according to the conditions.
+Visit [S3 POST documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html)
+for supported policy elements. If you include a condition, you must specify the valid value in the `Fields` parameter
+as well. A value will not be added automatically to the fields dictionary according to the conditions.
 
 ### Generate a Presigned Post
 
-Users can generate required url and fields for POST request as bellow:
+Users can generate required url and fields for POST request:
 
 ```typescript
 const client = new S3Client({ region: "us-west-2" });
@@ -86,7 +86,7 @@ You can also post a file with HTML form:
 
 ### Post File using FormData in Node.js
 
-You can use Node.js `request` module to post a file as bellow:
+In Node.js, use `form-data` package to post a file:
 
 ```typescript
 const { createReadStream } = require("fs");

--- a/packages/s3-presigned-post/README.md
+++ b/packages/s3-presigned-post/README.md
@@ -1,0 +1,103 @@
+# @aws-sdk/s3-resigned-post
+
+[![NPM version](https://img.shields.io/npm/v/@aws-sdk/s3-presigned-post/rc.svg)](https://www.npmjs.com/package/@aws-sdk/s3-presigned-post)
+[![NPM downloads](https://img.shields.io/npm/dm/@aws-sdk/s3-presigned-post/rc.svg)](https://www.npmjs.com/package/@aws-sdk/s3-presigned-post)
+
+This package provide a function generating URL and fields. Users without AWS credentials can use the URL and fields to
+to make a POST request to S3. The documentation for the server side feature can be found in [S3 API Reference](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-UsingHTTPPOST.html). Please read related sections for more context.
+
+### Import
+
+JavaScript Example:
+
+```javascript
+const { createPresignedPost } = require("@aws-sdk/s3-presigned-post");
+const { S3Client } = require("@aws-sdk/client-s3");
+```
+
+ES6 Example
+
+```javascript
+import { createPresignedPost } from "@aws-sdk/s3-presigned-post";
+import { S3Client } from "@aws-sdk/client-s3";
+```
+
+### Create a POST Policy
+
+You can optionally attach a policy to a presigned post. It specifies a list of conditions that the request must meet.
+For example:
+
+```typescript
+const Conditions = [{ acl: "public-read" }, { bucket: "johnsmith" }, ["starts-with", "$key", "user/eric/"]];
+```
+
+More supported policy elements are documented in [S3 POST documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html).
+Note that if you include a condition, you must specify the valid value in the `Fields` parameter as well. A value will
+not be added automatically to the fields dictionary according to the conditions.
+
+### Generate a Presigned Post
+
+Users can generate required url and fields for POST request as bellow:
+
+```typescript
+const client = new S3Client({ region: "us-west-2" });
+const Bucket = "johnsmith";
+const Key = "user/eric/1";
+const Fields = {
+  acl: "public-read",
+};
+const { url, fields } = await createPresignedPost({
+  Bucket,
+  Key,
+  Conditions,
+  Fields,
+  Expires: 600, //Seconds before the presigned post expires. 3600 by default.
+});
+```
+
+The `Bucket`, `Key` and other values in `Fields` must meet the conditions specified in `Conditions`. The `Key` can also
+contain `${filename}` that will be automatically replaced by the name of the file provided. See [the S3 reference](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTForms.html#sigv4-HTTPPOSTFormFields)
+for more information.
+
+### Post File using HTML Form
+
+You can also post a file with HTML form:
+
+```html
+<html>
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  </head>
+  <body>
+    <!-- Copy the 'url' value returned by createPresignedPost() -->
+    <form action="URL_VALUE" method="post" enctype="multipart/form-data">
+      <!-- Copy the 'fields' key:values returned by S3Client.generate_presigned_post() -->
+      <input type="hidden" name="key" value="VALUE" />
+      <input type="hidden" name="AWSAccessKeyId" value="VALUE" />
+      <input type="hidden" name="policy" value="VALUE" />
+      <input type="hidden" name="signature" value="VALUE" />
+      File:
+      <input type="file" name="file" /> <br />
+      <input type="submit" name="submit" value="Upload to Amazon S3" />
+    </form>
+  </body>
+</html>
+```
+
+### Post File using FormData in Node.js
+
+You can use Node.js `request` module to post a file as bellow:
+
+```typescript
+const { createReadStream } = require("fs");
+const FormData = require("form-data");
+
+const form = new FormData();
+Object.entries(fields).forEach(([field, value]) => {
+  form.append(field, value);
+});
+form.append("file", createReadStream("path/to/a/file"));
+form.submit(url, (err, res) => {
+  //handle the response
+});
+```

--- a/packages/s3-presigned-post/jest.config.js
+++ b/packages/s3-presigned-post/jest.config.js
@@ -1,0 +1,5 @@
+const base = require("../../jest.config.base.js");
+
+module.exports = {
+  ...base,
+};

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@aws-sdk/s3-presigned-post",
+  "version": "1.0.0-rc.3",
+  "scripts": {
+    "prepublishOnly": "yarn build:cjs && yarn build:es",
+    "pretest": "yarn build:cjs",
+    "build:cjs": "tsc -p tsconfig.cjs.json",
+    "build:es": "tsc -p tsconfig.es.json",
+    "build": "yarn build:es && yarn build:cjs",
+    "test": "jest"
+  },
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/es/index.js",
+  "types": "./dist/cjs/index.d.ts",
+  "author": {
+    "name": "AWS SDK for JavaScript Team",
+    "url": "https://aws.amazon.com/javascript/"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "@aws-sdk/signature-v4": "1.0.0-rc.3",
+    "@aws-sdk/types": "1.0.0-rc.3",
+    "@aws-sdk/util-format-url": "1.0.0-rc.3",
+    "@aws-sdk/util-hex-encoding": "1.0.0-rc.3",
+    "tslib": "^1.8.0"
+  },
+  "devDependencies": {
+    "@aws-sdk/client-s3": "1.0.0-rc.3",
+    "@aws-sdk/hash-node": "1.0.0-rc.3",
+    "@aws-sdk/protocol-http": "1.0.0-rc.3",
+    "@types/jest": "^26.0.4",
+    "@types/node": "^12.0.2",
+    "jest": "^26.1.0",
+    "typescript": "~4.0.2"
+  },
+  "engines": {
+    "node": ">= 10.0.0"
+  },
+  "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/s3-presigned-post",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aws/aws-sdk-js-v3.git",
+    "directory": "packages/s3-presigned-post"
+  }
+}

--- a/packages/s3-presigned-post/src/constants.ts
+++ b/packages/s3-presigned-post/src/constants.ts
@@ -1,0 +1,7 @@
+export const ALGORITHM_QUERY_PARAM = "X-Amz-Algorithm";
+export const CREDENTIAL_QUERY_PARAM = "X-Amz-Credential";
+export const AMZ_DATE_QUERY_PARAM = "X-Amz-Date";
+export const TOKEN_QUERY_PARAM = "X-Amz-Security-Token";
+export const SIGNATURE_QUERY_PARAM = "X-Amz-Signature";
+
+export const ALGORITHM_IDENTIFIER = "AWS4-HMAC-SHA256";

--- a/packages/s3-presigned-post/src/createPresignedPost.spec.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.spec.ts
@@ -1,0 +1,143 @@
+import { HttpRequest, SourceData } from "@aws-sdk/types";
+
+import {
+  ALGORITHM_IDENTIFIER,
+  ALGORITHM_QUERY_PARAM,
+  AMZ_DATE_QUERY_PARAM,
+  CREDENTIAL_QUERY_PARAM,
+  SIGNATURE_QUERY_PARAM,
+} from "./constants";
+
+const mockCreateScope = jest.fn().mockReturnValue("mock_credential_scope");
+const mockGetSigningKey = jest.fn().mockReturnValue(Buffer.from("mock_signing_key"));
+jest.mock("@aws-sdk/signature-v4", () => ({
+  createScope: mockCreateScope,
+  getSigningKey: mockGetSigningKey,
+}));
+
+const mockHexEncoder = jest.fn().mockReturnValue("mock_hex_encoded");
+jest.mock("@aws-sdk/util-hex-encoding", () => ({
+  toHex: mockHexEncoder,
+}));
+
+import { createPresignedPost } from "./createPresignedPost";
+
+const endpoint: HttpRequest = {
+  method: "POST",
+  protocol: "https:",
+  hostname: "s3.us-foo-1.amazonaws.com",
+  headers: {},
+  path: "/foo",
+};
+const region = "us-foo-1";
+const credentials = {
+  accessKeyId: "AKID",
+  secretAccessKey: "SECRET",
+};
+const mockHashUpdate = jest.fn();
+const mockHashCtor = jest.fn();
+const sha256 = function (secret: SourceData) {
+  mockHashCtor(secret);
+  //@ts-ignore mock constructor
+  this.update = function (data) {
+    mockHashUpdate(data);
+    return this;
+  };
+  //@ts-ignore mock constructor
+  this.digest = () => Buffer.from("mock_sha256_hash");
+};
+const mockS3Client = {
+  config: {
+    endpoint: async () => endpoint,
+    systemClockOffset: 0,
+    base64Encoder: jest.fn().mockReturnValue("mock_base64_encoded"),
+    utf8Decoder: jest.fn().mockReturnValue(Buffer.from("mock_utf8_decoded")),
+    sha256,
+    region: async () => region,
+    credentials: async () => credentials,
+  },
+};
+
+describe("createPresignedPost", () => {
+  const Bucket = "bucket";
+  const Key = "key";
+  //Mock Date.now() to be 2020-10-28T22:56:49.535Z
+  const dateNowMock = jest.spyOn(Date, "now").mockImplementation(() => 1603925809535);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(() => {
+    dateNowMock.mockRestore();
+  });
+
+  it("should correctly generate url and fields", async () => {
+    //@ts-ignore mock s3 client
+    const { url, fields } = await createPresignedPost(mockS3Client, {
+      Bucket,
+      Key,
+    });
+    expect(url).toBe("https://s3.us-foo-1.amazonaws.com/bucket"),
+      expect(fields).toEqual({
+        bucket: Bucket,
+        key: Key,
+        [ALGORITHM_QUERY_PARAM]: ALGORITHM_IDENTIFIER,
+        [CREDENTIAL_QUERY_PARAM]: `${credentials.accessKeyId}/mock_credential_scope`,
+        [AMZ_DATE_QUERY_PARAM]: "20201028T225649Z",
+        Policy: "mock_base64_encoded",
+        [SIGNATURE_QUERY_PARAM]: "mock_hex_encoded",
+      });
+
+    expect(mockCreateScope.mock.calls[0]).toEqual(["20201028", "us-foo-1", "s3"]);
+    expect(mockS3Client.config.utf8Decoder).toBeCalled();
+    expect(mockGetSigningKey.mock.calls[0]).toEqual([sha256, credentials, "20201028", "us-foo-1", "s3"]);
+  });
+
+  it("should generate presigned post with filename", async () => {
+    //@ts-ignore mock s3 client
+    await createPresignedPost(mockS3Client, {
+      Bucket,
+      Key: "path/to/${filename}",
+    });
+    const { conditions } = JSON.parse(mockS3Client.config.utf8Decoder.mock.calls[0]);
+    expect(conditions).toContainEqual(["starts-with", "$key", "path/to/"]);
+  });
+
+  it("should default expiration at 3600 seconds later", async () => {
+    //@ts-ignore mock s3 client
+    await createPresignedPost(mockS3Client, {
+      Bucket,
+      Key,
+    });
+    const policy = JSON.parse(mockS3Client.config.utf8Decoder.mock.calls[0]);
+    expect(policy).toMatchObject({
+      expiration: "2020-10-28T23:56:49Z",
+    });
+  });
+
+  it("should set expiration if set in parameters", async () => {
+    //@ts-ignore mock s3 client
+    await createPresignedPost(mockS3Client, {
+      Bucket,
+      Key,
+      Expires: 7200,
+    });
+    expect(JSON.parse(mockS3Client.config.utf8Decoder.mock.calls[0])).toMatchObject({
+      expiration: "2020-10-29T00:56:49Z",
+    });
+  });
+
+  it("should generate policies with prefilled fields", async () => {
+    //@ts-ignore mock s3 client
+    const { fields } = await createPresignedPost(mockS3Client, {
+      Bucket,
+      Key,
+      Conditions: [{ acl: "public-read" }],
+      Fields: { acl: "public-read" },
+    });
+    expect(fields).toMatchObject({ bucket: Bucket, key: Key, acl: "public-read" });
+    const { conditions } = JSON.parse(mockS3Client.config.utf8Decoder.mock.calls[0]);
+    expect(conditions).toContainEqual({ acl: "public-read" });
+  });
+});

--- a/packages/s3-presigned-post/src/createPresignedPost.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.ts
@@ -1,0 +1,101 @@
+import { S3Client } from "@aws-sdk/client-s3";
+import { createScope, getSigningKey } from "@aws-sdk/signature-v4";
+import { HashConstructor, SourceData } from "@aws-sdk/types";
+import { formatUrl } from "@aws-sdk/util-format-url";
+import { toHex } from "@aws-sdk/util-hex-encoding";
+
+import {
+  ALGORITHM_IDENTIFIER,
+  ALGORITHM_QUERY_PARAM,
+  AMZ_DATE_QUERY_PARAM,
+  CREDENTIAL_QUERY_PARAM,
+  SIGNATURE_QUERY_PARAM,
+  TOKEN_QUERY_PARAM,
+} from "./constants";
+import { Conditions as PolicyEntry } from "./types";
+
+type Fields = { [key: string]: string };
+
+export interface PresignedPostOptions {
+  Bucket: string;
+  Key: string;
+  Conditions?: PolicyEntry[];
+  Fields?: Fields;
+  Expires?: number;
+}
+
+export interface PresignedPost {
+  url: string;
+  fields: {};
+}
+
+/**
+ * Builds the url and the form fields used for a presigned s3 post
+ */
+export const createPresignedPost = async (
+  client: S3Client,
+  { Bucket, Key, Conditions = [], Fields = {}, Expires = 3600 }: PresignedPostOptions
+): Promise<PresignedPost> => {
+  const { systemClockOffset, base64Encoder, utf8Decoder, sha256 } = client.config;
+  const now = new Date(Date.now() + systemClockOffset);
+  // signingDate in format like '20201028T070711Z'
+  const signingDate = iso8601(now).replace(/[\-:]/g, "");
+  const shortDate = signingDate.substr(0, 8);
+  const clientRegion = await client.config.region();
+  // prepare credentials
+  const credentialScope = createScope(shortDate, clientRegion, "s3");
+  const clientCredentials = await client.config.credentials();
+  const credential = `${clientCredentials.accessKeyId}/${credentialScope}`;
+
+  const fields: Fields = {
+    ...Fields,
+    bucket: Bucket,
+    [ALGORITHM_QUERY_PARAM]: ALGORITHM_IDENTIFIER,
+    [CREDENTIAL_QUERY_PARAM]: credential,
+    [AMZ_DATE_QUERY_PARAM]: signingDate,
+    ...(clientCredentials.sessionToken ? { [TOKEN_QUERY_PARAM]: clientCredentials.sessionToken } : {}),
+  };
+
+  // prepare policies
+  const expiration = new Date(now.valueOf() + Expires * 1000);
+  const conditions: PolicyEntry[] = [
+    ...Conditions,
+    ...Object.entries(fields).map(([k, v]) => ({ [k]: v })),
+    Key.endsWith("${filename}")
+      ? ["starts-with", "$key", Key.substring(0, Key.lastIndexOf("${filename}"))]
+      : { key: Key },
+  ];
+  const encodedPolicy = base64Encoder(
+    utf8Decoder(
+      JSON.stringify({
+        expiration: iso8601(expiration),
+        conditions,
+      })
+    )
+  );
+  // sign the request
+  const signingKey = await getSigningKey(sha256, clientCredentials, shortDate, clientRegion, "s3");
+  const signature = await hmac(sha256, signingKey, encodedPolicy);
+
+  const endpoint = await client.config.endpoint();
+  if (!client.config.bucketEndpoint) {
+    endpoint.path = `/${Bucket}`;
+  }
+  return {
+    url: formatUrl(endpoint),
+    fields: {
+      ...fields,
+      key: Key,
+      Policy: encodedPolicy,
+      [SIGNATURE_QUERY_PARAM]: toHex(signature),
+    },
+  };
+};
+
+const iso8601 = (date: Date) => date.toISOString().replace(/\.\d{3}Z$/, "Z");
+
+const hmac = (ctor: HashConstructor, secret: SourceData, data: SourceData): Promise<Uint8Array> => {
+  const hash = new ctor(secret);
+  hash.update(data);
+  return hash.digest();
+};

--- a/packages/s3-presigned-post/src/createPresignedPost.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.ts
@@ -30,7 +30,7 @@ export interface PresignedPost {
 }
 
 /**
- * Builds the url and the form fields used for a presigned s3 post
+ * Builds the url and the form fields used for a presigned s3 post.
  */
 export const createPresignedPost = async (
   client: S3Client,
@@ -38,11 +38,13 @@ export const createPresignedPost = async (
 ): Promise<PresignedPost> => {
   const { systemClockOffset, base64Encoder, utf8Decoder, sha256 } = client.config;
   const now = new Date(Date.now() + systemClockOffset);
-  // signingDate in format like '20201028T070711Z'
+
+  // signingDate in format like '20201028T070711Z'.
   const signingDate = iso8601(now).replace(/[\-:]/g, "");
   const shortDate = signingDate.substr(0, 8);
   const clientRegion = await client.config.region();
-  // prepare credentials
+
+  // Prepare credentials.
   const credentialScope = createScope(shortDate, clientRegion, "s3");
   const clientCredentials = await client.config.credentials();
   const credential = `${clientCredentials.accessKeyId}/${credentialScope}`;
@@ -56,7 +58,7 @@ export const createPresignedPost = async (
     ...(clientCredentials.sessionToken ? { [TOKEN_QUERY_PARAM]: clientCredentials.sessionToken } : {}),
   };
 
-  // prepare policies
+  // Prepare policies.
   const expiration = new Date(now.valueOf() + Expires * 1000);
   const conditions: PolicyEntry[] = [
     ...Conditions,
@@ -73,7 +75,8 @@ export const createPresignedPost = async (
       })
     )
   );
-  // sign the request
+
+  // Sign the request.
   const signingKey = await getSigningKey(sha256, clientCredentials, shortDate, clientRegion, "s3");
   const signature = await hmac(sha256, signingKey, encodedPolicy);
 
@@ -81,6 +84,7 @@ export const createPresignedPost = async (
   if (!client.config.bucketEndpoint) {
     endpoint.path = `/${Bucket}`;
   }
+
   return {
     url: formatUrl(endpoint),
     fields: {

--- a/packages/s3-presigned-post/src/index.ts
+++ b/packages/s3-presigned-post/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./createPresignedPost";

--- a/packages/s3-presigned-post/src/types.ts
+++ b/packages/s3-presigned-post/src/types.ts
@@ -1,0 +1,7 @@
+type EqualCondition = ["eq", string, string] | { [key: string]: string };
+
+type StartsWithCondition = ["starts-with", string, string];
+
+type ContentLengthRangeCondition = ["content-length-range", number, number];
+
+export type Conditions = EqualCondition | StartsWithCondition | ContentLengthRangeCondition;

--- a/packages/s3-presigned-post/tsconfig.cjs.json
+++ b/packages/s3-presigned-post/tsconfig.cjs.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "rootDir": "./src",
+    "outDir": "./dist/cjs",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.cjs.json",
+  "include": ["src/"]
+}

--- a/packages/s3-presigned-post/tsconfig.es.json
+++ b/packages/s3-presigned-post/tsconfig.es.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
+    "rootDir": "./src",
+    "outDir": "./dist/es",
+    "baseUrl": "."
+  },
+  "extends": "../../tsconfig.es.json",
+  "include": ["src/"]
+}


### PR DESCRIPTION
Add support for generating presigned post url and fields. Users can use them to upload file without AWS credentials. 

Resolves: #395 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
