### PR TITLE
fix: SQS receive message middleware properly calls next() once

### DIFF
--- a/packages/middleware-sdk-sqs/src/receive-message.ts
+++ b/packages/middleware-sdk-sqs/src/receive-message.ts
@@ -44,9 +44,7 @@ export function receiveMessageMiddleware(options: PreviouslyResolved): Initializ
       throw new Error("Invalid MD5 checksum on messages: " + messageIds.join(", "));
     }
 
-    return next({
-      ...args,
-    });
+    return resp;
   };
 }
 

--- a/packages/middleware-sdk-sqs/src/receive-messages.spec.ts
+++ b/packages/middleware-sdk-sqs/src/receive-messages.spec.ts
@@ -14,6 +14,22 @@ describe("receiveMessageMiddleware", () => {
     mockHashDigest.mockClear();
   });
 
+  it("should only call next once", async () => {
+    const next = jest.fn().mockReturnValue({
+      output: {
+        Messages: [
+          { Body: "foo", MD5OfBody: "00", MessageId: "fooMessage" },
+          { Body: "bar", MD5OfBody: "00", MessageId: "barMessage" },
+        ],
+      },
+    });
+    const handler = receiveMessageMiddleware({
+      md5: MockHash,
+    })(next, {} as any);
+    await handler({ input: {} });
+    expect(next).toBeCalledTimes(1);
+  });
+
   it("should do nothing if the checksums match", async () => {
     const next = jest.fn().mockReturnValue({
       output: {


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/1394

*Description of changes:*
SQS middleware no longer calls next({...}) twice and now correctly returns messages from the queue.

```

(async () => {
    
    const QueueUrl = "https://sqs.us-west-2.amazonaws.com/119327258862/test-sqs-client.fifo";    

    try {
        const client = new SQS({});
        const res = await client.receiveMessage({
            QueueUrl,
            MaxNumberOfMessages: 1,
            WaitTimeSeconds: 10
        });
        console.log("actual returned messages", res.Messages.length);
        

    } catch (e) {
        console.log(e);
    }
})();
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
