### PR TITLE
fix(client-timestream-*): use correct endpoint prefix

### DIFF
--- a/clients/client-timestream-query/endpoints.ts
+++ b/clients/client-timestream-query/endpoints.ts
@@ -1,11 +1,11 @@
 import { RegionInfo, RegionInfoProvider } from "@aws-sdk/types";
 
 // Partition default templates
-const AWS_TEMPLATE = "timestream.{region}.amazonaws.com";
-const AWS_CN_TEMPLATE = "timestream.{region}.amazonaws.com.cn";
-const AWS_ISO_TEMPLATE = "timestream.{region}.c2s.ic.gov";
-const AWS_ISO_B_TEMPLATE = "timestream.{region}.sc2s.sgov.gov";
-const AWS_US_GOV_TEMPLATE = "timestream.{region}.amazonaws.com";
+const AWS_TEMPLATE = "query.timestream.{region}.amazonaws.com";
+const AWS_CN_TEMPLATE = "query.timestream.{region}.amazonaws.com.cn";
+const AWS_ISO_TEMPLATE = "query.timestream.{region}.c2s.ic.gov";
+const AWS_ISO_B_TEMPLATE = "query.timestream.{region}.sc2s.sgov.gov";
+const AWS_US_GOV_TEMPLATE = "query.timestream.{region}.amazonaws.com";
 
 // Partition regions
 const AWS_REGIONS = new Set([

--- a/clients/client-timestream-write/endpoints.ts
+++ b/clients/client-timestream-write/endpoints.ts
@@ -1,11 +1,11 @@
 import { RegionInfo, RegionInfoProvider } from "@aws-sdk/types";
 
 // Partition default templates
-const AWS_TEMPLATE = "timestream.{region}.amazonaws.com";
-const AWS_CN_TEMPLATE = "timestream.{region}.amazonaws.com.cn";
-const AWS_ISO_TEMPLATE = "timestream.{region}.c2s.ic.gov";
-const AWS_ISO_B_TEMPLATE = "timestream.{region}.sc2s.sgov.gov";
-const AWS_US_GOV_TEMPLATE = "timestream.{region}.amazonaws.com";
+const AWS_TEMPLATE = "ingest.timestream.{region}.amazonaws.com";
+const AWS_CN_TEMPLATE = "ingest.timestream.{region}.amazonaws.com.cn";
+const AWS_ISO_TEMPLATE = "ingest.timestream.{region}.c2s.ic.gov";
+const AWS_ISO_B_TEMPLATE = "ingest.timestream.{region}.sc2s.sgov.gov";
+const AWS_US_GOV_TEMPLATE = "ingest.timestream.{region}.amazonaws.com";
 
 // Partition regions
 const AWS_REGIONS = new Set([

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/endpoint-prefix.json
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/endpoint-prefix.json
@@ -206,6 +206,8 @@
   "Support": "support",
   "SWF": "swf",
   "Textract": "textract",
+  "Timestream Query": "query.timestream",
+  "Timestream Write": "ingest.timestream",
   "Transcribe": "transcribe",
   "Transcribe Streaming": "transcribestreaming",
   "Transfer": "transfer",


### PR DESCRIPTION
Fixes: #1624 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
