### PR TITLE
fix(signature-v4): add secrets to signing key cache key

### DIFF
--- a/packages/signature-v4/src/credentialDerivation.spec.ts
+++ b/packages/signature-v4/src/credentialDerivation.spec.ts
@@ -46,27 +46,27 @@ describe("getSigningKey", () => {
   });
 
   describe("caching", () => {
-    it("should return the same promise when called with the same date, region, service, and credentials", () => {
-      const promise1 = getSigningKey(Sha256, credentials, shortDate, region, service);
-      const promise2 = getSigningKey(Sha256, credentials, shortDate, region, service);
+    it("should return the same promise when called with the same date, region, service, and credentials", async () => {
+      const promise1 = await getSigningKey(Sha256, credentials, shortDate, region, service);
+      const promise2 = await getSigningKey(Sha256, credentials, shortDate, region, service);
       expect(promise1).toBe(promise2);
     });
 
-    it("should cache a maximum of 50 entries", () => {
-      const keyPromises: Array<Promise<Uint8Array>> = new Array(50);
+    it("should cache a maximum of 50 entries", async () => {
+      const keys: Array<Uint8Array> = new Array(50);
       // fill the cache
       for (let i = 0; i < 50; i++) {
-        keyPromises[i] = getSigningKey(Sha256, credentials, shortDate, `us-foo-${i.toString(10)}`, service);
+        keys[i] = await getSigningKey(Sha256, credentials, shortDate, `us-foo-${i.toString(10)}`, service);
       }
 
       // evict the oldest member from the cache
-      getSigningKey(Sha256, credentials, shortDate, `us-foo-50`, service);
+      await getSigningKey(Sha256, credentials, shortDate, `us-foo-50`, service);
 
       // the second oldest member should still be in cache
-      expect(keyPromises[1]).toBe(getSigningKey(Sha256, credentials, shortDate, `us-foo-1`, service));
+      expect(keys[1]).toBe(await getSigningKey(Sha256, credentials, shortDate, `us-foo-1`, service));
 
       // the oldest member should not be in the cache
-      expect(keyPromises[0]).not.toBe(getSigningKey(Sha256, credentials, shortDate, `us-foo-0`, service));
+      expect(keys[0]).not.toBe(await getSigningKey(Sha256, credentials, shortDate, `us-foo-0`, service));
     });
   });
 });

--- a/packages/signature-v4/src/credentialDerivation.spec.ts
+++ b/packages/signature-v4/src/credentialDerivation.spec.ts
@@ -46,10 +46,14 @@ describe("getSigningKey", () => {
   });
 
   describe("caching", () => {
-    it("should return the same promise when called with the same date, region, service, and credentials", async () => {
-      const promise1 = await getSigningKey(Sha256, credentials, shortDate, region, service);
-      const promise2 = await getSigningKey(Sha256, credentials, shortDate, region, service);
-      expect(promise1).toBe(promise2);
+    it("should return the same signing key when called with the same date, region, service, and credentials", async () => {
+      const mockSha256Constructor = jest.fn().mockImplementation((args) => {
+        return new Sha256(args);
+      });
+      const key1 = await getSigningKey(mockSha256Constructor, credentials, shortDate, region, service);
+      const key2 = await getSigningKey(mockSha256Constructor, credentials, shortDate, region, service);
+      expect(key1).toBe(key2);
+      expect(mockSha256Constructor).toHaveBeenCalledTimes(6);
     });
 
     it("should cache a maximum of 50 entries", async () => {
@@ -63,10 +67,10 @@ describe("getSigningKey", () => {
       await getSigningKey(Sha256, credentials, shortDate, `us-foo-50`, service);
 
       // the second oldest member should still be in cache
-      expect(keys[1]).toBe(await getSigningKey(Sha256, credentials, shortDate, `us-foo-1`, service));
+      await expect(getSigningKey(Sha256, credentials, shortDate, `us-foo-1`, service)).resolves.toStrictEqual(keys[1]);
 
       // the oldest member should not be in the cache
-      expect(keys[0]).not.toBe(await getSigningKey(Sha256, credentials, shortDate, `us-foo-0`, service));
+      await expect(getSigningKey(Sha256, credentials, shortDate, `us-foo-0`, service)).resolves.not.toBe(keys[0]);
     });
   });
 });


### PR DESCRIPTION
Fixes #1002 

*Description of changes:*
This change fix the issue that signing key is not refreshed between requests with only different secret access keys. I added a hash of both access key id and secrete access key as the cache key is signing keys. 

However, previously we cached pending promise of signing keys, but now we only cache the resolved promise of signing keys. So it's safer but may have wild performance implication. We can optimize this after we have benchmark metrics of this module.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
