### PR TITLE
fix(client-sts): disable auth for public assumeRole commands

### DIFF
--- a/clients/client-sts/STSClient.ts
+++ b/clients/client-sts/STSClient.ts
@@ -30,12 +30,7 @@ import {
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
 import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
-import {
-  AwsAuthInputConfig,
-  AwsAuthResolvedConfig,
-  getAwsAuthPlugin,
-  resolveAwsAuthConfig,
-} from "@aws-sdk/middleware-signing";
+import { AwsAuthInputConfig, AwsAuthResolvedConfig, resolveAwsAuthConfig } from "@aws-sdk/middleware-signing";
 import {
   UserAgentInputConfig,
   UserAgentResolvedConfig,
@@ -221,7 +216,6 @@ export class STSClient extends __Client<
     let _config_6 = resolveHostHeaderConfig(_config_5);
     super(_config_6);
     this.config = _config_6;
-    this.middlewareStack.use(getAwsAuthPlugin(this.config));
     this.middlewareStack.use(getRetryPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
     this.middlewareStack.use(getContentLengthPlugin(this.config));

--- a/clients/client-sts/commands/AssumeRoleCommand.ts
+++ b/clients/client-sts/commands/AssumeRoleCommand.ts
@@ -2,6 +2,7 @@ import { STSClientResolvedConfig, ServiceInputTypes, ServiceOutputTypes } from "
 import { AssumeRoleRequest, AssumeRoleResponse } from "../models/models_0";
 import { deserializeAws_queryAssumeRoleCommand, serializeAws_queryAssumeRoleCommand } from "../protocols/Aws_query";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -37,6 +38,7 @@ export class AssumeRoleCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<AssumeRoleCommandInput, AssumeRoleCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-sts/commands/DecodeAuthorizationMessageCommand.ts
+++ b/clients/client-sts/commands/DecodeAuthorizationMessageCommand.ts
@@ -5,6 +5,7 @@ import {
   serializeAws_queryDecodeAuthorizationMessageCommand,
 } from "../protocols/Aws_query";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -40,6 +41,7 @@ export class DecodeAuthorizationMessageCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<DecodeAuthorizationMessageCommandInput, DecodeAuthorizationMessageCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-sts/commands/GetAccessKeyInfoCommand.ts
+++ b/clients/client-sts/commands/GetAccessKeyInfoCommand.ts
@@ -5,6 +5,7 @@ import {
   serializeAws_queryGetAccessKeyInfoCommand,
 } from "../protocols/Aws_query";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -40,6 +41,7 @@ export class GetAccessKeyInfoCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetAccessKeyInfoCommandInput, GetAccessKeyInfoCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-sts/commands/GetCallerIdentityCommand.ts
+++ b/clients/client-sts/commands/GetCallerIdentityCommand.ts
@@ -5,6 +5,7 @@ import {
   serializeAws_queryGetCallerIdentityCommand,
 } from "../protocols/Aws_query";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -40,6 +41,7 @@ export class GetCallerIdentityCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetCallerIdentityCommandInput, GetCallerIdentityCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-sts/commands/GetFederationTokenCommand.ts
+++ b/clients/client-sts/commands/GetFederationTokenCommand.ts
@@ -5,6 +5,7 @@ import {
   serializeAws_queryGetFederationTokenCommand,
 } from "../protocols/Aws_query";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -40,6 +41,7 @@ export class GetFederationTokenCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetFederationTokenCommandInput, GetFederationTokenCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 

--- a/clients/client-sts/commands/GetSessionTokenCommand.ts
+++ b/clients/client-sts/commands/GetSessionTokenCommand.ts
@@ -5,6 +5,7 @@ import {
   serializeAws_queryGetSessionTokenCommand,
 } from "../protocols/Aws_query";
 import { getSerdePlugin } from "@aws-sdk/middleware-serde";
+import { getAwsAuthPlugin } from "@aws-sdk/middleware-signing";
 import { HttpRequest as __HttpRequest, HttpResponse as __HttpResponse } from "@aws-sdk/protocol-http";
 import { Command as $Command } from "@aws-sdk/smithy-client";
 import {
@@ -40,6 +41,7 @@ export class GetSessionTokenCommand extends $Command<
     options?: __HttpHandlerOptions
   ): Handler<GetSessionTokenCommandInput, GetSessionTokenCommandOutput> {
     this.middlewareStack.use(getSerdePlugin(configuration, this.serialize, this.deserialize));
+    this.middlewareStack.use(getAwsAuthPlugin(configuration));
 
     const stack = clientStack.concat(this.middlewareStack);
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1602

*Description of changes:*
Disables auth requirement for STS operations assumeRoleWithSAML and assumeRoleWithWebIdentity

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
