### PR TITLE
feat(util-waiter): add createWaiter()

### DIFF
--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -4,6 +4,7 @@
   "description": "Shared utilities for client waiters for the AWS SDK",
   "dependencies": {
     "@aws-sdk/abort-controller": "1.0.0-rc.8",
+    "@aws-sdk/types": "1.0.0-rc.8",
     "tslib": "^1.8.0"
   },
   "devDependencies": {

--- a/packages/util-waiter/src/createWaiter.spec.ts
+++ b/packages/util-waiter/src/createWaiter.spec.ts
@@ -1,6 +1,6 @@
 import { AbortController } from "@aws-sdk/abort-controller";
 
-import { WaiterState } from "./waiter";
+import { ResolvedWaiterOptions, WaiterState } from "./waiter";
 
 const mockValidate = jest.fn();
 jest.mock("./utils/validate", () => ({
@@ -21,8 +21,8 @@ describe("createWaiter", () => {
     minDelay: 2,
     maxDelay: 120,
     maxWaitTime: 9999,
-  };
-  const client = "client";
+    client: "client",
+  } as ResolvedWaiterOptions<any>;
   const input = "input";
 
   const abortedState = {
@@ -48,7 +48,6 @@ describe("createWaiter", () => {
         ...minimalWaiterConfig,
         maxWaitTime: 20,
       },
-      client,
       input,
       mockAcceptorChecks
     );
@@ -65,7 +64,6 @@ describe("createWaiter", () => {
         maxWaitTime: 20,
         abortController,
       },
-      client,
       input,
       mockAcceptorChecks
     );
@@ -81,7 +79,6 @@ describe("createWaiter", () => {
         ...minimalWaiterConfig,
         maxWaitTime: 20,
       },
-      client,
       input,
       mockAcceptorChecks
     );
@@ -96,7 +93,6 @@ describe("createWaiter", () => {
         ...minimalWaiterConfig,
         maxWaitTime: 20,
       },
-      client,
       input,
       mockAcceptorChecks
     );

--- a/packages/util-waiter/src/createWaiter.spec.ts
+++ b/packages/util-waiter/src/createWaiter.spec.ts
@@ -37,23 +37,6 @@ describe("createWaiter", () => {
   const successState = {
     state: WaiterState.SUCCESS,
   };
-  const timeoutState = {
-    state: WaiterState.TIMEOUT,
-  };
-
-  it("should timeout when maxTimeout is reached", async () => {
-    const mockAcceptorChecks = jest.fn().mockResolvedValue(retryState);
-    const statusPromise = createWaiter(
-      {
-        ...minimalWaiterConfig,
-        maxWaitTime: 20,
-      },
-      input,
-      mockAcceptorChecks
-    );
-    jest.advanceTimersByTime(20 * 1000);
-    expect(await statusPromise).toEqual(timeoutState);
-  });
 
   it("should abort when abortController is signalled", async () => {
     const abortController = new AbortController();

--- a/packages/util-waiter/src/createWaiter.spec.ts
+++ b/packages/util-waiter/src/createWaiter.spec.ts
@@ -1,0 +1,106 @@
+import { AbortController } from "@aws-sdk/abort-controller";
+
+import { WaiterState } from "./waiter";
+
+const mockValidate = jest.fn();
+jest.mock("./utils/validate", () => ({
+  validateWaiterOptions: mockValidate,
+}));
+
+jest.useFakeTimers();
+
+import { createWaiter } from "./createWaiter";
+
+describe("createWaiter", () => {
+  beforeEach(() => {
+    jest.clearAllTimers();
+    jest.clearAllMocks();
+  });
+
+  const minimalWaiterConfig = {
+    minDelay: 2,
+    maxDelay: 120,
+    maxWaitTime: 9999,
+  };
+  const client = "client";
+  const input = "input";
+
+  const abortedState = {
+    state: WaiterState.ABORTED,
+  };
+  const failureState = {
+    state: WaiterState.FAILURE,
+  };
+  const retryState = {
+    state: WaiterState.RETRY,
+  };
+  const successState = {
+    state: WaiterState.SUCCESS,
+  };
+  const timeoutState = {
+    state: WaiterState.TIMEOUT,
+  };
+
+  it("should timeout when maxTimeout is reached", async () => {
+    const mockAcceptorChecks = jest.fn().mockResolvedValue(retryState);
+    const statusPromise = createWaiter(
+      {
+        ...minimalWaiterConfig,
+        maxWaitTime: 20,
+      },
+      client,
+      input,
+      mockAcceptorChecks
+    );
+    jest.advanceTimersByTime(20 * 1000);
+    expect(await statusPromise).toEqual(timeoutState);
+  });
+
+  it("should abort when abortController is signalled", async () => {
+    const abortController = new AbortController();
+    const mockAcceptorChecks = jest.fn().mockResolvedValue(retryState);
+    const statusPromise = createWaiter(
+      {
+        ...minimalWaiterConfig,
+        maxWaitTime: 20,
+        abortController,
+      },
+      client,
+      input,
+      mockAcceptorChecks
+    );
+    jest.advanceTimersByTime(10 * 1000);
+    abortController.abort(); // Abort before maxWaitTime(20s);
+    expect(await statusPromise).toEqual(abortedState);
+  });
+
+  it("should success when acceptor checker returns seccess", async () => {
+    const mockAcceptorChecks = jest.fn().mockResolvedValue(successState);
+    const statusPromise = createWaiter(
+      {
+        ...minimalWaiterConfig,
+        maxWaitTime: 20,
+      },
+      client,
+      input,
+      mockAcceptorChecks
+    );
+    jest.advanceTimersByTime(minimalWaiterConfig.minDelay * 1000);
+    expect(await statusPromise).toEqual(successState);
+  });
+
+  it("should fail when acceptor checker returns failure", async () => {
+    const mockAcceptorChecks = jest.fn().mockResolvedValue(failureState);
+    const statusPromise = createWaiter(
+      {
+        ...minimalWaiterConfig,
+        maxWaitTime: 20,
+      },
+      client,
+      input,
+      mockAcceptorChecks
+    );
+    jest.advanceTimersByTime(minimalWaiterConfig.minDelay * 1000);
+    expect(await statusPromise).toEqual(failureState);
+  });
+});

--- a/packages/util-waiter/src/createWaiter.ts
+++ b/packages/util-waiter/src/createWaiter.ts
@@ -1,0 +1,47 @@
+import { AbortSignal } from "@aws-sdk/types";
+
+import { runPolling } from "./poller";
+import { sleep, validateWaiterOptions } from "./utils";
+import { WaiterOptions, WaiterResult, waiterServiceDefaults, WaiterState } from "./waiter";
+
+const waiterTimeout = async (seconds: number): Promise<WaiterResult> => {
+  await sleep(seconds);
+  return { state: WaiterState.TIMEOUT };
+};
+
+const abortTimeout = async (abortSignal: AbortSignal): Promise<WaiterResult> => {
+  return new Promise((resolve) => {
+    abortSignal.onabort = () => resolve({ state: WaiterState.ABORTED });
+  });
+};
+
+/**
+ * Create a waiter promise only resolves when:
+ * 1. Abort controller is signaled
+ * 2. Max wait time is reached
+ * 3. `acceptorChecks` succeeds, or fails
+ * Otherwise, it invokes `acceptorChecks` with exponential backoff delay.
+ *
+ * @internal
+ */
+export const createWaiter = async <Client, Input>(
+  options: WaiterOptions,
+  client: Client,
+  input: Input,
+  acceptorChecks: (client: Client, input: Input) => Promise<WaiterResult>
+): Promise<WaiterResult> => {
+  const params = {
+    ...waiterServiceDefaults,
+    ...options,
+  };
+  validateWaiterOptions(params);
+
+  const exitConditions = [
+    waiterTimeout(params.maxWaitTime),
+    runPolling<Client, Input>(params, client, input, acceptorChecks),
+  ];
+  if (options.abortController) {
+    exitConditions.push(abortTimeout(options.abortController.signal));
+  }
+  return Promise.race(exitConditions);
+};

--- a/packages/util-waiter/src/createWaiter.ts
+++ b/packages/util-waiter/src/createWaiter.ts
@@ -16,11 +16,11 @@ const abortTimeout = async (abortSignal: AbortSignal): Promise<WaiterResult> => 
 };
 
 /**
- * Create a waiter promise only resolves when:
+ * Create a waiter promise that only resolves when:
  * 1. Abort controller is signaled
  * 2. Max wait time is reached
  * 3. `acceptorChecks` succeeds, or fails
- * Otherwise, it invokes `acceptorChecks` with exponential backoff delay.
+ * Otherwise, it invokes `acceptorChecks` with exponential-backoff delay.
  *
  * @internal
  */

--- a/packages/util-waiter/src/createWaiter.ts
+++ b/packages/util-waiter/src/createWaiter.ts
@@ -35,7 +35,7 @@ export const createWaiter = async <Client extends SmithyClient, Input>(
   };
   validateWaiterOptions(params);
 
-  const exitConditions = [waiterTimeout(params.maxWaitTime), runPolling<Client, Input>(params, input, acceptorChecks)];
+  const exitConditions = [runPolling<Client, Input>(params, input, acceptorChecks)];
   if (options.abortController) {
     exitConditions.push(abortTimeout(options.abortController.signal));
   }

--- a/packages/util-waiter/src/index.spec.ts
+++ b/packages/util-waiter/src/index.spec.ts
@@ -2,10 +2,6 @@ import * as exported from "./index";
 
 describe("Waiter util module exports", () => {
   it("should export the proper functions", () => {
-    expect(exported.sleep).toBeDefined();
-    expect(exported.waiterTimeout).toBeDefined();
-    expect(exported.abortTimeout).toBeDefined();
-    expect(exported.validateWaiterOptions).toBeDefined();
-    expect(exported.runPolling).toBeDefined();
+    expect(exported.createWaiter).toBeDefined();
   });
 });

--- a/packages/util-waiter/src/index.ts
+++ b/packages/util-waiter/src/index.ts
@@ -1,4 +1,2 @@
-export * from "./utils/validate";
-export * from "./utils/sleep";
-export * from "./poller";
+export * from "./createWaiter";
 export * from "./waiter";

--- a/packages/util-waiter/src/poller.spec.ts
+++ b/packages/util-waiter/src/poller.spec.ts
@@ -87,7 +87,7 @@ describe(runPolling.name, () => {
     expect(sleep).toHaveBeenNthCalledWith(7, 30); // max delay
   });
 
-  it("resolves when maxWaitTime is reached", async () => {
+  it("resolves after the last attempt before reaching maxWaitTime ", async () => {
     let now = Date.now();
     const delay = 2;
     const nowMock = jest
@@ -108,7 +108,7 @@ describe(runPolling.name, () => {
     mockAcceptorChecks = jest.fn().mockResolvedValue(retryState);
     await expect(runPolling(localConfig, input, mockAcceptorChecks)).resolves.toStrictEqual(timeoutState);
     expect(sleep).toHaveBeenCalled();
-    expect(sleep).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
     nowMock.mockReset();
   });
 

--- a/packages/util-waiter/src/poller.spec.ts
+++ b/packages/util-waiter/src/poller.spec.ts
@@ -88,10 +88,20 @@ describe(runPolling.name, () => {
   });
 
   it("resolves when maxWaitTime is reached", async () => {
+    let now = Date.now();
+    const delay = 2;
+    const nowMock = jest
+      .spyOn(Date, "now")
+      .mockReturnValueOnce(now) // 1st invoke for getting the time stamp to wait until
+      .mockImplementation(() => {
+        const rtn = now;
+        now += delay * 1000;
+        return rtn;
+      });
     const localConfig = {
       ...config,
-      minDelay: 2,
-      maxDelay: 2,
+      minDelay: delay,
+      maxDelay: delay,
       maxWaitTime: 5,
     };
 
@@ -99,6 +109,7 @@ describe(runPolling.name, () => {
     await expect(runPolling(localConfig, input, mockAcceptorChecks)).resolves.toStrictEqual(timeoutState);
     expect(sleep).toHaveBeenCalled();
     expect(sleep).toHaveBeenCalledTimes(3);
+    nowMock.mockReset();
   });
 
   it("resolves when abortController is signalled", async () => {

--- a/packages/util-waiter/src/poller.ts
+++ b/packages/util-waiter/src/poller.ts
@@ -1,5 +1,5 @@
 import { sleep } from "./utils/sleep";
-import { ResolvedWaiterOptions, WaiterResult, WaiterState } from "./waiter";
+import { ResolvedWaiterOptions, SmithyClient, WaiterResult, WaiterState } from "./waiter";
 
 /**
  * Reference: https://awslabs.github.io/smithy/1.0/spec/waiters.html#waiter-retries
@@ -19,9 +19,8 @@ const randomInRange = (min: number, max: number) => min + Math.random() * (max -
  * @param input client input
  * @param stateChecker function that checks the acceptor states on each poll.
  */
-export const runPolling = async <T, S>(
-  { minDelay, maxDelay, maxWaitTime, abortController }: ResolvedWaiterOptions,
-  client: T,
+export const runPolling = async <T extends SmithyClient, S>(
+  { minDelay, maxDelay, maxWaitTime, abortController, client }: ResolvedWaiterOptions<T>,
   input: S,
   acceptorChecks: (client: T, input: S) => Promise<WaiterResult>
 ): Promise<WaiterResult> => {

--- a/packages/util-waiter/src/utils/index.ts
+++ b/packages/util-waiter/src/utils/index.ts
@@ -1,0 +1,2 @@
+export * from "./sleep";
+export * from "./validate";

--- a/packages/util-waiter/src/utils/sleep.spec.ts
+++ b/packages/util-waiter/src/utils/sleep.spec.ts
@@ -1,7 +1,4 @@
-import { AbortController } from "@aws-sdk/abort-controller";
-
-import { WaiterState } from "../waiter";
-import { abortTimeout, sleep, waiterTimeout } from "./sleep";
+import { sleep } from "./sleep";
 
 jest.useFakeTimers();
 
@@ -17,43 +14,6 @@ describe("Sleep Module", () => {
 
       expect(setTimeout).toHaveBeenCalledTimes(1);
       expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
-    });
-  });
-
-  describe(waiterTimeout.name, () => {
-    beforeEach(() => {
-      jest.clearAllMocks();
-      jest.clearAllTimers();
-    });
-
-    it("should call sleep with the proper number of seconds", () => {
-      waiterTimeout(3);
-      expect(setTimeout).toHaveBeenCalledTimes(1);
-      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 3000);
-    });
-
-    it("should call return state retry", async () => {
-      const result = waiterTimeout(1);
-      expect(setTimeout).toHaveBeenCalledTimes(1);
-      expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 1000);
-      jest.advanceTimersByTime(1000);
-      await expect(result).resolves.toEqual({ state: WaiterState.RETRY });
-    });
-  });
-
-  describe(abortTimeout.name, () => {
-    it("should listen to the abort control", async () => {
-      const abortControl = new AbortController();
-      const mockTimeout = 1000;
-      const race = Promise.race([
-        new Promise((resolve) => setTimeout(resolve, mockTimeout)),
-        abortTimeout(abortControl.signal),
-      ]);
-      abortControl.abort();
-      // jest.advanceTimersByTime(mockTimeout);
-      const result = await race;
-
-      await expect(result).toEqual({ state: WaiterState.ABORTED });
     });
   });
 });

--- a/packages/util-waiter/src/utils/sleep.ts
+++ b/packages/util-waiter/src/utils/sleep.ts
@@ -1,18 +1,3 @@
-import { AbortSignal } from "@aws-sdk/abort-controller";
-
-import { WaiterResult, WaiterState } from "../waiter";
-
 export const sleep = (seconds: number) => {
   return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 };
-
-// export const waiterTimeout = async (seconds: number): Promise<WaiterResult> => {
-//   await sleep(seconds);
-//   return { state: WaiterState.RETRY };
-// };
-
-// export const abortTimeout = async (abortSignal: AbortSignal): Promise<WaiterResult> => {
-//   return new Promise((resolve) => {
-//     abortSignal.onabort = () => resolve({ state: WaiterState.ABORTED });
-//   });
-// };

--- a/packages/util-waiter/src/utils/sleep.ts
+++ b/packages/util-waiter/src/utils/sleep.ts
@@ -6,13 +6,13 @@ export const sleep = (seconds: number) => {
   return new Promise((resolve) => setTimeout(resolve, seconds * 1000));
 };
 
-export const waiterTimeout = async (seconds: number): Promise<WaiterResult> => {
-  await sleep(seconds);
-  return { state: WaiterState.RETRY };
-};
+// export const waiterTimeout = async (seconds: number): Promise<WaiterResult> => {
+//   await sleep(seconds);
+//   return { state: WaiterState.RETRY };
+// };
 
-export const abortTimeout = async (abortSignal: AbortSignal): Promise<WaiterResult> => {
-  return new Promise((resolve) => {
-    abortSignal.onabort = () => resolve({ state: WaiterState.ABORTED });
-  });
-};
+// export const abortTimeout = async (abortSignal: AbortSignal): Promise<WaiterResult> => {
+//   return new Promise((resolve) => {
+//     abortSignal.onabort = () => resolve({ state: WaiterState.ABORTED });
+//   });
+// };

--- a/packages/util-waiter/src/utils/validate.spec.ts
+++ b/packages/util-waiter/src/utils/validate.spec.ts
@@ -2,13 +2,14 @@ import { ResolvedWaiterOptions } from "../waiter";
 import { validateWaiterOptions } from "./validate";
 
 describe(validateWaiterOptions.name, () => {
-  let waiterOptions: ResolvedWaiterOptions;
+  let waiterOptions: ResolvedWaiterOptions<any>;
 
   beforeEach(() => {
     waiterOptions = {
       maxWaitTime: 120,
       minDelay: 20,
       maxDelay: 120,
+      client: "client",
     };
   });
 

--- a/packages/util-waiter/src/utils/validate.spec.ts
+++ b/packages/util-waiter/src/utils/validate.spec.ts
@@ -1,8 +1,8 @@
-import { WaiterOptions } from "../waiter";
+import { ResolvedWaiterOptions } from "../waiter";
 import { validateWaiterOptions } from "./validate";
 
 describe(validateWaiterOptions.name, () => {
-  let waiterOptions: WaiterOptions;
+  let waiterOptions: ResolvedWaiterOptions;
 
   beforeEach(() => {
     waiterOptions = {

--- a/packages/util-waiter/src/utils/validate.ts
+++ b/packages/util-waiter/src/utils/validate.ts
@@ -1,10 +1,10 @@
-import { ResolvedWaiterOptions } from "../waiter";
+import { ResolvedWaiterOptions, SmithyClient } from "../waiter";
 
 /**
  * Validates that waiter options are passed correctly
  * @param options a waiter configuration object
  */
-export const validateWaiterOptions = (options: ResolvedWaiterOptions): void => {
+export const validateWaiterOptions = (options: ResolvedWaiterOptions<SmithyClient>): void => {
   if (options.maxWaitTime < 1) {
     throw `WaiterOptions.maxWaitTime must be greater than 0`;
   } else if (options.maxWaitTime <= options.minDelay) {

--- a/packages/util-waiter/src/utils/validate.ts
+++ b/packages/util-waiter/src/utils/validate.ts
@@ -1,10 +1,10 @@
-import { WaiterOptions } from "../waiter";
+import { ResolvedWaiterOptions } from "../waiter";
 
 /**
  * Validates that waiter options are passed correctly
  * @param options a waiter configuration object
  */
-export const validateWaiterOptions = (options: WaiterOptions): void => {
+export const validateWaiterOptions = (options: ResolvedWaiterOptions): void => {
   if (options.maxWaitTime < 1) {
     throw `WaiterOptions.maxWaitTime must be greater than 0`;
   } else if (options.maxWaitTime <= options.minDelay) {

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -1,6 +1,15 @@
-import { AbortController } from "@aws-sdk/types";
+import { AbortController, Client } from "@aws-sdk/types";
 
-export interface WaiterConfiguration {
+/**
+ * @internal
+ */
+export type SmithyClient = Client<any, any, any>;
+export interface WaiterConfiguration<Client extends SmithyClient> {
+  /**
+   * Required service client
+   */
+  client: Client;
+
   /**
    * The amount of time in seconds a user is willing to wait for a waiter to complete.
    */
@@ -12,7 +21,7 @@ export interface WaiterConfiguration {
   abortController?: AbortController;
 }
 
-export interface WaiterOptions extends WaiterConfiguration {
+export interface WaiterOptions<Client extends SmithyClient> extends WaiterConfiguration<Client> {
   /**
    * The minimum amount of time to delay between retries in seconds. This value defaults
    * to 2 if not specified. If specified, this value MUST be greater than or equal to 1
@@ -39,7 +48,8 @@ export const waiterServiceDefaults = {
 /**
  * @private
  */
-export type ResolvedWaiterOptions = WaiterOptions & Required<Pick<WaiterOptions, "minDelay" | "maxDelay">>;
+export type ResolvedWaiterOptions<Client extends SmithyClient> = WaiterOptions<Client> &
+  Required<Pick<WaiterOptions<Client>, "minDelay" | "maxDelay">>;
 
 export enum WaiterState {
   ABORTED = "ABORTED",

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -1,9 +1,8 @@
-import { AbortController } from "@aws-sdk/abort-controller";
+import { AbortController } from "@aws-sdk/types";
 
 export interface WaiterConfiguration {
   /**
-   * The amount of time in seconds a user is willing to wait for a waiter to complete. This
-   * defaults to 300 (5 minutes).
+   * The amount of time in seconds a user is willing to wait for a waiter to complete.
    */
   maxWaitTime: number;
 
@@ -19,21 +18,35 @@ export interface WaiterOptions extends WaiterConfiguration {
    * to 2 if not specified. If specified, this value MUST be greater than or equal to 1
    * and less than or equal to maxDelay.
    */
-  minDelay: number;
+  minDelay?: number;
 
   /**
    * The maximum amount of time to delay between retries in seconds. The maximum amount
    * of time in seconds to delay between each retry. This value defaults to 120 if not
    * specified (2 minutes). If specified, this value MUST be greater than or equal to 1.
    */
-  maxDelay: number;
+  maxDelay?: number;
 }
+
+/**
+ * @private
+ */
+export const waiterServiceDefaults = {
+  minDelay: 2,
+  maxDelay: 120,
+};
+
+/**
+ * @private
+ */
+export type ResolvedWaiterOptions = WaiterOptions & Required<Pick<WaiterOptions, "minDelay" | "maxDelay">>;
 
 export enum WaiterState {
   ABORTED = "ABORTED",
   FAILURE = "FAILURE",
   SUCCESS = "SUCCESS",
   RETRY = "RETRY",
+  TIMEOUT = "TIMEOUT",
 }
 
 export type WaiterResult = {


### PR DESCRIPTION
Refactors: https://github.com/aws/aws-sdk-js-v3/pull/1736

Refactor the original waiter util:
1. expose a createWaiter() only to clients in order to reduce the duplicated code-gen
2. fix infinite loop in job poller
3. fix potential number overflow

Example of how clients may use these utils:
```js
const waitForTableExists = (params: DynamoDBWaiter, input: DescribeTableInput): Promise<WaiterResult> => {
    return createWaiter({...waiterServiceDefaults, ...params}, params.client, input, tableExistsPoller);
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
