### PR TITLE
fix(s3-request-presigner): skip hoisting SSE headers

### DIFF
--- a/packages/s3-request-presigner/README.md
+++ b/packages/s3-request-presigner/README.md
@@ -34,6 +34,10 @@ You can get signed URL for other S3 operations too, like `PutObjectCommand`.
 `expiresIn` config from the examples above is optional. If not set, it's default
 at `900`.
 
+If your request contains server-side encryption(`SSE*`) configurations, because
+of S3 limitation, you need to send corresponding headers along with the
+presigned url. For more information, please go to [S3 SSE reference](https://docs.aws.amazon.com/AmazonS3/latest/dev/KMSUsingRESTAPI.html)
+
 If you already have a request, you can pre-sign the request following the
 section bellow.
 
@@ -50,7 +54,7 @@ const signer = new S3Presigner({
   credentials: credentialsProvider,
   sha256: nodeSha256, //if the signer is used in browser, use `browserSha256` then
 });
-const url = await signer.presign(request);
+const presigned = await signer.presign(request);
 ```
 
 ES6 Example:
@@ -64,7 +68,7 @@ const signer = new S3RequestPresigner({
   credentials: credentialsProvider,
   sha256: nodeSha256, //if the signer is used in browser, use `browserSha256` then
 });
-const url = await signer.presign(request);
+const presigned = await signer.presign(request);
 ```
 
 To avoid redundant construction parameters when instantiating the s3 presigner,
@@ -77,3 +81,12 @@ const signer = new S3RequestPresigner({
   ...s3.config,
 });
 ```
+
+If your request contains server-side encryption(`x-amz-server-side-encryption*`)
+headers, because of S3 limitation, you need to send these headers along
+with the presigned url. That is to say, the url only from calling `formatUrl()`
+to `presigned` is not sufficient to make a request. You need to send the
+server-side encryption headers along with url. These headers remain in the
+`presigned.headers`
+
+For more information, please go to [S3 SSE reference](https://docs.aws.amazon.com/AmazonS3/latest/dev/KMSUsingRESTAPI.html)

--- a/packages/s3-request-presigner/README.md
+++ b/packages/s3-request-presigner/README.md
@@ -86,7 +86,7 @@ If your request contains server-side encryption(`x-amz-server-side-encryption*`)
 headers, because of S3 limitation, you need to send these headers along
 with the presigned url. That is to say, the url only from calling `formatUrl()`
 to `presigned` is not sufficient to make a request. You need to send the
-server-side encryption headers along with url. These headers remain in the
+server-side encryption headers along with the url. These headers remain in the
 `presigned.headers`
 
 For more information, please go to [S3 SSE reference](https://docs.aws.amazon.com/AmazonS3/latest/dev/KMSUsingRESTAPI.html)

--- a/packages/s3-request-presigner/src/presigner.spec.ts
+++ b/packages/s3-request-presigner/src/presigner.spec.ts
@@ -95,11 +95,16 @@ describe("s3 presigner", () => {
       headers: {
         ...minimalRequest.headers,
         "x-amz-server-side-encryption": "kms",
+        "x-amz-server-side-encryption-customer-algorithm": "AES256",
       },
     });
     expect(signed.headers).toMatchObject({
       "x-amz-server-side-encryption": "kms",
     });
-    expect(signed.query?.["X-Amz-SignedHeaders"]).toEqual(expect.stringContaining("x-amz-server-side-encryption"));
+    const signedHeadersHeader = signed.query?.["X-Amz-SignedHeaders"];
+    const signedHeaders =
+      typeof signedHeadersHeader === "string" ? signedHeadersHeader.split(";") : signedHeadersHeader;
+    expect(signedHeaders).toContain("x-amz-server-side-encryption");
+    expect(signedHeaders).toContain("x-amz-server-side-encryption-customer-algorithm");
   });
 });

--- a/packages/s3-request-presigner/src/presigner.spec.ts
+++ b/packages/s3-request-presigner/src/presigner.spec.ts
@@ -87,4 +87,19 @@ describe("s3 presigner", () => {
       [EXPIRES_QUERY_PARAM]: "900",
     });
   });
+
+  it("should disable hoisting server-side-encryption headers to query", async () => {
+    const signer = new S3RequestPresigner(s3ResolvedConfig);
+    const signed = await signer.presign({
+      ...minimalRequest,
+      headers: {
+        ...minimalRequest.headers,
+        "x-amz-server-side-encryption": "kms",
+      },
+    });
+    expect(signed.headers).toMatchObject({
+      "x-amz-server-side-encryption": "kms",
+    });
+    expect(signed.query?.["X-Amz-SignedHeaders"]).toEqual(expect.stringContaining("x-amz-server-side-encryption"));
+  });
 });

--- a/packages/signature-v4/src/SignatureV4.ts
+++ b/packages/signature-v4/src/SignatureV4.ts
@@ -120,6 +120,7 @@ export class SignatureV4 implements RequestPresigner, RequestSigner, StringSigne
       signingDate = new Date(),
       expiresIn = 3600,
       unsignableHeaders,
+      unhoistableHeaders,
       signableHeaders,
       signingRegion,
       signingService,
@@ -135,7 +136,7 @@ export class SignatureV4 implements RequestPresigner, RequestSigner, StringSigne
     }
 
     const scope = createScope(shortDate, region, signingService ?? this.service);
-    const request = moveHeadersToQuery(prepareRequest(originalRequest));
+    const request = moveHeadersToQuery(prepareRequest(originalRequest), { unhoistableHeaders });
 
     if (credentials.sessionToken) {
       request.query[TOKEN_QUERY_PARAM] = credentials.sessionToken;

--- a/packages/signature-v4/src/moveHeadersToQuery.spec.ts
+++ b/packages/signature-v4/src/moveHeadersToQuery.spec.ts
@@ -68,4 +68,35 @@ describe("moveHeadersToQuery", () => {
       "X-Amz-Storage-Class": "STANDARD_IA",
     });
   });
+
+  it("should skip hoisting headers to the querystring supplied in unhoistedHeaders", () => {
+    const req = moveHeadersToQuery(
+      new HttpRequest({
+        ...minimalRequest,
+        headers: {
+          Host: "www.example.com",
+          "X-Amz-Website-Redirect-Location": "/index.html",
+          Foo: "bar",
+          fizz: "buzz",
+          SNAP: "crackle, pop",
+          "X-Amz-Storage-Class": "STANDARD_IA",
+        },
+      }),
+      {
+        unhoistableHeaders: new Set(["x-amz-website-redirect-location"]),
+      }
+    );
+
+    expect(req.query).toEqual({
+      "X-Amz-Storage-Class": "STANDARD_IA",
+    });
+
+    expect(req.headers).toEqual({
+      Host: "www.example.com",
+      "X-Amz-Website-Redirect-Location": "/index.html",
+      Foo: "bar",
+      fizz: "buzz",
+      SNAP: "crackle, pop",
+    });
+  });
 });

--- a/packages/signature-v4/src/moveHeadersToQuery.ts
+++ b/packages/signature-v4/src/moveHeadersToQuery.ts
@@ -5,12 +5,15 @@ import { cloneRequest } from "./cloneRequest";
 /**
  * @internal
  */
-export function moveHeadersToQuery(request: HttpRequest): HttpRequest & { query: QueryParameterBag } {
+export function moveHeadersToQuery(
+  request: HttpRequest,
+  options: { unhoistableHeaders?: Set<string> } = {}
+): HttpRequest & { query: QueryParameterBag } {
   const { headers, query = {} as QueryParameterBag } =
     typeof (request as any).clone === "function" ? (request as any).clone() : cloneRequest(request);
   for (const name of Object.keys(headers)) {
     const lname = name.toLowerCase();
-    if (lname.substr(0, 6) === "x-amz-") {
+    if (lname.substr(0, 6) === "x-amz-" && !options.unhoistableHeaders?.has(lname)) {
       query[name] = headers[name];
       delete headers[name];
     }

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -52,6 +52,17 @@ export interface RequestPresigningArguments extends RequestSigningArguments {
    * The number of seconds before the presigned URL expires
    */
   expiresIn?: number;
+
+  /**
+   * A set of string whose members represents headers that should not be hoisted
+   * to presigned request's query string. If not supplied, the presigner will
+   * move all the AWS-specific headers(starting with `x-amz-`) to the request
+   * query string. If supplied, these headers remain in the presigned request's
+   * header.
+   * All headers in the provided request will have their names converted to
+   * lower case and then checked for existence in the unhoistableHeaders set.
+   */
+  unhoistableHeaders?: Set<string>;
 }
 
 export interface EventSigningArguments extends SigningArguments {

--- a/packages/types/src/signature.ts
+++ b/packages/types/src/signature.ts
@@ -54,9 +54,9 @@ export interface RequestPresigningArguments extends RequestSigningArguments {
   expiresIn?: number;
 
   /**
-   * A set of string whose members represents headers that should not be hoisted
-   * to presigned request's query string. If not supplied, the presigner will
-   * move all the AWS-specific headers(starting with `x-amz-`) to the request
+   * A set of strings whose representing headers that should not be hoisted
+   * to presigned request's query string. If not supplied, the presigner
+   * moves all the AWS-specific headers (starting with `x-amz-`) to the request
    * query string. If supplied, these headers remain in the presigned request's
    * header.
    * All headers in the provided request will have their names converted to


### PR DESCRIPTION
*Issue #, if available:*
fix: https://github.com/aws/aws-sdk-js-v3/issues/1576

*Description of changes:*
When `signature-v4` generate a presigned url, it will try to hoist the headers to query strings, so these headers will exist in the url, hense easy to use. However, S3 requres server-side encryption headers to be signed in headers due to [S3 limitation](https://github.com/aws/aws-sdk-ruby/issues/874#issuecomment-135596055). So this change solve the issue by 2 changes:
1. Add a new config to the `signature-v4` presign config `unhoistableHeaders`. The presigner won't hoist the given headers to query before presign it.
2. In `s3-request-presigner`, it detects all the server-side encryption headers, and supply them to the `unhoistableHeaders` config of the presigner.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
