### PR TITLE
refactor(s3-presigned-post): use virtual hosted style URLs

### DIFF
--- a/packages/s3-presigned-post/src/createPresignedPost.spec.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.spec.ts
@@ -78,7 +78,7 @@ describe("createPresignedPost", () => {
       Bucket,
       Key,
     });
-    expect(url).toBe("https://s3.us-foo-1.amazonaws.com/bucket"),
+    expect(url).toBe("https://bucket.s3.us-foo-1.amazonaws.com"),
       expect(fields).toEqual({
         bucket: Bucket,
         key: Key,

--- a/packages/s3-presigned-post/src/createPresignedPost.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.ts
@@ -82,7 +82,7 @@ export const createPresignedPost = async (
 
   const endpoint = await client.config.endpoint();
   if (!client.config.bucketEndpoint) {
-    endpoint.path = `/${Bucket}`;
+    endpoint.hostname = `${Bucket}.${endpoint.hostname}`;
   }
 
   return {

--- a/packages/s3-presigned-post/src/createPresignedPost.ts
+++ b/packages/s3-presigned-post/src/createPresignedPost.ts
@@ -82,6 +82,13 @@ export const createPresignedPost = async (
 
   const endpoint = await client.config.endpoint();
   if (!client.config.bucketEndpoint) {
+    if (endpoint.path) {
+      // Path-style URLs are in use
+      endpoint.path = endpoint.path.slice(`${endpoint.path}/`.indexOf("/", 1));
+    } else {
+      // Virtual hosted style URLs are in use
+      endpoint.hostname = endpoint.hostname.slice(endpoint.hostname.indexOf(".") + 1);
+    }
     endpoint.hostname = `${Bucket}.${endpoint.hostname}`;
   }
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* According [to the AWS docs](https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#virtual-host-style-url-ex), path-style URLs will eventually be deprecated. Thus, virtual hosted style access should be preferred.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
