### PR TITLE
feat(service-error-classification): add 429 response as Throttling

### DIFF
--- a/packages/service-error-classification/src/index.spec.ts
+++ b/packages/service-error-classification/src/index.spec.ts
@@ -56,6 +56,12 @@ describe("isClockSkewError", () => {
 });
 
 describe("isThrottlingError", () => {
+  [429].forEach((httpStatusCode) => {
+    it(`should declare error with the HTTP Status Code "${httpStatusCode}" to be a Throttling error`, () => {
+      checkForErrorType(isTransientError, { httpStatusCode }, false);
+    });
+  });
+
   THROTTLING_ERROR_CODES.forEach((name) => {
     it(`should declare error with the name "${name}" to be a Throttling error`, () => {
       checkForErrorType(isThrottlingError, { name }, true);
@@ -90,13 +96,13 @@ describe("isThrottlingError", () => {
 
 describe("isTransientError", () => {
   TRANSIENT_ERROR_CODES.forEach((name) => {
-    it(`should declare error with the name "${name}" to be a Throttling error`, () => {
+    it(`should declare error with the name "${name}" to be a Transient error`, () => {
       checkForErrorType(isTransientError, { name }, true);
     });
   });
 
   TRANSIENT_ERROR_STATUS_CODES.forEach((httpStatusCode) => {
-    it(`should declare error with the HTTP Status Code "${httpStatusCode}" to be a Throttling error`, () => {
+    it(`should declare error with the HTTP Status Code "${httpStatusCode}" to be a Transient error`, () => {
       checkForErrorType(isTransientError, { httpStatusCode }, true);
     });
   });
@@ -104,7 +110,7 @@ describe("isTransientError", () => {
   while (true) {
     const name = Math.random().toString(36).substring(2);
     if (!TRANSIENT_ERROR_CODES.includes(name)) {
-      it(`should not declare error with the name "${name}" to be a Throttling error`, () => {
+      it(`should not declare error with the name "${name}" to be a Transient error`, () => {
         checkForErrorType(isTransientError, { name }, false);
       });
       break;
@@ -114,7 +120,7 @@ describe("isTransientError", () => {
   while (true) {
     const httpStatusCode = Math.ceil(Math.random() * 10 ** 3);
     if (!TRANSIENT_ERROR_STATUS_CODES.includes(httpStatusCode)) {
-      it(`should declare error with the HTTP Status Code "${httpStatusCode}" to be a Throttling error`, () => {
+      it(`should declare error with the HTTP Status Code "${httpStatusCode}" to be a Transient error`, () => {
         checkForErrorType(isTransientError, { httpStatusCode }, false);
       });
       break;

--- a/packages/service-error-classification/src/index.ts
+++ b/packages/service-error-classification/src/index.ts
@@ -12,7 +12,9 @@ export const isRetryableByTrait = (error: SdkError) => error.$retryable !== unde
 export const isClockSkewError = (error: SdkError) => CLOCK_SKEW_ERROR_CODES.includes(error.name);
 
 export const isThrottlingError = (error: SdkError) =>
-  THROTTLING_ERROR_CODES.includes(error.name) || error.$retryable?.throttling == true;
+  error.$metadata?.httpStatusCode === 429 ||
+  THROTTLING_ERROR_CODES.includes(error.name) ||
+  error.$retryable?.throttling == true;
 
 export const isTransientError = (error: SdkError) =>
   TRANSIENT_ERROR_CODES.includes(error.name) ||


### PR DESCRIPTION
*Issue #, if available:*
* Noticed while debugging https://github.com/aws/aws-sdk-js-v3/issues/1196
* Examples where status code 429 is retried:
  * JS SDK v2 https://github.com/aws/aws-sdk-js/pull/2895
  * Ruby https://github.com/aws/aws-sdk-ruby/pull/1889

*Description of changes:*
adds response with 429 status code as Throttling

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
