### PR TITLE
feat(credential-provider-node): use credential_process from profile

### DIFF
--- a/packages/credential-provider-node/src/index.spec.ts
+++ b/packages/credential-provider-node/src/index.spec.ts
@@ -395,5 +395,26 @@ describe("defaultProvider", () => {
       expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
       expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
     });
+
+    it("should consult the process provider if no credentials are found in the ini provider", async () => {
+      const creds = {
+        accessKeyId: "foo",
+        secretAccessKey: "bar",
+      };
+
+      (fromEnv() as any).mockImplementation(() => Promise.reject(new Error("PANIC")));
+      (fromIni() as any).mockImplementation(() => Promise.reject(new ProviderError("Nothing here!")));
+      (fromProcess() as any).mockImplementation(() => Promise.resolve(creds));
+      (fromInstanceMetadata() as any).mockImplementation(() => Promise.reject(new Error("PANIC")));
+      (fromContainerMetadata() as any).mockImplementation(() => Promise.reject(new Error("PANIC")));
+
+      process.env[ENV_PROFILE] = "foo";
+      expect(await defaultProvider()()).toEqual(creds);
+      expect((fromEnv() as any).mock.calls.length).toBe(0);
+      expect((fromIni() as any).mock.calls.length).toBe(1);
+      expect((fromProcess() as any).mock.calls.length).toBe(1);
+      expect((fromContainerMetadata() as any).mock.calls.length).toBe(0);
+      expect((fromInstanceMetadata() as any).mock.calls.length).toBe(0);
+    });
   });
 });

--- a/packages/credential-provider-node/src/index.ts
+++ b/packages/credential-provider-node/src/index.ts
@@ -44,7 +44,7 @@ export const ENV_IMDS_DISABLED = "AWS_EC2_METADATA_DISABLED";
 export function defaultProvider(init: FromIniInit & RemoteProviderInit & FromProcessInit = {}): CredentialProvider {
   const { profile = process.env[ENV_PROFILE] } = init;
   const providerChain = profile
-    ? fromIni(init)
+    ? chain(fromIni(init), fromProcess(init))
     : chain(fromEnv(), fromIni(init), fromProcess(init), remoteProvider(init));
 
   return memoize(


### PR DESCRIPTION
fixes #1772

*Issue #, if available:*
#1772

*Description of changes:* 
Consider credential_process defined in profile passed in AWS_PROFILE

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
