### PR TITLE
test(client-iam): check for IAM.getUser instead of listUsers

### DIFF
--- a/features/iam/iam.feature
+++ b/features/iam/iam.feature
@@ -7,8 +7,8 @@ Feature: IAM
   Scenario: Users
     Given I have an IAM username "js-test"
     And I create an IAM user with the username
-    And I list the IAM users
-    Then the list should contain the user
+    And I get the IAM user
+    Then the IAM user should exist
     And I delete the IAM user
 
   Scenario: Roles

--- a/features/iam/step_definitions/iam.js
+++ b/features/iam/step_definitions/iam.js
@@ -31,15 +31,12 @@ Given("I create an IAM user with the username", function (callback) {
   );
 });
 
-Given("I list the IAM users", function (callback) {
-  this.request("iam", "listUsers", {}, callback);
+Given("I get the IAM user", function (callback) {
+  this.request("iam", "getUser", { UserName: this.iamUser }, callback);
 });
 
-Then("the list should contain the user", function (callback) {
-  const name = this.iamUser;
-  this.assert.contains(this.data.Users, function (user) {
-    return user.UserName === name;
-  });
+Then("the IAM user should exist", function (callback) {
+  this.assert.equal(this.data.User.UserName, this.iamUser);
   callback();
 });
 


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js/pull/3542

*Description of changes:*
Checks for getUser instead of listUsers in IAM integration tests.

The test fails if there are more than 100 users, as it parses users from
first page of results. This code change explicitly requests for the created user
to ensure it doesn't return pages of results.

```console
$ yarn test:integration-legacy --tags @iam
yarn run v1.22.5
$ cucumber-js --fail-fast --tags @iam
...................

3 scenarios (3 passed)
13 steps (13 passed)
0m01.277s
Done in 3.93s.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
