### PR TITLE
fix(codegen): checkstyle errors in AddBuiltinPlugins.java

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -67,10 +67,10 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                         .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_MIDDLEWARE)
                         // See operationUsesAwsAuth() below for AwsAuth Middleware customizations.
                         .servicePredicate(
-                            (m, s) -> 
-                                !testServiceId(s, "Cognito Identity") &&
-                                !testServiceId(s, "STS") &&
-                                !hasOptionalAuthOperation(m, s)
+                            (m, s) ->
+                                !testServiceId(s, "Cognito Identity")
+                                && !testServiceId(s, "STS")
+                                && !hasOptionalAuthOperation(m, s)
                         ).build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.MIDDLEWARE_RETRY.dependency, "Retry")


### PR DESCRIPTION
*Issue #, if available:*
The codegen-ci is failing in master https://github.com/aws/aws-sdk-js-v3/runs/1476861228#step:5:31
These errors were mistakenly introduced in PR https://github.com/aws/aws-sdk-js-v3/pull/1706

*Description of changes:*
fix checkstyle errors in AddBuiltinPlugins.java

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
