### PR TITLE
test(client-cloudwatch-logs): pass logGroupNamePrefix in describeLogGroups

### DIFF
--- a/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
+++ b/features/cloudwatchlogs/step_definitions/cloudwatchlogs.js
@@ -13,7 +13,7 @@ Given("I create a CloudWatch logGroup with prefix {string}", function (prefix, c
 });
 
 Given("I list the CloudWatch logGroups", function (callback) {
-  this.request(null, "describeLogGroups", {}, callback);
+  this.request(null, "describeLogGroups", { logGroupNamePrefix: this.logGroupName }, callback);
 });
 
 Then("the list should contain the CloudWatch logGroup", function (callback) {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js/pull/3538

*Description of changes:*
Passes logGroupNamePrefix in describeLogGroups in client-cloudwatch-logs integration tests.

The test fails if there are more than 50 logGroups, as it parses logGroups from
first page of results. This code change explicitly requests for the created logGroup
to ensure it doesn't return pages of results.

Verified that integration tests are successful:
```console
$ yarn test:integration-legacy --tags @cloudwatchlogs 
yarn run v1.22.5
$ cucumber-js --fail-fast --tags @cloudwatchlogs
..........

2 scenarios (2 passed)
6 steps (6 passed)
0m00.095s
Done in 2.80s.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
