### PR TITLE
fix(middleware-sdk-sqs): call next() exactly once in sendMessageMiddleware

### DIFF
--- a/packages/middleware-sdk-sqs/src/send-message-batch.spec.ts
+++ b/packages/middleware-sdk-sqs/src/send-message-batch.spec.ts
@@ -14,6 +14,31 @@ describe("sendMessageBatchMiddleware", () => {
     mockHashDigest.mockClear();
   });
 
+  it("should call next exactly once", async () => {
+    const next = jest.fn().mockReturnValue({
+      output: {
+        Successful: [
+          { Id: "foo", MD5OfMessageBody: "00" },
+          { Id: "bar", MD5OfMessageBody: "00" },
+        ],
+      },
+    });
+    const handler = sendMessageBatchMiddleware({
+      md5: MockHash,
+    })(next, {} as any);
+
+    await handler({
+      input: {
+        Entries: [
+          { Id: "foo", MessageBody: "0" },
+          { Id: "bar", MessageBody: "0" },
+        ],
+      },
+    });
+
+    expect(next).toBeCalledTimes(1);
+  });
+
   it("should do nothing if the checksums match", async () => {
     const next = jest.fn().mockReturnValue({
       output: {

--- a/packages/middleware-sdk-sqs/src/send-message-batch.ts
+++ b/packages/middleware-sdk-sqs/src/send-message-batch.ts
@@ -21,42 +21,40 @@ interface SendMessageBatchResultEntry {
   MessageId: string | undefined;
 }
 
-export function sendMessageBatchMiddleware(options: PreviouslyResolved): InitializeMiddleware<any, any> {
-  return <Output extends MetadataBearer>(
-    next: InitializeHandler<any, Output>
-  ): InitializeHandler<any, Output> => async (
-    args: InitializeHandlerArguments<any>
-  ): Promise<InitializeHandlerOutput<Output>> => {
-    const resp = await next({ ...args });
-    const output = (resp.output as unknown) as SendMessageBatchResult;
-    const messageIds = [];
-    const entries: { [index: string]: SendMessageBatchResultEntry } = {};
-    if (output.Successful !== undefined) {
-      for (const entry of output.Successful) {
-        if (entry.Id !== undefined) {
-          entries[entry.Id] = entry;
-        }
+export const sendMessageBatchMiddleware = (options: PreviouslyResolved): InitializeMiddleware<any, any> => <
+  Output extends MetadataBearer
+>(
+  next: InitializeHandler<any, Output>
+): InitializeHandler<any, Output> => async (
+  args: InitializeHandlerArguments<any>
+): Promise<InitializeHandlerOutput<Output>> => {
+  const resp = await next({ ...args });
+  const output = (resp.output as unknown) as SendMessageBatchResult;
+  const messageIds = [];
+  const entries: { [index: string]: SendMessageBatchResultEntry } = {};
+  if (output.Successful !== undefined) {
+    for (const entry of output.Successful) {
+      if (entry.Id !== undefined) {
+        entries[entry.Id] = entry;
       }
     }
-    for (const entry of args.input.Entries) {
-      if (entries[entry.Id]) {
-        const md5 = entries[entry.Id].MD5OfMessageBody;
-        const hash = new options.md5();
-        hash.update(entry.MessageBody || "");
-        if (md5 !== toHex(await hash.digest())) {
-          messageIds.push(entries[entry.Id].MessageId);
-        }
+  }
+  for (const entry of args.input.Entries) {
+    if (entries[entry.Id]) {
+      const md5 = entries[entry.Id].MD5OfMessageBody;
+      const hash = new options.md5();
+      hash.update(entry.MessageBody || "");
+      if (md5 !== toHex(await hash.digest())) {
+        messageIds.push(entries[entry.Id].MessageId);
       }
     }
-    if (messageIds.length > 0) {
-      throw new Error("Invalid MD5 checksum on messages: " + messageIds.join(", "));
-    }
+  }
+  if (messageIds.length > 0) {
+    throw new Error("Invalid MD5 checksum on messages: " + messageIds.join(", "));
+  }
 
-    return next({
-      ...args,
-    });
-  };
-}
+  return resp;
+};
 
 export const sendMessageBatchMiddlewareOptions: InitializeHandlerOptions = {
   step: "initialize",

--- a/packages/middleware-sdk-sqs/src/send-message.spec.ts
+++ b/packages/middleware-sdk-sqs/src/send-message.spec.ts
@@ -14,6 +14,19 @@ describe("sendMessageMiddleware", () => {
     mockHashDigest.mockClear();
   });
 
+  it("should only call next once", async () => {
+    const next = jest.fn().mockReturnValue({
+      output: {
+        MD5OfMessageBody: "00",
+      },
+    });
+    const handler = sendMessageMiddleware({
+      md5: MockHash,
+    })(next, {} as any);
+    await handler({ input: {} });
+    expect(next).toBeCalledTimes(1);
+  });
+
   it("should do nothing if the checksum matches", async () => {
     const next = jest.fn().mockReturnValue({
       output: {
@@ -24,9 +37,7 @@ describe("sendMessageMiddleware", () => {
       md5: MockHash,
     })(next, {} as any);
 
-    await handler({
-      input: {},
-    });
+    await handler({ input: {} });
 
     expect(mockHashUpdate.mock.calls.length).toBe(1);
     expect(mockHashDigest.mock.calls.length).toBe(1);

--- a/packages/middleware-sdk-sqs/src/send-message.ts
+++ b/packages/middleware-sdk-sqs/src/send-message.ts
@@ -15,22 +15,22 @@ interface SendMessageResult {
   MD5OfMessageBody?: string;
 }
 
-export function sendMessageMiddleware(options: PreviouslyResolved): InitializeMiddleware<any, any> {
-  return <Output extends MetadataBearer>(
-    next: InitializeHandler<any, Output>
-  ): InitializeHandler<any, Output> => async (
-    args: InitializeHandlerArguments<any>
-  ): Promise<InitializeHandlerOutput<Output>> => {
-    const resp = await next({ ...args });
-    const output = resp.output as SendMessageResult;
-    const hash = new options.md5();
-    hash.update(args.input.MessageBody || "");
-    if (output.MD5OfMessageBody !== toHex(await hash.digest())) {
-      throw new Error("InvalidChecksumError");
-    }
-    return resp;
-  };
-}
+export const sendMessageMiddleware = (options: PreviouslyResolved): InitializeMiddleware<any, any> => <
+  Output extends MetadataBearer
+>(
+  next: InitializeHandler<any, Output>
+): InitializeHandler<any, Output> => async (
+  args: InitializeHandlerArguments<any>
+): Promise<InitializeHandlerOutput<Output>> => {
+  const resp = await next({ ...args });
+  const output = resp.output as SendMessageResult;
+  const hash = new options.md5();
+  hash.update(args.input.MessageBody || "");
+  if (output.MD5OfMessageBody !== toHex(await hash.digest())) {
+    throw new Error("InvalidChecksumError");
+  }
+  return resp;
+};
 
 export const sendMessageMiddlewareOptions: InitializeHandlerOptions = {
   step: "initialize",

--- a/packages/middleware-sdk-sqs/src/send-message.ts
+++ b/packages/middleware-sdk-sqs/src/send-message.ts
@@ -28,9 +28,7 @@ export function sendMessageMiddleware(options: PreviouslyResolved): InitializeMi
     if (output.MD5OfMessageBody !== toHex(await hash.digest())) {
       throw new Error("InvalidChecksumError");
     }
-    return next({
-      ...args,
-    });
+    return resp;
   };
 }
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1742

*Description of changes:*
call next() exactly once in sendMessageMiddleware

Verified that the issue is not reproducible with code from https://github.com/aws/aws-sdk-js-v3/issues/1742#issuecomment-740401577

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
