### PR TITLE
fix(codegen): add aws-iam-traits dependency

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/build.gradle.kts
+++ b/codegen/smithy-aws-typescript-codegen/build.gradle.kts
@@ -34,6 +34,7 @@ tasks.withType<Test> {
 
 dependencies {
     api("software.amazon.smithy:smithy-aws-traits:1.0.5")
+    api("software.amazon.smithy:smithy-aws-iam-traits:1.0.5")
     api("software.amazon.smithy:smithy-typescript-codegen:0.2.0")
     testCompile("org.junit.jupiter:junit-jupiter-api:5.4.0")
     testRuntime("org.junit.jupiter:junit-jupiter-engine:5.4.0")


### PR DESCRIPTION
Adds the `aws-iam-traits` dependency so that models that include these traits will be able to resolve the traits and successfully generate clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
