### PR TITLE
fix(logger): disable logging of raw HTTP request/response

### DIFF
--- a/packages/middleware-serde/src/deserializerMiddleware.spec.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.spec.ts
@@ -85,14 +85,4 @@ describe("deserializerMiddleware", () => {
     expect(logger.info).toHaveBeenCalledTimes(1);
     expect(logger.info).toHaveBeenCalledWith({ output: outputWithoutMetadata });
   });
-
-  it("logs response if context.logger has debug function", async () => {
-    const logger = ({ debug: jest.fn() } as unknown) as Logger;
-
-    const response = await deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, { logger })(mockArgs);
-
-    expect(response).toStrictEqual(mockResponse);
-    expect(logger.debug).toHaveBeenCalledTimes(1);
-    expect(logger.debug).toHaveBeenCalledWith({ httpResponse: mockNextResponse.response });
-  });
 });

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -20,12 +20,6 @@ export const deserializerMiddleware = <Input extends object, Output extends obje
 
   const { response } = await next(args);
 
-  if (typeof logger?.debug === "function") {
-    logger.debug({
-      httpResponse: response,
-    });
-  }
-
   const parsed = await deserializer(response, options);
 
   // Log parsed after $metadata is removed in https://github.com/aws/aws-sdk-js-v3/issues/1490

--- a/packages/middleware-serde/src/serializerMiddleware.spec.ts
+++ b/packages/middleware-serde/src/serializerMiddleware.spec.ts
@@ -83,14 +83,4 @@ describe("serializerMiddleware", () => {
     expect(logger.info).toHaveBeenCalledTimes(1);
     expect(logger.info).toHaveBeenCalledWith({ input: mockArgs.input });
   });
-
-  it("logs request if context.logger has debug function", async () => {
-    const logger = ({ debug: jest.fn() } as unknown) as Logger;
-
-    const response = await serializerMiddleware(mockOptions, mockSerializer)(mockNext, { logger })(mockArgs);
-
-    expect(response).toStrictEqual(mockReturn);
-    expect(logger.debug).toHaveBeenCalledTimes(1);
-    expect(logger.debug).toHaveBeenCalledWith({ httpRequest: mockRequest });
-  });
 });

--- a/packages/middleware-serde/src/serializerMiddleware.ts
+++ b/packages/middleware-serde/src/serializerMiddleware.ts
@@ -27,12 +27,6 @@ export const serializerMiddleware = <Input extends object, Output extends object
 
   const request = await serializer(args.input, options);
 
-  if (typeof logger?.debug === "function") {
-    logger.debug({
-      httpRequest: request,
-    });
-  }
-
   return next({
     ...args,
     request,


### PR DESCRIPTION
*Issue #, if available:*
Internal JS-2221

*Description of changes:*
Disable logging of raw HTTP request/response, as it logs sensitive data in raw HTTP request/response.

<details>
<summary>Example code</summary>

```js
const { IAM } = require("@aws-sdk/client-iam");

(async () => {
  const region = "us-west-2";
  const logger = console;

  const client = new IAM({ region, logger });
  await client.changePassword({
    OldPassword: "OldPassword",
    NewPassword: "NewPassword",
  });
})();
```

</details>

<details>
<summary>Relevant logger output</summary>

```console
{ clientName: 'IAMClient', commandName: 'ChangePasswordCommand' }
{
  input: {
    OldPassword: '***SensitiveInformation***',
    NewPassword: '***SensitiveInformation***'
  }
}
{
  httpRequest: HttpRequest {
    method: 'POST',
    hostname: 'iam.amazonaws.com',
    port: undefined,
    query: {},
    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
    body: 'NewPassword=NewPassword&OldPassword=OldPassword&Action=ChangePassword&Version=2010-05-08',
    protocol: 'https:',
    path: '/'
  }
}
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
