### PR TITLE
fix(abort-controller): make AbortSignal WHATWG Spec compliant

### DIFF
--- a/packages/abort-controller/src/AbortSignal.ts
+++ b/packages/abort-controller/src/AbortSignal.ts
@@ -1,8 +1,8 @@
 import { AbortHandler, AbortSignal as IAbortSignal } from "@aws-sdk/types";
 
 export class AbortSignal implements IAbortSignal {
-  public onabort?: AbortHandler;
-  private _aborted!: boolean;
+  public onabort: AbortHandler | null = null;
+  private _aborted = false;
 
   constructor() {
     Object.defineProperty(this, "_aborted", {
@@ -24,8 +24,8 @@ export class AbortSignal implements IAbortSignal {
   abort(): void {
     this._aborted = true;
     if (this.onabort) {
-      this.onabort();
-      this.onabort = undefined;
+      this.onabort(this);
+      this.onabort = null;
     }
   }
 }

--- a/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
+++ b/packages/fetch-http-handler/src/fetch-http-handler.spec.ts
@@ -105,6 +105,7 @@ describe.skip(FetchHttpHandler.name, () => {
       fetchHttpHandler.handle({} as any, {
         abortSignal: {
           aborted: true,
+          onabort: null,
         },
       })
     ).rejects.toHaveProperty("name", "AbortError");
@@ -130,6 +131,7 @@ describe.skip(FetchHttpHandler.name, () => {
     await fetchHttpHandler.handle({} as any, {
       abortSignal: {
         aborted: false,
+        onabort: null,
       },
     });
 

--- a/packages/node-http-handler/src/node-http-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http-handler.spec.ts
@@ -450,6 +450,7 @@ describe("NodeHttpHandler", () => {
           {
             abortSignal: {
               aborted: true,
+              onabort: null,
             },
           }
         )

--- a/packages/node-http-handler/src/node-http2-handler.spec.ts
+++ b/packages/node-http-handler/src/node-http2-handler.spec.ts
@@ -143,6 +143,7 @@ describe("NodeHttp2Handler", () => {
         nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {
           abortSignal: {
             aborted: true,
+            onabort: null,
           },
         })
       ).rejects.toHaveProperty("name", "AbortError");
@@ -161,6 +162,7 @@ describe("NodeHttp2Handler", () => {
         nodeH2Handler.handle(new HttpRequest(getMockReqOptions()), {
           abortSignal: {
             aborted: true,
+            onabort: null,
           },
         })
       ).rejects.toHaveProperty("name", "AbortError");

--- a/packages/types/src/abort.ts
+++ b/packages/types/src/abort.ts
@@ -1,5 +1,5 @@
 export interface AbortHandler {
-  (): void;
+  (this: AbortSignal, ev: any): any;
 }
 
 /**
@@ -18,7 +18,7 @@ export interface AbortSignal {
    * A function to be invoked when the action represented by this signal has
    * been cancelled.
    */
-  onabort?: AbortHandler;
+  onabort: AbortHandler | null;
 }
 
 /**


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1159

*Description of changes:*
Makes AbortSignal [WHATWG Spec](https://dom.spec.whatwg.org/#interface-abortcontroller) compliant.

Verified that no errors were thrown with the following code:
```js
const { DynamoDBClient, ListTablesCommand } = require("@aws-sdk/client-dynamodb");

// Commenting the import verifies the fix with AbortController Web API.
// Uncommenting the import verifies the fix with abort-controller npm package.
// const { AbortController } = require("abort-controller");

const abortSignal = new AbortController().signal;
const client = new DynamoDBClient({});

client.send(
  new ListTablesCommand({}),
  { abortSignal }
);
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
