### PR TITLE
chore(client-cognito-identity): add default credentialDefaultProvider

### DIFF
--- a/clients/client-cognito-identity/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity/runtimeConfig.browser.ts
@@ -21,7 +21,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: (() => {}) as any,
+  credentialDefaultProvider: invalidFunction("Credential is missing") as any,
   defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   region: invalidFunction("Region is missing") as any,

--- a/clients/client-cognito-identity/runtimeConfig.ts
+++ b/clients/client-cognito-identity/runtimeConfig.ts
@@ -23,12 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: ((options: any) => {
-    try {
-      return credentialDefaultProvider(options);
-    } catch (e) {}
-    return {};
-  }) as any,
+  credentialDefaultProvider,
   defaultUserAgent: defaultUserAgent(packageInfo.name, packageInfo.version),
   maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),
   region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -124,7 +124,6 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                         + "trait was found on " + service.getId());
             }
         }
-        runtimeConfigs.putAll(getCredentialProviderConfig(service, target));
         runtimeConfigs.putAll(getDefaultConfig(target));
         return runtimeConfigs;
     }
@@ -145,6 +144,13 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                             writer.addImport("invalidFunction", "invalidFunction",
                                     TypeScriptDependency.INVALID_DEPENDENCY.packageName);
                             writer.write("region: invalidFunction(\"Region is missing\") as any,");
+                        },
+                        "credentialDefaultProvider", writer -> {
+                            writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
+                            writer.addImport("invalidFunction", "invalidFunction",
+                                    TypeScriptDependency.INVALID_DEPENDENCY.packageName);
+                            writer.write(
+                                    "credentialDefaultProvider: invalidFunction(\"Credential is missing\") as any,");
                         },
                         "maxAttempts", writer -> {
                             writer.addDependency(TypeScriptDependency.MIDDLEWARE_RETRY);
@@ -167,41 +173,17 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                             writer.write(
                                 "region: loadNodeConfig(NODE_REGION_CONFIG_OPTIONS, NODE_REGION_CONFIG_FILE_OPTIONS),");
                         },
+                        "credentialDefaultProvider", writer -> {
+                            writer.addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE);
+                            writer.addImport("defaultProvider", "credentialDefaultProvider",
+                                    AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName);
+                            writer.write("credentialDefaultProvider,");
+                        },
                         "maxAttempts", writer -> {
                             writer.addImport("NODE_MAX_ATTEMPT_CONFIG_OPTIONS", "NODE_MAX_ATTEMPT_CONFIG_OPTIONS",
                                 TypeScriptDependency.MIDDLEWARE_RETRY.packageName);
                             writer.write("maxAttempts: loadNodeConfig(NODE_MAX_ATTEMPT_CONFIG_OPTIONS),");
                         }
-                );
-            default:
-                return Collections.emptyMap();
-        }
-    }
-
-    private Map<String, Consumer<TypeScriptWriter>> getCredentialProviderConfig(
-            ServiceShape service,
-            LanguageTarget target
-    ) {
-        String serviceId = service.getTrait(ServiceTrait.class).map(ServiceTrait::getSdkId).orElse("");
-        switch (target) {
-            case BROWSER:
-                return MapUtils.of(
-                    "credentialDefaultProvider", writer -> {
-                        writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
-                        writer.addImport("invalidFunction", "invalidFunction",
-                                TypeScriptDependency.INVALID_DEPENDENCY.packageName);
-                        writer.write(
-                                "credentialDefaultProvider: invalidFunction(\"Credential is missing\") as any,");
-                    }
-                );
-            case NODE:
-                return MapUtils.of(
-                    "credentialDefaultProvider", writer -> {
-                        writer.addDependency(AwsDependency.CREDENTIAL_PROVIDER_NODE);
-                        writer.addImport("defaultProvider", "credentialDefaultProvider",
-                                AwsDependency.CREDENTIAL_PROVIDER_NODE.packageName);
-                        writer.write("credentialDefaultProvider,");
-                    }
                 );
             default:
                 return Collections.emptyMap();


### PR DESCRIPTION
*Issue #, if available:*
Noticed while debugging STS.assumeRoleWithWebIdentity issue in https://github.com/aws/aws-sdk-js-v3/issues/1602

*Description of changes:*
add default credentialDefaultProvider in client-cognito-identity as customization for specific commands is done in https://github.com/aws/aws-sdk-js-v3/blob/778b3051b890d0fa907688dfb8064167f22cb316/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java#L171-L176

Tested with the following:

<details>
<summary>Code</summary>

```js
const {
  CognitoIdentity,
} = require("/home/trivikr/workspace/aws-sdk-js-v3/clients/client-cognito-identity");

(async () => {
  const region = "us-west-2";

  const client = new CognitoIdentity({ region });
  console.log(await client.getId({ IdentityPoolId: "<REDACTED>" }));
})();
```

</details>

<details>
<summary>Output</summary>

```console
{
  '$metadata': {
    httpStatusCode: 200,
    httpHeaders: {
      date: 'Thu, 19 Nov 2020 22:55:03 GMT',
      'content-type': 'application/x-amz-json-1.1',
      'content-length': '63',
      connection: 'keep-alive',
      'x-amzn-requestid': 'bfa5ab15-17de-4b25-a67a-b5af882dcb1e'
    },
    requestId: 'bfa5ab15-17de-4b25-a67a-b5af882dcb1e',
    attempts: 1,
    totalRetryDelay: 0
  },
  IdentityId: '<REDACTED>'
}
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
