### PR TITLE
fix(node-http-handler): set maxSockets above 0 in test

### DIFF
--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -18,12 +18,12 @@ import {
 describe("NodeHttpHandler", () => {
   describe("constructor", () => {
     it("can set httpAgent and httpsAgent", () => {
-      let maxSockets = Math.round(Math.random() * 50);
+      let maxSockets = Math.round(Math.random() * 50) + 1;
       let nodeHttpHandler = new NodeHttpHandler({
         httpAgent: new http.Agent({ maxSockets }),
       });
       expect((nodeHttpHandler as any).httpAgent.maxSockets).toEqual(maxSockets);
-      maxSockets = Math.round(Math.random() * 50);
+      maxSockets = Math.round(Math.random() * 50) + 1;
       nodeHttpHandler = new NodeHttpHandler({
         httpsAgent: new https.Agent({ maxSockets }),
       });


### PR DESCRIPTION
*Issue #, if available:*

#1539

*Description of changes:*

Just browsing, but it looks at first glance like the issue with the test is that `maxSockets` will sometimes be set to 0 – due to Math.random() and Math.round(). My guess is that a setting of `maxSockets = 0` gets turned into `Infinity` – so the test will fail in these cases. This change ensures `maxSockets` will always be at least `1` in this test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
