### PR TITLE
fix(package.json): migrate @aws-sdk/types into devDependencies

### DIFF
--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -19,13 +19,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -21,7 +21,6 @@
     "@aws-sdk/chunked-blob-reader": "1.0.0-rc.3",
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@aws-sdk/sha256-tree-hash": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
@@ -30,7 +29,8 @@
     "@aws-sdk/util-utf8-browser": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/body-checksum-browser",
   "repository": {

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -22,7 +22,6 @@
     "@aws-sdk/is-array-buffer": "1.0.0-rc.3",
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@aws-sdk/sha256-tree-hash": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
@@ -31,7 +30,8 @@
     "@aws-sdk/util-utf8-node": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -22,11 +22,11 @@
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "tslib": "^1.8.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "dependencies": {
     "@aws-sdk/signature-v4": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "engines": {

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -21,13 +21,13 @@
   "dependencies": {
     "@aws-sdk/client-cognito-identity": "1.0.0-rc.4",
     "@aws-sdk/property-provider": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -23,14 +23,14 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/property-provider": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "types": "./dist/cjs/index.d.ts",
   "engines": {

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -23,7 +23,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/property-provider": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
@@ -31,7 +30,8 @@
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
     "nock": "^13.0.2",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "types": "./dist/cjs/index.d.ts",
   "engines": {

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -24,14 +24,14 @@
   "dependencies": {
     "@aws-sdk/property-provider": "1.0.0-rc.3",
     "@aws-sdk/shared-ini-file-loader": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "types": "./dist/cjs/index.d.ts",
   "engines": {

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -30,7 +30,6 @@
     "@aws-sdk/credential-provider-ini": "1.0.0-rc.3",
     "@aws-sdk/credential-provider-process": "1.0.0-rc.3",
     "@aws-sdk/property-provider": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
@@ -38,7 +37,8 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "types": "./dist/cjs/index.d.ts",
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-node",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -25,14 +25,14 @@
     "@aws-sdk/credential-provider-ini": "1.0.0-rc.3",
     "@aws-sdk/property-provider": "1.0.0-rc.3",
     "@aws-sdk/shared-ini-file-loader": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "types": "./dist/cjs/index.d.ts",
   "engines": {

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -19,14 +19,14 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/eventstream-marshaller": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -19,7 +19,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/crc32": "^1.0.0",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
@@ -29,7 +28,8 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "browser": {
     "@aws-sdk/util-utf8-node": "@aws-sdk/util-utf8-browser"

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -20,13 +20,13 @@
   "dependencies": {
     "@aws-sdk/eventstream-marshaller": "1.0.0-rc.3",
     "@aws-sdk/eventstream-serde-universal": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -18,13 +18,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -20,14 +20,14 @@
   "dependencies": {
     "@aws-sdk/eventstream-marshaller": "1.0.0-rc.3",
     "@aws-sdk/eventstream-serde-universal": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -19,14 +19,14 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/eventstream-marshaller": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/util-utf8-node": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -21,14 +21,14 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@aws-sdk/querystring-builder": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-base64-browser": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/abort-controller": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/fetch-http-handler",
   "repository": {

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-sdk/chunked-blob-reader": "1.0.0-rc.3",
     "@aws-sdk/chunked-blob-reader-native": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
@@ -28,7 +27,8 @@
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "react-native": {
     "@aws-sdk/chunked-blob-reader": "@aws-sdk/chunked-blob-reader-native"

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -22,10 +22,10 @@
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-buffer-from": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -18,7 +18,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
@@ -27,7 +26,8 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -25,10 +25,10 @@
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-utf8-browser": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -20,13 +20,13 @@
   "dependencies": {
     "@aws-sdk/is-array-buffer": "1.0.0-rc.3",
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -19,7 +19,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-arn-parser": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
@@ -28,7 +27,8 @@
     "@aws-sdk/node-config-provider": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -20,13 +20,13 @@
   "dependencies": {
     "@aws-sdk/middleware-header-default": "1.0.0-rc.3",
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -18,13 +18,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -19,7 +19,6 @@
   "module": "./dist/es/index.js",
   "types": "./dist/cjs/index.d.ts",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
@@ -27,7 +26,8 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@aws-sdk/service-error-classification": "1.0.0-rc.4",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "react-native-get-random-values": "^1.4.0",
     "tslib": "^1.8.0",
     "uuid": "^3.0.0"
@@ -30,7 +29,8 @@
     "@aws-sdk/smithy-client": "1.0.0-rc.4",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -19,7 +19,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/signature-v4": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-format-url": "1.0.0-rc.4",
     "@aws-sdk/util-uri-escape": "1.0.0-rc.3",
     "tslib": "^1.8.0"
@@ -27,7 +26,8 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@aws-sdk/signature-v4": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-format-url": "1.0.0-rc.4",
     "@aws-sdk/util-uri-escape": "1.0.0-rc.3",
     "tslib": "^1.8.0"
@@ -28,7 +27,8 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -18,13 +18,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-sdk/middleware-bucket-endpoint": "1.0.0-rc.4",
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-arn-parser": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
@@ -28,7 +27,8 @@
     "@aws-sdk/middleware-stack": "1.0.0-rc.4",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -18,14 +18,14 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -22,7 +22,6 @@
     "@aws-sdk/middleware-signing": "1.0.0-rc.3",
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@aws-sdk/signature-v4": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-format-url": "1.0.0-rc.4",
     "react-native-get-random-values": "^1.4.0",
     "tslib": "^1.8.0",
@@ -33,7 +32,8 @@
     "jest": "^26.1.0",
     "jest-websocket-mock": "^2.0.2",
     "mock-socket": "^9.0.3",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -18,13 +18,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -20,12 +20,12 @@
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@aws-sdk/signature-v4": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "engines": {

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -18,13 +18,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -20,13 +20,13 @@
   "module": "./dist/es/index.js",
   "types": "./dist/cjs/index.d.ts",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -22,14 +22,14 @@
   "dependencies": {
     "@aws-sdk/property-provider": "1.0.0-rc.3",
     "@aws-sdk/shared-ini-file-loader": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -23,14 +23,14 @@
     "@aws-sdk/abort-controller": "1.0.0-rc.3",
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@aws-sdk/querystring-builder": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "jest": {
     "coveragePathIgnorePatterns": [

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -21,7 +21,6 @@
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@aws-sdk/signature-v4": "1.0.0-rc.3",
     "@aws-sdk/smithy-client": "1.0.0-rc.4",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-create-request": "1.0.0-rc.4",
     "@aws-sdk/util-format-url": "1.0.0-rc.4",
     "tslib": "^1.8.0"
@@ -32,7 +31,8 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -18,13 +18,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -19,13 +19,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -18,14 +18,14 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-uri-escape": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -18,13 +18,13 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -19,7 +19,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/signature-v4": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-format-url": "1.0.0-rc.4",
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.3",
     "tslib": "^1.8.0"
@@ -31,7 +30,8 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -21,7 +21,6 @@
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@aws-sdk/signature-v4": "1.0.0-rc.3",
     "@aws-sdk/smithy-client": "1.0.0-rc.4",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-create-request": "1.0.0-rc.4",
     "@aws-sdk/util-format-url": "1.0.0-rc.4",
     "tslib": "^1.8.0"
@@ -32,7 +31,8 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -18,7 +18,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
@@ -27,7 +26,8 @@
     "@aws-sdk/util-utf8-node": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -20,7 +20,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/is-array-buffer": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "@aws-sdk/util-hex-encoding": "1.0.0-rc.3",
     "@aws-sdk/util-uri-escape": "1.0.0-rc.3",
     "tslib": "^1.8.0"
@@ -31,7 +30,8 @@
     "@aws-sdk/util-buffer-from": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/middleware-stack": "1.0.0-rc.4",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/url-parser-browser/package.json
+++ b/packages/url-parser-browser/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/querystring-parser": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/url-parser-browser",
   "repository": {

--- a/packages/url-parser-node/package.json
+++ b/packages/url-parser-node/package.json
@@ -19,7 +19,6 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/querystring-parser": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0",
     "url": "^0.11.0"
   },
@@ -27,7 +26,8 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "react-native": {
     "url": "url/"

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@aws-sdk/middleware-stack": "1.0.0-rc.4",
     "@aws-sdk/smithy-client": "1.0.0-rc.4",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
@@ -28,7 +27,8 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.3",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/querystring-builder": "1.0.0-rc.3",
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -18,14 +18,14 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "1.0.0-rc.3",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-user-agent-browser",
   "repository": {

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -18,7 +18,6 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "@aws-sdk/types": "1.0.0-rc.3",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
@@ -26,7 +25,8 @@
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",
-    "typescript": "~4.0.2"
+    "typescript": "~4.0.2",
+    "@aws-sdk/types": "1.0.0-rc.3"
   },
   "engines": {
     "node": ">= 10.0.0"


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/1649

*Description of changes:*
Moves @aws-sdk/types into devDependencies from dependencies for packages/ and lib/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
