### PR TITLE
fix(node-http-handler): throw TimeoutError for Node.js timeouts

### DIFF
--- a/packages/node-http-handler/src/constants.ts
+++ b/packages/node-http-handler/src/constants.ts
@@ -1,0 +1,4 @@
+/**
+ * Node.js system error codes that indicate timeout.
+ */
+export const NODEJS_TIMEOUT_ERROR_CODES = ["ECONNRESET", "EPIPE", "ETIMEDOUT"];

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -4,6 +4,7 @@ import { HttpHandlerOptions } from "@aws-sdk/types";
 import { Agent as hAgent, request as hRequest } from "http";
 import { Agent as hsAgent, request as hsRequest, RequestOptions } from "https";
 
+import { NODEJS_TIMEOUT_ERROR_CODES } from "./constants";
 import { getTransformedHeaders } from "./get-transformed-headers";
 import { setConnectionTimeout } from "./set-connection-timeout";
 import { setSocketTimeout } from "./set-socket-timeout";
@@ -84,7 +85,7 @@ export class NodeHttpHandler implements HttpHandler {
       });
 
       req.on("error", (err: Error) => {
-        if (["ECONNRESET", "EPIPE", "ETIMEDOUT"].includes((err as any).code)) {
+        if (NODEJS_TIMEOUT_ERROR_CODES.includes((err as any).code)) {
           reject(Object.assign(err, { name: "TimeoutError" }));
         } else {
           reject(err);

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -83,7 +83,13 @@ export class NodeHttpHandler implements HttpHandler {
         resolve({ response: httpResponse });
       });
 
-      req.on("error", reject);
+      req.on("error", (err: Error) => {
+        if (["ECONNRESET", "EPIPE", "ETIMEDOUT"].includes((err as any).code)) {
+          reject(Object.assign(err, { name: "TimeoutError" }));
+        } else {
+          reject(err);
+        }
+      });
 
       // wire-up any timeout logic
       setConnectionTimeout(req, reject, this.connectionTimeout);


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1196

*Description of changes:*
This PR throws TimeoutError for Node.js timeouts (`"ECONNRESET"`, `"EPIPE"`, `"ETIMEDOUT"`), so that retryMiddleware can retry them.
* Tested with repro code given in https://github.com/aws/aws-sdk-js-v3/issues/1196#issuecomment-634060411
* The node-http-handler tests are being refactored in https://github.com/trivikr/aws-sdk-js-v3/tree/node-http-handler-tests and the test for this PR would be added later. This PR is posted to ensure fix is pushed in **rc.7** release on 11/19.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
