### PR TITLE
docs: re-add docs overwritten in 11/20 clients update

### DIFF
--- a/clients/client-chime/commands/CreateAppInstanceAdminCommand.ts
+++ b/clients/client-chime/commands/CreateAppInstanceAdminCommand.ts
@@ -20,6 +20,20 @@ import {
 export type CreateAppInstanceAdminCommandInput = CreateAppInstanceAdminRequest;
 export type CreateAppInstanceAdminCommandOutput = CreateAppInstanceAdminResponse & __MetadataBearer;
 
+/**
+ * <p>Promotes an <code>AppInstanceUser</code> to an <code>AppInstanceAdmin</code>. The promoted user can perform the following actions. </p>
+ *          <ul>
+ *             <li>
+ *                <p>
+ *                   <code>ChannelModerator</code> actions across all channels in the app instance.</p>
+ *             </li>
+ *             <li>
+ *                <p>
+ *                   <code>DeleteChannelMessage</code> actions.</p>
+ *             </li>
+ *          </ul>
+ *          <p>Only an <code>AppInstanceUser</code> can be promoted to an <code>AppInstanceAdmin</code> role.</p>
+ */
 export class CreateAppInstanceAdminCommand extends $Command<
   CreateAppInstanceAdminCommandInput,
   CreateAppInstanceAdminCommandOutput,
@@ -34,6 +48,9 @@ export class CreateAppInstanceAdminCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/CreateAppInstanceCommand.ts
+++ b/clients/client-chime/commands/CreateAppInstanceCommand.ts
@@ -20,6 +20,10 @@ import {
 export type CreateAppInstanceCommandInput = CreateAppInstanceRequest;
 export type CreateAppInstanceCommandOutput = CreateAppInstanceResponse & __MetadataBearer;
 
+/**
+ * <p>Creates an Amazon Chime Messaging SDK <code>AppInstance</code> under an AWS Account. Only Messaging SDK customers use this API.
+ *            <code>CreateAppInstance</code> supports <code>idempotency</code> behavior as described in the AWS API Standard.</p>
+ */
 export class CreateAppInstanceCommand extends $Command<
   CreateAppInstanceCommandInput,
   CreateAppInstanceCommandOutput,
@@ -34,6 +38,9 @@ export class CreateAppInstanceCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/CreateAppInstanceUserCommand.ts
+++ b/clients/client-chime/commands/CreateAppInstanceUserCommand.ts
@@ -20,6 +20,10 @@ import {
 export type CreateAppInstanceUserCommandInput = CreateAppInstanceUserRequest;
 export type CreateAppInstanceUserCommandOutput = CreateAppInstanceUserResponse & __MetadataBearer;
 
+/**
+ * <p>Creates a user under an Amazon Chime <code>AppInstance</code>. The request consists of a unique <code>appInstanceUserId</code> and
+ *            <code>Name</code> for that user.</p>
+ */
 export class CreateAppInstanceUserCommand extends $Command<
   CreateAppInstanceUserCommandInput,
   CreateAppInstanceUserCommandOutput,
@@ -34,6 +38,9 @@ export class CreateAppInstanceUserCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/CreateChannelBanCommand.ts
+++ b/clients/client-chime/commands/CreateChannelBanCommand.ts
@@ -20,6 +20,13 @@ import {
 export type CreateChannelBanCommandInput = CreateChannelBanRequest;
 export type CreateChannelBanCommandOutput = CreateChannelBanResponse & __MetadataBearer;
 
+/**
+ * <p>Permanently bans a member from a channel. Moderators can't add banned members to a channel.
+ *            To undo a ban, you first have to <code>DeleteChannelBan</code>, and then <code>CreateChannelMembership</code>.
+ *            Bans are cleaned up when you delete users or channels.
+ *        </p>
+ *          <p>If you ban a user who is already part of a channel, that user is automatically kicked from the channel.</p>
+ */
 export class CreateChannelBanCommand extends $Command<
   CreateChannelBanCommandInput,
   CreateChannelBanCommandOutput,
@@ -34,6 +41,9 @@ export class CreateChannelBanCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/CreateChannelCommand.ts
+++ b/clients/client-chime/commands/CreateChannelCommand.ts
@@ -20,6 +20,11 @@ import {
 export type CreateChannelCommandInput = CreateChannelRequest;
 export type CreateChannelCommandOutput = CreateChannelResponse & __MetadataBearer;
 
+/**
+ * <p>Creates a channel to which you can add users and send messages.</p>
+ *          <p>
+ *             <b>Restriction</b>: You can't change a channel's privacy.</p>
+ */
 export class CreateChannelCommand extends $Command<
   CreateChannelCommandInput,
   CreateChannelCommandOutput,
@@ -34,6 +39,9 @@ export class CreateChannelCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/CreateChannelMembershipCommand.ts
+++ b/clients/client-chime/commands/CreateChannelMembershipCommand.ts
@@ -20,6 +20,36 @@ import {
 export type CreateChannelMembershipCommandInput = CreateChannelMembershipRequest;
 export type CreateChannelMembershipCommandOutput = CreateChannelMembershipResponse & __MetadataBearer;
 
+/**
+ * <p>Adds a user to a channel. The <code>InvitedBy</code> response field is derived from the request header.
+ *            A channel member can:</p>
+ *          <ul>
+ *             <li>
+ *                <p>List messages</p>
+ *             </li>
+ *             <li>
+ *                <p>Send messages</p>
+ *             </li>
+ *             <li>
+ *                <p>Receive messages</p>
+ *             </li>
+ *             <li>
+ *                <p>Edit their own messages</p>
+ *             </li>
+ *             <li>
+ *                <p>Leave the channel</p>
+ *             </li>
+ *          </ul>
+ *          <p>Privacy settings impact this action as follows:</p>
+ *          <ul>
+ *             <li>
+ *                <p>Public Channels: You do not need to be a member to list messages, but you must be a member to send messages.</p>
+ *             </li>
+ *             <li>
+ *                <p>Private Channels: You must be a member to list or send messages.</p>
+ *             </li>
+ *          </ul>
+ */
 export class CreateChannelMembershipCommand extends $Command<
   CreateChannelMembershipCommandInput,
   CreateChannelMembershipCommandOutput,
@@ -34,6 +64,9 @@ export class CreateChannelMembershipCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/CreateChannelModeratorCommand.ts
+++ b/clients/client-chime/commands/CreateChannelModeratorCommand.ts
@@ -20,6 +20,26 @@ import {
 export type CreateChannelModeratorCommandInput = CreateChannelModeratorRequest;
 export type CreateChannelModeratorCommandOutput = CreateChannelModeratorResponse & __MetadataBearer;
 
+/**
+ * <p>Creates a new <code>ChannelModerator</code>. A channel moderator can:</p>
+ *          <ul>
+ *             <li>
+ *                <p>Add and remove other members of the channel.</p>
+ *             </li>
+ *             <li>
+ *                <p>Add and remove other moderators of the channel.</p>
+ *             </li>
+ *             <li>
+ *                <p>Add and remove user bans for the channel.</p>
+ *             </li>
+ *             <li>
+ *                <p>Redact messages in the channel.</p>
+ *             </li>
+ *             <li>
+ *                <p>List messages in the channel.</p>
+ *             </li>
+ *          </ul>
+ */
 export class CreateChannelModeratorCommand extends $Command<
   CreateChannelModeratorCommandInput,
   CreateChannelModeratorCommandOutput,
@@ -34,6 +54,9 @@ export class CreateChannelModeratorCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DeleteAppInstanceAdminCommand.ts
+++ b/clients/client-chime/commands/DeleteAppInstanceAdminCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteAppInstanceAdminCommandInput = DeleteAppInstanceAdminRequest;
 export type DeleteAppInstanceAdminCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Demotes an <code>AppInstanceAdmin</code> to an <code>AppInstanceUser</code>. This action does not delete the user.</p>
+ */
 export class DeleteAppInstanceAdminCommand extends $Command<
   DeleteAppInstanceAdminCommandInput,
   DeleteAppInstanceAdminCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteAppInstanceAdminCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DeleteAppInstanceCommand.ts
+++ b/clients/client-chime/commands/DeleteAppInstanceCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteAppInstanceCommandInput = DeleteAppInstanceRequest;
 export type DeleteAppInstanceCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Deletes an <code>AppInstance</code> and all associated data asynchronously.</p>
+ */
 export class DeleteAppInstanceCommand extends $Command<
   DeleteAppInstanceCommandInput,
   DeleteAppInstanceCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteAppInstanceCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DeleteAppInstanceStreamingConfigurationsCommand.ts
+++ b/clients/client-chime/commands/DeleteAppInstanceStreamingConfigurationsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteAppInstanceStreamingConfigurationsCommandInput = DeleteAppInstanceStreamingConfigurationsRequest;
 export type DeleteAppInstanceStreamingConfigurationsCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Deletes the streaming configurations of an app instance.</p>
+ */
 export class DeleteAppInstanceStreamingConfigurationsCommand extends $Command<
   DeleteAppInstanceStreamingConfigurationsCommandInput,
   DeleteAppInstanceStreamingConfigurationsCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteAppInstanceStreamingConfigurationsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DeleteAppInstanceUserCommand.ts
+++ b/clients/client-chime/commands/DeleteAppInstanceUserCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteAppInstanceUserCommandInput = DeleteAppInstanceUserRequest;
 export type DeleteAppInstanceUserCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Deletes an <code>AppInstanceUser</code>.</p>
+ */
 export class DeleteAppInstanceUserCommand extends $Command<
   DeleteAppInstanceUserCommandInput,
   DeleteAppInstanceUserCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteAppInstanceUserCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DeleteChannelBanCommand.ts
+++ b/clients/client-chime/commands/DeleteChannelBanCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteChannelBanCommandInput = DeleteChannelBanRequest;
 export type DeleteChannelBanCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Removes a user from a channel's ban list.</p>
+ */
 export class DeleteChannelBanCommand extends $Command<
   DeleteChannelBanCommandInput,
   DeleteChannelBanCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteChannelBanCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DeleteChannelCommand.ts
+++ b/clients/client-chime/commands/DeleteChannelCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteChannelCommandInput = DeleteChannelRequest;
 export type DeleteChannelCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Immediately makes a channel and its memberships inaccessible and marks them for deletion. This is an irreversible process.</p>
+ */
 export class DeleteChannelCommand extends $Command<
   DeleteChannelCommandInput,
   DeleteChannelCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteChannelCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DeleteChannelMembershipCommand.ts
+++ b/clients/client-chime/commands/DeleteChannelMembershipCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteChannelMembershipCommandInput = DeleteChannelMembershipRequest;
 export type DeleteChannelMembershipCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Removes a member from a channel.</p>
+ */
 export class DeleteChannelMembershipCommand extends $Command<
   DeleteChannelMembershipCommandInput,
   DeleteChannelMembershipCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteChannelMembershipCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DeleteChannelMessageCommand.ts
+++ b/clients/client-chime/commands/DeleteChannelMessageCommand.ts
@@ -20,6 +20,10 @@ import {
 export type DeleteChannelMessageCommandInput = DeleteChannelMessageRequest;
 export type DeleteChannelMessageCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Deletes a channel message. Only admins can perform this action. Deletion makes messages inaccessible immediately. A
+ *            background process deletes any revisions created by <code>UpdateChannelMessage</code>.</p>
+ */
 export class DeleteChannelMessageCommand extends $Command<
   DeleteChannelMessageCommandInput,
   DeleteChannelMessageCommandOutput,
@@ -34,6 +38,9 @@ export class DeleteChannelMessageCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DeleteChannelModeratorCommand.ts
+++ b/clients/client-chime/commands/DeleteChannelModeratorCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteChannelModeratorCommandInput = DeleteChannelModeratorRequest;
 export type DeleteChannelModeratorCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Deletes a channel moderator.</p>
+ */
 export class DeleteChannelModeratorCommand extends $Command<
   DeleteChannelModeratorCommandInput,
   DeleteChannelModeratorCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteChannelModeratorCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DescribeAppInstanceAdminCommand.ts
+++ b/clients/client-chime/commands/DescribeAppInstanceAdminCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DescribeAppInstanceAdminCommandInput = DescribeAppInstanceAdminRequest;
 export type DescribeAppInstanceAdminCommandOutput = DescribeAppInstanceAdminResponse & __MetadataBearer;
 
+/**
+ * <p>Returns the full details of an <code>AppInstanceAdmin</code>.</p>
+ */
 export class DescribeAppInstanceAdminCommand extends $Command<
   DescribeAppInstanceAdminCommandInput,
   DescribeAppInstanceAdminCommandOutput,
@@ -34,6 +37,9 @@ export class DescribeAppInstanceAdminCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DescribeAppInstanceCommand.ts
+++ b/clients/client-chime/commands/DescribeAppInstanceCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DescribeAppInstanceCommandInput = DescribeAppInstanceRequest;
 export type DescribeAppInstanceCommandOutput = DescribeAppInstanceResponse & __MetadataBearer;
 
+/**
+ * <p>Returns the full details of an <code>AppInstance</code>.</p>
+ */
 export class DescribeAppInstanceCommand extends $Command<
   DescribeAppInstanceCommandInput,
   DescribeAppInstanceCommandOutput,
@@ -34,6 +37,9 @@ export class DescribeAppInstanceCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DescribeAppInstanceUserCommand.ts
+++ b/clients/client-chime/commands/DescribeAppInstanceUserCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DescribeAppInstanceUserCommandInput = DescribeAppInstanceUserRequest;
 export type DescribeAppInstanceUserCommandOutput = DescribeAppInstanceUserResponse & __MetadataBearer;
 
+/**
+ * <p>Returns the full details of an <code>AppInstanceUser</code>.</p>
+ */
 export class DescribeAppInstanceUserCommand extends $Command<
   DescribeAppInstanceUserCommandInput,
   DescribeAppInstanceUserCommandOutput,
@@ -34,6 +37,9 @@ export class DescribeAppInstanceUserCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DescribeChannelBanCommand.ts
+++ b/clients/client-chime/commands/DescribeChannelBanCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DescribeChannelBanCommandInput = DescribeChannelBanRequest;
 export type DescribeChannelBanCommandOutput = DescribeChannelBanResponse & __MetadataBearer;
 
+/**
+ * <p>Returns the full details of a channel ban.</p>
+ */
 export class DescribeChannelBanCommand extends $Command<
   DescribeChannelBanCommandInput,
   DescribeChannelBanCommandOutput,
@@ -34,6 +37,9 @@ export class DescribeChannelBanCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DescribeChannelCommand.ts
+++ b/clients/client-chime/commands/DescribeChannelCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DescribeChannelCommandInput = DescribeChannelRequest;
 export type DescribeChannelCommandOutput = DescribeChannelResponse & __MetadataBearer;
 
+/**
+ * <p>Returns the full details of a channel in an Amazon Chime app instance.</p>
+ */
 export class DescribeChannelCommand extends $Command<
   DescribeChannelCommandInput,
   DescribeChannelCommandOutput,
@@ -34,6 +37,9 @@ export class DescribeChannelCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DescribeChannelMembershipCommand.ts
+++ b/clients/client-chime/commands/DescribeChannelMembershipCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DescribeChannelMembershipCommandInput = DescribeChannelMembershipRequest;
 export type DescribeChannelMembershipCommandOutput = DescribeChannelMembershipResponse & __MetadataBearer;
 
+/**
+ * <p>Returns the full details of a user's channel membership.</p>
+ */
 export class DescribeChannelMembershipCommand extends $Command<
   DescribeChannelMembershipCommandInput,
   DescribeChannelMembershipCommandOutput,
@@ -34,6 +37,9 @@ export class DescribeChannelMembershipCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DescribeChannelMembershipForAppInstanceUserCommand.ts
+++ b/clients/client-chime/commands/DescribeChannelMembershipForAppInstanceUserCommand.ts
@@ -24,6 +24,9 @@ export type DescribeChannelMembershipForAppInstanceUserCommandInput = DescribeCh
 export type DescribeChannelMembershipForAppInstanceUserCommandOutput = DescribeChannelMembershipForAppInstanceUserResponse &
   __MetadataBearer;
 
+/**
+ * <p>Returns the details of a channel based on the membership of the <code>AppInstanceUser</code> specified.</p>
+ */
 export class DescribeChannelMembershipForAppInstanceUserCommand extends $Command<
   DescribeChannelMembershipForAppInstanceUserCommandInput,
   DescribeChannelMembershipForAppInstanceUserCommandOutput,
@@ -38,6 +41,9 @@ export class DescribeChannelMembershipForAppInstanceUserCommand extends $Command
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DescribeChannelModeratedByAppInstanceUserCommand.ts
+++ b/clients/client-chime/commands/DescribeChannelModeratedByAppInstanceUserCommand.ts
@@ -24,6 +24,9 @@ export type DescribeChannelModeratedByAppInstanceUserCommandInput = DescribeChan
 export type DescribeChannelModeratedByAppInstanceUserCommandOutput = DescribeChannelModeratedByAppInstanceUserResponse &
   __MetadataBearer;
 
+/**
+ * <p>Returns the full details of a channel moderated by the specified <code>AppInstanceUser</code>.</p>
+ */
 export class DescribeChannelModeratedByAppInstanceUserCommand extends $Command<
   DescribeChannelModeratedByAppInstanceUserCommandInput,
   DescribeChannelModeratedByAppInstanceUserCommandOutput,
@@ -38,6 +41,9 @@ export class DescribeChannelModeratedByAppInstanceUserCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/DescribeChannelModeratorCommand.ts
+++ b/clients/client-chime/commands/DescribeChannelModeratorCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DescribeChannelModeratorCommandInput = DescribeChannelModeratorRequest;
 export type DescribeChannelModeratorCommandOutput = DescribeChannelModeratorResponse & __MetadataBearer;
 
+/**
+ * <p>Returns the full details of a single ChannelModerator.</p>
+ */
 export class DescribeChannelModeratorCommand extends $Command<
   DescribeChannelModeratorCommandInput,
   DescribeChannelModeratorCommandOutput,
@@ -34,6 +37,9 @@ export class DescribeChannelModeratorCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/GetAppInstanceRetentionSettingsCommand.ts
+++ b/clients/client-chime/commands/GetAppInstanceRetentionSettingsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type GetAppInstanceRetentionSettingsCommandInput = GetAppInstanceRetentionSettingsRequest;
 export type GetAppInstanceRetentionSettingsCommandOutput = GetAppInstanceRetentionSettingsResponse & __MetadataBearer;
 
+/**
+ * <p>Gets the retention settings for an app instance.</p>
+ */
 export class GetAppInstanceRetentionSettingsCommand extends $Command<
   GetAppInstanceRetentionSettingsCommandInput,
   GetAppInstanceRetentionSettingsCommandOutput,
@@ -34,6 +37,9 @@ export class GetAppInstanceRetentionSettingsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/GetAppInstanceStreamingConfigurationsCommand.ts
+++ b/clients/client-chime/commands/GetAppInstanceStreamingConfigurationsCommand.ts
@@ -24,6 +24,9 @@ export type GetAppInstanceStreamingConfigurationsCommandInput = GetAppInstanceSt
 export type GetAppInstanceStreamingConfigurationsCommandOutput = GetAppInstanceStreamingConfigurationsResponse &
   __MetadataBearer;
 
+/**
+ * <p>Gets the streaming settings for an app instance.</p>
+ */
 export class GetAppInstanceStreamingConfigurationsCommand extends $Command<
   GetAppInstanceStreamingConfigurationsCommandInput,
   GetAppInstanceStreamingConfigurationsCommandOutput,
@@ -38,6 +41,9 @@ export class GetAppInstanceStreamingConfigurationsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/GetChannelMessageCommand.ts
+++ b/clients/client-chime/commands/GetChannelMessageCommand.ts
@@ -20,6 +20,9 @@ import {
 export type GetChannelMessageCommandInput = GetChannelMessageRequest;
 export type GetChannelMessageCommandOutput = GetChannelMessageResponse & __MetadataBearer;
 
+/**
+ * <p>Gets the full details of a channel message.</p>
+ */
 export class GetChannelMessageCommand extends $Command<
   GetChannelMessageCommandInput,
   GetChannelMessageCommandOutput,
@@ -34,6 +37,9 @@ export class GetChannelMessageCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/GetMessagingSessionEndpointCommand.ts
+++ b/clients/client-chime/commands/GetMessagingSessionEndpointCommand.ts
@@ -20,6 +20,9 @@ import {
 export type GetMessagingSessionEndpointCommandInput = GetMessagingSessionEndpointRequest;
 export type GetMessagingSessionEndpointCommandOutput = GetMessagingSessionEndpointResponse & __MetadataBearer;
 
+/**
+ * <p>The endpoint for the messaging session.</p>
+ */
 export class GetMessagingSessionEndpointCommand extends $Command<
   GetMessagingSessionEndpointCommandInput,
   GetMessagingSessionEndpointCommandOutput,
@@ -34,6 +37,9 @@ export class GetMessagingSessionEndpointCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/GetVoiceConnectorLoggingConfigurationCommand.ts
+++ b/clients/client-chime/commands/GetVoiceConnectorLoggingConfigurationCommand.ts
@@ -26,8 +26,7 @@ export type GetVoiceConnectorLoggingConfigurationCommandOutput = GetVoiceConnect
 
 /**
  * <p>Retrieves the logging configuration details for the specified Amazon Chime Voice
- *       Connector. Shows whether SIP message logs are enabled for sending to Amazon CloudWatch
- *       Logs.</p>
+ *       Connector. Shows whether SIP message logs are enabled for sending to Amazon CloudWatch.</p>
  */
 export class GetVoiceConnectorLoggingConfigurationCommand extends $Command<
   GetVoiceConnectorLoggingConfigurationCommandInput,

--- a/clients/client-chime/commands/ListAppInstanceAdminsCommand.ts
+++ b/clients/client-chime/commands/ListAppInstanceAdminsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListAppInstanceAdminsCommandInput = ListAppInstanceAdminsRequest;
 export type ListAppInstanceAdminsCommandOutput = ListAppInstanceAdminsResponse & __MetadataBearer;
 
+/**
+ * <p>Returns a list of the administrators in the app instance.</p>
+ */
 export class ListAppInstanceAdminsCommand extends $Command<
   ListAppInstanceAdminsCommandInput,
   ListAppInstanceAdminsCommandOutput,
@@ -34,6 +37,9 @@ export class ListAppInstanceAdminsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/ListAppInstanceUsersCommand.ts
+++ b/clients/client-chime/commands/ListAppInstanceUsersCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListAppInstanceUsersCommandInput = ListAppInstanceUsersRequest;
 export type ListAppInstanceUsersCommandOutput = ListAppInstanceUsersResponse & __MetadataBearer;
 
+/**
+ * <p>List all <code>AppInstanceUsers</code> created under a single app instance.</p>
+ */
 export class ListAppInstanceUsersCommand extends $Command<
   ListAppInstanceUsersCommandInput,
   ListAppInstanceUsersCommandOutput,
@@ -34,6 +37,9 @@ export class ListAppInstanceUsersCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/ListAppInstancesCommand.ts
+++ b/clients/client-chime/commands/ListAppInstancesCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListAppInstancesCommandInput = ListAppInstancesRequest;
 export type ListAppInstancesCommandOutput = ListAppInstancesResponse & __MetadataBearer;
 
+/**
+ * <p>Lists all Amazon Chime app instances created under a single AWS account.</p>
+ */
 export class ListAppInstancesCommand extends $Command<
   ListAppInstancesCommandInput,
   ListAppInstancesCommandOutput,
@@ -34,6 +37,9 @@ export class ListAppInstancesCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/ListChannelBansCommand.ts
+++ b/clients/client-chime/commands/ListChannelBansCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListChannelBansCommandInput = ListChannelBansRequest;
 export type ListChannelBansCommandOutput = ListChannelBansResponse & __MetadataBearer;
 
+/**
+ * <p>Lists all the users banned from a particular channel.</p>
+ */
 export class ListChannelBansCommand extends $Command<
   ListChannelBansCommandInput,
   ListChannelBansCommandOutput,
@@ -34,6 +37,9 @@ export class ListChannelBansCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/ListChannelMembershipsCommand.ts
+++ b/clients/client-chime/commands/ListChannelMembershipsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListChannelMembershipsCommandInput = ListChannelMembershipsRequest;
 export type ListChannelMembershipsCommandOutput = ListChannelMembershipsResponse & __MetadataBearer;
 
+/**
+ * <p>Lists all channel memberships in a channel.</p>
+ */
 export class ListChannelMembershipsCommand extends $Command<
   ListChannelMembershipsCommandInput,
   ListChannelMembershipsCommandOutput,
@@ -34,6 +37,9 @@ export class ListChannelMembershipsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/ListChannelMembershipsForAppInstanceUserCommand.ts
+++ b/clients/client-chime/commands/ListChannelMembershipsForAppInstanceUserCommand.ts
@@ -24,6 +24,10 @@ export type ListChannelMembershipsForAppInstanceUserCommandInput = ListChannelMe
 export type ListChannelMembershipsForAppInstanceUserCommandOutput = ListChannelMembershipsForAppInstanceUserResponse &
   __MetadataBearer;
 
+/**
+ * <p>Lists all channels that a particular <code>AppInstanceUser</code> is a part of. Only an <code>AppInstanceAdmin</code> can call the
+ *            API with a user ARN that is not their own.</p>
+ */
 export class ListChannelMembershipsForAppInstanceUserCommand extends $Command<
   ListChannelMembershipsForAppInstanceUserCommandInput,
   ListChannelMembershipsForAppInstanceUserCommandOutput,
@@ -38,6 +42,9 @@ export class ListChannelMembershipsForAppInstanceUserCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/ListChannelMessagesCommand.ts
+++ b/clients/client-chime/commands/ListChannelMessagesCommand.ts
@@ -20,6 +20,14 @@ import {
 export type ListChannelMessagesCommandInput = ListChannelMessagesRequest;
 export type ListChannelMessagesCommandOutput = ListChannelMessagesResponse & __MetadataBearer;
 
+/**
+ * <p>List all the messages in a channel. Returns a paginated list of <code>ChannelMessages</code>.
+ *            Sorted in descending order by default, based on the creation timestamp.</p>
+ *          <note>
+ *             <p>Redacted messages appear in the results as empty, since they are only redacted, not deleted.
+ *            Deleted messages do not appear in the results. This action always returns the latest version of an edited message.</p>
+ *          </note>
+ */
 export class ListChannelMessagesCommand extends $Command<
   ListChannelMessagesCommandInput,
   ListChannelMessagesCommandOutput,
@@ -34,6 +42,9 @@ export class ListChannelMessagesCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/ListChannelModeratorsCommand.ts
+++ b/clients/client-chime/commands/ListChannelModeratorsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListChannelModeratorsCommandInput = ListChannelModeratorsRequest;
 export type ListChannelModeratorsCommandOutput = ListChannelModeratorsResponse & __MetadataBearer;
 
+/**
+ * <p>Lists all the moderators for a channel.</p>
+ */
 export class ListChannelModeratorsCommand extends $Command<
   ListChannelModeratorsCommandInput,
   ListChannelModeratorsCommandOutput,
@@ -34,6 +37,9 @@ export class ListChannelModeratorsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/ListChannelsCommand.ts
+++ b/clients/client-chime/commands/ListChannelsCommand.ts
@@ -20,6 +20,21 @@ import {
 export type ListChannelsCommandInput = ListChannelsRequest;
 export type ListChannelsCommandOutput = ListChannelsResponse & __MetadataBearer;
 
+/**
+ * <p>Lists all Channels created under a single Chime App as a paginated list. You can specify filters to narrow results.</p>
+ *          <p class="title">
+ *             <b>Functionality & restrictions</b>
+ *          </p>
+ *          <ul>
+ *             <li>
+ *                <p>Use privacy = <code>PUBLIC</code> to retrieve all public channels in the account</p>
+ *             </li>
+ *             <li>
+ *                <p>Only an <code>AppInstanceAdmin</code> can set privacy = <code>PRIVATE</code> to list the private channels in an
+ *                account.</p>
+ *             </li>
+ *          </ul>
+ */
 export class ListChannelsCommand extends $Command<
   ListChannelsCommandInput,
   ListChannelsCommandOutput,
@@ -34,6 +49,9 @@ export class ListChannelsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/ListChannelsModeratedByAppInstanceUserCommand.ts
+++ b/clients/client-chime/commands/ListChannelsModeratedByAppInstanceUserCommand.ts
@@ -24,6 +24,9 @@ export type ListChannelsModeratedByAppInstanceUserCommandInput = ListChannelsMod
 export type ListChannelsModeratedByAppInstanceUserCommandOutput = ListChannelsModeratedByAppInstanceUserResponse &
   __MetadataBearer;
 
+/**
+ * <p>A list of the channels moderated by an app instance user.</p>
+ */
 export class ListChannelsModeratedByAppInstanceUserCommand extends $Command<
   ListChannelsModeratedByAppInstanceUserCommandInput,
   ListChannelsModeratedByAppInstanceUserCommandOutput,
@@ -38,6 +41,9 @@ export class ListChannelsModeratedByAppInstanceUserCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/PutAppInstanceRetentionSettingsCommand.ts
+++ b/clients/client-chime/commands/PutAppInstanceRetentionSettingsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type PutAppInstanceRetentionSettingsCommandInput = PutAppInstanceRetentionSettingsRequest;
 export type PutAppInstanceRetentionSettingsCommandOutput = PutAppInstanceRetentionSettingsResponse & __MetadataBearer;
 
+/**
+ * <p>Sets the amount of time in days that a given app instance retains data.</p>
+ */
 export class PutAppInstanceRetentionSettingsCommand extends $Command<
   PutAppInstanceRetentionSettingsCommandInput,
   PutAppInstanceRetentionSettingsCommandOutput,
@@ -34,6 +37,9 @@ export class PutAppInstanceRetentionSettingsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/PutAppInstanceStreamingConfigurationsCommand.ts
+++ b/clients/client-chime/commands/PutAppInstanceStreamingConfigurationsCommand.ts
@@ -24,6 +24,9 @@ export type PutAppInstanceStreamingConfigurationsCommandInput = PutAppInstanceSt
 export type PutAppInstanceStreamingConfigurationsCommandOutput = PutAppInstanceStreamingConfigurationsResponse &
   __MetadataBearer;
 
+/**
+ * <p>The data streaming configurations of an app instance.</p>
+ */
 export class PutAppInstanceStreamingConfigurationsCommand extends $Command<
   PutAppInstanceStreamingConfigurationsCommandInput,
   PutAppInstanceStreamingConfigurationsCommandOutput,
@@ -38,6 +41,9 @@ export class PutAppInstanceStreamingConfigurationsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/RedactChannelMessageCommand.ts
+++ b/clients/client-chime/commands/RedactChannelMessageCommand.ts
@@ -20,6 +20,10 @@ import {
 export type RedactChannelMessageCommandInput = RedactChannelMessageRequest;
 export type RedactChannelMessageCommandOutput = RedactChannelMessageResponse & __MetadataBearer;
 
+/**
+ * <p>Redacts message content, but not metadata. The message exists in the back end, but the action returns null content, and the state
+ *            shows as redacted.</p>
+ */
 export class RedactChannelMessageCommand extends $Command<
   RedactChannelMessageCommandInput,
   RedactChannelMessageCommandOutput,
@@ -34,6 +38,9 @@ export class RedactChannelMessageCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/RedactRoomMessageCommand.ts
+++ b/clients/client-chime/commands/RedactRoomMessageCommand.ts
@@ -21,7 +21,7 @@ export type RedactRoomMessageCommandInput = RedactRoomMessageRequest;
 export type RedactRoomMessageCommandOutput = RedactRoomMessageResponse & __MetadataBearer;
 
 /**
- * <p>Redacts the specified message from the specified Amazon Chime chat room.</p>
+ * <p>Redacts the specified message from the specified Amazon Chime channel.</p>
  */
 export class RedactRoomMessageCommand extends $Command<
   RedactRoomMessageCommandInput,

--- a/clients/client-chime/commands/SendChannelMessageCommand.ts
+++ b/clients/client-chime/commands/SendChannelMessageCommand.ts
@@ -20,6 +20,15 @@ import {
 export type SendChannelMessageCommandInput = SendChannelMessageRequest;
 export type SendChannelMessageCommandOutput = SendChannelMessageResponse & __MetadataBearer;
 
+/**
+ * <p>Sends a message to a particular channel that the member is a part of.</p>
+ *
+ *          <note>
+ *             <p>
+ *                <code>STANDARD</code> messages can contain 4KB of data and the 1KB of metadata. <code>CONTROL</code> messages can contain 30
+ *            bytes of data and no metadata.</p>
+ *          </note>
+ */
 export class SendChannelMessageCommand extends $Command<
   SendChannelMessageCommandInput,
   SendChannelMessageCommandOutput,
@@ -34,6 +43,9 @@ export class SendChannelMessageCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/UpdateAppInstanceCommand.ts
+++ b/clients/client-chime/commands/UpdateAppInstanceCommand.ts
@@ -20,6 +20,9 @@ import {
 export type UpdateAppInstanceCommandInput = UpdateAppInstanceRequest;
 export type UpdateAppInstanceCommandOutput = UpdateAppInstanceResponse & __MetadataBearer;
 
+/**
+ * <p>Updates <code>AppInstance</code> metadata.</p>
+ */
 export class UpdateAppInstanceCommand extends $Command<
   UpdateAppInstanceCommandInput,
   UpdateAppInstanceCommandOutput,
@@ -34,6 +37,9 @@ export class UpdateAppInstanceCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/UpdateAppInstanceUserCommand.ts
+++ b/clients/client-chime/commands/UpdateAppInstanceUserCommand.ts
@@ -20,6 +20,9 @@ import {
 export type UpdateAppInstanceUserCommandInput = UpdateAppInstanceUserRequest;
 export type UpdateAppInstanceUserCommandOutput = UpdateAppInstanceUserResponse & __MetadataBearer;
 
+/**
+ * <p>Updates the details for an <code>AppInstanceUser</code>. You can update names and metadata.</p>
+ */
 export class UpdateAppInstanceUserCommand extends $Command<
   UpdateAppInstanceUserCommandInput,
   UpdateAppInstanceUserCommandOutput,
@@ -34,6 +37,9 @@ export class UpdateAppInstanceUserCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/UpdateChannelCommand.ts
+++ b/clients/client-chime/commands/UpdateChannelCommand.ts
@@ -20,6 +20,11 @@ import {
 export type UpdateChannelCommandInput = UpdateChannelRequest;
 export type UpdateChannelCommandOutput = UpdateChannelResponse & __MetadataBearer;
 
+/**
+ * <p>Update a channel's attributes.</p>
+ *          <p>
+ *             <b>Restriction</b>: You can't change a channel's privacy.</p>
+ */
 export class UpdateChannelCommand extends $Command<
   UpdateChannelCommandInput,
   UpdateChannelCommandOutput,
@@ -34,6 +39,9 @@ export class UpdateChannelCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/UpdateChannelMessageCommand.ts
+++ b/clients/client-chime/commands/UpdateChannelMessageCommand.ts
@@ -20,6 +20,9 @@ import {
 export type UpdateChannelMessageCommandInput = UpdateChannelMessageRequest;
 export type UpdateChannelMessageCommandOutput = UpdateChannelMessageResponse & __MetadataBearer;
 
+/**
+ * <p>Updates the content of a message.</p>
+ */
 export class UpdateChannelMessageCommand extends $Command<
   UpdateChannelMessageCommandInput,
   UpdateChannelMessageCommandOutput,
@@ -34,6 +37,9 @@ export class UpdateChannelMessageCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/commands/UpdateChannelReadMarkerCommand.ts
+++ b/clients/client-chime/commands/UpdateChannelReadMarkerCommand.ts
@@ -20,6 +20,9 @@ import {
 export type UpdateChannelReadMarkerCommandInput = UpdateChannelReadMarkerRequest;
 export type UpdateChannelReadMarkerCommandOutput = UpdateChannelReadMarkerResponse & __MetadataBearer;
 
+/**
+ * <p>Sets the timestamp to the point when a user last read messages in a channel.</p>
+ */
 export class UpdateChannelReadMarkerCommand extends $Command<
   UpdateChannelReadMarkerCommandInput,
   UpdateChannelReadMarkerCommandOutput,
@@ -34,6 +37,9 @@ export class UpdateChannelReadMarkerCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ChimeClientResolvedConfig,

--- a/clients/client-chime/pagination/ListAppInstanceAdminsPaginator.ts
+++ b/clients/client-chime/pagination/ListAppInstanceAdminsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListAppInstanceAdminsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListAppInstanceAdminsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListAppInstanceAdminsCommandInput,

--- a/clients/client-chime/pagination/ListAppInstanceUsersPaginator.ts
+++ b/clients/client-chime/pagination/ListAppInstanceUsersPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListAppInstanceUsersCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListAppInstanceUsersCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListAppInstanceUsersCommandInput,

--- a/clients/client-chime/pagination/ListAppInstancesPaginator.ts
+++ b/clients/client-chime/pagination/ListAppInstancesPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListAppInstancesCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListAppInstancesCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListAppInstancesCommandInput,

--- a/clients/client-chime/pagination/ListChannelBansPaginator.ts
+++ b/clients/client-chime/pagination/ListChannelBansPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListChannelBansCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListChannelBansCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListChannelBansCommandInput,

--- a/clients/client-chime/pagination/ListChannelMembershipsForAppInstanceUserPaginator.ts
+++ b/clients/client-chime/pagination/ListChannelMembershipsForAppInstanceUserPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListChannelMembershipsForAppInstanceUserCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListChannelMembershipsForAppInstanceUserCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListChannelMembershipsForAppInstanceUserCommandInput,

--- a/clients/client-chime/pagination/ListChannelMembershipsPaginator.ts
+++ b/clients/client-chime/pagination/ListChannelMembershipsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListChannelMembershipsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListChannelMembershipsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListChannelMembershipsCommandInput,

--- a/clients/client-chime/pagination/ListChannelMessagesPaginator.ts
+++ b/clients/client-chime/pagination/ListChannelMessagesPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListChannelMessagesCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListChannelMessagesCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListChannelMessagesCommandInput,

--- a/clients/client-chime/pagination/ListChannelModeratorsPaginator.ts
+++ b/clients/client-chime/pagination/ListChannelModeratorsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListChannelModeratorsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListChannelModeratorsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListChannelModeratorsCommandInput,

--- a/clients/client-chime/pagination/ListChannelsModeratedByAppInstanceUserPaginator.ts
+++ b/clients/client-chime/pagination/ListChannelsModeratedByAppInstanceUserPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListChannelsModeratedByAppInstanceUserCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListChannelsModeratedByAppInstanceUserCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListChannelsModeratedByAppInstanceUserCommandInput,

--- a/clients/client-chime/pagination/ListChannelsPaginator.ts
+++ b/clients/client-chime/pagination/ListChannelsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListChannelsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListChannelsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListChannelsCommandInput,

--- a/clients/client-chime/pagination/ListSipMediaApplicationsPaginator.ts
+++ b/clients/client-chime/pagination/ListSipMediaApplicationsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListSipMediaApplicationsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListSipMediaApplicationsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListSipMediaApplicationsCommandInput,

--- a/clients/client-chime/pagination/ListSipRulesPaginator.ts
+++ b/clients/client-chime/pagination/ListSipRulesPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ChimePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ChimeClient,
   input: ListSipRulesCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListSipRulesCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Chime,
   input: ListSipRulesCommandInput,

--- a/clients/client-cloudhsm-v2/commands/ModifyBackupAttributesCommand.ts
+++ b/clients/client-cloudhsm-v2/commands/ModifyBackupAttributesCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ModifyBackupAttributesCommandInput = ModifyBackupAttributesRequest;
 export type ModifyBackupAttributesCommandOutput = ModifyBackupAttributesResponse & __MetadataBearer;
 
+/**
+ * <p>Modifies attributes for AWS CloudHSM backup.</p>
+ */
 export class ModifyBackupAttributesCommand extends $Command<
   ModifyBackupAttributesCommandInput,
   ModifyBackupAttributesCommandOutput,
@@ -34,6 +37,9 @@ export class ModifyBackupAttributesCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: CloudHSMV2ClientResolvedConfig,

--- a/clients/client-cloudhsm-v2/commands/ModifyClusterCommand.ts
+++ b/clients/client-cloudhsm-v2/commands/ModifyClusterCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ModifyClusterCommandInput = ModifyClusterRequest;
 export type ModifyClusterCommandOutput = ModifyClusterResponse & __MetadataBearer;
 
+/**
+ * <p>Modifies AWS CloudHSM cluster.</p>
+ */
 export class ModifyClusterCommand extends $Command<
   ModifyClusterCommandInput,
   ModifyClusterCommandOutput,
@@ -34,6 +37,9 @@ export class ModifyClusterCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: CloudHSMV2ClientResolvedConfig,

--- a/clients/client-cloudwatch-events/commands/CreateArchiveCommand.ts
+++ b/clients/client-cloudwatch-events/commands/CreateArchiveCommand.ts
@@ -23,7 +23,7 @@ export type CreateArchiveCommandOutput = CreateArchiveResponse & __MetadataBeare
 /**
  * <p>Creates an archive of events with the specified settings. When you create an archive,
  *             incoming events might not immediately start being sent to the archive. Allow a short
- *             period of time for changes to take effect.</p>
+ *             period of time for changes to take effect. If you do not specify a pattern to filter events sent to the archive, all events are sent to the archive except replayed events. Replayed events are not sent to an archive.</p>
  */
 export class CreateArchiveCommand extends $Command<
   CreateArchiveCommandInput,

--- a/clients/client-cloudwatch-events/commands/PutTargetsCommand.ts
+++ b/clients/client-cloudwatch-events/commands/PutTargetsCommand.ts
@@ -92,12 +92,13 @@ export type PutTargetsCommandOutput = PutTargetsResponse & __MetadataBearer;
  *             goes to by using the <code>KinesisParameters</code> argument. To invoke a command on
  *             multiple EC2 instances with one rule, you can use the <code>RunCommandParameters</code>
  *             field.</p>
+ *
  *         <p>To be able to make API calls against the resources that you own, Amazon EventBridge
- *             (CloudWatch Events) needs the appropriate permissions. For AWS Lambda and Amazon SNS
- *             resources, EventBridge relies on resource-based policies. For EC2 instances, Kinesis
- *             data streams, AWS Step Functions state machines and API Gateway REST APIs, EventBridge
- *             relies on IAM roles that you specify in the <code>RoleARN</code> argument in
- *                 <code>PutTargets</code>. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html">Authentication and Access Control</a> in the <i>Amazon EventBridge User
+ *             (CloudWatch Events) needs the appropriate permissions. For AWS Lambda and Amazon SNS resources,
+ *             EventBridge relies on resource-based policies. For EC2 instances, Kinesis data
+ *             streams, AWS Step Functions state machines and API Gateway REST APIs, EventBridge relies on IAM roles
+ *             that you specify in the <code>RoleARN</code> argument in <code>PutTargets</code>. For more information,
+ *             see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html">Authentication and Access Control</a> in the <i>Amazon EventBridge User
  *                 Guide</i>.</p>
  *
  *         <p>If another AWS account is in the same region and has granted you permission (using
@@ -107,8 +108,8 @@ export type PutTargetsCommandOutput = PutTargetsResponse & __MetadataBearer;
  *             run <code>PutTargets</code>. If your account sends events to another account, your
  *             account is charged for each sent event. Each event sent to another account is charged as
  *             a custom event. The account receiving the event is not charged. For more information,
- *             see <a href="https://aws.amazon.com/eventbridge/pricing/">Amazon EventBridge
- *                 (CloudWatch Events) Pricing</a>.</p>
+ *             see <a href="https://aws.amazon.com/eventbridge/pricing/">Amazon EventBridge (CloudWatch Events)
+ *                 Pricing</a>.</p>
  *
  *         <note>
  *             <p>

--- a/clients/client-codeguru-reviewer/commands/CreateCodeReviewCommand.ts
+++ b/clients/client-codeguru-reviewer/commands/CreateCodeReviewCommand.ts
@@ -22,7 +22,11 @@ export type CreateCodeReviewCommandOutput = CreateCodeReviewResponse & __Metadat
 
 /**
  * <p>
- *          Use to create a code review for a repository analysis.
+ *          Use to create a code review with a <a href="https://docs.aws.amazon.com/codeguru/latest/reviewer-api/API_CodeReviewType.html">
+ *                <code>CodeReviewType</code>
+ *             </a>
+ *          of <code>RepositoryAnalysis</code>. This type of code review analyzes all code under a specified branch in an associated repository.
+ *          <code>PullRequest</code> code reviews are automatically triggered by a pull request so cannot be created using this method.
  *       </p>
  */
 export class CreateCodeReviewCommand extends $Command<

--- a/clients/client-codeguru-reviewer/commands/ListTagsForResourceCommand.ts
+++ b/clients/client-codeguru-reviewer/commands/ListTagsForResourceCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListTagsForResourceCommandInput = ListTagsForResourceRequest;
 export type ListTagsForResourceCommandOutput = ListTagsForResourceResponse & __MetadataBearer;
 
+/**
+ * <p>Returns the list of tags associated with an associated repository resource.</p>
+ */
 export class ListTagsForResourceCommand extends $Command<
   ListTagsForResourceCommandInput,
   ListTagsForResourceCommandOutput,
@@ -34,6 +37,9 @@ export class ListTagsForResourceCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: CodeGuruReviewerClientResolvedConfig,

--- a/clients/client-codeguru-reviewer/commands/TagResourceCommand.ts
+++ b/clients/client-codeguru-reviewer/commands/TagResourceCommand.ts
@@ -20,6 +20,9 @@ import {
 export type TagResourceCommandInput = TagResourceRequest;
 export type TagResourceCommandOutput = TagResourceResponse & __MetadataBearer;
 
+/**
+ * <p>Adds one or more tags to an associated repository.</p>
+ */
 export class TagResourceCommand extends $Command<
   TagResourceCommandInput,
   TagResourceCommandOutput,
@@ -34,6 +37,9 @@ export class TagResourceCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: CodeGuruReviewerClientResolvedConfig,

--- a/clients/client-codeguru-reviewer/commands/UntagResourceCommand.ts
+++ b/clients/client-codeguru-reviewer/commands/UntagResourceCommand.ts
@@ -20,6 +20,9 @@ import {
 export type UntagResourceCommandInput = UntagResourceRequest;
 export type UntagResourceCommandOutput = UntagResourceResponse & __MetadataBearer;
 
+/**
+ * <p>Removes a tag from an associated repository.</p>
+ */
 export class UntagResourceCommand extends $Command<
   UntagResourceCommandInput,
   UntagResourceCommandOutput,
@@ -34,6 +37,9 @@ export class UntagResourceCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: CodeGuruReviewerClientResolvedConfig,

--- a/clients/client-connect/commands/AssociateApprovedOriginCommand.ts
+++ b/clients/client-connect/commands/AssociateApprovedOriginCommand.ts
@@ -20,6 +20,9 @@ import {
 export type AssociateApprovedOriginCommandInput = AssociateApprovedOriginRequest;
 export type AssociateApprovedOriginCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Associates an approved origin to an Amazon Connect instance.</p>
+ */
 export class AssociateApprovedOriginCommand extends $Command<
   AssociateApprovedOriginCommandInput,
   AssociateApprovedOriginCommandOutput,
@@ -34,6 +37,9 @@ export class AssociateApprovedOriginCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/AssociateInstanceStorageConfigCommand.ts
+++ b/clients/client-connect/commands/AssociateInstanceStorageConfigCommand.ts
@@ -20,6 +20,15 @@ import {
 export type AssociateInstanceStorageConfigCommandInput = AssociateInstanceStorageConfigRequest;
 export type AssociateInstanceStorageConfigCommandOutput = AssociateInstanceStorageConfigResponse & __MetadataBearer;
 
+/**
+ * <p>Associates a storage resource type for the first time. You can only associate one type of
+ *      storage configuration in a single call. This means, for example, that you can't define an
+ *      instance with multiple S3 buckets for storing chat transcripts.</p>
+ *
+ *          <p>This API does not create a resource that doesn't exist. It only associates it to the
+ *      instance. Ensure that the resource being specified in the storage configuration, like an Amazon
+ *      S3 bucket, exists when being used for association.</p>
+ */
 export class AssociateInstanceStorageConfigCommand extends $Command<
   AssociateInstanceStorageConfigCommandInput,
   AssociateInstanceStorageConfigCommandOutput,
@@ -34,6 +43,9 @@ export class AssociateInstanceStorageConfigCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/AssociateLambdaFunctionCommand.ts
+++ b/clients/client-connect/commands/AssociateLambdaFunctionCommand.ts
@@ -20,6 +20,9 @@ import {
 export type AssociateLambdaFunctionCommandInput = AssociateLambdaFunctionRequest;
 export type AssociateLambdaFunctionCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Allows the specified Amazon Connect instance to access the specified Lambda function.</p>
+ */
 export class AssociateLambdaFunctionCommand extends $Command<
   AssociateLambdaFunctionCommandInput,
   AssociateLambdaFunctionCommandOutput,
@@ -34,6 +37,9 @@ export class AssociateLambdaFunctionCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/AssociateLexBotCommand.ts
+++ b/clients/client-connect/commands/AssociateLexBotCommand.ts
@@ -20,6 +20,9 @@ import {
 export type AssociateLexBotCommandInput = AssociateLexBotRequest;
 export type AssociateLexBotCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Allows the specified Amazon Connect instance to access the specified Amazon Lex bot.</p>
+ */
 export class AssociateLexBotCommand extends $Command<
   AssociateLexBotCommandInput,
   AssociateLexBotCommandOutput,
@@ -34,6 +37,9 @@ export class AssociateLexBotCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/AssociateSecurityKeyCommand.ts
+++ b/clients/client-connect/commands/AssociateSecurityKeyCommand.ts
@@ -20,6 +20,9 @@ import {
 export type AssociateSecurityKeyCommandInput = AssociateSecurityKeyRequest;
 export type AssociateSecurityKeyCommandOutput = AssociateSecurityKeyResponse & __MetadataBearer;
 
+/**
+ * <p>Associates a security key to the instance.</p>
+ */
 export class AssociateSecurityKeyCommand extends $Command<
   AssociateSecurityKeyCommandInput,
   AssociateSecurityKeyCommandOutput,
@@ -34,6 +37,9 @@ export class AssociateSecurityKeyCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/CreateInstanceCommand.ts
+++ b/clients/client-connect/commands/CreateInstanceCommand.ts
@@ -20,6 +20,11 @@ import {
 export type CreateInstanceCommandInput = CreateInstanceRequest;
 export type CreateInstanceCommandOutput = CreateInstanceResponse & __MetadataBearer;
 
+/**
+ * <p>Initiates an Amazon Connect instance with all the supported channels enabled. It does not attach any
+ *    storage (such as Amazon S3, or Kinesis) or allow for any configurations on features such as
+ *    Contact Lens for Amazon Connect. </p>
+ */
 export class CreateInstanceCommand extends $Command<
   CreateInstanceCommandInput,
   CreateInstanceCommandOutput,
@@ -34,6 +39,9 @@ export class CreateInstanceCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/DeleteInstanceCommand.ts
+++ b/clients/client-connect/commands/DeleteInstanceCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteInstanceCommandInput = DeleteInstanceRequest;
 export type DeleteInstanceCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Deletes the Amazon Connect instance.</p>
+ */
 export class DeleteInstanceCommand extends $Command<
   DeleteInstanceCommandInput,
   DeleteInstanceCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteInstanceCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/DescribeInstanceAttributeCommand.ts
+++ b/clients/client-connect/commands/DescribeInstanceAttributeCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DescribeInstanceAttributeCommandInput = DescribeInstanceAttributeRequest;
 export type DescribeInstanceAttributeCommandOutput = DescribeInstanceAttributeResponse & __MetadataBearer;
 
+/**
+ * <p>Describes the specified instance attribute.</p>
+ */
 export class DescribeInstanceAttributeCommand extends $Command<
   DescribeInstanceAttributeCommandInput,
   DescribeInstanceAttributeCommandOutput,
@@ -34,6 +37,9 @@ export class DescribeInstanceAttributeCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/DescribeInstanceCommand.ts
+++ b/clients/client-connect/commands/DescribeInstanceCommand.ts
@@ -20,6 +20,14 @@ import {
 export type DescribeInstanceCommandInput = DescribeInstanceRequest;
 export type DescribeInstanceCommandOutput = DescribeInstanceResponse & __MetadataBearer;
 
+/**
+ * <p>Returns the current state of the specified instance identifier. It tracks the instance while it is
+ *    being created and returns an error status if applicable. </p>
+ *          <p>If an instance is not created
+ *    successfully, the instance status reason field returns details relevant to the reason. The instance
+ *    in a failed state is returned only for 24 hours after
+ *    the CreateInstance API was invoked.</p>
+ */
 export class DescribeInstanceCommand extends $Command<
   DescribeInstanceCommandInput,
   DescribeInstanceCommandOutput,
@@ -34,6 +42,9 @@ export class DescribeInstanceCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/DescribeInstanceStorageConfigCommand.ts
+++ b/clients/client-connect/commands/DescribeInstanceStorageConfigCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DescribeInstanceStorageConfigCommandInput = DescribeInstanceStorageConfigRequest;
 export type DescribeInstanceStorageConfigCommandOutput = DescribeInstanceStorageConfigResponse & __MetadataBearer;
 
+/**
+ * <p>Retrieves the current storage configurations for the specified resource type, association ID, and instance ID.</p>
+ */
 export class DescribeInstanceStorageConfigCommand extends $Command<
   DescribeInstanceStorageConfigCommandInput,
   DescribeInstanceStorageConfigCommandOutput,
@@ -34,6 +37,9 @@ export class DescribeInstanceStorageConfigCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/DisassociateApprovedOriginCommand.ts
+++ b/clients/client-connect/commands/DisassociateApprovedOriginCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DisassociateApprovedOriginCommandInput = DisassociateApprovedOriginRequest;
 export type DisassociateApprovedOriginCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Revokes access to integrated applications from Amazon Connect.</p>
+ */
 export class DisassociateApprovedOriginCommand extends $Command<
   DisassociateApprovedOriginCommandInput,
   DisassociateApprovedOriginCommandOutput,
@@ -34,6 +37,9 @@ export class DisassociateApprovedOriginCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/DisassociateInstanceStorageConfigCommand.ts
+++ b/clients/client-connect/commands/DisassociateInstanceStorageConfigCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DisassociateInstanceStorageConfigCommandInput = DisassociateInstanceStorageConfigRequest;
 export type DisassociateInstanceStorageConfigCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Removes the storage type configurations for the specified resource type and association ID.</p>
+ */
 export class DisassociateInstanceStorageConfigCommand extends $Command<
   DisassociateInstanceStorageConfigCommandInput,
   DisassociateInstanceStorageConfigCommandOutput,
@@ -34,6 +37,9 @@ export class DisassociateInstanceStorageConfigCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/DisassociateLambdaFunctionCommand.ts
+++ b/clients/client-connect/commands/DisassociateLambdaFunctionCommand.ts
@@ -20,6 +20,10 @@ import {
 export type DisassociateLambdaFunctionCommandInput = DisassociateLambdaFunctionRequest;
 export type DisassociateLambdaFunctionCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Remove the Lambda function from the drop-down options available in the relevant contact flow
+ *    blocks.</p>
+ */
 export class DisassociateLambdaFunctionCommand extends $Command<
   DisassociateLambdaFunctionCommandInput,
   DisassociateLambdaFunctionCommandOutput,
@@ -34,6 +38,9 @@ export class DisassociateLambdaFunctionCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/DisassociateLexBotCommand.ts
+++ b/clients/client-connect/commands/DisassociateLexBotCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DisassociateLexBotCommandInput = DisassociateLexBotRequest;
 export type DisassociateLexBotCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Revokes authorization from the specified instance to access the specified Amazon Lex bot.</p>
+ */
 export class DisassociateLexBotCommand extends $Command<
   DisassociateLexBotCommandInput,
   DisassociateLexBotCommandOutput,
@@ -34,6 +37,9 @@ export class DisassociateLexBotCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/DisassociateSecurityKeyCommand.ts
+++ b/clients/client-connect/commands/DisassociateSecurityKeyCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DisassociateSecurityKeyCommandInput = DisassociateSecurityKeyRequest;
 export type DisassociateSecurityKeyCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Deletes the specified security key.</p>
+ */
 export class DisassociateSecurityKeyCommand extends $Command<
   DisassociateSecurityKeyCommandInput,
   DisassociateSecurityKeyCommandOutput,
@@ -34,6 +37,9 @@ export class DisassociateSecurityKeyCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/ListApprovedOriginsCommand.ts
+++ b/clients/client-connect/commands/ListApprovedOriginsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListApprovedOriginsCommandInput = ListApprovedOriginsRequest;
 export type ListApprovedOriginsCommandOutput = ListApprovedOriginsResponse & __MetadataBearer;
 
+/**
+ * <p>Returns a paginated list of all approved origins associated with the instance.</p>
+ */
 export class ListApprovedOriginsCommand extends $Command<
   ListApprovedOriginsCommandInput,
   ListApprovedOriginsCommandOutput,
@@ -34,6 +37,9 @@ export class ListApprovedOriginsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/ListInstanceAttributesCommand.ts
+++ b/clients/client-connect/commands/ListInstanceAttributesCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListInstanceAttributesCommandInput = ListInstanceAttributesRequest;
 export type ListInstanceAttributesCommandOutput = ListInstanceAttributesResponse & __MetadataBearer;
 
+/**
+ * <p>Returns a paginated list of all attribute types for the given instance.</p>
+ */
 export class ListInstanceAttributesCommand extends $Command<
   ListInstanceAttributesCommandInput,
   ListInstanceAttributesCommandOutput,
@@ -34,6 +37,9 @@ export class ListInstanceAttributesCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/ListInstanceStorageConfigsCommand.ts
+++ b/clients/client-connect/commands/ListInstanceStorageConfigsCommand.ts
@@ -20,6 +20,10 @@ import {
 export type ListInstanceStorageConfigsCommandInput = ListInstanceStorageConfigsRequest;
 export type ListInstanceStorageConfigsCommandOutput = ListInstanceStorageConfigsResponse & __MetadataBearer;
 
+/**
+ * <p>Returns a paginated list of storage configs for the identified instance and resource
+ *    type.</p>
+ */
 export class ListInstanceStorageConfigsCommand extends $Command<
   ListInstanceStorageConfigsCommandInput,
   ListInstanceStorageConfigsCommandOutput,
@@ -34,6 +38,9 @@ export class ListInstanceStorageConfigsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/ListInstancesCommand.ts
+++ b/clients/client-connect/commands/ListInstancesCommand.ts
@@ -20,6 +20,11 @@ import {
 export type ListInstancesCommandInput = ListInstancesRequest;
 export type ListInstancesCommandOutput = ListInstancesResponse & __MetadataBearer;
 
+/**
+ * <p>Return a list of instances which are in active state, creation-in-progress state, and failed
+ *    state. Instances that aren't successfully created (they are in a failed state) are returned only
+ *    for 24 hours after the CreateInstance API was invoked.</p>
+ */
 export class ListInstancesCommand extends $Command<
   ListInstancesCommandInput,
   ListInstancesCommandOutput,
@@ -34,6 +39,9 @@ export class ListInstancesCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/ListLambdaFunctionsCommand.ts
+++ b/clients/client-connect/commands/ListLambdaFunctionsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListLambdaFunctionsCommandInput = ListLambdaFunctionsRequest;
 export type ListLambdaFunctionsCommandOutput = ListLambdaFunctionsResponse & __MetadataBearer;
 
+/**
+ * <p>Returns a paginated list of all the Lambda functions that show up in the drop-down options in the relevant contact flow blocks.</p>
+ */
 export class ListLambdaFunctionsCommand extends $Command<
   ListLambdaFunctionsCommandInput,
   ListLambdaFunctionsCommandOutput,
@@ -34,6 +37,9 @@ export class ListLambdaFunctionsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/ListLexBotsCommand.ts
+++ b/clients/client-connect/commands/ListLexBotsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListLexBotsCommandInput = ListLexBotsRequest;
 export type ListLexBotsCommandOutput = ListLexBotsResponse & __MetadataBearer;
 
+/**
+ * <p>Returns a paginated list of all the Amazon Lex bots currently associated with the instance.</p>
+ */
 export class ListLexBotsCommand extends $Command<
   ListLexBotsCommandInput,
   ListLexBotsCommandOutput,
@@ -34,6 +37,9 @@ export class ListLexBotsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/ListSecurityKeysCommand.ts
+++ b/clients/client-connect/commands/ListSecurityKeysCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListSecurityKeysCommandInput = ListSecurityKeysRequest;
 export type ListSecurityKeysCommandOutput = ListSecurityKeysResponse & __MetadataBearer;
 
+/**
+ * <p>Returns a paginated list of all security keys associated with the instance.</p>
+ */
 export class ListSecurityKeysCommand extends $Command<
   ListSecurityKeysCommandInput,
   ListSecurityKeysCommandOutput,
@@ -34,6 +37,9 @@ export class ListSecurityKeysCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/UpdateInstanceAttributeCommand.ts
+++ b/clients/client-connect/commands/UpdateInstanceAttributeCommand.ts
@@ -20,6 +20,9 @@ import {
 export type UpdateInstanceAttributeCommandInput = UpdateInstanceAttributeRequest;
 export type UpdateInstanceAttributeCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Updates the value for the specified attribute type.</p>
+ */
 export class UpdateInstanceAttributeCommand extends $Command<
   UpdateInstanceAttributeCommandInput,
   UpdateInstanceAttributeCommandOutput,
@@ -34,6 +37,9 @@ export class UpdateInstanceAttributeCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/commands/UpdateInstanceStorageConfigCommand.ts
+++ b/clients/client-connect/commands/UpdateInstanceStorageConfigCommand.ts
@@ -20,6 +20,9 @@ import {
 export type UpdateInstanceStorageConfigCommandInput = UpdateInstanceStorageConfigRequest;
 export type UpdateInstanceStorageConfigCommandOutput = __MetadataBearer;
 
+/**
+ * <p>Updates an existing configuration for a resource type. This API is idempotent.</p>
+ */
 export class UpdateInstanceStorageConfigCommand extends $Command<
   UpdateInstanceStorageConfigCommandInput,
   UpdateInstanceStorageConfigCommandOutput,
@@ -34,6 +37,9 @@ export class UpdateInstanceStorageConfigCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: ConnectClientResolvedConfig,

--- a/clients/client-connect/pagination/ListApprovedOriginsPaginator.ts
+++ b/clients/client-connect/pagination/ListApprovedOriginsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ConnectPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ConnectClient,
   input: ListApprovedOriginsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListApprovedOriginsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Connect,
   input: ListApprovedOriginsCommandInput,

--- a/clients/client-connect/pagination/ListInstanceAttributesPaginator.ts
+++ b/clients/client-connect/pagination/ListInstanceAttributesPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ConnectPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ConnectClient,
   input: ListInstanceAttributesCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListInstanceAttributesCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Connect,
   input: ListInstanceAttributesCommandInput,

--- a/clients/client-connect/pagination/ListInstanceStorageConfigsPaginator.ts
+++ b/clients/client-connect/pagination/ListInstanceStorageConfigsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ConnectPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ConnectClient,
   input: ListInstanceStorageConfigsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListInstanceStorageConfigsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Connect,
   input: ListInstanceStorageConfigsCommandInput,

--- a/clients/client-connect/pagination/ListInstancesPaginator.ts
+++ b/clients/client-connect/pagination/ListInstancesPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ConnectPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ConnectClient,
   input: ListInstancesCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListInstancesCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Connect,
   input: ListInstancesCommandInput,

--- a/clients/client-connect/pagination/ListLambdaFunctionsPaginator.ts
+++ b/clients/client-connect/pagination/ListLambdaFunctionsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ConnectPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ConnectClient,
   input: ListLambdaFunctionsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListLambdaFunctionsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Connect,
   input: ListLambdaFunctionsCommandInput,

--- a/clients/client-connect/pagination/ListLexBotsPaginator.ts
+++ b/clients/client-connect/pagination/ListLexBotsPaginator.ts
@@ -4,6 +4,9 @@ import { ListLexBotsCommand, ListLexBotsCommandInput, ListLexBotsCommandOutput }
 import { ConnectPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ConnectClient,
   input: ListLexBotsCommandInput,
@@ -12,6 +15,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListLexBotsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Connect,
   input: ListLexBotsCommandInput,

--- a/clients/client-connect/pagination/ListSecurityKeysPaginator.ts
+++ b/clients/client-connect/pagination/ListSecurityKeysPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { ConnectPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: ConnectClient,
   input: ListSecurityKeysCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListSecurityKeysCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Connect,
   input: ListSecurityKeysCommandInput,

--- a/clients/client-cost-explorer/commands/GetCostAndUsageCommand.ts
+++ b/clients/client-cost-explorer/commands/GetCostAndUsageCommand.ts
@@ -26,7 +26,8 @@ export type GetCostAndUsageCommandOutput = GetCostAndUsageResponse & __MetadataB
  * 			your data by various dimensions, such as <code>SERVICE</code> or <code>AZ</code>, in a specific time range. For a complete list
  * 			of valid dimensions, see the
  * 			<a href="https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetDimensionValues.html">GetDimensionValues</a>
- * 		  operation. Master account in an organization in AWS Organizations have access to all member accounts.</p>
+ * 		  operation. Management account in an organization in AWS Organizations have access to all member accounts.</p>
+ * 	        <p>For information about filter limitations, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-limits.html">Quotas and restrictions</a> in the <i>Billing and Cost Management User Guide</i>.</p>
  */
 export class GetCostAndUsageCommand extends $Command<
   GetCostAndUsageCommandInput,

--- a/clients/client-cost-explorer/commands/GetCostAndUsageWithResourcesCommand.ts
+++ b/clients/client-cost-explorer/commands/GetCostAndUsageWithResourcesCommand.ts
@@ -25,7 +25,7 @@ export type GetCostAndUsageWithResourcesCommandOutput = GetCostAndUsageWithResou
  * 	    usage-related metric, such as <code>BlendedCosts</code> or <code>UsageQuantity</code>, that
  * 	    you want the request to return. You can also filter and group your data by various dimensions,
  * 	    such as <code>SERVICE</code> or <code>AZ</code>, in a specific time range. For a complete list
- * 	    of valid dimensions, see the <a href="https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetDimensionValues.html">GetDimensionValues</a> operation. Master account in an organization in AWS
+ * 	    of valid dimensions, see the <a href="https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetDimensionValues.html">GetDimensionValues</a> operation. Management account in an organization in AWS
  * 	    Organizations have access to all member accounts. This API is currently available for the Amazon Elastic Compute Cloud – Compute service only.</p>
  * 	        <note>
  *             <p>This is an opt-in only feature. You can enable this feature from the Cost Explorer Settings page. For information on how to access the Settings page, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/ce-access.html">Controlling Access for Cost Explorer</a> in the <i>AWS Billing and Cost Management User Guide</i>.</p>

--- a/clients/client-cost-explorer/commands/GetReservationCoverageCommand.ts
+++ b/clients/client-cost-explorer/commands/GetReservationCoverageCommand.ts
@@ -22,7 +22,7 @@ export type GetReservationCoverageCommandOutput = GetReservationCoverageResponse
 
 /**
  * <p>Retrieves the reservation coverage for your account. This enables you to see how much of your Amazon Elastic Compute Cloud, Amazon ElastiCache, Amazon Relational Database Service, or
- * 		  Amazon Redshift usage is covered by a reservation. An organization's master account can see the coverage of the associated member accounts. This supports dimensions, Cost Categories, and nested expressions.
+ * 		  Amazon Redshift usage is covered by a reservation. An organization's management account can see the coverage of the associated member accounts. This supports dimensions, Cost Categories, and nested expressions.
  * 			For any time period, you can filter data about reservation usage by the following dimensions:</p>
  * 		       <ul>
  *             <li>

--- a/clients/client-cost-explorer/commands/GetReservationUtilizationCommand.ts
+++ b/clients/client-cost-explorer/commands/GetReservationUtilizationCommand.ts
@@ -21,7 +21,7 @@ export type GetReservationUtilizationCommandInput = GetReservationUtilizationReq
 export type GetReservationUtilizationCommandOutput = GetReservationUtilizationResponse & __MetadataBearer;
 
 /**
- * <p>Retrieves the reservation utilization for your account. Master account in an organization have access to member accounts.
+ * <p>Retrieves the reservation utilization for your account. Management account in an organization have access to member accounts.
  * 			You can filter data by dimensions in a time period. You can use <code>GetDimensionValues</code> to determine the possible
  * 			dimension values. Currently, you can group only by <code>SUBSCRIPTION_ID</code>. </p>
  */

--- a/clients/client-cost-explorer/commands/GetSavingsPlansCoverageCommand.ts
+++ b/clients/client-cost-explorer/commands/GetSavingsPlansCoverageCommand.ts
@@ -21,7 +21,7 @@ export type GetSavingsPlansCoverageCommandInput = GetSavingsPlansCoverageRequest
 export type GetSavingsPlansCoverageCommandOutput = GetSavingsPlansCoverageResponse & __MetadataBearer;
 
 /**
- * <p>Retrieves the Savings Plans covered for your account. This enables you to see how much of your cost is covered by a Savings Plan. An organization’s master account can see the coverage of the associated member accounts. This supports dimensions, Cost Categories, and nested expressions. For any time period, you can filter data for Savings Plans usage with the following dimensions:</p>
+ * <p>Retrieves the Savings Plans covered for your account. This enables you to see how much of your cost is covered by a Savings Plan. An organization’s management account can see the coverage of the associated member accounts. This supports dimensions, Cost Categories, and nested expressions. For any time period, you can filter data for Savings Plans usage with the following dimensions:</p>
  * 	        <ul>
  *             <li>
  *                <p>

--- a/clients/client-cost-explorer/commands/GetSavingsPlansUtilizationCommand.ts
+++ b/clients/client-cost-explorer/commands/GetSavingsPlansUtilizationCommand.ts
@@ -21,7 +21,7 @@ export type GetSavingsPlansUtilizationCommandInput = GetSavingsPlansUtilizationR
 export type GetSavingsPlansUtilizationCommandOutput = GetSavingsPlansUtilizationResponse & __MetadataBearer;
 
 /**
- * <p>Retrieves the Savings Plans utilization for your account across date ranges with daily or monthly granularity. Master account in an organization have access to member accounts. You can use <code>GetDimensionValues</code> in <code>SAVINGS_PLANS</code> to determine the possible dimension values.</p>
+ * <p>Retrieves the Savings Plans utilization for your account across date ranges with daily or monthly granularity. Management account in an organization have access to member accounts. You can use <code>GetDimensionValues</code> in <code>SAVINGS_PLANS</code> to determine the possible dimension values.</p>
  * 	        <note>
  *             <p>You cannot group by any dimension values for <code>GetSavingsPlansUtilization</code>.</p>
  *          </note>

--- a/clients/client-directory-service/commands/AddRegionCommand.ts
+++ b/clients/client-directory-service/commands/AddRegionCommand.ts
@@ -17,6 +17,9 @@ import {
 export type AddRegionCommandInput = AddRegionRequest;
 export type AddRegionCommandOutput = AddRegionResult & __MetadataBearer;
 
+/**
+ * <p>Adds two domain controllers in the specified Region for the specified directory.</p>
+ */
 export class AddRegionCommand extends $Command<
   AddRegionCommandInput,
   AddRegionCommandOutput,
@@ -31,6 +34,9 @@ export class AddRegionCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: DirectoryServiceClientResolvedConfig,

--- a/clients/client-directory-service/commands/ConnectDirectoryCommand.ts
+++ b/clients/client-directory-service/commands/ConnectDirectoryCommand.ts
@@ -22,7 +22,10 @@ export type ConnectDirectoryCommandOutput = ConnectDirectoryResult & __MetadataB
 
 /**
  * <p>Creates an AD Connector to connect to an on-premises directory.</p>
- *          <p>Before you call <code>ConnectDirectory</code>, ensure that all of the required permissions have been explicitly granted through a policy. For details about what permissions are required to run the <code>ConnectDirectory</code> operation, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/UsingWithDS_IAM_ResourcePermissions.html">AWS Directory Service API Permissions: Actions, Resources, and Conditions Reference</a>.</p>
+ *          <p>Before you call <code>ConnectDirectory</code>, ensure that all of the required permissions
+ *       have been explicitly granted through a policy. For details about what permissions are required
+ *       to run the <code>ConnectDirectory</code> operation, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/UsingWithDS_IAM_ResourcePermissions.html">AWS Directory Service API Permissions: Actions, Resources, and Conditions
+ *       Reference</a>.</p>
  */
 export class ConnectDirectoryCommand extends $Command<
   ConnectDirectoryCommandInput,

--- a/clients/client-directory-service/commands/CreateComputerCommand.ts
+++ b/clients/client-directory-service/commands/CreateComputerCommand.ts
@@ -21,7 +21,7 @@ export type CreateComputerCommandInput = CreateComputerRequest;
 export type CreateComputerCommandOutput = CreateComputerResult & __MetadataBearer;
 
 /**
- * <p>Creates a computer account in the specified directory, and joins the computer to the directory.</p>
+ * <p>Creates an Active Directory computer object in the specified directory.</p>
  */
 export class CreateComputerCommand extends $Command<
   CreateComputerCommandInput,

--- a/clients/client-directory-service/commands/CreateDirectoryCommand.ts
+++ b/clients/client-directory-service/commands/CreateDirectoryCommand.ts
@@ -21,8 +21,12 @@ export type CreateDirectoryCommandInput = CreateDirectoryRequest;
 export type CreateDirectoryCommandOutput = CreateDirectoryResult & __MetadataBearer;
 
 /**
- * <p>Creates a Simple AD directory. For more information, see <a href="https://docs.aws.amazon.com/directoryservice/latest/admin-guide/directory_simple_ad.html">Simple Active Directory</a> in the <i>AWS Directory Service Admin Guide</i>.</p>
- *          <p>Before you call <code>CreateDirectory</code>, ensure that all of the required permissions have been explicitly granted through a policy. For details about what permissions are required to run the <code>CreateDirectory</code> operation, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/UsingWithDS_IAM_ResourcePermissions.html">AWS Directory Service API Permissions: Actions, Resources, and Conditions Reference</a>.</p>
+ * <p>Creates a Simple AD directory. For more information, see <a href="https://docs.aws.amazon.com/directoryservice/latest/admin-guide/directory_simple_ad.html">Simple Active Directory</a> in the <i>AWS Directory Service Admin
+ *         Guide</i>.</p>
+ *          <p>Before you call <code>CreateDirectory</code>, ensure that all of the required permissions
+ *       have been explicitly granted through a policy. For details about what permissions are required
+ *       to run the <code>CreateDirectory</code> operation, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/UsingWithDS_IAM_ResourcePermissions.html">AWS Directory Service API Permissions: Actions, Resources, and Conditions
+ *       Reference</a>.</p>
  */
 export class CreateDirectoryCommand extends $Command<
   CreateDirectoryCommandInput,

--- a/clients/client-directory-service/commands/CreateLogSubscriptionCommand.ts
+++ b/clients/client-directory-service/commands/CreateLogSubscriptionCommand.ts
@@ -21,8 +21,8 @@ export type CreateLogSubscriptionCommandInput = CreateLogSubscriptionRequest;
 export type CreateLogSubscriptionCommandOutput = CreateLogSubscriptionResult & __MetadataBearer;
 
 /**
- * <p>Creates a subscription to forward real-time Directory Service domain controller
- *       security logs to the specified Amazon CloudWatch log group in your AWS account.</p>
+ * <p>Creates a subscription to forward real-time Directory Service domain controller security
+ *       logs to the specified Amazon CloudWatch log group in your AWS account.</p>
  */
 export class CreateLogSubscriptionCommand extends $Command<
   CreateLogSubscriptionCommandInput,

--- a/clients/client-directory-service/commands/DeleteDirectoryCommand.ts
+++ b/clients/client-directory-service/commands/DeleteDirectoryCommand.ts
@@ -22,7 +22,10 @@ export type DeleteDirectoryCommandOutput = DeleteDirectoryResult & __MetadataBea
 
 /**
  * <p>Deletes an AWS Directory Service directory.</p>
- *          <p>Before you call <code>DeleteDirectory</code>, ensure that all of the required permissions have been explicitly granted through a policy. For details about what permissions are required to run the <code>DeleteDirectory</code> operation, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/UsingWithDS_IAM_ResourcePermissions.html">AWS Directory Service API Permissions: Actions, Resources, and Conditions Reference</a>.</p>
+ *          <p>Before you call <code>DeleteDirectory</code>, ensure that all of the required permissions
+ *       have been explicitly granted through a policy. For details about what permissions are required
+ *       to run the <code>DeleteDirectory</code> operation, see <a href="http://docs.aws.amazon.com/directoryservice/latest/admin-guide/UsingWithDS_IAM_ResourcePermissions.html">AWS Directory Service API Permissions: Actions, Resources, and Conditions
+ *       Reference</a>.</p>
  */
 export class DeleteDirectoryCommand extends $Command<
   DeleteDirectoryCommandInput,

--- a/clients/client-directory-service/commands/DescribeCertificateCommand.ts
+++ b/clients/client-directory-service/commands/DescribeCertificateCommand.ts
@@ -21,7 +21,8 @@ export type DescribeCertificateCommandInput = DescribeCertificateRequest;
 export type DescribeCertificateCommandOutput = DescribeCertificateResult & __MetadataBearer;
 
 /**
- * <p>Displays information about the certificate registered for a secured LDAP connection.</p>
+ * <p>Displays information about the certificate registered for a secured LDAP
+ *       connection.</p>
  */
 export class DescribeCertificateCommand extends $Command<
   DescribeCertificateCommandInput,

--- a/clients/client-directory-service/commands/DescribeDirectoriesCommand.ts
+++ b/clients/client-directory-service/commands/DescribeDirectoriesCommand.ts
@@ -23,14 +23,15 @@ export type DescribeDirectoriesCommandOutput = DescribeDirectoriesResult & __Met
 /**
  * <p>Obtains information about the directories that belong to this account.</p>
  *          <p>You can retrieve information about specific directories by passing the directory
- *          identifiers in the <code>DirectoryIds</code> parameter. Otherwise, all directories that belong to
- *          the current account are returned.</p>
+ *       identifiers in the <code>DirectoryIds</code> parameter. Otherwise, all directories that belong
+ *       to the current account are returned.</p>
  *          <p>This operation supports pagination with the use of the <code>NextToken</code> request and
- *          response parameters. If more results are available, the
- *             <code>DescribeDirectoriesResult.NextToken</code> member contains a token that you pass in the
- *          next call to <a>DescribeDirectories</a> to retrieve the next set of items.</p>
+ *       response parameters. If more results are available, the
+ *         <code>DescribeDirectoriesResult.NextToken</code> member contains a token that you pass in
+ *       the next call to <a>DescribeDirectories</a> to retrieve the next set of
+ *       items.</p>
  *          <p>You can also specify a maximum number of return results with the <code>Limit</code>
- *          parameter.</p>
+ *       parameter.</p>
  */
 export class DescribeDirectoriesCommand extends $Command<
   DescribeDirectoriesCommandInput,

--- a/clients/client-directory-service/commands/DescribeRegionsCommand.ts
+++ b/clients/client-directory-service/commands/DescribeRegionsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DescribeRegionsCommandInput = DescribeRegionsRequest;
 export type DescribeRegionsCommandOutput = DescribeRegionsResult & __MetadataBearer;
 
+/**
+ * <p>Provides information about the Regions that are configured for multi-Region replication.</p>
+ */
 export class DescribeRegionsCommand extends $Command<
   DescribeRegionsCommandInput,
   DescribeRegionsCommandOutput,
@@ -34,6 +37,9 @@ export class DescribeRegionsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: DirectoryServiceClientResolvedConfig,

--- a/clients/client-directory-service/commands/ListCertificatesCommand.ts
+++ b/clients/client-directory-service/commands/ListCertificatesCommand.ts
@@ -21,7 +21,8 @@ export type ListCertificatesCommandInput = ListCertificatesRequest;
 export type ListCertificatesCommandOutput = ListCertificatesResult & __MetadataBearer;
 
 /**
- * <p>For the specified directory, lists all the certificates registered for a secured LDAP connection.</p>
+ * <p>For the specified directory, lists all the certificates registered for a secured LDAP
+ *       connection.</p>
  */
 export class ListCertificatesCommand extends $Command<
   ListCertificatesCommandInput,

--- a/clients/client-directory-service/commands/RemoveRegionCommand.ts
+++ b/clients/client-directory-service/commands/RemoveRegionCommand.ts
@@ -20,6 +20,9 @@ import {
 export type RemoveRegionCommandInput = RemoveRegionRequest;
 export type RemoveRegionCommandOutput = RemoveRegionResult & __MetadataBearer;
 
+/**
+ * <p>Stops all replication and removes the domain controllers from the specified Region. You cannot remove the primary Region with this operation. Instead, use the <code>DeleteDirectory</code> API.</p>
+ */
 export class RemoveRegionCommand extends $Command<
   RemoveRegionCommandInput,
   RemoveRegionCommandOutput,
@@ -34,6 +37,9 @@ export class RemoveRegionCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: DirectoryServiceClientResolvedConfig,

--- a/clients/client-directory-service/commands/ResetUserPasswordCommand.ts
+++ b/clients/client-directory-service/commands/ResetUserPasswordCommand.ts
@@ -21,18 +21,20 @@ export type ResetUserPasswordCommandInput = ResetUserPasswordRequest;
 export type ResetUserPasswordCommandOutput = ResetUserPasswordResult & __MetadataBearer;
 
 /**
- * <p>Resets the password for any user in your AWS Managed Microsoft AD or Simple AD directory.</p>
- *          <p>You can reset the password for any user in your directory with the following exceptions:</p>
+ * <p>Resets the password for any user in your AWS Managed Microsoft AD or Simple AD
+ *       directory.</p>
+ *          <p>You can reset the password for any user in your directory with the following
+ *       exceptions:</p>
  *          <ul>
  *             <li>
- *                <p>For Simple AD, you cannot reset the password for any user that is a member of either the
- *             <b>Domain Admins</b> or <b>Enterprise
+ *                <p>For Simple AD, you cannot reset the password for any user that is a member of either
+ *           the <b>Domain Admins</b> or <b>Enterprise
  *             Admins</b> group except for the administrator user.</p>
  *             </li>
  *             <li>
- *                <p>For AWS Managed Microsoft AD, you can only reset the password for a user that is in an OU
- *           based off of the NetBIOS name that you typed when you created your directory. For example,
- *           you cannot reset the password for a user in the <b>AWS
+ *                <p>For AWS Managed Microsoft AD, you can only reset the password for a user that is in an
+ *           OU based off of the NetBIOS name that you typed when you created your directory. For
+ *           example, you cannot reset the password for a user in the <b>AWS
  *             Reserved</b> OU. For more information about the OU structure for an AWS Managed
  *           Microsoft AD directory, see <a href="https://docs.aws.amazon.com/directoryservice/latest/admin-guide/ms_ad_getting_started_what_gets_created.html">What Gets Created</a> in the <i>AWS Directory Service Administration
  *             Guide</i>.</p>

--- a/clients/client-eventbridge/commands/CreateArchiveCommand.ts
+++ b/clients/client-eventbridge/commands/CreateArchiveCommand.ts
@@ -23,7 +23,7 @@ export type CreateArchiveCommandOutput = CreateArchiveResponse & __MetadataBeare
 /**
  * <p>Creates an archive of events with the specified settings. When you create an archive,
  *             incoming events might not immediately start being sent to the archive. Allow a short
- *             period of time for changes to take effect.</p>
+ *             period of time for changes to take effect. If you do not specify a pattern to filter events sent to the archive, all events are sent to the archive except replayed events. Replayed events are not sent to an archive.</p>
  */
 export class CreateArchiveCommand extends $Command<
   CreateArchiveCommandInput,

--- a/clients/client-eventbridge/commands/PutTargetsCommand.ts
+++ b/clients/client-eventbridge/commands/PutTargetsCommand.ts
@@ -92,12 +92,13 @@ export type PutTargetsCommandOutput = PutTargetsResponse & __MetadataBearer;
  *             goes to by using the <code>KinesisParameters</code> argument. To invoke a command on
  *             multiple EC2 instances with one rule, you can use the <code>RunCommandParameters</code>
  *             field.</p>
+ *
  *         <p>To be able to make API calls against the resources that you own, Amazon EventBridge
- *             (CloudWatch Events) needs the appropriate permissions. For AWS Lambda and Amazon SNS
- *             resources, EventBridge relies on resource-based policies. For EC2 instances, Kinesis
- *             data streams, AWS Step Functions state machines and API Gateway REST APIs, EventBridge
- *             relies on IAM roles that you specify in the <code>RoleARN</code> argument in
- *                 <code>PutTargets</code>. For more information, see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html">Authentication and Access Control</a> in the <i>Amazon EventBridge User
+ *             (CloudWatch Events) needs the appropriate permissions. For AWS Lambda and Amazon SNS resources,
+ *             EventBridge relies on resource-based policies. For EC2 instances, Kinesis data
+ *             streams, AWS Step Functions state machines and API Gateway REST APIs, EventBridge relies on IAM roles
+ *             that you specify in the <code>RoleARN</code> argument in <code>PutTargets</code>. For more information,
+ *             see <a href="https://docs.aws.amazon.com/eventbridge/latest/userguide/auth-and-access-control-eventbridge.html">Authentication and Access Control</a> in the <i>Amazon EventBridge User
  *                 Guide</i>.</p>
  *
  *         <p>If another AWS account is in the same region and has granted you permission (using
@@ -107,8 +108,8 @@ export type PutTargetsCommandOutput = PutTargetsResponse & __MetadataBearer;
  *             run <code>PutTargets</code>. If your account sends events to another account, your
  *             account is charged for each sent event. Each event sent to another account is charged as
  *             a custom event. The account receiving the event is not charged. For more information,
- *             see <a href="https://aws.amazon.com/eventbridge/pricing/">Amazon EventBridge
- *                 (CloudWatch Events) Pricing</a>.</p>
+ *             see <a href="https://aws.amazon.com/eventbridge/pricing/">Amazon EventBridge (CloudWatch Events)
+ *                 Pricing</a>.</p>
  *
  *         <note>
  *             <p>

--- a/clients/client-glue/commands/CheckSchemaVersionValidityCommand.ts
+++ b/clients/client-glue/commands/CheckSchemaVersionValidityCommand.ts
@@ -20,6 +20,9 @@ import {
 export type CheckSchemaVersionValidityCommandInput = CheckSchemaVersionValidityInput;
 export type CheckSchemaVersionValidityCommandOutput = CheckSchemaVersionValidityResponse & __MetadataBearer;
 
+/**
+ * <p>Validates the supplied schema. This call has no side effects, it simply validates using the supplied schema using <code>DataFormat</code> as the format. Since it does not take a schema set name, no compatibility checks are performed.</p>
+ */
 export class CheckSchemaVersionValidityCommand extends $Command<
   CheckSchemaVersionValidityCommandInput,
   CheckSchemaVersionValidityCommandOutput,
@@ -34,6 +37,9 @@ export class CheckSchemaVersionValidityCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/CreateRegistryCommand.ts
+++ b/clients/client-glue/commands/CreateRegistryCommand.ts
@@ -20,6 +20,9 @@ import {
 export type CreateRegistryCommandInput = CreateRegistryInput;
 export type CreateRegistryCommandOutput = CreateRegistryResponse & __MetadataBearer;
 
+/**
+ * <p>Creates a new registry which may be used to hold a collection of schemas.</p>
+ */
 export class CreateRegistryCommand extends $Command<
   CreateRegistryCommandInput,
   CreateRegistryCommandOutput,
@@ -34,6 +37,9 @@ export class CreateRegistryCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/CreateSchemaCommand.ts
+++ b/clients/client-glue/commands/CreateSchemaCommand.ts
@@ -20,6 +20,11 @@ import {
 export type CreateSchemaCommandInput = CreateSchemaInput;
 export type CreateSchemaCommandOutput = CreateSchemaResponse & __MetadataBearer;
 
+/**
+ * <p>Creates a new schema set and registers the schema definition. Returns an error if the schema set already exists without actually registering the version.</p>
+ *          <p>When the schema set is created, a version checkpoint will be set to the first version. Compatibility mode "DISABLED" restricts any additional schema versions from being added after the first schema version. For all other compatibility modes, validation of compatibility settings will be applied only from the second version onwards when the <code>RegisterSchemaVersion</code> API is used.</p>
+ *          <p>When this API is called without a <code>RegistryId</code>, this will create an entry for a "default-registry" in the registry database tables, if it is not already present.</p>
+ */
 export class CreateSchemaCommand extends $Command<
   CreateSchemaCommandInput,
   CreateSchemaCommandOutput,
@@ -34,6 +39,9 @@ export class CreateSchemaCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/DeleteRegistryCommand.ts
+++ b/clients/client-glue/commands/DeleteRegistryCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteRegistryCommandInput = DeleteRegistryInput;
 export type DeleteRegistryCommandOutput = DeleteRegistryResponse & __MetadataBearer;
 
+/**
+ * <p>Delete the entire registry including schema and all of its versions. To get the status of the delete operation, you can call the <code>GetRegistry</code> API after the asynchronous call. Deleting a registry will disable all online operations for the registry such as the <code>UpdateRegistry</code>, <code>CreateSchema</code>, <code>UpdateSchema</code>, and <code>RegisterSchemaVersion</code> APIs. </p>
+ */
 export class DeleteRegistryCommand extends $Command<
   DeleteRegistryCommandInput,
   DeleteRegistryCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteRegistryCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/DeleteSchemaCommand.ts
+++ b/clients/client-glue/commands/DeleteSchemaCommand.ts
@@ -20,6 +20,9 @@ import {
 export type DeleteSchemaCommandInput = DeleteSchemaInput;
 export type DeleteSchemaCommandOutput = DeleteSchemaResponse & __MetadataBearer;
 
+/**
+ * <p>Deletes the entire schema set, including the schema set and all of its versions. To get the status of the delete operation, you can call <code>GetSchema</code> API after the asynchronous call. Deleting a registry will disable all online operations for the schema, such as the <code>GetSchemaByDefinition</code>, and <code>RegisterSchemaVersion</code> APIs.</p>
+ */
 export class DeleteSchemaCommand extends $Command<
   DeleteSchemaCommandInput,
   DeleteSchemaCommandOutput,
@@ -34,6 +37,9 @@ export class DeleteSchemaCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/DeleteSchemaVersionsCommand.ts
+++ b/clients/client-glue/commands/DeleteSchemaVersionsCommand.ts
@@ -20,6 +20,12 @@ import {
 export type DeleteSchemaVersionsCommandInput = DeleteSchemaVersionsInput;
 export type DeleteSchemaVersionsCommandOutput = DeleteSchemaVersionsResponse & __MetadataBearer;
 
+/**
+ * <p>Remove versions from the specified schema. A version number or range may be supplied. If the compatibility mode forbids deleting of a version that is necessary, such as BACKWARDS_FULL, an error is returned.  Calling the <code>GetSchemaVersions</code> API after this call will list the status of the deleted versions.</p>
+ *          <p>When the range of version numbers contain check pointed version, the API will return a 409 conflict and will not proceed with the deletion. You have to remove the checkpoint first using the <code>DeleteSchemaCheckpoint</code> API before using this API.</p>
+ *          <p>You cannot use the <code>DeleteSchemaVersions</code> API to delete the first schema version in the schema set. The first schema version can only be deleted by the <code>DeleteSchema</code> API. This operation will also delete the attached <code>SchemaVersionMetadata</code> under the schema versions. Hard deletes will be enforced on the database.</p>
+ *          <p>If the compatibility mode forbids deleting of a version that is necessary, such as BACKWARDS_FULL, an error is returned.</p>
+ */
 export class DeleteSchemaVersionsCommand extends $Command<
   DeleteSchemaVersionsCommandInput,
   DeleteSchemaVersionsCommandOutput,
@@ -34,6 +40,9 @@ export class DeleteSchemaVersionsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/GetRegistryCommand.ts
+++ b/clients/client-glue/commands/GetRegistryCommand.ts
@@ -20,6 +20,9 @@ import {
 export type GetRegistryCommandInput = GetRegistryInput;
 export type GetRegistryCommandOutput = GetRegistryResponse & __MetadataBearer;
 
+/**
+ * <p>Describes the specified registry in detail.</p>
+ */
 export class GetRegistryCommand extends $Command<
   GetRegistryCommandInput,
   GetRegistryCommandOutput,
@@ -34,6 +37,9 @@ export class GetRegistryCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/GetSchemaByDefinitionCommand.ts
+++ b/clients/client-glue/commands/GetSchemaByDefinitionCommand.ts
@@ -20,6 +20,9 @@ import {
 export type GetSchemaByDefinitionCommandInput = GetSchemaByDefinitionInput;
 export type GetSchemaByDefinitionCommandOutput = GetSchemaByDefinitionResponse & __MetadataBearer;
 
+/**
+ * <p>Retrieves a schema by the <code>SchemaDefinition</code>. The schema definition is sent to the Schema Registry, canonicalized, and hashed. If the hash is matched within the scope of the <code>SchemaName</code> or ARN (or the default registry, if none is supplied), that schema’s metadata is returned. Otherwise, a 404 or NotFound error is returned. Schema versions in <code>Deleted</code> statuses will not be included in the results.</p>
+ */
 export class GetSchemaByDefinitionCommand extends $Command<
   GetSchemaByDefinitionCommandInput,
   GetSchemaByDefinitionCommandOutput,
@@ -34,6 +37,9 @@ export class GetSchemaByDefinitionCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/GetSchemaCommand.ts
+++ b/clients/client-glue/commands/GetSchemaCommand.ts
@@ -17,6 +17,9 @@ import {
 export type GetSchemaCommandInput = GetSchemaInput;
 export type GetSchemaCommandOutput = GetSchemaResponse & __MetadataBearer;
 
+/**
+ * <p>Describes the specified schema in detail.</p>
+ */
 export class GetSchemaCommand extends $Command<
   GetSchemaCommandInput,
   GetSchemaCommandOutput,
@@ -31,6 +34,9 @@ export class GetSchemaCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/GetSchemaVersionCommand.ts
+++ b/clients/client-glue/commands/GetSchemaVersionCommand.ts
@@ -20,6 +20,9 @@ import {
 export type GetSchemaVersionCommandInput = GetSchemaVersionInput;
 export type GetSchemaVersionCommandOutput = GetSchemaVersionResponse & __MetadataBearer;
 
+/**
+ * <p>Get the specified schema by its unique ID assigned when a version of the schema is created or registered. Schema versions in Deleted status will not be included in the results.</p>
+ */
 export class GetSchemaVersionCommand extends $Command<
   GetSchemaVersionCommandInput,
   GetSchemaVersionCommandOutput,
@@ -34,6 +37,9 @@ export class GetSchemaVersionCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/GetSchemaVersionsDiffCommand.ts
+++ b/clients/client-glue/commands/GetSchemaVersionsDiffCommand.ts
@@ -20,6 +20,10 @@ import {
 export type GetSchemaVersionsDiffCommandInput = GetSchemaVersionsDiffInput;
 export type GetSchemaVersionsDiffCommandOutput = GetSchemaVersionsDiffResponse & __MetadataBearer;
 
+/**
+ * <p>Fetches the schema version difference in the specified difference type between two stored schema versions in the Schema Registry.</p>
+ *          <p>This API allows you to compare two schema versions between two schema definitions under the same schema.</p>
+ */
 export class GetSchemaVersionsDiffCommand extends $Command<
   GetSchemaVersionsDiffCommandInput,
   GetSchemaVersionsDiffCommandOutput,
@@ -34,6 +38,9 @@ export class GetSchemaVersionsDiffCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/ListRegistriesCommand.ts
+++ b/clients/client-glue/commands/ListRegistriesCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListRegistriesCommandInput = ListRegistriesInput;
 export type ListRegistriesCommandOutput = ListRegistriesResponse & __MetadataBearer;
 
+/**
+ * <p>Returns a list of registries that you have created, with minimal registry information. Registries in the <code>Deleting</code> status will not be included in the results. Empty results will be returned if there are no registries available.</p>
+ */
 export class ListRegistriesCommand extends $Command<
   ListRegistriesCommandInput,
   ListRegistriesCommandOutput,
@@ -34,6 +37,9 @@ export class ListRegistriesCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/ListSchemaVersionsCommand.ts
+++ b/clients/client-glue/commands/ListSchemaVersionsCommand.ts
@@ -20,6 +20,9 @@ import {
 export type ListSchemaVersionsCommandInput = ListSchemaVersionsInput;
 export type ListSchemaVersionsCommandOutput = ListSchemaVersionsResponse & __MetadataBearer;
 
+/**
+ * <p>Returns a list of schema versions that you have created, with minimal information. Schema versions in Deleted status will not be included in the results. Empty results will be returned if there are no schema versions available.</p>
+ */
 export class ListSchemaVersionsCommand extends $Command<
   ListSchemaVersionsCommandInput,
   ListSchemaVersionsCommandOutput,
@@ -34,6 +37,9 @@ export class ListSchemaVersionsCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/ListSchemasCommand.ts
+++ b/clients/client-glue/commands/ListSchemasCommand.ts
@@ -20,6 +20,10 @@ import {
 export type ListSchemasCommandInput = ListSchemasInput;
 export type ListSchemasCommandOutput = ListSchemasResponse & __MetadataBearer;
 
+/**
+ * <p>Returns a list of schemas with minimal details. Schemas in Deleting status will not be included in the results. Empty results will be returned if there are no schemas available.</p>
+ *          <p>When the <code>RegistryId</code> is not provided, all the schemas across registries will be part of the API response.</p>
+ */
 export class ListSchemasCommand extends $Command<
   ListSchemasCommandInput,
   ListSchemasCommandOutput,
@@ -34,6 +38,9 @@ export class ListSchemasCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/PutSchemaVersionMetadataCommand.ts
+++ b/clients/client-glue/commands/PutSchemaVersionMetadataCommand.ts
@@ -20,6 +20,9 @@ import {
 export type PutSchemaVersionMetadataCommandInput = PutSchemaVersionMetadataInput;
 export type PutSchemaVersionMetadataCommandOutput = PutSchemaVersionMetadataResponse & __MetadataBearer;
 
+/**
+ * <p>Puts the metadata key value pair for a specified schema version ID. A maximum of 10 key value pairs will be allowed per schema version. They can be added over one or more calls.</p>
+ */
 export class PutSchemaVersionMetadataCommand extends $Command<
   PutSchemaVersionMetadataCommandInput,
   PutSchemaVersionMetadataCommandOutput,
@@ -34,6 +37,9 @@ export class PutSchemaVersionMetadataCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/QuerySchemaVersionMetadataCommand.ts
+++ b/clients/client-glue/commands/QuerySchemaVersionMetadataCommand.ts
@@ -20,6 +20,9 @@ import {
 export type QuerySchemaVersionMetadataCommandInput = QuerySchemaVersionMetadataInput;
 export type QuerySchemaVersionMetadataCommandOutput = QuerySchemaVersionMetadataResponse & __MetadataBearer;
 
+/**
+ * <p>Queries for the schema version metadata information. </p>
+ */
 export class QuerySchemaVersionMetadataCommand extends $Command<
   QuerySchemaVersionMetadataCommandInput,
   QuerySchemaVersionMetadataCommandOutput,
@@ -34,6 +37,9 @@ export class QuerySchemaVersionMetadataCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/RegisterSchemaVersionCommand.ts
+++ b/clients/client-glue/commands/RegisterSchemaVersionCommand.ts
@@ -20,6 +20,11 @@ import {
 export type RegisterSchemaVersionCommandInput = RegisterSchemaVersionInput;
 export type RegisterSchemaVersionCommandOutput = RegisterSchemaVersionResponse & __MetadataBearer;
 
+/**
+ * <p>Adds a new version to the existing schema. Returns an error if new version of schema does not meet the compatibility requirements of the schema set. This API will not create a new schema set and will return a 404 error if the schema set is not already present in the Schema Registry.</p>
+ *          <p>If this is the first schema definition to be registered in the Schema Registry, this API will store the schema version and return immediately. Otherwise, this call has the potential to run longer than other operations due to compatibility modes. You can call the <code>GetSchemaVersion</code> API with the <code>SchemaVersionId</code> to check compatibility modes.</p>
+ * 	        <p>If the same schema definition is already stored in Schema Registry as a version, the schema ID of the existing schema is returned to the caller.</p>
+ */
 export class RegisterSchemaVersionCommand extends $Command<
   RegisterSchemaVersionCommandInput,
   RegisterSchemaVersionCommandOutput,
@@ -34,6 +39,9 @@ export class RegisterSchemaVersionCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/RemoveSchemaVersionMetadataCommand.ts
+++ b/clients/client-glue/commands/RemoveSchemaVersionMetadataCommand.ts
@@ -20,6 +20,9 @@ import {
 export type RemoveSchemaVersionMetadataCommandInput = RemoveSchemaVersionMetadataInput;
 export type RemoveSchemaVersionMetadataCommandOutput = RemoveSchemaVersionMetadataResponse & __MetadataBearer;
 
+/**
+ * <p>Removes a key value pair from the schema version metadata for the specified schema version ID.</p>
+ */
 export class RemoveSchemaVersionMetadataCommand extends $Command<
   RemoveSchemaVersionMetadataCommandInput,
   RemoveSchemaVersionMetadataCommandOutput,
@@ -34,6 +37,9 @@ export class RemoveSchemaVersionMetadataCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/UpdateRegistryCommand.ts
+++ b/clients/client-glue/commands/UpdateRegistryCommand.ts
@@ -20,6 +20,9 @@ import {
 export type UpdateRegistryCommandInput = UpdateRegistryInput;
 export type UpdateRegistryCommandOutput = UpdateRegistryResponse & __MetadataBearer;
 
+/**
+ * <p>Updates an existing registry which is used to hold a collection of schemas. The updated properties relate to the registry, and do not modify any of the schemas within the registry. </p>
+ */
 export class UpdateRegistryCommand extends $Command<
   UpdateRegistryCommandInput,
   UpdateRegistryCommandOutput,
@@ -34,6 +37,9 @@ export class UpdateRegistryCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/commands/UpdateSchemaCommand.ts
+++ b/clients/client-glue/commands/UpdateSchemaCommand.ts
@@ -20,6 +20,12 @@ import {
 export type UpdateSchemaCommandInput = UpdateSchemaInput;
 export type UpdateSchemaCommandOutput = UpdateSchemaResponse & __MetadataBearer;
 
+/**
+ * <p>Updates the description, compatibility setting, or version checkpoint for a schema set.</p>
+ * 	        <p>For updating the compatibility setting, the call will not validate compatibility for the entire set of schema versions with the new compatibility setting. If the value for <code>Compatibility</code> is provided, the <code>VersionNumber</code> (a checkpoint) is also required. The API will validate the checkpoint version number for consistency.</p>
+ *          <p>If the value for the <code>VersionNumber</code> (checkpoint) is provided, <code>Compatibility</code> is optional and this can be used to set/reset a checkpoint for the schema.</p>
+ * 	        <p>This update will happen only if the schema is in the AVAILABLE state.</p>
+ */
 export class UpdateSchemaCommand extends $Command<
   UpdateSchemaCommandInput,
   UpdateSchemaCommandOutput,
@@ -34,6 +40,9 @@ export class UpdateSchemaCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: GlueClientResolvedConfig,

--- a/clients/client-glue/pagination/GetResourcePoliciesPaginator.ts
+++ b/clients/client-glue/pagination/GetResourcePoliciesPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { GluePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: GlueClient,
   input: GetResourcePoliciesCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new GetResourcePoliciesCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Glue,
   input: GetResourcePoliciesCommandInput,

--- a/clients/client-glue/pagination/ListRegistriesPaginator.ts
+++ b/clients/client-glue/pagination/ListRegistriesPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { GluePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: GlueClient,
   input: ListRegistriesCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListRegistriesCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Glue,
   input: ListRegistriesCommandInput,

--- a/clients/client-glue/pagination/ListSchemaVersionsPaginator.ts
+++ b/clients/client-glue/pagination/ListSchemaVersionsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { GluePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: GlueClient,
   input: ListSchemaVersionsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListSchemaVersionsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Glue,
   input: ListSchemaVersionsCommandInput,

--- a/clients/client-glue/pagination/ListSchemasPaginator.ts
+++ b/clients/client-glue/pagination/ListSchemasPaginator.ts
@@ -4,6 +4,9 @@ import { ListSchemasCommand, ListSchemasCommandInput, ListSchemasCommandOutput }
 import { GluePaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: GlueClient,
   input: ListSchemasCommandInput,
@@ -12,6 +15,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new ListSchemasCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Glue,
   input: ListSchemasCommandInput,

--- a/clients/client-kinesis-analytics-v2/commands/CreateApplicationPresignedUrlCommand.ts
+++ b/clients/client-kinesis-analytics-v2/commands/CreateApplicationPresignedUrlCommand.ts
@@ -24,6 +24,21 @@ import {
 export type CreateApplicationPresignedUrlCommandInput = CreateApplicationPresignedUrlRequest;
 export type CreateApplicationPresignedUrlCommandOutput = CreateApplicationPresignedUrlResponse & __MetadataBearer;
 
+/**
+ * <p>Creates and returns a URL that you can use to connect to
+ *             an application's extension. Currently, the only
+ *             available extension is the Apache Flink dashboard.</p>
+ *         <p>The IAM role or user used to call this API defines the permissions to access the extension.
+ *             Once the presigned URL is created, no additional permission is required to access this URL. IAM
+ *             authorization policies for this API are also enforced for every HTTP request that attempts to
+ *             connect to the extension.
+ *         </p>
+ *         <note>
+ *             <p>The URL that you get from a call to CreateApplicationPresignedUrl must be used within 3 minutes
+ *             to be valid.
+ *             If you first try to use the URL after the 3-minute limit expires, the service returns an HTTP 403 Forbidden error.</p>
+ *          </note>
+ */
 export class CreateApplicationPresignedUrlCommand extends $Command<
   CreateApplicationPresignedUrlCommandInput,
   CreateApplicationPresignedUrlCommandOutput,
@@ -38,6 +53,9 @@ export class CreateApplicationPresignedUrlCommand extends $Command<
     // End section: command_constructor
   }
 
+  /**
+   * @internal
+   */
   resolveMiddleware(
     clientStack: MiddlewareStack<ServiceInputTypes, ServiceOutputTypes>,
     configuration: KinesisAnalyticsV2ClientResolvedConfig,

--- a/clients/client-kinesis-analytics-v2/commands/StopApplicationCommand.ts
+++ b/clients/client-kinesis-analytics-v2/commands/StopApplicationCommand.ts
@@ -26,9 +26,12 @@ export type StopApplicationCommandOutput = StopApplicationResponse & __MetadataB
 
 /**
  * <p>Stops the application from processing data. You can stop
- *       an application only if it is in the running state.
- *       You can use the <a>DescribeApplication</a> operation to find the application state.
+ *       an application only if it is in the running status, unless you set the <code>Force</code>
+ *         parameter to <code>true</code>.</p>
+ *          <p>You can use the <a>DescribeApplication</a> operation to find the application status.
  *        </p>
+ *          <p>Kinesis Data Analytics takes a snapshot when the application is stopped, unless <code>Force</code> is set
+ *           to <code>true</code>.</p>
  */
 export class StopApplicationCommand extends $Command<
   StopApplicationCommandInput,

--- a/clients/client-lambda/commands/CreateEventSourceMappingCommand.ts
+++ b/clients/client-lambda/commands/CreateEventSourceMappingCommand.ts
@@ -45,6 +45,12 @@ export type CreateEventSourceMappingCommandOutput = EventSourceMappingConfigurat
  *             </li>
  *             <li>
  *                <p>
+ *                   <a href="https://docs.aws.amazon.com/lambda/latest/dg/with-mq.html">Using AWS Lambda with Amazon
+ *           MQ</a>
+ *                </p>
+ *             </li>
+ *             <li>
+ *                <p>
  *                   <a href="https://docs.aws.amazon.com/lambda/latest/dg/with-msk.html">Using AWS Lambda with Amazon
  *           MSK</a>
  *                </p>

--- a/clients/client-lex-model-building-service/commands/CreateBotVersionCommand.ts
+++ b/clients/client-lex-model-building-service/commands/CreateBotVersionCommand.ts
@@ -25,18 +25,19 @@ export type CreateBotVersionCommandInput = CreateBotVersionRequest;
 export type CreateBotVersionCommandOutput = CreateBotVersionResponse & __MetadataBearer;
 
 /**
- * <p>Creates a new version of the bot based on the <code>$LATEST</code> version. If the
- *         <code>$LATEST</code> version of this resource hasn't changed since you created the last
- *       version, Amazon Lex doesn't create a new version. It returns the last created version.</p>
+ * <p>Creates a new version of the bot based on the <code>$LATEST</code>
+ *       version. If the <code>$LATEST</code> version of this resource hasn't
+ *       changed since you created the last version, Amazon Lex doesn't create a new
+ *       version. It returns the last created version.</p>
  *          <note>
- *             <p>You can update only the <code>$LATEST</code> version of the bot. You can't update the
- *         numbered versions that you create with the <code>CreateBotVersion</code>
- *         operation.</p>
+ *             <p>You can update only the <code>$LATEST</code> version of the bot.
+ *         You can't update the numbered versions that you create with the
+ *           <code>CreateBotVersion</code> operation.</p>
  *          </note>
- *          <p> When you create the first version of a bot, Amazon Lex sets the version to 1. Subsequent
- *       versions increment by 1. For more information, see <a>versioning-intro</a>. </p>
- *          <p> This operation requires permission for the <code>lex:CreateBotVersion</code> action.
- *     </p>
+ *          <p> When you create the first version of a bot, Amazon Lex sets the version
+ *       to 1. Subsequent versions increment by 1. For more information, see <a>versioning-intro</a>. </p>
+ *          <p> This operation requires permission for the
+ *         <code>lex:CreateBotVersion</code> action. </p>
  */
 export class CreateBotVersionCommand extends $Command<
   CreateBotVersionCommandInput,

--- a/clients/client-lex-model-building-service/commands/CreateIntentVersionCommand.ts
+++ b/clients/client-lex-model-building-service/commands/CreateIntentVersionCommand.ts
@@ -25,19 +25,20 @@ export type CreateIntentVersionCommandInput = CreateIntentVersionRequest;
 export type CreateIntentVersionCommandOutput = CreateIntentVersionResponse & __MetadataBearer;
 
 /**
- * <p>Creates a new version of an intent based on the <code>$LATEST</code> version of the
- *       intent. If the <code>$LATEST</code> version of this intent hasn't changed since you last
- *       updated it, Amazon Lex doesn't create a new version. It returns the last version you
+ * <p>Creates a new version of an intent based on the
+ *         <code>$LATEST</code> version of the intent. If the <code>$LATEST</code>
+ *       version of this intent hasn't changed since you last updated it, Amazon Lex
+ *       doesn't create a new version. It returns the last version you
  *       created.</p>
  *          <note>
- *             <p>You can update only the <code>$LATEST</code> version of the intent. You can't update
- *         the numbered versions that you create with the <code>CreateIntentVersion</code>
- *         operation.</p>
+ *             <p>You can update only the <code>$LATEST</code> version of the
+ *         intent. You can't update the numbered versions that you create with the
+ *           <code>CreateIntentVersion</code> operation.</p>
  *          </note>
- *          <p> When you create a version of an intent, Amazon Lex sets the version to 1. Subsequent
- *       versions increment by 1. For more information, see <a>versioning-intro</a>. </p>
- *          <p>This operation requires permissions to perform the <code>lex:CreateIntentVersion</code>
- *       action. </p>
+ *          <p> When you create a version of an intent, Amazon Lex sets the version to
+ *       1. Subsequent versions increment by 1. For more information, see <a>versioning-intro</a>. </p>
+ *          <p>This operation requires permissions to perform the
+ *         <code>lex:CreateIntentVersion</code> action. </p>
  */
 export class CreateIntentVersionCommand extends $Command<
   CreateIntentVersionCommandInput,

--- a/clients/client-lex-model-building-service/commands/CreateSlotTypeVersionCommand.ts
+++ b/clients/client-lex-model-building-service/commands/CreateSlotTypeVersionCommand.ts
@@ -25,21 +25,22 @@ export type CreateSlotTypeVersionCommandInput = CreateSlotTypeVersionRequest;
 export type CreateSlotTypeVersionCommandOutput = CreateSlotTypeVersionResponse & __MetadataBearer;
 
 /**
- * <p>Creates a new version of a slot type based on the <code>$LATEST</code> version of the
- *       specified slot type. If the <code>$LATEST</code> version of this resource has not changed
- *       since the last version that you created, Amazon Lex doesn't create a new version. It returns the
- *       last version that you created. </p>
+ * <p>Creates a new version of a slot type based on the
+ *         <code>$LATEST</code> version of the specified slot type. If the
+ *         <code>$LATEST</code> version of this resource has not changed since the
+ *       last version that you created, Amazon Lex doesn't create a new version. It
+ *       returns the last version that you created. </p>
  *          <note>
- *             <p>You can update only the <code>$LATEST</code> version of a slot type. You can't update
- *         the numbered versions that you create with the <code>CreateSlotTypeVersion</code>
- *         operation.</p>
+ *             <p>You can update only the <code>$LATEST</code> version of a slot
+ *         type. You can't update the numbered versions that you create with the
+ *           <code>CreateSlotTypeVersion</code> operation.</p>
  *          </note>
  *
- *          <p>When you create a version of a slot type, Amazon Lex sets the version to 1. Subsequent
- *       versions increment by 1. For more information, see <a>versioning-intro</a>. </p>
+ *          <p>When you create a version of a slot type, Amazon Lex sets the version to
+ *       1. Subsequent versions increment by 1. For more information, see <a>versioning-intro</a>. </p>
  *
- *          <p>This operation requires permissions for the <code>lex:CreateSlotTypeVersion</code>
- *       action.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:CreateSlotTypeVersion</code> action.</p>
  */
 export class CreateSlotTypeVersionCommand extends $Command<
   CreateSlotTypeVersionCommandInput,

--- a/clients/client-lex-model-building-service/commands/DeleteBotAliasCommand.ts
+++ b/clients/client-lex-model-building-service/commands/DeleteBotAliasCommand.ts
@@ -26,12 +26,14 @@ export type DeleteBotAliasCommandOutput = __MetadataBearer;
 
 /**
  * <p>Deletes an alias for the specified bot. </p>
- *          <p>You can't delete an alias that is used in the association between a bot and a messaging
- *       channel. If an alias is used in a channel association, the <code>DeleteBot</code> operation
- *       returns a <code>ResourceInUseException</code> exception that includes a reference to the
- *       channel association that refers to the bot. You can remove the reference to the alias by
- *       deleting the channel association. If you get the same exception again, delete the referring
- *       association until the <code>DeleteBotAlias</code> operation is successful.</p>
+ *          <p>You can't delete an alias that is used in the association between a
+ *       bot and a messaging channel. If an alias is used in a channel association,
+ *       the <code>DeleteBot</code> operation returns a
+ *         <code>ResourceInUseException</code> exception that includes a reference
+ *       to the channel association that refers to the bot. You can remove the
+ *       reference to the alias by deleting the channel association. If you get the
+ *       same exception again, delete the referring association until the
+ *         <code>DeleteBotAlias</code> operation is successful.</p>
  */
 export class DeleteBotAliasCommand extends $Command<
   DeleteBotAliasCommandInput,

--- a/clients/client-lex-model-building-service/commands/DeleteBotChannelAssociationCommand.ts
+++ b/clients/client-lex-model-building-service/commands/DeleteBotChannelAssociationCommand.ts
@@ -25,9 +25,10 @@ export type DeleteBotChannelAssociationCommandInput = DeleteBotChannelAssociatio
 export type DeleteBotChannelAssociationCommandOutput = __MetadataBearer;
 
 /**
- * <p>Deletes the association between an Amazon Lex bot and a messaging platform.</p>
- *          <p>This operation requires permission for the <code>lex:DeleteBotChannelAssociation</code>
- *       action.</p>
+ * <p>Deletes the association between an Amazon Lex bot and a messaging
+ *       platform.</p>
+ *          <p>This operation requires permission for the
+ *         <code>lex:DeleteBotChannelAssociation</code> action.</p>
  */
 export class DeleteBotChannelAssociationCommand extends $Command<
   DeleteBotChannelAssociationCommandInput,

--- a/clients/client-lex-model-building-service/commands/DeleteBotCommand.ts
+++ b/clients/client-lex-model-building-service/commands/DeleteBotCommand.ts
@@ -25,21 +25,23 @@ export type DeleteBotCommandInput = DeleteBotRequest;
 export type DeleteBotCommandOutput = __MetadataBearer;
 
 /**
- * <p>Deletes all versions of the bot, including the <code>$LATEST</code> version. To delete
- *       a specific version of the bot, use the <a>DeleteBotVersion</a> operation. The
- *         <code>DeleteBot</code> operation doesn't immediately remove the bot schema. Instead, it is
- *       marked for deletion and removed later.</p>
- *          <p>Amazon Lex stores utterances indefinitely for improving the ability of your bot to respond
- *       to user inputs. These utterances are not removed when the bot is deleted. To remove the
- *       utterances, use the <a>DeleteUtterances</a> operation.</p>
- *          <p>If a bot has an alias, you can't delete it. Instead, the <code>DeleteBot</code>
- *       operation returns a <code>ResourceInUseException</code> exception that includes a reference to
- *       the alias that refers to the bot. To remove the reference to the bot, delete the alias. If you
- *       get the same exception again, delete the referring alias until the <code>DeleteBot</code>
- *       operation is successful.</p>
+ * <p>Deletes all versions of the bot, including the <code>$LATEST</code>
+ *       version. To delete a specific version of the bot, use the <a>DeleteBotVersion</a> operation. The <code>DeleteBot</code>
+ *       operation doesn't immediately remove the bot schema. Instead, it is marked
+ *       for deletion and removed later.</p>
+ *          <p>Amazon Lex stores utterances indefinitely for improving the ability of
+ *       your bot to respond to user inputs. These utterances are not removed when
+ *       the bot is deleted. To remove the utterances, use the <a>DeleteUtterances</a> operation.</p>
+ *          <p>If a bot has an alias, you can't delete it. Instead, the
+ *         <code>DeleteBot</code> operation returns a
+ *         <code>ResourceInUseException</code> exception that includes a reference
+ *       to the alias that refers to the bot. To remove the reference to the bot,
+ *       delete the alias. If you get the same exception again, delete the
+ *       referring alias until the <code>DeleteBot</code> operation is
+ *       successful.</p>
  *
- *          <p>This operation requires permissions for the <code>lex:DeleteBot</code>
- *       action.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:DeleteBot</code> action.</p>
  */
 export class DeleteBotCommand extends $Command<
   DeleteBotCommandInput,

--- a/clients/client-lex-model-building-service/commands/DeleteBotVersionCommand.ts
+++ b/clients/client-lex-model-building-service/commands/DeleteBotVersionCommand.ts
@@ -25,9 +25,10 @@ export type DeleteBotVersionCommandInput = DeleteBotVersionRequest;
 export type DeleteBotVersionCommandOutput = __MetadataBearer;
 
 /**
- * <p>Deletes a specific version of a bot. To delete all versions of a bot, use the <a>DeleteBot</a> operation. </p>
- *          <p>This operation requires permissions for the <code>lex:DeleteBotVersion</code>
- *       action.</p>
+ * <p>Deletes a specific version of a bot. To delete all versions of a
+ *       bot, use the <a>DeleteBot</a> operation. </p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:DeleteBotVersion</code> action.</p>
  */
 export class DeleteBotVersionCommand extends $Command<
   DeleteBotVersionCommandInput,

--- a/clients/client-lex-model-building-service/commands/DeleteIntentCommand.ts
+++ b/clients/client-lex-model-building-service/commands/DeleteIntentCommand.ts
@@ -25,22 +25,24 @@ export type DeleteIntentCommandInput = DeleteIntentRequest;
 export type DeleteIntentCommandOutput = __MetadataBearer;
 
 /**
- * <p>Deletes all versions of the intent, including the <code>$LATEST</code> version. To
- *       delete a specific version of the intent, use the <a>DeleteIntentVersion</a>
- *       operation.</p>
- *          <p> You can delete a version of an intent only if it is not referenced. To delete an
- *       intent that is referred to in one or more bots (see <a>how-it-works</a>), you must
- *       remove those references first. </p>
+ * <p>Deletes all versions of the intent, including the
+ *         <code>$LATEST</code> version. To delete a specific version of the
+ *       intent, use the <a>DeleteIntentVersion</a> operation.</p>
+ *          <p> You can delete a version of an intent only if it is not
+ *       referenced. To delete an intent that is referred to in one or more bots
+ *       (see <a>how-it-works</a>), you must remove those references
+ *       first. </p>
  *          <note>
- *             <p> If you get the <code>ResourceInUseException</code> exception, it provides an example
- *         reference that shows where the intent is referenced. To remove the reference to the intent,
- *         either update the bot or delete it. If you get the same exception when you attempt to delete
- *         the intent again, repeat until the intent has no references and the call to
+ *             <p> If you get the <code>ResourceInUseException</code> exception, it
+ *         provides an example reference that shows where the intent is referenced.
+ *         To remove the reference to the intent, either update the bot or delete
+ *         it. If you get the same exception when you attempt to delete the intent
+ *         again, repeat until the intent has no references and the call to
  *           <code>DeleteIntent</code> is successful. </p>
  *          </note>
  *
- *          <p> This operation requires permission for the <code>lex:DeleteIntent</code> action.
- *     </p>
+ *          <p> This operation requires permission for the
+ *         <code>lex:DeleteIntent</code> action. </p>
  */
 export class DeleteIntentCommand extends $Command<
   DeleteIntentCommandInput,

--- a/clients/client-lex-model-building-service/commands/DeleteIntentVersionCommand.ts
+++ b/clients/client-lex-model-building-service/commands/DeleteIntentVersionCommand.ts
@@ -25,10 +25,10 @@ export type DeleteIntentVersionCommandInput = DeleteIntentVersionRequest;
 export type DeleteIntentVersionCommandOutput = __MetadataBearer;
 
 /**
- * <p>Deletes a specific version of an intent. To delete all versions of a intent, use the
- *         <a>DeleteIntent</a> operation. </p>
- *          <p>This operation requires permissions for the <code>lex:DeleteIntentVersion</code>
- *       action.</p>
+ * <p>Deletes a specific version of an intent. To delete all versions of
+ *       a intent, use the <a>DeleteIntent</a> operation. </p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:DeleteIntentVersion</code> action.</p>
  */
 export class DeleteIntentVersionCommand extends $Command<
   DeleteIntentVersionCommandInput,

--- a/clients/client-lex-model-building-service/commands/DeleteSlotTypeCommand.ts
+++ b/clients/client-lex-model-building-service/commands/DeleteSlotTypeCommand.ts
@@ -25,20 +25,23 @@ export type DeleteSlotTypeCommandInput = DeleteSlotTypeRequest;
 export type DeleteSlotTypeCommandOutput = __MetadataBearer;
 
 /**
- * <p>Deletes all versions of the slot type, including the <code>$LATEST</code> version. To
- *       delete a specific version of the slot type, use the <a>DeleteSlotTypeVersion</a>
- *       operation.</p>
- *          <p> You can delete a version of a slot type only if it is not referenced. To delete a slot
- *       type that is referred to in one or more intents, you must remove those references first. </p>
+ * <p>Deletes all versions of the slot type, including the
+ *         <code>$LATEST</code> version. To delete a specific version of the slot
+ *       type, use the <a>DeleteSlotTypeVersion</a> operation.</p>
+ *          <p> You can delete a version of a slot type only if it is not
+ *       referenced. To delete a slot type that is referred to in one or more
+ *       intents, you must remove those references first. </p>
  *          <note>
- *             <p> If you get the <code>ResourceInUseException</code> exception, the exception provides
- *         an example reference that shows the intent where the slot type is referenced. To remove the
- *         reference to the slot type, either update the intent or delete it. If you get the same
- *         exception when you attempt to delete the slot type again, repeat until the slot type has no
- *         references and the <code>DeleteSlotType</code> call is successful. </p>
+ *             <p> If you get the <code>ResourceInUseException</code> exception,
+ *         the exception provides an example reference that shows the intent where
+ *         the slot type is referenced. To remove the reference to the slot type,
+ *         either update the intent or delete it. If you get the same exception
+ *         when you attempt to delete the slot type again, repeat until the slot
+ *         type has no references and the <code>DeleteSlotType</code> call is
+ *         successful. </p>
  *          </note>
- *          <p>This operation requires permission for the <code>lex:DeleteSlotType</code>
- *       action.</p>
+ *          <p>This operation requires permission for the
+ *         <code>lex:DeleteSlotType</code> action.</p>
  */
 export class DeleteSlotTypeCommand extends $Command<
   DeleteSlotTypeCommandInput,

--- a/clients/client-lex-model-building-service/commands/DeleteSlotTypeVersionCommand.ts
+++ b/clients/client-lex-model-building-service/commands/DeleteSlotTypeVersionCommand.ts
@@ -25,10 +25,10 @@ export type DeleteSlotTypeVersionCommandInput = DeleteSlotTypeVersionRequest;
 export type DeleteSlotTypeVersionCommandOutput = __MetadataBearer;
 
 /**
- * <p>Deletes a specific version of a slot type. To delete all versions of a slot type, use
- *       the <a>DeleteSlotType</a> operation. </p>
- *          <p>This operation requires permissions for the <code>lex:DeleteSlotTypeVersion</code>
- *       action.</p>
+ * <p>Deletes a specific version of a slot type. To delete all versions
+ *       of a slot type, use the <a>DeleteSlotType</a> operation. </p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:DeleteSlotTypeVersion</code> action.</p>
  */
 export class DeleteSlotTypeVersionCommand extends $Command<
   DeleteSlotTypeVersionCommandInput,

--- a/clients/client-lex-model-building-service/commands/DeleteUtterancesCommand.ts
+++ b/clients/client-lex-model-building-service/commands/DeleteUtterancesCommand.ts
@@ -26,16 +26,17 @@ export type DeleteUtterancesCommandOutput = __MetadataBearer;
 
 /**
  * <p>Deletes stored utterances.</p>
- *          <p>Amazon Lex stores the utterances that users send to your bot. Utterances are stored for 15
- *       days for use with the <a>GetUtterancesView</a> operation, and then stored
- *       indefinitely for use in improving the ability of your bot to respond to user input.</p>
- *          <p>Use the <code>DeleteUtterances</code> operation to manually delete stored utterances
- *       for a specific user. When you use the <code>DeleteUtterances</code> operation, utterances
- *       stored for improving your bot's ability to respond to user input are deleted immediately.
- *       Utterances stored for use with the <code>GetUtterancesView</code> operation are deleted after
- *       15 days.</p>
- *          <p>This operation requires permissions for the <code>lex:DeleteUtterances</code>
- *       action.</p>
+ *          <p>Amazon Lex stores the utterances that users send to your bot. Utterances
+ *       are stored for 15 days for use with the <a>GetUtterancesView</a> operation, and then stored indefinitely for use in improving the
+ *       ability of your bot to respond to user input.</p>
+ *          <p>Use the <code>DeleteUtterances</code> operation to manually delete
+ *       stored utterances for a specific user. When you use the
+ *         <code>DeleteUtterances</code> operation, utterances stored for improving
+ *       your bot's ability to respond to user input are deleted immediately.
+ *       Utterances stored for use with the <code>GetUtterancesView</code>
+ *       operation are deleted after 15 days.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:DeleteUtterances</code> action.</p>
  */
 export class DeleteUtterancesCommand extends $Command<
   DeleteUtterancesCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetBotAliasCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetBotAliasCommand.ts
@@ -25,10 +25,10 @@ export type GetBotAliasCommandInput = GetBotAliasRequest;
 export type GetBotAliasCommandOutput = GetBotAliasResponse & __MetadataBearer;
 
 /**
- * <p>Returns information about an Amazon Lex bot alias. For more information about aliases, see
- *         <a>versioning-aliases</a>.</p>
- *          <p>This operation requires permissions for the <code>lex:GetBotAlias</code>
- *       action.</p>
+ * <p>Returns information about an Amazon Lex bot alias. For more information
+ *       about aliases, see <a>versioning-aliases</a>.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:GetBotAlias</code> action.</p>
  */
 export class GetBotAliasCommand extends $Command<
   GetBotAliasCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetBotAliasesCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetBotAliasesCommand.ts
@@ -26,8 +26,8 @@ export type GetBotAliasesCommandOutput = GetBotAliasesResponse & __MetadataBeare
 
 /**
  * <p>Returns a list of aliases for a specified Amazon Lex bot.</p>
- *          <p>This operation requires permissions for the <code>lex:GetBotAliases</code>
- *       action.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:GetBotAliases</code> action.</p>
  */
 export class GetBotAliasesCommand extends $Command<
   GetBotAliasesCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetBotChannelAssociationCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetBotChannelAssociationCommand.ts
@@ -25,10 +25,10 @@ export type GetBotChannelAssociationCommandInput = GetBotChannelAssociationReque
 export type GetBotChannelAssociationCommandOutput = GetBotChannelAssociationResponse & __MetadataBearer;
 
 /**
- * <p>Returns information about the association between an Amazon Lex bot and a messaging
- *       platform.</p>
- *          <p>This operation requires permissions for the <code>lex:GetBotChannelAssociation</code>
- *       action.</p>
+ * <p>Returns information about the association between an Amazon Lex bot and
+ *       a messaging platform.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:GetBotChannelAssociation</code> action.</p>
  */
 export class GetBotChannelAssociationCommand extends $Command<
   GetBotChannelAssociationCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetBotChannelAssociationsCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetBotChannelAssociationsCommand.ts
@@ -25,9 +25,11 @@ export type GetBotChannelAssociationsCommandInput = GetBotChannelAssociationsReq
 export type GetBotChannelAssociationsCommandOutput = GetBotChannelAssociationsResponse & __MetadataBearer;
 
 /**
- * <p> Returns a list of all of the channels associated with the specified bot. </p>
- *          <p>The <code>GetBotChannelAssociations</code> operation requires permissions for the
- *         <code>lex:GetBotChannelAssociations</code> action.</p>
+ * <p> Returns a list of all of the channels associated with the
+ *       specified bot. </p>
+ *          <p>The <code>GetBotChannelAssociations</code> operation requires
+ *       permissions for the <code>lex:GetBotChannelAssociations</code>
+ *       action.</p>
  */
 export class GetBotChannelAssociationsCommand extends $Command<
   GetBotChannelAssociationsCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetBotCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetBotCommand.ts
@@ -22,9 +22,10 @@ export type GetBotCommandInput = GetBotRequest;
 export type GetBotCommandOutput = GetBotResponse & __MetadataBearer;
 
 /**
- * <p>Returns metadata information for a specific bot. You must provide the bot name and the
- *       bot version or alias. </p>
- *          <p> This operation requires permissions for the <code>lex:GetBot</code> action. </p>
+ * <p>Returns metadata information for a specific bot. You must provide
+ *       the bot name and the bot version or alias. </p>
+ *          <p> This operation requires permissions for the
+ *         <code>lex:GetBot</code> action. </p>
  */
 export class GetBotCommand extends $Command<
   GetBotCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetBotVersionsCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetBotVersionsCommand.ts
@@ -26,14 +26,16 @@ export type GetBotVersionsCommandOutput = GetBotVersionsResponse & __MetadataBea
 
 /**
  * <p>Gets information about all of the versions of a bot.</p>
- *          <p>The <code>GetBotVersions</code> operation returns a <code>BotMetadata</code> object for
- *       each version of a bot. For example, if a bot has three numbered versions, the
- *         <code>GetBotVersions</code> operation returns four <code>BotMetadata</code> objects in the
- *       response, one for each numbered version and one for the <code>$LATEST</code> version. </p>
- *          <p>The <code>GetBotVersions</code> operation always returns at least one version, the
- *         <code>$LATEST</code> version.</p>
- *          <p>This operation requires permissions for the <code>lex:GetBotVersions</code>
- *       action.</p>
+ *          <p>The <code>GetBotVersions</code> operation returns a
+ *         <code>BotMetadata</code> object for each version of a bot. For example,
+ *       if a bot has three numbered versions, the <code>GetBotVersions</code>
+ *       operation returns four <code>BotMetadata</code> objects in the response,
+ *       one for each numbered version and one for the <code>$LATEST</code>
+ *       version. </p>
+ *          <p>The <code>GetBotVersions</code> operation always returns at least
+ *       one version, the <code>$LATEST</code> version.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:GetBotVersions</code> action.</p>
  */
 export class GetBotVersionsCommand extends $Command<
   GetBotVersionsCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetBotsCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetBotsCommand.ts
@@ -28,16 +28,18 @@ export type GetBotsCommandOutput = GetBotsResponse & __MetadataBearer;
  * <p>Returns bot information as follows: </p>
  *          <ul>
  *             <li>
- *                <p>If you provide the <code>nameContains</code> field, the response includes
- *           information for the <code>$LATEST</code> version of all bots whose name contains the
- *           specified string.</p>
+ *                <p>If you provide the <code>nameContains</code> field, the
+ *           response includes information for the <code>$LATEST</code> version of
+ *           all bots whose name contains the specified string.</p>
  *             </li>
  *             <li>
- *                <p>If you don't specify the <code>nameContains</code> field, the operation returns
- *           information about the <code>$LATEST</code> version of all of your bots.</p>
+ *                <p>If you don't specify the <code>nameContains</code> field, the
+ *           operation returns information about the <code>$LATEST</code> version
+ *           of all of your bots.</p>
  *             </li>
  *          </ul>
- *          <p>This operation requires permission for the <code>lex:GetBots</code> action.</p>
+ *          <p>This operation requires permission for the <code>lex:GetBots</code>
+ *       action.</p>
  */
 export class GetBotsCommand extends $Command<
   GetBotsCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetBuiltinIntentCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetBuiltinIntentCommand.ts
@@ -26,8 +26,8 @@ export type GetBuiltinIntentCommandOutput = GetBuiltinIntentResponse & __Metadat
 
 /**
  * <p>Returns information about a built-in intent.</p>
- *          <p>This operation requires permission for the <code>lex:GetBuiltinIntent</code>
- *       action.</p>
+ *          <p>This operation requires permission for the
+ *         <code>lex:GetBuiltinIntent</code> action.</p>
  */
 export class GetBuiltinIntentCommand extends $Command<
   GetBuiltinIntentCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetBuiltinIntentsCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetBuiltinIntentsCommand.ts
@@ -25,9 +25,10 @@ export type GetBuiltinIntentsCommandInput = GetBuiltinIntentsRequest;
 export type GetBuiltinIntentsCommandOutput = GetBuiltinIntentsResponse & __MetadataBearer;
 
 /**
- * <p>Gets a list of built-in intents that meet the specified criteria.</p>
- *          <p>This operation requires permission for the <code>lex:GetBuiltinIntents</code>
- *       action.</p>
+ * <p>Gets a list of built-in intents that meet the specified
+ *       criteria.</p>
+ *          <p>This operation requires permission for the
+ *         <code>lex:GetBuiltinIntents</code> action.</p>
  */
 export class GetBuiltinIntentsCommand extends $Command<
   GetBuiltinIntentsCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetBuiltinSlotTypesCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetBuiltinSlotTypesCommand.ts
@@ -25,11 +25,13 @@ export type GetBuiltinSlotTypesCommandInput = GetBuiltinSlotTypesRequest;
 export type GetBuiltinSlotTypesCommandOutput = GetBuiltinSlotTypesResponse & __MetadataBearer;
 
 /**
- * <p>Gets a list of built-in slot types that meet the specified criteria.</p>
- *          <p>For a list of built-in slot types, see <a href="https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/slot-type-reference">Slot Type Reference</a> in the <i>Alexa Skills Kit</i>.</p>
+ * <p>Gets a list of built-in slot types that meet the specified
+ *       criteria.</p>
+ *          <p>For a list of built-in slot types, see <a href="https://developer.amazon.com/public/solutions/alexa/alexa-skills-kit/docs/built-in-intent-ref/slot-type-reference">Slot Type Reference</a> in the <i>Alexa Skills
+ *         Kit</i>.</p>
  *
- *          <p>This operation requires permission for the <code>lex:GetBuiltInSlotTypes</code>
- *       action.</p>
+ *          <p>This operation requires permission for the
+ *         <code>lex:GetBuiltInSlotTypes</code> action.</p>
  */
 export class GetBuiltinSlotTypesCommand extends $Command<
   GetBuiltinSlotTypesCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetExportCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetExportCommand.ts
@@ -25,7 +25,8 @@ export type GetExportCommandInput = GetExportRequest;
 export type GetExportCommandOutput = GetExportResponse & __MetadataBearer;
 
 /**
- * <p>Exports the contents of a Amazon Lex resource in a specified format. </p>
+ * <p>Exports the contents of a Amazon Lex resource in a specified format.
+ *     </p>
  */
 export class GetExportCommand extends $Command<
   GetExportCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetImportCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetImportCommand.ts
@@ -25,8 +25,8 @@ export type GetImportCommandInput = GetImportRequest;
 export type GetImportCommandOutput = GetImportResponse & __MetadataBearer;
 
 /**
- * <p>Gets information about an import job started with the <code>StartImport</code>
- *       operation.</p>
+ * <p>Gets information about an import job started with the
+ *         <code>StartImport</code> operation.</p>
  */
 export class GetImportCommand extends $Command<
   GetImportCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetIntentCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetIntentCommand.ts
@@ -25,10 +25,10 @@ export type GetIntentCommandInput = GetIntentRequest;
 export type GetIntentCommandOutput = GetIntentResponse & __MetadataBearer;
 
 /**
- * <p> Returns information about an intent. In addition to the intent name, you must specify
- *       the intent version. </p>
- *          <p> This operation requires permissions to perform the <code>lex:GetIntent</code> action.
- *     </p>
+ * <p> Returns information about an intent. In addition to the intent
+ *       name, you must specify the intent version. </p>
+ *          <p> This operation requires permissions to perform the
+ *         <code>lex:GetIntent</code> action. </p>
  */
 export class GetIntentCommand extends $Command<
   GetIntentCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetIntentVersionsCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetIntentVersionsCommand.ts
@@ -26,14 +26,16 @@ export type GetIntentVersionsCommandOutput = GetIntentVersionsResponse & __Metad
 
 /**
  * <p>Gets information about all of the versions of an intent.</p>
- *          <p>The <code>GetIntentVersions</code> operation returns an <code>IntentMetadata</code>
- *       object for each version of an intent. For example, if an intent has three numbered versions,
- *       the <code>GetIntentVersions</code> operation returns four <code>IntentMetadata</code> objects
- *       in the response, one for each numbered version and one for the <code>$LATEST</code> version. </p>
- *          <p>The <code>GetIntentVersions</code> operation always returns at least one version, the
- *         <code>$LATEST</code> version.</p>
- *          <p>This operation requires permissions for the <code>lex:GetIntentVersions</code>
- *       action.</p>
+ *          <p>The <code>GetIntentVersions</code> operation returns an
+ *         <code>IntentMetadata</code> object for each version of an intent. For
+ *       example, if an intent has three numbered versions, the
+ *         <code>GetIntentVersions</code> operation returns four
+ *         <code>IntentMetadata</code> objects in the response, one for each
+ *       numbered version and one for the <code>$LATEST</code> version. </p>
+ *          <p>The <code>GetIntentVersions</code> operation always returns at
+ *       least one version, the <code>$LATEST</code> version.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:GetIntentVersions</code> action.</p>
  */
 export class GetIntentVersionsCommand extends $Command<
   GetIntentVersionsCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetIntentsCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetIntentsCommand.ts
@@ -29,15 +29,17 @@ export type GetIntentsCommandOutput = GetIntentsResponse & __MetadataBearer;
  *          <ul>
  *             <li>
  *                <p>If you specify the <code>nameContains</code> field, returns the
- *             <code>$LATEST</code> version of all intents that contain the specified string.</p>
+ *             <code>$LATEST</code> version of all intents that contain the
+ *           specified string.</p>
  *             </li>
  *             <li>
- *                <p> If you don't specify the <code>nameContains</code> field, returns information
- *           about the <code>$LATEST</code> version of all intents. </p>
+ *                <p> If you don't specify the <code>nameContains</code> field,
+ *           returns information about the <code>$LATEST</code> version of all
+ *           intents. </p>
  *             </li>
  *          </ul>
- *          <p> The operation requires permission for the <code>lex:GetIntents</code> action.
- *     </p>
+ *          <p> The operation requires permission for the
+ *         <code>lex:GetIntents</code> action. </p>
  */
 export class GetIntentsCommand extends $Command<
   GetIntentsCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetSlotTypeCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetSlotTypeCommand.ts
@@ -25,10 +25,11 @@ export type GetSlotTypeCommandInput = GetSlotTypeRequest;
 export type GetSlotTypeCommandOutput = GetSlotTypeResponse & __MetadataBearer;
 
 /**
- * <p>Returns information about a specific version of a slot type. In addition to specifying
- *       the slot type name, you must specify the slot type version.</p>
- *          <p>This operation requires permissions for the <code>lex:GetSlotType</code>
- *       action.</p>
+ * <p>Returns information about a specific version of a slot type. In
+ *       addition to specifying the slot type name, you must specify the slot type
+ *       version.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:GetSlotType</code> action.</p>
  */
 export class GetSlotTypeCommand extends $Command<
   GetSlotTypeCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetSlotTypeVersionsCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetSlotTypeVersionsCommand.ts
@@ -26,15 +26,16 @@ export type GetSlotTypeVersionsCommandOutput = GetSlotTypeVersionsResponse & __M
 
 /**
  * <p>Gets information about all versions of a slot type.</p>
- *          <p>The <code>GetSlotTypeVersions</code> operation returns a <code>SlotTypeMetadata</code>
- *       object for each version of a slot type. For example, if a slot type has three numbered
- *       versions, the <code>GetSlotTypeVersions</code> operation returns four
- *         <code>SlotTypeMetadata</code> objects in the response, one for each numbered version and one
- *       for the <code>$LATEST</code> version. </p>
- *          <p>The <code>GetSlotTypeVersions</code> operation always returns at least one version, the
- *         <code>$LATEST</code> version.</p>
- *          <p>This operation requires permissions for the <code>lex:GetSlotTypeVersions</code>
- *       action.</p>
+ *          <p>The <code>GetSlotTypeVersions</code> operation returns a
+ *         <code>SlotTypeMetadata</code> object for each version of a slot type.
+ *       For example, if a slot type has three numbered versions, the
+ *         <code>GetSlotTypeVersions</code> operation returns four
+ *         <code>SlotTypeMetadata</code> objects in the response, one for each
+ *       numbered version and one for the <code>$LATEST</code> version. </p>
+ *          <p>The <code>GetSlotTypeVersions</code> operation always returns at
+ *       least one version, the <code>$LATEST</code> version.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:GetSlotTypeVersions</code> action.</p>
  */
 export class GetSlotTypeVersionsCommand extends $Command<
   GetSlotTypeVersionsCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetSlotTypesCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetSlotTypesCommand.ts
@@ -29,16 +29,17 @@ export type GetSlotTypesCommandOutput = GetSlotTypesResponse & __MetadataBearer;
  *          <ul>
  *             <li>
  *                <p>If you specify the <code>nameContains</code> field, returns the
- *             <code>$LATEST</code> version of all slot types that contain the specified
- *           string.</p>
+ *             <code>$LATEST</code> version of all slot types that contain the
+ *           specified string.</p>
  *             </li>
  *             <li>
- *                <p> If you don't specify the <code>nameContains</code> field, returns information
- *           about the <code>$LATEST</code> version of all slot types. </p>
+ *                <p> If you don't specify the <code>nameContains</code> field,
+ *           returns information about the <code>$LATEST</code> version of all slot
+ *           types. </p>
  *             </li>
  *          </ul>
- *          <p> The operation requires permission for the <code>lex:GetSlotTypes</code> action.
- *     </p>
+ *          <p> The operation requires permission for the
+ *         <code>lex:GetSlotTypes</code> action. </p>
  */
 export class GetSlotTypesCommand extends $Command<
   GetSlotTypesCommandInput,

--- a/clients/client-lex-model-building-service/commands/GetUtterancesViewCommand.ts
+++ b/clients/client-lex-model-building-service/commands/GetUtterancesViewCommand.ts
@@ -25,24 +25,29 @@ export type GetUtterancesViewCommandInput = GetUtterancesViewRequest;
 export type GetUtterancesViewCommandOutput = GetUtterancesViewResponse & __MetadataBearer;
 
 /**
- * <p>Use the <code>GetUtterancesView</code> operation to get information about the
- *       utterances that your users have made to your bot. You can use this list to tune the utterances
- *       that your bot responds to.</p>
- *          <p>For example, say that you have created a bot to order flowers. After your users have
- *       used your bot for a while, use the <code>GetUtterancesView</code> operation to see the
- *       requests that they have made and whether they have been successful. You might find that the
- *       utterance "I want flowers" is not being recognized. You could add this utterance to the
- *         <code>OrderFlowers</code> intent so that your bot recognizes that utterance.</p>
- *          <p>After you publish a new version of a bot, you can get information about the old version
- *       and the new so that you can compare the performance across the two versions. </p>
- *          <p>Utterance statistics are generated once a day. Data is available for the last 15 days.
- *       You can request information for up to 5 versions of your bot in each request. Amazon Lex returns
- *       the most frequent utterances received by the bot in the last 15 days. The response contains
- *       information about a maximum of 100 utterances for each version.</p>
- *          <p>If you set <code>childDirected</code> field to true when you created your bot, or if
- *       you opted out of participating in improving Amazon Lex, utterances are not available.</p>
- *          <p>This operation requires permissions for the <code>lex:GetUtterancesView</code>
- *       action.</p>
+ * <p>Use the <code>GetUtterancesView</code> operation to get information
+ *       about the utterances that your users have made to your bot. You can use
+ *       this list to tune the utterances that your bot responds to.</p>
+ *          <p>For example, say that you have created a bot to order flowers.
+ *       After your users have used your bot for a while, use the
+ *         <code>GetUtterancesView</code> operation to see the requests that they
+ *       have made and whether they have been successful. You might find that the
+ *       utterance "I want flowers" is not being recognized. You could add this
+ *       utterance to the <code>OrderFlowers</code> intent so that your bot
+ *       recognizes that utterance.</p>
+ *          <p>After you publish a new version of a bot, you can get information
+ *       about the old version and the new so that you can compare the performance
+ *       across the two versions. </p>
+ *          <p>Utterance statistics are generated once a day. Data is available
+ *       for the last 15 days. You can request information for up to 5 versions of
+ *       your bot in each request. Amazon Lex returns the most frequent utterances
+ *       received by the bot in the last 15 days. The response contains information
+ *       about a maximum of 100 utterances for each version.</p>
+ *          <p>If you set <code>childDirected</code> field to true when you
+ *       created your bot, or if you opted out of participating in improving Amazon Lex,
+ *       utterances are not available.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:GetUtterancesView</code> action.</p>
  */
 export class GetUtterancesViewCommand extends $Command<
   GetUtterancesViewCommandInput,

--- a/clients/client-lex-model-building-service/commands/ListTagsForResourceCommand.ts
+++ b/clients/client-lex-model-building-service/commands/ListTagsForResourceCommand.ts
@@ -25,8 +25,8 @@ export type ListTagsForResourceCommandInput = ListTagsForResourceRequest;
 export type ListTagsForResourceCommandOutput = ListTagsForResourceResponse & __MetadataBearer;
 
 /**
- * <p>Gets a list of tags associated with the specified resource. Only bots, bot aliases, and
- *       bot channels can have tags associated with them.</p>
+ * <p>Gets a list of tags associated with the specified resource. Only bots,
+ *       bot aliases, and bot channels can have tags associated with them.</p>
  */
 export class ListTagsForResourceCommand extends $Command<
   ListTagsForResourceCommandInput,

--- a/clients/client-lex-model-building-service/commands/PutBotAliasCommand.ts
+++ b/clients/client-lex-model-building-service/commands/PutBotAliasCommand.ts
@@ -25,11 +25,12 @@ export type PutBotAliasCommandInput = PutBotAliasRequest;
 export type PutBotAliasCommandOutput = PutBotAliasResponse & __MetadataBearer;
 
 /**
- * <p>Creates an alias for the specified version of the bot or replaces an alias for the
- *       specified bot. To change the version of the bot that the alias points to, replace the alias.
- *       For more information about aliases, see <a>versioning-aliases</a>.</p>
- *          <p>This operation requires permissions for the <code>lex:PutBotAlias</code> action.
- *     </p>
+ * <p>Creates an alias for the specified version of the bot or replaces
+ *       an alias for the specified bot. To change the version of the bot that the
+ *       alias points to, replace the alias. For more information about aliases,
+ *       see <a>versioning-aliases</a>.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:PutBotAlias</code> action. </p>
  */
 export class PutBotAliasCommand extends $Command<
   PutBotAliasCommandInput,

--- a/clients/client-lex-model-building-service/commands/PutBotCommand.ts
+++ b/clients/client-lex-model-building-service/commands/PutBotCommand.ts
@@ -22,20 +22,24 @@ export type PutBotCommandInput = PutBotRequest;
 export type PutBotCommandOutput = PutBotResponse & __MetadataBearer;
 
 /**
- * <p>Creates an Amazon Lex conversational bot or replaces an existing bot. When you create or
- *       update a bot you are only required to specify a name, a locale, and whether the bot is
- *       directed toward children under age 13. You can use this to add intents later, or to remove
- *       intents from an existing bot. When you create a bot with the minimum information, the bot is
- *       created or updated but Amazon Lex returns the <code></code> response <code>FAILED</code>. You can build
- *       the bot after you add one or more intents. For more information about Amazon Lex bots, see <a>how-it-works</a>. </p>
- *          <p>If you specify the name of an existing bot, the fields in the request replace the
- *       existing values in the <code>$LATEST</code> version of the bot. Amazon Lex removes any fields that
- *       you don't provide values for in the request, except for the <code>idleTTLInSeconds</code> and
- *         <code>privacySettings</code> fields, which are set to their default values. If you don't
- *       specify values for required fields, Amazon Lex throws an exception.</p>
+ * <p>Creates an Amazon Lex conversational bot or replaces an existing bot.
+ *       When you create or update a bot you are only required to specify a name, a
+ *       locale, and whether the bot is directed toward children under age 13. You
+ *       can use this to add intents later, or to remove intents from an existing
+ *       bot. When you create a bot with the minimum information, the bot is
+ *       created or updated but Amazon Lex returns the <code></code> response
+ *         <code>FAILED</code>. You can build the bot after you add one or more
+ *       intents. For more information about Amazon Lex bots, see <a>how-it-works</a>. </p>
+ *          <p>If you specify the name of an existing bot, the fields in the
+ *       request replace the existing values in the <code>$LATEST</code> version of
+ *       the bot. Amazon Lex removes any fields that you don't provide values for in the
+ *       request, except for the <code>idleTTLInSeconds</code> and
+ *         <code>privacySettings</code> fields, which are set to their default
+ *       values. If you don't specify values for required fields, Amazon Lex throws an
+ *       exception.</p>
  *
- *          <p>This operation requires permissions for the <code>lex:PutBot</code> action. For more
- *       information, see <a>security-iam</a>.</p>
+ *          <p>This operation requires permissions for the <code>lex:PutBot</code>
+ *       action. For more information, see <a>security-iam</a>.</p>
  */
 export class PutBotCommand extends $Command<
   PutBotCommandInput,

--- a/clients/client-lex-model-building-service/commands/PutIntentCommand.ts
+++ b/clients/client-lex-model-building-service/commands/PutIntentCommand.ts
@@ -26,56 +26,63 @@ export type PutIntentCommandOutput = PutIntentResponse & __MetadataBearer;
 
 /**
  * <p>Creates an intent or replaces an existing intent.</p>
- *          <p>To define the interaction between the user and your bot, you use one or more intents.
- *       For a pizza ordering bot, for example, you would create an <code>OrderPizza</code> intent. </p>
- *          <p>To create an intent or replace an existing intent, you must provide the
- *       following:</p>
+ *          <p>To define the interaction between the user and your bot, you use
+ *       one or more intents. For a pizza ordering bot, for example, you would
+ *       create an <code>OrderPizza</code> intent. </p>
+ *          <p>To create an intent or replace an existing intent, you must provide
+ *       the following:</p>
  *          <ul>
  *             <li>
  *                <p>Intent name. For example, <code>OrderPizza</code>.</p>
  *             </li>
  *             <li>
- *                <p>Sample utterances. For example, "Can I order a pizza, please." and "I want to order
- *           a pizza."</p>
+ *                <p>Sample utterances. For example, "Can I order a pizza, please."
+ *           and "I want to order a pizza."</p>
  *             </li>
  *             <li>
- *                <p>Information to be gathered. You specify slot types for the information that your
- *           bot will request from the user. You can specify standard slot types, such as a date or a
- *           time, or custom slot types such as the size and crust of a pizza.</p>
+ *                <p>Information to be gathered. You specify slot types for the
+ *           information that your bot will request from the user. You can specify
+ *           standard slot types, such as a date or a time, or custom slot types
+ *           such as the size and crust of a pizza.</p>
  *             </li>
  *             <li>
- *                <p>How the intent will be fulfilled. You can provide a Lambda function or configure
- *           the intent to return the intent information to the client application. If you use a Lambda
- *           function, when all of the intent information is available, Amazon Lex invokes your Lambda
- *           function. If you configure your intent to return the intent information to the client
- *           application. </p>
+ *                <p>How the intent will be fulfilled. You can provide a Lambda
+ *           function or configure the intent to return the intent information to
+ *           the client application. If you use a Lambda function, when all of the
+ *           intent information is available, Amazon Lex invokes your Lambda function.
+ *           If you configure your intent to return the intent information to the
+ *           client application. </p>
  *             </li>
  *          </ul>
- *          <p>You can specify other optional information in the request, such as:</p>
+ *          <p>You can specify other optional information in the request, such
+ *       as:</p>
  *
  *          <ul>
  *             <li>
- *                <p>A confirmation prompt to ask the user to confirm an intent. For example, "Shall I
- *           order your pizza?"</p>
+ *                <p>A confirmation prompt to ask the user to confirm an intent. For
+ *           example, "Shall I order your pizza?"</p>
  *             </li>
  *             <li>
- *                <p>A conclusion statement to send to the user after the intent has been fulfilled. For
- *           example, "I placed your pizza order."</p>
+ *                <p>A conclusion statement to send to the user after the intent has
+ *           been fulfilled. For example, "I placed your pizza order."</p>
  *             </li>
  *             <li>
- *                <p>A follow-up prompt that asks the user for additional activity. For example, asking
- *           "Do you want to order a drink with your pizza?"</p>
+ *                <p>A follow-up prompt that asks the user for additional activity.
+ *           For example, asking "Do you want to order a drink with your
+ *           pizza?"</p>
  *             </li>
  *          </ul>
- *          <p>If you specify an existing intent name to update the intent, Amazon Lex replaces the values
- *       in the <code>$LATEST</code> version of the intent with the values in the request. Amazon Lex
- *       removes fields that you don't provide in the request. If you don't specify the required
- *       fields, Amazon Lex throws an exception. When you update the <code>$LATEST</code> version of an
- *       intent, the <code>status</code> field of any bot that uses the <code>$LATEST</code> version of
- *       the intent is set to <code>NOT_BUILT</code>.</p>
+ *          <p>If you specify an existing intent name to update the intent, Amazon Lex
+ *       replaces the values in the <code>$LATEST</code> version of the intent with
+ *       the values in the request. Amazon Lex removes fields that you don't provide in
+ *       the request. If you don't specify the required fields, Amazon Lex throws an
+ *       exception. When you update the <code>$LATEST</code> version of an intent,
+ *       the <code>status</code> field of any bot that uses the
+ *         <code>$LATEST</code> version of the intent is set to
+ *         <code>NOT_BUILT</code>.</p>
  *          <p>For more information, see <a>how-it-works</a>.</p>
- *          <p>This operation requires permissions for the <code>lex:PutIntent</code>
- *       action.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:PutIntent</code> action.</p>
  */
 export class PutIntentCommand extends $Command<
   PutIntentCommandInput,

--- a/clients/client-lex-model-building-service/commands/PutSlotTypeCommand.ts
+++ b/clients/client-lex-model-building-service/commands/PutSlotTypeCommand.ts
@@ -25,19 +25,22 @@ export type PutSlotTypeCommandInput = PutSlotTypeRequest;
 export type PutSlotTypeCommandOutput = PutSlotTypeResponse & __MetadataBearer;
 
 /**
- * <p>Creates a custom slot type or replaces an existing custom slot type.</p>
- *          <p>To create a custom slot type, specify a name for the slot type and a set of enumeration
- *       values, which are the values that a slot of this type can assume. For more information, see
- *         <a>how-it-works</a>.</p>
- *          <p>If you specify the name of an existing slot type, the fields in the request replace the
- *       existing values in the <code>$LATEST</code> version of the slot type. Amazon Lex removes the fields
- *       that you don't provide in the request. If you don't specify required fields, Amazon Lex throws an
- *       exception. When you update the <code>$LATEST</code> version of a slot type, if a bot uses the
- *         <code>$LATEST</code> version of an intent that contains the slot type, the bot's
- *         <code>status</code> field is set to <code>NOT_BUILT</code>.</p>
+ * <p>Creates a custom slot type or replaces an existing custom slot
+ *       type.</p>
+ *          <p>To create a custom slot type, specify a name for the slot type and
+ *       a set of enumeration values, which are the values that a slot of this type
+ *       can assume. For more information, see <a>how-it-works</a>.</p>
+ *          <p>If you specify the name of an existing slot type, the fields in the
+ *       request replace the existing values in the <code>$LATEST</code> version of
+ *       the slot type. Amazon Lex removes the fields that you don't provide in the
+ *       request. If you don't specify required fields, Amazon Lex throws an exception.
+ *       When you update the <code>$LATEST</code> version of a slot type, if a bot
+ *       uses the <code>$LATEST</code> version of an intent that contains the slot
+ *       type, the bot's <code>status</code> field is set to
+ *       <code>NOT_BUILT</code>.</p>
  *
- *          <p>This operation requires permissions for the <code>lex:PutSlotType</code>
- *       action.</p>
+ *          <p>This operation requires permissions for the
+ *         <code>lex:PutSlotType</code> action.</p>
  */
 export class PutSlotTypeCommand extends $Command<
   PutSlotTypeCommandInput,

--- a/clients/client-lex-model-building-service/commands/TagResourceCommand.ts
+++ b/clients/client-lex-model-building-service/commands/TagResourceCommand.ts
@@ -25,8 +25,8 @@ export type TagResourceCommandInput = TagResourceRequest;
 export type TagResourceCommandOutput = TagResourceResponse & __MetadataBearer;
 
 /**
- * <p>Adds the specified tags to the specified resource. If a tag key already exists, the
- *       existing value is replaced with the new value.</p>
+ * <p>Adds the specified tags to the specified resource. If a tag key
+ *       already exists, the existing value is replaced with the new value.</p>
  */
 export class TagResourceCommand extends $Command<
   TagResourceCommandInput,

--- a/clients/client-redshift/pagination/DescribeClusterDbRevisionsPaginator.ts
+++ b/clients/client-redshift/pagination/DescribeClusterDbRevisionsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { RedshiftPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: RedshiftClient,
   input: DescribeClusterDbRevisionsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new DescribeClusterDbRevisionsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Redshift,
   input: DescribeClusterDbRevisionsCommandInput,

--- a/clients/client-redshift/pagination/DescribeClusterTracksPaginator.ts
+++ b/clients/client-redshift/pagination/DescribeClusterTracksPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { RedshiftPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: RedshiftClient,
   input: DescribeClusterTracksCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new DescribeClusterTracksCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Redshift,
   input: DescribeClusterTracksCommandInput,

--- a/clients/client-redshift/pagination/DescribeSnapshotCopyGrantsPaginator.ts
+++ b/clients/client-redshift/pagination/DescribeSnapshotCopyGrantsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { RedshiftPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: RedshiftClient,
   input: DescribeSnapshotCopyGrantsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new DescribeSnapshotCopyGrantsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Redshift,
   input: DescribeSnapshotCopyGrantsCommandInput,

--- a/clients/client-redshift/pagination/DescribeSnapshotSchedulesPaginator.ts
+++ b/clients/client-redshift/pagination/DescribeSnapshotSchedulesPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { RedshiftPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: RedshiftClient,
   input: DescribeSnapshotSchedulesCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new DescribeSnapshotSchedulesCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Redshift,
   input: DescribeSnapshotSchedulesCommandInput,

--- a/clients/client-redshift/pagination/DescribeTableRestoreStatusPaginator.ts
+++ b/clients/client-redshift/pagination/DescribeTableRestoreStatusPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { RedshiftPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: RedshiftClient,
   input: DescribeTableRestoreStatusCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new DescribeTableRestoreStatusCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Redshift,
   input: DescribeTableRestoreStatusCommandInput,

--- a/clients/client-redshift/pagination/DescribeTagsPaginator.ts
+++ b/clients/client-redshift/pagination/DescribeTagsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { RedshiftPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: RedshiftClient,
   input: DescribeTagsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new DescribeTagsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Redshift,
   input: DescribeTagsCommandInput,

--- a/clients/client-redshift/pagination/GetReservedNodeExchangeOfferingsPaginator.ts
+++ b/clients/client-redshift/pagination/GetReservedNodeExchangeOfferingsPaginator.ts
@@ -8,6 +8,9 @@ import {
 import { RedshiftPaginationConfiguration } from "./Interfaces";
 import { Paginator } from "@aws-sdk/types";
 
+/**
+ * @private
+ */
 const makePagedClientRequest = async (
   client: RedshiftClient,
   input: GetReservedNodeExchangeOfferingsCommandInput,
@@ -16,6 +19,9 @@ const makePagedClientRequest = async (
   // @ts-ignore
   return await client.send(new GetReservedNodeExchangeOfferingsCommand(input), ...args);
 };
+/**
+ * @private
+ */
 const makePagedRequest = async (
   client: Redshift,
   input: GetReservedNodeExchangeOfferingsCommandInput,

--- a/clients/client-s3/commands/DeleteBucketPolicyCommand.ts
+++ b/clients/client-s3/commands/DeleteBucketPolicyCommand.ts
@@ -40,8 +40,6 @@ export type DeleteBucketPolicyCommandOutput = __MetadataBearer;
  *             ability to perform this action.</p>
  *          </important>
  *
- *
- *
  *          <p>For more information about bucket policies, see <a href=" https://docs.aws.amazon.com/AmazonS3/latest/dev/using-iam-policies.html">Using Bucket Policies and
  *             UserPolicies</a>. </p>
  *          <p>The following operations are related to <code>DeleteBucketPolicy</code>

--- a/clients/client-s3/commands/GetObjectCommand.ts
+++ b/clients/client-s3/commands/GetObjectCommand.ts
@@ -42,12 +42,13 @@ export type GetObjectCommandOutput = GetObjectOutput & __MetadataBearer;
  *          BitTorrent. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/S3Torrent.html">Amazon S3
  *             Torrent</a>. For more information about returning the ACL of an object, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetObjectAcl.html">GetObjectAcl</a>.</p>
  *
- *          <p>If the object you are retrieving is stored in the S3 Glacier, S3 Glacier Deep Archive,
- *          S3 Intelligent-Tiering Archive, or S3 Intelligent-Tiering Deep Archive storage classes, before you can retrieve
- *          the object you must first restore a copy using <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a>. Otherwise, this
- *          operation returns an <code>InvalidObjectStateError</code> error. For information about
- *          restoring archived objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html">Restoring
- *             Archived Objects</a>.</p>
+ *          <p>If the object you are retrieving is stored in the S3 Glacier or
+ *          S3 Glacier Deep Archive storage class, or S3 Intelligent-Tiering Archive or
+ *          S3 Intelligent-Tiering Deep Archive tiers, before you can retrieve the object you must first restore a
+ *          copy using <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/API_RestoreObject.html">RestoreObject</a>. Otherwise, this operation returns an
+ *             <code>InvalidObjectStateError</code> error. For information about restoring archived
+ *          objects, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/restoring-objects.html">Restoring Archived
+ *             Objects</a>.</p>
  *
  *          <p>Encryption request headers, like <code>x-amz-server-side-encryption</code>, should not
  *          be sent for GET requests if your object uses server-side encryption with CMKs stored in AWS

--- a/clients/client-s3/commands/PutBucketLifecycleConfigurationCommand.ts
+++ b/clients/client-s3/commands/PutBucketLifecycleConfigurationCommand.ts
@@ -36,6 +36,7 @@ export type PutBucketLifecycleConfigurationCommandOutput = __MetadataBearer;
  *          </note>
  *
  *
+ *
  *          <p>
  *             <b>Rules</b>
  *          </p>

--- a/clients/client-s3/commands/PutBucketReplicationCommand.ts
+++ b/clients/client-s3/commands/PutBucketReplicationCommand.ts
@@ -47,12 +47,8 @@ export type PutBucketReplicationCommandOutput = __MetadataBearer;
  *             <code>DeleteMarkerReplication</code>, <code>Status</code>, and
  *          <code>Priority</code>.</p>
  *          <note>
- *             <p>The latest version of the replication configuration XML is V2. XML V2 replication
- *             configurations are those that contain the <code>Filter</code> element for rules, and
- *             rules that specify S3 Replication Time Control (S3 RTC). In XML V2 replication configurations, Amazon S3 doesn't
- *             replicate delete markers. Therefore, you must set the
- *                <code>DeleteMarkerReplication</code> element to <code>Disabled</code>. For backward
- *             compatibility, Amazon S3 continues to support the XML V1 replication configuration.</p>
+ *             <p>If you are using an earlier version of the replication configuration, Amazon S3 handles
+ *             replication of delete markers differently. For more information, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/replication-add-config.html#replication-backward-compat-considerations">Backward Compatibility</a>.</p>
  *          </note>
  *          <p>For information about enabling versioning on a bucket, see <a href="https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html">Using Versioning</a>.</p>
  *

--- a/clients/client-s3/commands/RestoreObjectCommand.ts
+++ b/clients/client-s3/commands/RestoreObjectCommand.ts
@@ -141,16 +141,17 @@ export type RestoreObjectCommandOutput = RestoreObjectOutput & __MetadataBearer;
  *             </li>
  *          </ul>
  *          <p>
- *             <b>Restoring Archives</b>
+ *             <b>Restoring objects</b>
  *          </p>
- *          <p>Objects that you archive to the S3 Glacier,
- *          S3 Glacier Deep Archive, S3 Intelligent-Tiering Archive, or S3 Intelligent-Tiering Deep Archive storage
- *          classes are not accessible in real time. For objects in Archive Access tier or
- *          Deep Archive Access tier you must first initiate a restore request, and then wait until the object
- *          is moved into the Frequent Access tier. For objects in S3 Glacier or
- *          S3 Glacier Deep Archive you must first initiate a restore request, and then wait
- *          until a temporary copy of the object is available. To access an archived object, you must
- *          restore the object for the duration (number of days) that you specify.</p>
+ *          <p>Objects that you archive to the S3 Glacier or
+ *          S3 Glacier Deep Archive storage class, and S3 Intelligent-Tiering Archive or
+ *          S3 Intelligent-Tiering Deep Archive tiers are not accessible in real time. For objects in
+ *          Archive Access or Deep Archive Access tiers you must first initiate a restore request, and
+ *          then wait until the object is moved into the Frequent Access tier. For objects in
+ *          S3 Glacier or S3 Glacier Deep Archive storage classes you must
+ *          first initiate a restore request, and then wait until a temporary copy of the object is
+ *          available. To access an archived object, you must restore the object for the duration
+ *          (number of days) that you specify.</p>
  *          <p>To restore a specific object version, you can provide a version ID. If you don't provide
  *          a version ID, Amazon S3 restores the current version.</p>
  *          <p>When restoring an archived object (or using a select request), you can specify one of
@@ -162,14 +163,14 @@ export type RestoreObjectCommandOutput = RestoreObjectOutput & __MetadataBearer;
  *                   <b>
  *                      <code>Expedited</code>
  *                   </b> - Expedited retrievals
- *                allow you to quickly access your data stored in the S3 Glacier or
- *                S3 Intelligent-Tiering Archive storage class when occasional urgent requests for a subset of
- *                archives are required. For all but the largest archived objects (250 MB+), data
- *                accessed using Expedited retrievals is typically made available within 1–5 minutes.
- *                Provisioned capacity ensures that retrieval capacity for Expedited retrievals is
- *                available when you need it. Expedited retrievals and provisioned capacity are not
- *                available for objects stored in the S3 Glacier Deep Archive or
- *                S3 Intelligent-Tiering Deep Archive storage class.</p>
+ *                allow you to quickly access your data stored in the S3 Glacier
+ *                storage class or S3 Intelligent-Tiering Archive tier when occasional urgent requests for a
+ *                subset of archives are required. For all but the largest archived objects (250 MB+),
+ *                data accessed using Expedited retrievals is typically made available within 1–5
+ *                minutes. Provisioned capacity ensures that retrieval capacity for Expedited
+ *                retrievals is available when you need it. Expedited retrievals and provisioned
+ *                capacity are not available for objects stored in the S3 Glacier Deep Archive
+ *                storage class or S3 Intelligent-Tiering Deep Archive tier.</p>
  *             </li>
  *             <li>
  *                <p>
@@ -179,10 +180,10 @@ export type RestoreObjectCommandOutput = RestoreObjectOutput & __MetadataBearer;
  *                you to access any of your archived objects within several hours. This is the default
  *                option for retrieval requests that do not specify the retrieval option. Standard
  *                retrievals typically finish within 3–5 hours for objects stored in the
- *                S3 Glacier or S3 Intelligent-Tiering Archive storage class. They typically
- *                finish within 12 hours for objects stored in the S3 Glacier Deep Archive or
- *                S3 Intelligent-Tiering Deep Archive storage class. Standard retrievals are free for objects stored
- *                in S3 Intelligent-Tiering.</p>
+ *                S3 Glacier storage class or S3 Intelligent-Tiering Archive tier. They
+ *                typically finish within 12 hours for objects stored in the
+ *                S3 Glacier Deep Archive storage class or S3 Intelligent-Tiering Deep Archive tier.
+ *                Standard retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
  *             </li>
  *             <li>
  *                <p>
@@ -191,10 +192,10 @@ export type RestoreObjectCommandOutput = RestoreObjectOutput & __MetadataBearer;
  *                   </b> - Bulk retrievals are the
  *                lowest-cost retrieval option in S3 Glacier, enabling you to retrieve large amounts,
  *                even petabytes, of data inexpensively. Bulk retrievals typically finish within 5–12
- *                hours for objects stored in the S3 Glacier or S3 Intelligent-Tiering Archive
- *                storage class. They typically finish within 48 hours for objects stored in the
- *                S3 Glacier Deep Archive or S3 Intelligent-Tiering Deep Archive storage class. Bulk
- *                retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
+ *                hours for objects stored in the S3 Glacier storage class or
+ *                S3 Intelligent-Tiering Archive tier. They typically finish within 48 hours for objects stored
+ *                in the S3 Glacier Deep Archive storage class or S3 Intelligent-Tiering Deep Archive tier.
+ *                Bulk retrievals are free for objects stored in S3 Intelligent-Tiering.</p>
  *             </li>
  *          </ul>
  *          <p>For more information about archive retrieval options and provisioned capacity for

--- a/clients/client-service-catalog-appregistry/commands/AssociateAttributeGroupCommand.ts
+++ b/clients/client-service-catalog-appregistry/commands/AssociateAttributeGroupCommand.ts
@@ -25,7 +25,9 @@ export type AssociateAttributeGroupCommandInput = AssociateAttributeGroupRequest
 export type AssociateAttributeGroupCommandOutput = AssociateAttributeGroupResponse & __MetadataBearer;
 
 /**
- * <p>Associates an attribute group with an application to augment the application's metadata with the group's attributes. This way applications can be described with user-defined details which are machine-readable (e.g. for third-party integrations).</p>
+ * <p>Associates an attribute group with an application to augment the application's metadata
+ *       with the group's attributes. This feature enables applications to be described with
+ *       user-defined details that are machine-readable, such as third-party integrations.</p>
  */
 export class AssociateAttributeGroupCommand extends $Command<
   AssociateAttributeGroupCommandInput,

--- a/clients/client-service-catalog-appregistry/commands/CreateAttributeGroupCommand.ts
+++ b/clients/client-service-catalog-appregistry/commands/CreateAttributeGroupCommand.ts
@@ -25,7 +25,10 @@ export type CreateAttributeGroupCommandInput = CreateAttributeGroupRequest;
 export type CreateAttributeGroupCommandOutput = CreateAttributeGroupResponse & __MetadataBearer;
 
 /**
- * <p>Creates a new attribute group as a container for user-defined attributes. This approach enables users to have full control over their cloud application's metadata in a rich machine-readable format to facilitate integration with automated workflows and third-party tools.</p>
+ * <p>Creates a new attribute group as a container for user-defined attributes. This feature
+ *       enables users to have full control over their cloud application's metadata in a rich
+ *       machine-readable format to facilitate integration with automated workflows and third-party
+ *       tools.</p>
  */
 export class CreateAttributeGroupCommand extends $Command<
   CreateAttributeGroupCommandInput,

--- a/clients/client-service-catalog-appregistry/commands/DeleteApplicationCommand.ts
+++ b/clients/client-service-catalog-appregistry/commands/DeleteApplicationCommand.ts
@@ -25,7 +25,7 @@ export type DeleteApplicationCommandInput = DeleteApplicationRequest;
 export type DeleteApplicationCommandOutput = DeleteApplicationResponse & __MetadataBearer;
 
 /**
- * <p>Delete an application, specified either by its application ID or name.</p>
+ * <p>Deletes an application that is specified either by its application ID or name. All associated attribute groups and resources must be disassociated from it before deleting an application.</p>
  */
 export class DeleteApplicationCommand extends $Command<
   DeleteApplicationCommandInput,

--- a/clients/client-service-catalog-appregistry/commands/DisassociateAttributeGroupCommand.ts
+++ b/clients/client-service-catalog-appregistry/commands/DisassociateAttributeGroupCommand.ts
@@ -25,7 +25,7 @@ export type DisassociateAttributeGroupCommandInput = DisassociateAttributeGroupR
 export type DisassociateAttributeGroupCommandOutput = DisassociateAttributeGroupResponse & __MetadataBearer;
 
 /**
- * <p>Disassociates an attribute group from an application to remove the extra attributes contained in the attribute group from the application's metadata. This operation reverts AssociateAttributeGroup.</p>
+ * <p>Disassociates an attribute group from an application to remove the extra attributes contained in the attribute group from the application's metadata. This operation reverts <code>AssociateAttributeGroup</code>.</p>
  */
 export class DisassociateAttributeGroupCommand extends $Command<
   DisassociateAttributeGroupCommandInput,

--- a/clients/client-service-catalog-appregistry/commands/GetApplicationCommand.ts
+++ b/clients/client-service-catalog-appregistry/commands/GetApplicationCommand.ts
@@ -25,7 +25,7 @@ export type GetApplicationCommandInput = GetApplicationRequest;
 export type GetApplicationCommandOutput = GetApplicationResponse & __MetadataBearer;
 
 /**
- * <p>Retrieves metadata information about one of your applications. The application can be specified either by its unique ID or by its name (which is unique within one account in one region at a given point in time). Specify by ID in automated workflows if you want to make sure that the exact same application is returned or a ResourceNotFoundException is thrown, avoiding the ABA addressing problem.</p>
+ * <p>Retrieves metadata information about one of your applications. The application can be specified either by its unique ID or by its name (which is unique within one account in one region at a given point in time). Specify by ID in automated workflows if you want to make sure that the exact same application is returned or a <code>ResourceNotFoundException</code> is thrown, avoiding the ABA addressing problem.</p>
  */
 export class GetApplicationCommand extends $Command<
   GetApplicationCommandInput,

--- a/clients/client-service-catalog-appregistry/commands/GetAttributeGroupCommand.ts
+++ b/clients/client-service-catalog-appregistry/commands/GetAttributeGroupCommand.ts
@@ -25,7 +25,7 @@ export type GetAttributeGroupCommandInput = GetAttributeGroupRequest;
 export type GetAttributeGroupCommandOutput = GetAttributeGroupResponse & __MetadataBearer;
 
 /**
- * <p>Retrieves an attribute group, either by its name or its ID.</p>
+ * <p>Retrieves an attribute group, either by its name or its ID. The attribute group can be specified either by its unique ID or by its name.</p>
  */
 export class GetAttributeGroupCommand extends $Command<
   GetAttributeGroupCommandInput,


### PR DESCRIPTION
*Issue #, if available:*
The necessary docs were merged in https://github.com/aws/aws-sdk-js-v3/pull/1716
Some of them were overwritten in 11/20 clients update in https://github.com/aws/aws-sdk-js-v3/pull/1711

*Description of changes:*
re-add docs overwritten in 11/20 clients update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
