### PR TITLE
fix(codegen): import SENSITIVE_STRING only when used

### DIFF
--- a/clients/client-accessanalyzer/models/models_0.ts
+++ b/clients/client-accessanalyzer/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-acm-pca/models/models_0.ts
+++ b/clients/client-acm-pca/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum KeyAlgorithm {

--- a/clients/client-amplifybackend/models/models_0.ts
+++ b/clients/client-amplifybackend/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AdditionalConstraintsElement {

--- a/clients/client-api-gateway/models/models_0.ts
+++ b/clients/client-api-gateway/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-apigatewaymanagementapi/models/models_0.ts
+++ b/clients/client-apigatewaymanagementapi/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface DeleteConnectionRequest {

--- a/clients/client-apigatewayv2/models/models_0.ts
+++ b/clients/client-apigatewayv2/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-app-mesh/models/models_0.ts
+++ b/clients/client-app-mesh/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-appintegrations/models/models_0.ts
+++ b/clients/client-appintegrations/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-application-auto-scaling/models/models_0.ts
+++ b/clients/client-application-auto-scaling/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AdjustmentType {

--- a/clients/client-application-discovery-service/models/models_0.ts
+++ b/clients/client-application-discovery-service/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-application-insights/models/models_0.ts
+++ b/clients/client-application-insights/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-appsync/models/models_0.ts
+++ b/clients/client-appsync/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-athena/models/models_0.ts
+++ b/clients/client-athena/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface BatchGetNamedQueryInput {

--- a/clients/client-auditmanager/models/models_0.ts
+++ b/clients/client-auditmanager/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-auto-scaling-plans/models/models_0.ts
+++ b/clients/client-auto-scaling-plans/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-auto-scaling/models/models_0.ts
+++ b/clients/client-auto-scaling/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-batch/models/models_0.ts
+++ b/clients/client-batch/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum ArrayJobDependency {

--- a/clients/client-braket/models/models_0.ts
+++ b/clients/client-braket/models/models_0.ts
@@ -1,8 +1,4 @@
-import {
-  SENSITIVE_STRING,
-  LazyJsonString as __LazyJsonString,
-  SmithyException as __SmithyException,
-} from "@aws-sdk/smithy-client";
+import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-clouddirectory/models/models_0.ts
+++ b/clients/client-clouddirectory/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-cloudformation/models/models_0.ts
+++ b/clients/client-cloudformation/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export type AccountGateStatus = "FAILED" | "SKIPPED" | "SUCCEEDED";

--- a/clients/client-cloudfront/models/models_1.ts
+++ b/clients/client-cloudfront/models/models_1.ts
@@ -39,7 +39,7 @@ import {
   TrustedSigners,
   ViewerCertificate,
 } from "./models_0";
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface GetRealtimeLogConfigResult {

--- a/clients/client-cloudhsm-v2/models/models_0.ts
+++ b/clients/client-cloudhsm-v2/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum BackupState {

--- a/clients/client-cloudhsm/models/models_0.ts
+++ b/clients/client-cloudhsm/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-cloudsearch-domain/models/models_0.ts
+++ b/clients/client-cloudsearch-domain/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 

--- a/clients/client-cloudsearch/models/models_0.ts
+++ b/clients/client-cloudsearch/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-cloudtrail/models/models_0.ts
+++ b/clients/client-cloudtrail/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-cloudwatch-events/models/models_0.ts
+++ b/clients/client-cloudwatch-events/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface ActivateEventSourceRequest {

--- a/clients/client-cloudwatch-logs/models/models_0.ts
+++ b/clients/client-cloudwatch-logs/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateKmsKeyRequest {

--- a/clients/client-cloudwatch/models/models_0.ts
+++ b/clients/client-cloudwatch/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export type AlarmType = "CompositeAlarm" | "MetricAlarm";

--- a/clients/client-codeartifact/models/models_0.ts
+++ b/clients/client-codeartifact/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 

--- a/clients/client-codecommit/models/models_0.ts
+++ b/clients/client-codecommit/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-codecommit/models/models_1.ts
+++ b/clients/client-codecommit/models/models_1.ts
@@ -13,7 +13,7 @@ import {
   PullRequestStatusEnum,
   RepositoryTrigger,
 } from "./models_0";
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum OrderEnum {

--- a/clients/client-codedeploy/models/models_0.ts
+++ b/clients/client-codedeploy/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-codeguru-reviewer/models/models_0.ts
+++ b/clients/client-codeguru-reviewer/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-codeguruprofiler/models/models_0.ts
+++ b/clients/client-codeguruprofiler/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AgentParameterField {

--- a/clients/client-codestar-connections/models/models_0.ts
+++ b/clients/client-codestar-connections/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum ProviderType {

--- a/clients/client-cognito-identity/models/models_0.ts
+++ b/clients/client-cognito-identity/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AmbiguousRoleResolutionType {

--- a/clients/client-cognito-sync/models/models_0.ts
+++ b/clients/client-cognito-sync/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-comprehendmedical/models/models_0.ts
+++ b/clients/client-comprehendmedical/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum EntityType {

--- a/clients/client-compute-optimizer/models/models_0.ts
+++ b/clients/client-compute-optimizer/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-config-service/models/models_0.ts
+++ b/clients/client-config-service/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-connect-contact-lens/models/models_0.ts
+++ b/clients/client-connect-contact-lens/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-connectparticipant/models/models_0.ts
+++ b/clients/client-connectparticipant/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-cost-and-usage-report-service/models/models_0.ts
+++ b/clients/client-cost-and-usage-report-service/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AdditionalArtifact {

--- a/clients/client-cost-explorer/models/models_0.ts
+++ b/clients/client-cost-explorer/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AccountScope {

--- a/clients/client-customer-profiles/models/models_0.ts
+++ b/clients/client-customer-profiles/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-data-pipeline/models/models_0.ts
+++ b/clients/client-data-pipeline/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-databrew/models/models_0.ts
+++ b/clients/client-databrew/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-dataexchange/models/models_0.ts
+++ b/clients/client-dataexchange/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-dax/models/models_0.ts
+++ b/clients/client-dax/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-detective/models/models_0.ts
+++ b/clients/client-detective/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptInvitationRequest {

--- a/clients/client-device-farm/models/models_0.ts
+++ b/clients/client-device-farm/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-devops-guru/models/models_0.ts
+++ b/clients/client-devops-guru/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-direct-connect/models/models_0.ts
+++ b/clients/client-direct-connect/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-dlm/models/models_0.ts
+++ b/clients/client-dlm/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-docdb/models/models_0.ts
+++ b/clients/client-docdb/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-dynamodb-streams/models/models_0.ts
+++ b/clients/client-dynamodb-streams/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-dynamodb/models/models_0.ts
+++ b/clients/client-dynamodb/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-ec2-instance-connect/models/models_0.ts
+++ b/clients/client-ec2-instance-connect/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-ec2/models/models_1.ts
+++ b/clients/client-ec2/models/models_1.ts
@@ -46,7 +46,6 @@ import {
   VpcPeeringConnection,
   _InstanceType,
 } from "./models_0";
-import { SENSITIVE_STRING } from "@aws-sdk/smithy-client";
 
 /**
  * <p>Describes the monitoring for the instance.</p>

--- a/clients/client-ec2/models/models_2.ts
+++ b/clients/client-ec2/models/models_2.ts
@@ -64,7 +64,6 @@ import {
   TransitGatewayRoute,
   TransitGatewayRouteTable,
 } from "./models_1";
-import { SENSITIVE_STRING } from "@aws-sdk/smithy-client";
 
 export interface DeleteTransitGatewayPeeringAttachmentResult {
   /**

--- a/clients/client-ec2/models/models_3.ts
+++ b/clients/client-ec2/models/models_3.ts
@@ -83,7 +83,6 @@ import {
   PermissionGroup,
   ProductCode,
 } from "./models_2";
-import { SENSITIVE_STRING } from "@aws-sdk/smithy-client";
 
 export interface DescribeLocalGatewayRouteTablesResult {
   /**

--- a/clients/client-ecr-public/models/models_0.ts
+++ b/clients/client-ecr-public/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-ecr/models/models_0.ts
+++ b/clients/client-ecr/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface BatchCheckLayerAvailabilityRequest {

--- a/clients/client-ecs/models/models_0.ts
+++ b/clients/client-ecs/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-efs/models/models_0.ts
+++ b/clients/client-efs/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-eks/models/models_0.ts
+++ b/clients/client-eks/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AddonIssueCode {

--- a/clients/client-elastic-beanstalk/models/models_0.ts
+++ b/clients/client-elastic-beanstalk/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-elastic-inference/models/models_0.ts
+++ b/clients/client-elastic-inference/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-elastic-load-balancing-v2/models/models_0.ts
+++ b/clients/client-elastic-load-balancing-v2/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AuthenticateCognitoActionConditionalBehaviorEnum {

--- a/clients/client-elastic-load-balancing/models/models_0.ts
+++ b/clients/client-elastic-load-balancing/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-elastic-transcoder/models/models_0.ts
+++ b/clients/client-elastic-transcoder/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-elasticache/models/models_0.ts
+++ b/clients/client-elasticache/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-emr/models/models_0.ts
+++ b/clients/client-emr/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum ActionOnFailure {

--- a/clients/client-eventbridge/models/models_0.ts
+++ b/clients/client-eventbridge/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface ActivateEventSourceRequest {

--- a/clients/client-fms/models/models_0.ts
+++ b/clients/client-fms/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AccountRoleStatus {

--- a/clients/client-forecastquery/models/models_0.ts
+++ b/clients/client-forecastquery/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-glacier/models/models_0.ts
+++ b/clients/client-glacier/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 

--- a/clients/client-global-accelerator/models/models_0.ts
+++ b/clients/client-global-accelerator/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum IpAddressType {

--- a/clients/client-glue/models/models_0.ts
+++ b/clients/client-glue/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-glue/models/models_1.ts
+++ b/clients/client-glue/models/models_1.ts
@@ -49,7 +49,7 @@ import {
   Workflow,
   WorkflowRun,
 } from "./models_0";
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface GetJobBookmarkResponse {

--- a/clients/client-greengrass/models/models_0.ts
+++ b/clients/client-greengrass/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-groundstation/models/models_0.ts
+++ b/clients/client-groundstation/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AngleUnits {

--- a/clients/client-guardduty/models/models_0.ts
+++ b/clients/client-guardduty/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptInvitationRequest {

--- a/clients/client-health/models/models_0.ts
+++ b/clients/client-health/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum EntityStatusCode {

--- a/clients/client-healthlake/models/models_0.ts
+++ b/clients/client-healthlake/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-imagebuilder/models/models_0.ts
+++ b/clients/client-imagebuilder/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum ImageStatus {

--- a/clients/client-inspector/models/models_0.ts
+++ b/clients/client-inspector/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AccessDeniedErrorCode {

--- a/clients/client-iot-1click-devices-service/models/models_0.ts
+++ b/clients/client-iot-1click-devices-service/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface DeviceDescription {

--- a/clients/client-iot-1click-projects/models/models_0.ts
+++ b/clients/client-iot-1click-projects/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateDeviceWithPlacementRequest {

--- a/clients/client-iot-data-plane/models/models_0.ts
+++ b/clients/client-iot-data-plane/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-iot-events-data/models/models_0.ts
+++ b/clients/client-iot-events-data/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-iot-events/models/models_0.ts
+++ b/clients/client-iot-events/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-iot-jobs-data-plane/models/models_0.ts
+++ b/clients/client-iot-jobs-data-plane/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-iot/models/models_1.ts
+++ b/clients/client-iot/models/models_1.ts
@@ -53,7 +53,7 @@ import {
   TopicRuleDestinationStatus,
   TopicRulePayload,
 } from "./models_0";
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface DescribeAuditTaskResponse {

--- a/clients/client-iot/models/models_2.ts
+++ b/clients/client-iot/models/models_2.ts
@@ -34,7 +34,7 @@ import {
   ThingGroupIndexingConfiguration,
   ThingIndexingConfiguration,
 } from "./models_1";
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-iotanalytics/models/models_0.ts
+++ b/clients/client-iotanalytics/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-iotsitewise/models/models_0.ts
+++ b/clients/client-iotsitewise/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-iotthingsgraph/models/models_0.ts
+++ b/clients/client-iotthingsgraph/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateEntityToThingRequest {

--- a/clients/client-ivs/models/models_0.ts
+++ b/clients/client-ivs/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AccessDeniedException extends __SmithyException, $MetadataBearer {

--- a/clients/client-kafka/models/models_0.ts
+++ b/clients/client-kafka/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-kinesis-analytics-v2/models/models_0.ts
+++ b/clients/client-kinesis-analytics-v2/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-kinesis-analytics/models/models_0.ts
+++ b/clients/client-kinesis-analytics/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-kinesis-video-archived-media/models/models_0.ts
+++ b/clients/client-kinesis-video-archived-media/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 

--- a/clients/client-kinesis-video-media/models/models_0.ts
+++ b/clients/client-kinesis-video-media/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 

--- a/clients/client-kinesis-video-signaling/models/models_0.ts
+++ b/clients/client-kinesis-video-signaling/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-kinesis-video/models/models_0.ts
+++ b/clients/client-kinesis-video/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-kinesis/models/models_0.ts
+++ b/clients/client-kinesis/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-lakeformation/models/models_0.ts
+++ b/clients/client-lakeformation/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-license-manager/models/models_0.ts
+++ b/clients/client-license-manager/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptGrantRequest {

--- a/clients/client-lookoutvision/models/models_0.ts
+++ b/clients/client-lookoutvision/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 

--- a/clients/client-machine-learning/models/models_0.ts
+++ b/clients/client-machine-learning/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum TaggableResourceType {

--- a/clients/client-macie/models/models_0.ts
+++ b/clients/client-macie/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-macie2/models/models_0.ts
+++ b/clients/client-macie2/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AdminStatus {

--- a/clients/client-marketplace-catalog/models/models_0.ts
+++ b/clients/client-marketplace-catalog/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-marketplace-commerce-analytics/models/models_0.ts
+++ b/clients/client-marketplace-commerce-analytics/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum DataSetType {

--- a/clients/client-marketplace-entitlement-service/models/models_0.ts
+++ b/clients/client-marketplace-entitlement-service/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum GetEntitlementFilterName {

--- a/clients/client-marketplace-metering/models/models_0.ts
+++ b/clients/client-marketplace-metering/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-mediaconnect/models/models_0.ts
+++ b/clients/client-mediaconnect/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum Algorithm {

--- a/clients/client-mediaconvert/models/models_0.ts
+++ b/clients/client-mediaconvert/models/models_0.ts
@@ -1,5 +1,3 @@
-import { SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-
 export enum AudioChannelTag {
   C = "C",
   CS = "CS",

--- a/clients/client-mediaconvert/models/models_1.ts
+++ b/clients/client-mediaconvert/models/models_1.ts
@@ -37,7 +37,7 @@ import {
   Rectangle,
   VideoCodec,
 } from "./models_0";
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum H264EntropyEncoding {

--- a/clients/client-medialive/models/models_0.ts
+++ b/clients/client-medialive/models/models_0.ts
@@ -1,5 +1,3 @@
-import { SENSITIVE_STRING } from "@aws-sdk/smithy-client";
-
 /**
  * Input Channel Level
  */

--- a/clients/client-medialive/models/models_1.ts
+++ b/clients/client-medialive/models/models_1.ts
@@ -50,7 +50,7 @@ import {
   OutputGroup,
   ReservationResourceSpecification,
 } from "./models_0";
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 

--- a/clients/client-mediapackage-vod/models/models_0.ts
+++ b/clients/client-mediapackage-vod/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum __PeriodTriggersElement {

--- a/clients/client-mediapackage/models/models_0.ts
+++ b/clients/client-mediapackage/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum __AdTriggersElement {

--- a/clients/client-mediastore-data/models/models_0.ts
+++ b/clients/client-mediastore-data/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 

--- a/clients/client-mediastore/models/models_0.ts
+++ b/clients/client-mediastore/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum MethodName {

--- a/clients/client-mediatailor/models/models_0.ts
+++ b/clients/client-mediatailor/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum Mode {

--- a/clients/client-migration-hub/models/models_0.ts
+++ b/clients/client-migration-hub/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-migrationhub-config/models/models_0.ts
+++ b/clients/client-migrationhub-config/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-mobile/models/models_0.ts
+++ b/clients/client-mobile/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-mq/models/models_0.ts
+++ b/clients/client-mq/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-mturk/models/models_0.ts
+++ b/clients/client-mturk/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptQualificationRequestRequest {

--- a/clients/client-neptune/models/models_0.ts
+++ b/clients/client-neptune/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AddRoleToDBClusterMessage {

--- a/clients/client-network-firewall/models/models_0.ts
+++ b/clients/client-network-firewall/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-networkmanager/models/models_0.ts
+++ b/clients/client-networkmanager/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-opsworks/models/models_0.ts
+++ b/clients/client-opsworks/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-outposts/models/models_0.ts
+++ b/clients/client-outposts/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-personalize-events/models/models_0.ts
+++ b/clients/client-personalize-events/models/models_0.ts
@@ -1,8 +1,4 @@
-import {
-  SENSITIVE_STRING,
-  LazyJsonString as __LazyJsonString,
-  SmithyException as __SmithyException,
-} from "@aws-sdk/smithy-client";
+import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-pi/models/models_0.ts
+++ b/clients/client-pi/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-pinpoint-email/models/models_0.ts
+++ b/clients/client-pinpoint-email/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-pinpoint-sms-voice/models/models_0.ts
+++ b/clients/client-pinpoint-sms-voice/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-pinpoint/models/models_0.ts
+++ b/clients/client-pinpoint/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum __EndpointTypesElement {

--- a/clients/client-pinpoint/models/models_1.ts
+++ b/clients/client-pinpoint/models/models_1.ts
@@ -55,7 +55,6 @@ import {
   WriteJourneyRequest,
   WriteSegmentRequest,
 } from "./models_0";
-import { SENSITIVE_STRING } from "@aws-sdk/smithy-client";
 
 export interface GetJourneyDateRangeKpiRequest {
   /**

--- a/clients/client-pricing/models/models_0.ts
+++ b/clients/client-pricing/models/models_0.ts
@@ -1,8 +1,4 @@
-import {
-  SENSITIVE_STRING,
-  LazyJsonString as __LazyJsonString,
-  SmithyException as __SmithyException,
-} from "@aws-sdk/smithy-client";
+import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-qldb-session/models/models_0.ts
+++ b/clients/client-qldb-session/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-ram/models/models_0.ts
+++ b/clients/client-ram/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptResourceShareInvitationRequest {

--- a/clients/client-rds-data/models/models_0.ts
+++ b/clients/client-rds-data/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-rds/models/models_1.ts
+++ b/clients/client-rds/models/models_1.ts
@@ -30,7 +30,7 @@ import {
   Tag,
   UserAuthConfig,
 } from "./models_0";
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-redshift-data/models/models_0.ts
+++ b/clients/client-redshift-data/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface CancelStatementRequest {

--- a/clients/client-redshift/models/models_1.ts
+++ b/clients/client-redshift/models/models_1.ts
@@ -10,7 +10,7 @@ import {
   TableRestoreStatus,
   UsageLimitBreachAction,
 } from "./models_0";
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-rekognition/models/models_0.ts
+++ b/clients/client-rekognition/models/models_0.ts
@@ -1,8 +1,4 @@
-import {
-  SENSITIVE_STRING,
-  LazyJsonString as __LazyJsonString,
-  SmithyException as __SmithyException,
-} from "@aws-sdk/smithy-client";
+import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-resource-groups-tagging-api/models/models_0.ts
+++ b/clients/client-resource-groups-tagging-api/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-resource-groups/models/models_0.ts
+++ b/clients/client-resource-groups/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-robomaker/models/models_0.ts
+++ b/clients/client-robomaker/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum Architecture {

--- a/clients/client-route-53/models/models_0.ts
+++ b/clients/client-route-53/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export type AccountLimitType =

--- a/clients/client-route53resolver/models/models_0.ts
+++ b/clients/client-route53resolver/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-s3-control/models/models_0.ts
+++ b/clients/client-s3-control/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-s3outposts/models/models_0.ts
+++ b/clients/client-s3outposts/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-sagemaker-a2i-runtime/models/models_0.ts
+++ b/clients/client-sagemaker-a2i-runtime/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface DeleteHumanLoopRequest {

--- a/clients/client-sagemaker-edge/models/models_0.ts
+++ b/clients/client-sagemaker-edge/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface GetDeviceRegistrationRequest {

--- a/clients/client-sagemaker-featurestore-runtime/models/models_0.ts
+++ b/clients/client-sagemaker-featurestore-runtime/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-sagemaker/models/models_0.ts
+++ b/clients/client-sagemaker/models/models_0.ts
@@ -1,8 +1,4 @@
-import {
-  SENSITIVE_STRING,
-  LazyJsonString as __LazyJsonString,
-  SmithyException as __SmithyException,
-} from "@aws-sdk/smithy-client";
+import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-sagemaker/models/models_2.ts
+++ b/clients/client-sagemaker/models/models_2.ts
@@ -134,7 +134,6 @@ import {
   Workteam,
   _InstanceType,
 } from "./models_1";
-import { SENSITIVE_STRING } from "@aws-sdk/smithy-client";
 
 export interface DisassociateTrialComponentRequest {
   /**

--- a/clients/client-sagemaker/models/models_3.ts
+++ b/clients/client-sagemaker/models/models_3.ts
@@ -1,6 +1,5 @@
 import { BooleanOperator } from "./models_0";
 import { Filter, NestedFilters, ResourceType, SearchSortOrder } from "./models_2";
-import { SENSITIVE_STRING } from "@aws-sdk/smithy-client";
 
 /**
  * <p>A multi-expression that searches for the specified resource or resources in a search. All resource

--- a/clients/client-savingsplans/models/models_0.ts
+++ b/clients/client-savingsplans/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface CreateSavingsPlanRequest {

--- a/clients/client-schemas/models/models_0.ts
+++ b/clients/client-schemas/models/models_0.ts
@@ -1,8 +1,4 @@
-import {
-  SENSITIVE_STRING,
-  LazyJsonString as __LazyJsonString,
-  SmithyException as __SmithyException,
-} from "@aws-sdk/smithy-client";
+import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum DiscovererState {

--- a/clients/client-securityhub/models/models_0.ts
+++ b/clients/client-securityhub/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AcceptInvitationRequest {

--- a/clients/client-securityhub/models/models_1.ts
+++ b/clients/client-securityhub/models/models_1.ts
@@ -7,7 +7,6 @@ import {
   RecordState,
   Result,
 } from "./models_0";
-import { SENSITIVE_STRING } from "@aws-sdk/smithy-client";
 
 export interface GetFindingsResponse {
   /**

--- a/clients/client-serverlessapplicationrepository/models/models_0.ts
+++ b/clients/client-serverlessapplicationrepository/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-service-catalog-appregistry/models/models_0.ts
+++ b/clients/client-service-catalog-appregistry/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-service-catalog/models/models_0.ts
+++ b/clients/client-service-catalog/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum PortfolioShareType {

--- a/clients/client-service-quotas/models/models_0.ts
+++ b/clients/client-service-quotas/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-servicediscovery/models/models_0.ts
+++ b/clients/client-servicediscovery/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-ses/models/models_0.ts
+++ b/clients/client-ses/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-shield/models/models_0.ts
+++ b/clients/client-shield/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-signer/models/models_0.ts
+++ b/clients/client-signer/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-sms/models/models_0.ts
+++ b/clients/client-sms/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum AppLaunchConfigurationStatus {

--- a/clients/client-snowball/models/models_0.ts
+++ b/clients/client-snowball/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-sns/models/models_0.ts
+++ b/clients/client-sns/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AddPermissionInput {

--- a/clients/client-sqs/models/models_0.ts
+++ b/clients/client-sqs/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-sso-oidc/models/models_0.ts
+++ b/clients/client-sso-oidc/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AccessDeniedException extends __SmithyException, $MetadataBearer {

--- a/clients/client-sts/models/models_0.ts
+++ b/clients/client-sts/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-support/models/models_0.ts
+++ b/clients/client-support/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-swf/models/models_0.ts
+++ b/clients/client-swf/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-synthetics/models/models_0.ts
+++ b/clients/client-synthetics/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-textract/models/models_0.ts
+++ b/clients/client-textract/models/models_0.ts
@@ -1,8 +1,4 @@
-import {
-  SENSITIVE_STRING,
-  LazyJsonString as __LazyJsonString,
-  SmithyException as __SmithyException,
-} from "@aws-sdk/smithy-client";
+import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-timestream-write/models/models_0.ts
+++ b/clients/client-timestream-write/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-transcribe-streaming/models/models_0.ts
+++ b/clients/client-transcribe-streaming/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum ItemType {

--- a/clients/client-transcribe/models/models_0.ts
+++ b/clients/client-transcribe/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-waf-regional/models/models_0.ts
+++ b/clients/client-waf-regional/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum WafActionType {

--- a/clients/client-waf/models/models_0.ts
+++ b/clients/client-waf/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export enum WafActionType {

--- a/clients/client-wafv2/models/models_0.ts
+++ b/clients/client-wafv2/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-worklink/models/models_0.ts
+++ b/clients/client-worklink/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface AssociateDomainRequest {

--- a/clients/client-workmailmessageflow/models/models_0.ts
+++ b/clients/client-workmailmessageflow/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 import { Readable } from "stream";
 

--- a/clients/client-workspaces/models/models_0.ts
+++ b/clients/client-workspaces/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/clients/client-xray/models/models_0.ts
+++ b/clients/client-xray/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 /**

--- a/protocol_tests/aws-ec2/models/models_0.ts
+++ b/protocol_tests/aws-ec2/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface EmptyInputAndEmptyOutputInput {}

--- a/protocol_tests/aws-json/models/models_0.ts
+++ b/protocol_tests/aws-json/models/models_0.ts
@@ -1,8 +1,4 @@
-import {
-  SENSITIVE_STRING,
-  LazyJsonString as __LazyJsonString,
-  SmithyException as __SmithyException,
-} from "@aws-sdk/smithy-client";
+import { LazyJsonString as __LazyJsonString, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface EmptyStruct {}

--- a/protocol_tests/aws-query/models/models_0.ts
+++ b/protocol_tests/aws-query/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export interface EmptyInputAndEmptyOutputInput {}

--- a/protocol_tests/aws-restjson/models/models_0.ts
+++ b/protocol_tests/aws-restjson/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export type FooEnum = "0" | "1" | "Bar" | "Baz" | "Foo";

--- a/protocol_tests/aws-restxml/models/models_0.ts
+++ b/protocol_tests/aws-restxml/models/models_0.ts
@@ -1,4 +1,4 @@
-import { SENSITIVE_STRING, SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
+import { SmithyException as __SmithyException } from "@aws-sdk/smithy-client";
 import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
 
 export type FooEnum = "0" | "1" | "Bar" | "Baz" | "Foo";


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/awslabs/smithy-typescript/pull/244

*Description of changes:*
import SENSITIVE_STRING only when used

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
