### PR TITLE
chore(client-cognito-identity): remove auth customizations

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -67,10 +67,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
                         .withConventions(AwsDependency.MIDDLEWARE_SIGNING.dependency, "AwsAuth", HAS_MIDDLEWARE)
                         // See operationUsesAwsAuth() below for AwsAuth Middleware customizations.
                         .servicePredicate(
-                            (m, s) ->
-                                !testServiceId(s, "Cognito Identity")
-                                && !testServiceId(s, "STS")
-                                && !hasOptionalAuthOperation(m, s)
+                            (m, s) -> !testServiceId(s, "STS") && !hasOptionalAuthOperation(m, s)
                         ).build(),
                 RuntimeClientPlugin.builder()
                         .withConventions(TypeScriptDependency.MIDDLEWARE_RETRY.dependency, "Retry")
@@ -169,15 +166,6 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
     }
 
     private static boolean operationUsesAwsAuth(Model model, ServiceShape service, OperationShape operation) {
-        // Cognito Identity doesn't need auth for GetId, GetOpenIdToken, GetCredentialsForIdentity, UnlinkIdentity.
-        // Remove when optionalAuth model update is published in V261331976.
-        if (testServiceId(service, "Cognito Identity")) {
-            Boolean isUnsignedCommand = SetUtils
-                    .of("GetId", "GetOpenIdToken", "GetCredentialsForIdentity", "UnlinkIdentity")
-                    .contains(operation.getId().getName());
-            return !isUnsignedCommand;
-        }
-
         // STS doesn't need auth for AssumeRoleWithWebIdentity, AssumeRoleWithSAML.
         // Remove when optionalAuth model update is published in 0533102932.
         if (testServiceId(service, "STS")) {


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js/pull/3543

*Description of changes:*
The customization is no longer required as smithy `optionalAuth` was added to respective APIs in 11/20 models update.
* PR: https://github.com/aws/aws-sdk-js-v3/pull/1711
* Code: https://github.com/aws/aws-sdk-js-v3/blob/fdc692e0d872efea01a5a6ad21211dc5499d979e/codegen/sdk-codegen/aws-models/cognito-identity.2014-06-30.json#L760

Verified that running codegen doesn't update the client-cognito-identity:
```console
$ yarn generate-clients -g codegen/sdk-codegen/aws-models/cognito-identity.2014-06-30.json
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
