### PR TITLE
fix(fetch-http-handler): omit body for HEAD/GET methods

### DIFF
--- a/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
@@ -86,6 +86,56 @@ describe.skip(FetchHttpHandler.name, () => {
     expect(requestCall[0]).toBe("https://foo.amazonaws.com:443/test/?bar=baz");
   });
 
+  it("will omit body if method is GET", async () => {
+    const mockResponse = {
+      headers: { entries: jest.fn().mockReturnValue([]) },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    (global as any).fetch = mockFetch;
+
+    const httpRequest = new HttpRequest({
+      headers: {},
+      hostname: "foo.amazonaws.com",
+      method: "GET",
+      path: "/",
+      body: "will be omitted",
+    });
+    const fetchHttpHandler = new FetchHttpHandler();
+
+    await fetchHttpHandler.handle(httpRequest, {});
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    const requestCall = mockRequest.mock.calls[0];
+    expect(requestCall[1].body).toBeUndefined();
+  });
+
+  it("will omit body if method is HEAD", async () => {
+    const mockResponse = {
+      headers: { entries: jest.fn().mockReturnValue([]) },
+      blob: jest.fn().mockResolvedValue(new Blob()),
+    };
+    const mockFetch = jest.fn().mockResolvedValue(mockResponse);
+
+    (global as any).fetch = mockFetch;
+
+    const httpRequest = new HttpRequest({
+      headers: {},
+      hostname: "foo.amazonaws.com",
+      method: "HEAD",
+      path: "/",
+      body: "will be omitted",
+    });
+    const fetchHttpHandler = new FetchHttpHandler();
+
+    await fetchHttpHandler.handle(httpRequest, {});
+
+    expect(mockFetch.mock.calls.length).toBe(1);
+    const requestCall = mockRequest.mock.calls[0];
+    expect(requestCall[1].body).toBeUndefined();
+  });
+
   it("will not make request if already aborted", async () => {
     const mockResponse = {
       headers: {

--- a/packages/fetch-http-handler/src/fetch-http-handler.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.ts
@@ -44,12 +44,15 @@ export class FetchHttpHandler implements HttpHandler {
       }
     }
 
-    const port = request.port;
+    const { port, method } = request;
     const url = `${request.protocol}//${request.hostname}${port ? `:${port}` : ""}${path}`;
+    // Request constructor doesn't allow GET/HEAD request with body
+    // ref: https://github.com/whatwg/fetch/issues/551
+    const body = method === "GET" || method === "HEAD" ? undefined : request.body;
     const requestOptions: RequestInit = {
-      body: request.body,
+      body,
       headers: new Headers(request.headers),
-      method: request.method,
+      method: method,
     };
 
     // some browsers support abort signal


### PR DESCRIPTION
fixes: https://github.com/aws/aws-sdk-js-v3/issues/1633
Smithy pr: https://github.com/awslabs/smithy-typescript/pull/238

- [x]  Integration tests
- [x]  Protocol tests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
