### PR TITLE
fix(middleware-sdk-sqs): Fix MD5 verification on SendMessageBatch.

### DIFF
--- a/packages/middleware-sdk-sqs/src/send-message-batch.ts
+++ b/packages/middleware-sdk-sqs/src/send-message-batch.ts
@@ -42,7 +42,7 @@ export function sendMessageBatchMiddleware(options: PreviouslyResolved): Initial
       if (entries[entry.Id]) {
         const md5 = entries[entry.Id].MD5OfMessageBody;
         const hash = new options.md5();
-        hash.update(entry.MD5OfMessageBody || "");
+        hash.update(entry.MessageBody || "");
         if (md5 !== toHex(await hash.digest())) {
           messageIds.push(entries[entry.Id].MessageId);
         }


### PR DESCRIPTION
## What's in there

This PR fixes a bug in SendMessageBatch that make MD5 verifications against the hashes returned by AWS always fail.

## Note to maintainers

The test suite for this file mocks the MD5 factory, making this error non catchable and the test useless.

## Legal

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
