### PR TITLE
chore(types): make handlerOptions optional

### DIFF
--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -25,12 +25,10 @@ export class FetchHttpHandler implements HttpHandler {
   }
 
   destroy(): void {
-    // Do nothing. TLS and HTTP/2 connection pooling is handled by the
-    // browser.
+    // Do nothing. TLS and HTTP/2 connection pooling is handled by the browser.
   }
 
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
-    const abortSignal = options?.abortSignal;
+  handle(request: HttpRequest, { abortSignal }: HttpHandlerOptions = {}): Promise<{ response: HttpResponse }> {
     const requestTimeoutInMs = this.requestTimeout;
 
     // if the request was already aborted, prevent doing extra work

--- a/packages/node-http-handler/src/node-http-handler.ts
+++ b/packages/node-http-handler/src/node-http-handler.ts
@@ -51,7 +51,7 @@ export class NodeHttpHandler implements HttpHandler {
     this.httpsAgent.destroy();
   }
 
-  handle(request: HttpRequest, { abortSignal }: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, { abortSignal }: HttpHandlerOptions = {}): Promise<{ response: HttpResponse }> {
     return new Promise((resolve, reject) => {
       // if the request was already aborted, prevent doing extra work
       if (abortSignal?.aborted) {

--- a/packages/node-http-handler/src/node-http2-handler.ts
+++ b/packages/node-http-handler/src/node-http2-handler.ts
@@ -44,7 +44,7 @@ export class NodeHttp2Handler implements HttpHandler {
     this.connectionPool.clear();
   }
 
-  handle(request: HttpRequest, { abortSignal }: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, { abortSignal }: HttpHandlerOptions = {}): Promise<{ response: HttpResponse }> {
     return new Promise((resolve, reject) => {
       // if the request was already aborted, prevent doing extra work
       if (abortSignal?.aborted) {

--- a/packages/types/src/transfer.ts
+++ b/packages/types/src/transfer.ts
@@ -8,7 +8,7 @@ export interface RequestHandler<RequestType, ResponseType, HandlerOptions = {}> 
    */
   metadata?: RequestHandlerMetadata;
   destroy?: () => void;
-  handle: (request: RequestType, handlerOptions: HandlerOptions) => Promise<RequestHandlerOutput<ResponseType>>;
+  handle: (request: RequestType, handlerOptions?: HandlerOptions) => Promise<RequestHandlerOutput<ResponseType>>;
 }
 
 export interface RequestHandlerMetadata {

--- a/protocol_tests/aws-ec2/tests/functional/ec2query.spec.ts
+++ b/protocol_tests/aws-ec2/tests/functional/ec2query.spec.ts
@@ -32,7 +32,7 @@ class EXPECTED_REQUEST_SERIALIZATION_ERROR {
  * request. The thrown exception contains the serialized request.
  */
 class RequestSerializationTestHandler implements HttpHandler {
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.reject(new EXPECTED_REQUEST_SERIALIZATION_ERROR(request));
   }
 }
@@ -60,7 +60,7 @@ class ResponseDeserializationTestHandler implements HttpHandler {
     this.body = body;
   }
 
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
       response: {
         statusCode: this.code,

--- a/protocol_tests/aws-json/tests/functional/awsjson1_1.spec.ts
+++ b/protocol_tests/aws-json/tests/functional/awsjson1_1.spec.ts
@@ -18,7 +18,7 @@ class EXPECTED_REQUEST_SERIALIZATION_ERROR {
  * request. The thrown exception contains the serialized request.
  */
 class RequestSerializationTestHandler implements HttpHandler {
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.reject(new EXPECTED_REQUEST_SERIALIZATION_ERROR(request));
   }
 }
@@ -46,7 +46,7 @@ class ResponseDeserializationTestHandler implements HttpHandler {
     this.body = body;
   }
 
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
       response: {
         statusCode: this.code,

--- a/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
+++ b/protocol_tests/aws-query/tests/functional/awsquery.spec.ts
@@ -38,7 +38,7 @@ class EXPECTED_REQUEST_SERIALIZATION_ERROR {
  * request. The thrown exception contains the serialized request.
  */
 class RequestSerializationTestHandler implements HttpHandler {
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.reject(new EXPECTED_REQUEST_SERIALIZATION_ERROR(request));
   }
 }
@@ -66,7 +66,7 @@ class ResponseDeserializationTestHandler implements HttpHandler {
     this.body = body;
   }
 
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
       response: {
         statusCode: this.code,

--- a/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
+++ b/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
@@ -44,7 +44,7 @@ class EXPECTED_REQUEST_SERIALIZATION_ERROR {
  * request. The thrown exception contains the serialized request.
  */
 class RequestSerializationTestHandler implements HttpHandler {
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.reject(new EXPECTED_REQUEST_SERIALIZATION_ERROR(request));
   }
 }
@@ -72,7 +72,7 @@ class ResponseDeserializationTestHandler implements HttpHandler {
     this.body = body;
   }
 
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
       response: {
         statusCode: this.code,

--- a/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
+++ b/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
@@ -54,7 +54,7 @@ class EXPECTED_REQUEST_SERIALIZATION_ERROR {
  * request. The thrown exception contains the serialized request.
  */
 class RequestSerializationTestHandler implements HttpHandler {
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.reject(new EXPECTED_REQUEST_SERIALIZATION_ERROR(request));
   }
 }
@@ -82,7 +82,7 @@ class ResponseDeserializationTestHandler implements HttpHandler {
     this.body = body;
   }
 
-  handle(request: HttpRequest, options: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
+  handle(request: HttpRequest, options?: HttpHandlerOptions): Promise<{ response: HttpResponse }> {
     return Promise.resolve({
       response: {
         statusCode: this.code,


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1695

*Description of changes:*
make handlerOptions optional in RequestHandler

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
