### PR TITLE
chore(url-parser-node): use WHATWG URL instead of url.parse

### DIFF
--- a/packages/credential-provider-imds/src/fromContainerMetadata.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.ts
@@ -1,6 +1,7 @@
 import { ProviderError } from "@aws-sdk/property-provider";
 import { CredentialProvider } from "@aws-sdk/types";
 import { RequestOptions } from "http";
+import { parse } from "url";
 
 import { httpRequest } from "./remoteProvider/httpRequest";
 import { fromImdsCredentials, isImdsCredentials } from "./remoteProvider/ImdsCredentials";
@@ -63,7 +64,7 @@ function getCmdsUri(): Promise<RequestOptions> {
   }
 
   if (process.env[ENV_CMDS_FULL_URI]) {
-    const parsed = new URL(process.env[ENV_CMDS_FULL_URI]!);
+    const parsed = parse(process.env[ENV_CMDS_FULL_URI]!);
     if (!parsed.hostname || !(parsed.hostname in GREENGRASS_HOSTS)) {
       return Promise.reject(
         new ProviderError(`${parsed.hostname} is not a valid container metadata service hostname`, false)

--- a/packages/credential-provider-imds/src/fromContainerMetadata.ts
+++ b/packages/credential-provider-imds/src/fromContainerMetadata.ts
@@ -1,7 +1,6 @@
 import { ProviderError } from "@aws-sdk/property-provider";
 import { CredentialProvider } from "@aws-sdk/types";
 import { RequestOptions } from "http";
-import { parse } from "url";
 
 import { httpRequest } from "./remoteProvider/httpRequest";
 import { fromImdsCredentials, isImdsCredentials } from "./remoteProvider/ImdsCredentials";
@@ -64,7 +63,7 @@ function getCmdsUri(): Promise<RequestOptions> {
   }
 
   if (process.env[ENV_CMDS_FULL_URI]) {
-    const parsed = parse(process.env[ENV_CMDS_FULL_URI]!);
+    const parsed = new URL(process.env[ENV_CMDS_FULL_URI]!);
     if (!parsed.hostname || !(parsed.hostname in GREENGRASS_HOSTS)) {
       return Promise.reject(
         new ProviderError(`${parsed.hostname} is not a valid container metadata service hostname`, false)

--- a/packages/url-parser-node/src/index.spec.ts
+++ b/packages/url-parser-node/src/index.spec.ts
@@ -3,43 +3,61 @@ import { Endpoint } from "@aws-sdk/types";
 import { parseUrl } from "./";
 
 describe("parseUrl", () => {
-  const testCases = new Map<string, Endpoint>([
-    [
-      "https://www.example.com/path/to%20the/file.ext?snap=cr%C3%A4ckle&snap=p%C3%B4p&fizz=buzz&quux",
-      {
-        protocol: "https:",
-        hostname: "www.example.com",
-        path: "/path/to%20the/file.ext",
-        query: {
-          snap: ["cräckle", "pôp"],
-          fizz: "buzz",
-          quux: null,
+  describe("should correctly parse string", () => {
+    const successCases: [string, Endpoint][] = [
+      [
+        "https://www.example.com/path/to%20the/file.ext?snap=cr%C3%A4ckle&snap=p%C3%B4p&fizz=buzz&quux",
+        {
+          protocol: "https:",
+          hostname: "www.example.com",
+          path: "/path/to%20the/file.ext",
+          query: {
+            snap: ["cräckle", "pôp"],
+            fizz: "buzz",
+            quux: null,
+          },
         },
-      },
-    ],
-    [
-      "http://example.com:54321",
-      {
-        protocol: "http:",
-        hostname: "example.com",
-        port: 54321,
-        path: "/",
-      },
-    ],
-    [
-      "https://example.com?foo=bar",
-      {
-        protocol: "https:",
-        hostname: "example.com",
-        path: "/",
-        query: { foo: "bar" },
-      },
-    ],
-  ]);
+      ],
+      [
+        "http://example.com:54321",
+        {
+          protocol: "http:",
+          hostname: "example.com",
+          port: 54321,
+          path: "/",
+        },
+      ],
+      [
+        "https://example.com?foo=bar",
+        {
+          protocol: "https:",
+          hostname: "example.com",
+          path: "/",
+          query: { foo: "bar" },
+        },
+      ],
+    ];
 
-  for (const [url, parsed] of testCases) {
-    it(`should correctly parse ${url}`, () => {
-      expect(parseUrl(url)).toEqual(parsed);
+    successCases.forEach(([url, parsed]) => {
+      it(url, () => {
+        expect(parseUrl(url)).toEqual(parsed);
+      });
     });
-  }
+  });
+
+  describe("should throw error", () => {
+    const failureCases: [string, Error][] = [
+      ["example.com", new TypeError("Invalid URL: example.com")],
+      ["endpoint", new TypeError("Invalid URL: endpoint")],
+    ];
+
+    failureCases.forEach(([url, error]) => {
+      it(url, () => {
+        expect(() => {
+          const output = parseUrl(url);
+          console.log(output);
+        }).toThrow(error);
+      });
+    });
+  });
 });

--- a/packages/url-parser-node/src/index.ts
+++ b/packages/url-parser-node/src/index.ts
@@ -1,9 +1,8 @@
 import { parseQueryString } from "@aws-sdk/querystring-parser";
 import { Endpoint, QueryParameterBag, UrlParser } from "@aws-sdk/types";
-import { parse } from "url";
 
 export const parseUrl: UrlParser = (url: string): Endpoint => {
-  const { hostname = "localhost", pathname = "/", port, protocol = "https:", search } = parse(url);
+  const { hostname = "localhost", pathname = "/", port, protocol = "https:", search } = new URL(url);
 
   let query: QueryParameterBag | undefined;
   if (search) {


### PR DESCRIPTION
*Issue #, if available:*
Resolves: https://github.com/aws/aws-sdk-js-v3/issues/999

*Description of changes:*
use WHATWG URL instead of url.parse
* url.parse has been deprecated and it recommends using the WHATWG URL API https://nodejs.org/api/url.html#url_url_parse_urlstring_parsequerystring_slashesdenotehost
* WHATWG URL has been available on Global Object since v10.0.0 https://nodejs.org/api/url.html#url_the_whatwg_url_api

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
