### PR TITLE
fix(clients): populate sdkId in serviceId and default to use arnNamespace as signingName

### DIFF
--- a/clients/client-accessanalyzer/endpoints.ts
+++ b/clients/client-accessanalyzer/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "access-analyzer", ...regionInfo });
 };

--- a/clients/client-accessanalyzer/runtimeConfig.shared.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "access-analyzer",
+  serviceId: "AccessAnalyzer",
 };

--- a/clients/client-acm-pca/endpoints.ts
+++ b/clients/client-acm-pca/endpoints.ts
@@ -197,5 +197,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "acm-pca", ...regionInfo });
 };

--- a/clients/client-acm-pca/runtimeConfig.shared.ts
+++ b/clients/client-acm-pca/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "acm-pca",
+  serviceId: "ACM PCA",
 };

--- a/clients/client-acm/endpoints.ts
+++ b/clients/client-acm/endpoints.ts
@@ -197,5 +197,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "acm", ...regionInfo });
 };

--- a/clients/client-acm/runtimeConfig.shared.ts
+++ b/clients/client-acm/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "acm",
+  serviceId: "ACM",
 };

--- a/clients/client-alexa-for-business/endpoints.ts
+++ b/clients/client-alexa-for-business/endpoints.ts
@@ -83,5 +83,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "a4b", ...regionInfo });
 };

--- a/clients/client-alexa-for-business/runtimeConfig.shared.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "a4b",
+  serviceId: "Alexa For Business",
 };

--- a/clients/client-amplify/endpoints.ts
+++ b/clients/client-amplify/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "amplify", ...regionInfo });
 };

--- a/clients/client-amplify/runtimeConfig.shared.ts
+++ b/clients/client-amplify/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "amplify",
+  serviceId: "Amplify",
 };

--- a/clients/client-amplifybackend/endpoints.ts
+++ b/clients/client-amplifybackend/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "amplifybackend", ...regionInfo });
 };

--- a/clients/client-amplifybackend/runtimeConfig.shared.ts
+++ b/clients/client-amplifybackend/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "amplifybackend",
+  serviceId: "AmplifyBackend",
 };

--- a/clients/client-api-gateway/endpoints.ts
+++ b/clients/client-api-gateway/endpoints.ts
@@ -215,5 +215,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "apigateway", ...regionInfo });
 };

--- a/clients/client-api-gateway/runtimeConfig.shared.ts
+++ b/clients/client-api-gateway/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "apigateway",
+  serviceId: "API Gateway",
 };

--- a/clients/client-apigatewaymanagementapi/endpoints.ts
+++ b/clients/client-apigatewaymanagementapi/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "apigateway", ...regionInfo });
 };

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.shared.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "apigateway",
+  serviceId: "ApiGatewayManagementApi",
 };

--- a/clients/client-apigatewayv2/endpoints.ts
+++ b/clients/client-apigatewayv2/endpoints.ts
@@ -215,5 +215,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "apigateway", ...regionInfo });
 };

--- a/clients/client-apigatewayv2/runtimeConfig.shared.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "apigateway",
+  serviceId: "ApiGatewayV2",
 };

--- a/clients/client-app-mesh/endpoints.ts
+++ b/clients/client-app-mesh/endpoints.ts
@@ -161,5 +161,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "appmesh", ...regionInfo });
 };

--- a/clients/client-app-mesh/runtimeConfig.shared.ts
+++ b/clients/client-app-mesh/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "appmesh",
+  serviceId: "App Mesh",
 };

--- a/clients/client-appconfig/endpoints.ts
+++ b/clients/client-appconfig/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "appconfig", ...regionInfo });
 };

--- a/clients/client-appconfig/runtimeConfig.shared.ts
+++ b/clients/client-appconfig/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "appconfig",
+  serviceId: "AppConfig",
 };

--- a/clients/client-appflow/endpoints.ts
+++ b/clients/client-appflow/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "appflow", ...regionInfo });
 };

--- a/clients/client-appflow/runtimeConfig.shared.ts
+++ b/clients/client-appflow/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "appflow",
+  serviceId: "Appflow",
 };

--- a/clients/client-appintegrations/endpoints.ts
+++ b/clients/client-appintegrations/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "app-integrations", ...regionInfo });
 };

--- a/clients/client-appintegrations/runtimeConfig.shared.ts
+++ b/clients/client-appintegrations/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "app-integrations",
+  serviceId: "AppIntegrations",
 };

--- a/clients/client-application-auto-scaling/endpoints.ts
+++ b/clients/client-application-auto-scaling/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "application-autoscaling", ...regionInfo });
 };

--- a/clients/client-application-auto-scaling/runtimeConfig.shared.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "application-autoscaling",
+  serviceId: "Application Auto Scaling",
 };

--- a/clients/client-application-discovery-service/endpoints.ts
+++ b/clients/client-application-discovery-service/endpoints.ts
@@ -89,5 +89,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "discovery", ...regionInfo });
 };

--- a/clients/client-application-discovery-service/runtimeConfig.shared.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "discovery",
+  serviceId: "Application Discovery Service",
 };

--- a/clients/client-application-insights/endpoints.ts
+++ b/clients/client-application-insights/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "applicationinsights", ...regionInfo });
 };

--- a/clients/client-application-insights/runtimeConfig.shared.ts
+++ b/clients/client-application-insights/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "applicationinsights",
+  serviceId: "Application Insights",
 };

--- a/clients/client-appstream/endpoints.ts
+++ b/clients/client-appstream/endpoints.ts
@@ -150,5 +150,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "appstream", ...regionInfo });
 };

--- a/clients/client-appstream/runtimeConfig.shared.ts
+++ b/clients/client-appstream/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "appstream",
+  serviceId: "AppStream",
 };

--- a/clients/client-appsync/endpoints.ts
+++ b/clients/client-appsync/endpoints.ts
@@ -143,5 +143,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "appsync", ...regionInfo });
 };

--- a/clients/client-appsync/runtimeConfig.shared.ts
+++ b/clients/client-appsync/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "appsync",
+  serviceId: "AppSync",
 };

--- a/clients/client-athena/endpoints.ts
+++ b/clients/client-athena/endpoints.ts
@@ -191,5 +191,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "athena", ...regionInfo });
 };

--- a/clients/client-athena/runtimeConfig.shared.ts
+++ b/clients/client-athena/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "athena",
+  serviceId: "Athena",
 };

--- a/clients/client-auditmanager/endpoints.ts
+++ b/clients/client-auditmanager/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "auditmanager", ...regionInfo });
 };

--- a/clients/client-auditmanager/runtimeConfig.shared.ts
+++ b/clients/client-auditmanager/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "auditmanager",
+  serviceId: "AuditManager",
 };

--- a/clients/client-auto-scaling-plans/endpoints.ts
+++ b/clients/client-auto-scaling-plans/endpoints.ts
@@ -155,5 +155,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "autoscaling-plans", ...regionInfo });
 };

--- a/clients/client-auto-scaling-plans/runtimeConfig.shared.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "autoscaling-plans",
+  serviceId: "Auto Scaling Plans",
 };

--- a/clients/client-auto-scaling/endpoints.ts
+++ b/clients/client-auto-scaling/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "autoscaling", ...regionInfo });
 };

--- a/clients/client-auto-scaling/runtimeConfig.shared.ts
+++ b/clients/client-auto-scaling/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "autoscaling",
+  serviceId: "Auto Scaling",
 };

--- a/clients/client-backup/endpoints.ts
+++ b/clients/client-backup/endpoints.ts
@@ -185,5 +185,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "backup", ...regionInfo });
 };

--- a/clients/client-backup/runtimeConfig.shared.ts
+++ b/clients/client-backup/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "backup",
+  serviceId: "Backup",
 };

--- a/clients/client-batch/endpoints.ts
+++ b/clients/client-batch/endpoints.ts
@@ -197,5 +197,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "batch", ...regionInfo });
 };

--- a/clients/client-batch/runtimeConfig.shared.ts
+++ b/clients/client-batch/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "batch",
+  serviceId: "Batch",
 };

--- a/clients/client-braket/endpoints.ts
+++ b/clients/client-braket/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "braket", ...regionInfo });
 };

--- a/clients/client-braket/runtimeConfig.shared.ts
+++ b/clients/client-braket/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "braket",
+  serviceId: "Braket",
 };

--- a/clients/client-budgets/endpoints.ts
+++ b/clients/client-budgets/endpoints.ts
@@ -78,5 +78,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         return defaultRegionInfoProvider("aws-global");
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "budgets", ...regionInfo });
 };

--- a/clients/client-budgets/runtimeConfig.shared.ts
+++ b/clients/client-budgets/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "budgets",
+  serviceId: "Budgets",
 };

--- a/clients/client-chime/endpoints.ts
+++ b/clients/client-chime/endpoints.ts
@@ -78,5 +78,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         return defaultRegionInfoProvider("aws-global");
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "chime", ...regionInfo });
 };

--- a/clients/client-chime/runtimeConfig.shared.ts
+++ b/clients/client-chime/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "chime",
+  serviceId: "Chime",
 };

--- a/clients/client-cloud9/endpoints.ts
+++ b/clients/client-cloud9/endpoints.ts
@@ -119,5 +119,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cloud9", ...regionInfo });
 };

--- a/clients/client-cloud9/runtimeConfig.shared.ts
+++ b/clients/client-cloud9/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cloud9",
+  serviceId: "Cloud9",
 };

--- a/clients/client-clouddirectory/endpoints.ts
+++ b/clients/client-clouddirectory/endpoints.ts
@@ -137,5 +137,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "clouddirectory", ...regionInfo });
 };

--- a/clients/client-clouddirectory/runtimeConfig.shared.ts
+++ b/clients/client-clouddirectory/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "clouddirectory",
+  serviceId: "CloudDirectory",
 };

--- a/clients/client-cloudformation/endpoints.ts
+++ b/clients/client-cloudformation/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cloudformation", ...regionInfo });
 };

--- a/clients/client-cloudformation/runtimeConfig.shared.ts
+++ b/clients/client-cloudformation/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cloudformation",
+  serviceId: "CloudFormation",
 };

--- a/clients/client-cloudfront/endpoints.ts
+++ b/clients/client-cloudfront/endpoints.ts
@@ -82,5 +82,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         return defaultRegionInfoProvider("aws-global");
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cloudfront", ...regionInfo });
 };

--- a/clients/client-cloudfront/runtimeConfig.shared.ts
+++ b/clients/client-cloudfront/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cloudfront",
+  serviceId: "CloudFront",
 };

--- a/clients/client-cloudhsm-v2/endpoints.ts
+++ b/clients/client-cloudhsm-v2/endpoints.ts
@@ -220,5 +220,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cloudhsm", ...regionInfo });
 };

--- a/clients/client-cloudhsm-v2/runtimeConfig.shared.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cloudhsm",
+  serviceId: "CloudHSM V2",
 };

--- a/clients/client-cloudhsm/endpoints.ts
+++ b/clients/client-cloudhsm/endpoints.ts
@@ -143,5 +143,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cloudhsm", ...regionInfo });
 };

--- a/clients/client-cloudhsm/runtimeConfig.shared.ts
+++ b/clients/client-cloudhsm/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cloudhsm",
+  serviceId: "CloudHSM",
 };

--- a/clients/client-cloudsearch-domain/endpoints.ts
+++ b/clients/client-cloudsearch-domain/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cloudsearch", ...regionInfo });
 };

--- a/clients/client-cloudsearch-domain/runtimeConfig.shared.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cloudsearch",
+  serviceId: "CloudSearch Domain",
 };

--- a/clients/client-cloudsearch/endpoints.ts
+++ b/clients/client-cloudsearch/endpoints.ts
@@ -137,5 +137,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cloudsearch", ...regionInfo });
 };

--- a/clients/client-cloudsearch/runtimeConfig.shared.ts
+++ b/clients/client-cloudsearch/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cloudsearch",
+  serviceId: "CloudSearch",
 };

--- a/clients/client-cloudtrail/endpoints.ts
+++ b/clients/client-cloudtrail/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cloudtrail", ...regionInfo });
 };

--- a/clients/client-cloudtrail/runtimeConfig.shared.ts
+++ b/clients/client-cloudtrail/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cloudtrail",
+  serviceId: "CloudTrail",
 };

--- a/clients/client-cloudwatch-events/endpoints.ts
+++ b/clients/client-cloudwatch-events/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "events", ...regionInfo });
 };

--- a/clients/client-cloudwatch-events/runtimeConfig.shared.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "events",
+  serviceId: "CloudWatch Events",
 };

--- a/clients/client-cloudwatch-logs/endpoints.ts
+++ b/clients/client-cloudwatch-logs/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "logs", ...regionInfo });
 };

--- a/clients/client-cloudwatch-logs/runtimeConfig.shared.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "logs",
+  serviceId: "CloudWatch Logs",
 };

--- a/clients/client-cloudwatch/endpoints.ts
+++ b/clients/client-cloudwatch/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "monitoring", ...regionInfo });
 };

--- a/clients/client-cloudwatch/runtimeConfig.shared.ts
+++ b/clients/client-cloudwatch/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "monitoring",
+  serviceId: "CloudWatch",
 };

--- a/clients/client-codeartifact/endpoints.ts
+++ b/clients/client-codeartifact/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "codeartifact", ...regionInfo });
 };

--- a/clients/client-codebuild/endpoints.ts
+++ b/clients/client-codebuild/endpoints.ts
@@ -237,5 +237,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "codebuild", ...regionInfo });
 };

--- a/clients/client-codebuild/runtimeConfig.shared.ts
+++ b/clients/client-codebuild/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "codebuild",
+  serviceId: "CodeBuild",
 };

--- a/clients/client-codecommit/endpoints.ts
+++ b/clients/client-codecommit/endpoints.ts
@@ -198,5 +198,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "codecommit", ...regionInfo });
 };

--- a/clients/client-codecommit/runtimeConfig.shared.ts
+++ b/clients/client-codecommit/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "codecommit",
+  serviceId: "CodeCommit",
 };

--- a/clients/client-codedeploy/endpoints.ts
+++ b/clients/client-codedeploy/endpoints.ts
@@ -257,5 +257,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "codedeploy", ...regionInfo });
 };

--- a/clients/client-codedeploy/runtimeConfig.shared.ts
+++ b/clients/client-codedeploy/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "codedeploy",
+  serviceId: "CodeDeploy",
 };

--- a/clients/client-codeguru-reviewer/endpoints.ts
+++ b/clients/client-codeguru-reviewer/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "codeguru-reviewer", ...regionInfo });
 };

--- a/clients/client-codeguru-reviewer/runtimeConfig.shared.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "codeguru-reviewer",
+  serviceId: "CodeGuru Reviewer",
 };

--- a/clients/client-codeguruprofiler/endpoints.ts
+++ b/clients/client-codeguruprofiler/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "codeguru-profiler", ...regionInfo });
 };

--- a/clients/client-codeguruprofiler/runtimeConfig.shared.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "codeguru-profiler",
+  serviceId: "CodeGuruProfiler",
 };

--- a/clients/client-codepipeline/endpoints.ts
+++ b/clients/client-codepipeline/endpoints.ts
@@ -173,5 +173,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "codepipeline", ...regionInfo });
 };

--- a/clients/client-codepipeline/runtimeConfig.shared.ts
+++ b/clients/client-codepipeline/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "codepipeline",
+  serviceId: "CodePipeline",
 };

--- a/clients/client-codestar-connections/endpoints.ts
+++ b/clients/client-codestar-connections/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "codestar-connections", ...regionInfo });
 };

--- a/clients/client-codestar-connections/runtimeConfig.shared.ts
+++ b/clients/client-codestar-connections/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "codestar-connections",
+  serviceId: "CodeStar connections",
 };

--- a/clients/client-codestar-notifications/endpoints.ts
+++ b/clients/client-codestar-notifications/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "codestar-notifications", ...regionInfo });
 };

--- a/clients/client-codestar-notifications/runtimeConfig.shared.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "codestar-notifications",
+  serviceId: "codestar notifications",
 };

--- a/clients/client-codestar/endpoints.ts
+++ b/clients/client-codestar/endpoints.ts
@@ -149,5 +149,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "codestar", ...regionInfo });
 };

--- a/clients/client-codestar/runtimeConfig.shared.ts
+++ b/clients/client-codestar/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "codestar",
+  serviceId: "CodeStar",
 };

--- a/clients/client-cognito-identity-provider/endpoints.ts
+++ b/clients/client-cognito-identity-provider/endpoints.ts
@@ -149,5 +149,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cognito-idp", ...regionInfo });
 };

--- a/clients/client-cognito-identity-provider/runtimeConfig.shared.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cognito-idp",
+  serviceId: "Cognito Identity Provider",
 };

--- a/clients/client-cognito-identity/endpoints.ts
+++ b/clients/client-cognito-identity/endpoints.ts
@@ -155,5 +155,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cognito-identity", ...regionInfo });
 };

--- a/clients/client-cognito-identity/runtimeConfig.shared.ts
+++ b/clients/client-cognito-identity/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cognito-identity",
+  serviceId: "Cognito Identity",
 };

--- a/clients/client-cognito-sync/endpoints.ts
+++ b/clients/client-cognito-sync/endpoints.ts
@@ -143,5 +143,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cognito-sync", ...regionInfo });
 };

--- a/clients/client-cognito-sync/runtimeConfig.shared.ts
+++ b/clients/client-cognito-sync/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cognito-sync",
+  serviceId: "Cognito Sync",
 };

--- a/clients/client-comprehend/endpoints.ts
+++ b/clients/client-comprehend/endpoints.ts
@@ -137,5 +137,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "comprehend", ...regionInfo });
 };

--- a/clients/client-comprehend/runtimeConfig.shared.ts
+++ b/clients/client-comprehend/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "comprehend",
+  serviceId: "Comprehend",
 };

--- a/clients/client-comprehendmedical/endpoints.ts
+++ b/clients/client-comprehendmedical/endpoints.ts
@@ -119,5 +119,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "comprehendmedical", ...regionInfo });
 };

--- a/clients/client-comprehendmedical/runtimeConfig.shared.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "comprehendmedical",
+  serviceId: "ComprehendMedical",
 };

--- a/clients/client-compute-optimizer/endpoints.ts
+++ b/clients/client-compute-optimizer/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "compute-optimizer", ...regionInfo });
 };

--- a/clients/client-compute-optimizer/runtimeConfig.shared.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "compute-optimizer",
+  serviceId: "Compute Optimizer",
 };

--- a/clients/client-config-service/endpoints.ts
+++ b/clients/client-config-service/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "config", ...regionInfo });
 };

--- a/clients/client-config-service/runtimeConfig.shared.ts
+++ b/clients/client-config-service/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "config",
+  serviceId: "Config Service",
 };

--- a/clients/client-connect-contact-lens/endpoints.ts
+++ b/clients/client-connect-contact-lens/endpoints.ts
@@ -107,5 +107,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "connect", ...regionInfo });
 };

--- a/clients/client-connect-contact-lens/runtimeConfig.shared.ts
+++ b/clients/client-connect-contact-lens/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "connect",
+  serviceId: "Connect Contact Lens",
 };

--- a/clients/client-connect/endpoints.ts
+++ b/clients/client-connect/endpoints.ts
@@ -107,5 +107,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "connect", ...regionInfo });
 };

--- a/clients/client-connect/runtimeConfig.shared.ts
+++ b/clients/client-connect/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "connect",
+  serviceId: "Connect",
 };

--- a/clients/client-connectparticipant/endpoints.ts
+++ b/clients/client-connectparticipant/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "connect", ...regionInfo });
 };

--- a/clients/client-connectparticipant/runtimeConfig.shared.ts
+++ b/clients/client-connectparticipant/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "connect",
+  serviceId: "ConnectParticipant",
 };

--- a/clients/client-cost-and-usage-report-service/endpoints.ts
+++ b/clients/client-cost-and-usage-report-service/endpoints.ts
@@ -83,5 +83,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "cur", ...regionInfo });
 };

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.shared.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "cur",
+  serviceId: "Cost and Usage Report Service",
 };

--- a/clients/client-cost-explorer/endpoints.ts
+++ b/clients/client-cost-explorer/endpoints.ts
@@ -78,5 +78,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         return defaultRegionInfoProvider("aws-global");
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ce", ...regionInfo });
 };

--- a/clients/client-cost-explorer/runtimeConfig.shared.ts
+++ b/clients/client-cost-explorer/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ce",
+  serviceId: "Cost Explorer",
 };

--- a/clients/client-customer-profiles/endpoints.ts
+++ b/clients/client-customer-profiles/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "profile", ...regionInfo });
 };

--- a/clients/client-customer-profiles/runtimeConfig.shared.ts
+++ b/clients/client-customer-profiles/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "profile",
+  serviceId: "Customer Profiles",
 };

--- a/clients/client-data-pipeline/endpoints.ts
+++ b/clients/client-data-pipeline/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "datapipeline", ...regionInfo });
 };

--- a/clients/client-data-pipeline/runtimeConfig.shared.ts
+++ b/clients/client-data-pipeline/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "datapipeline",
+  serviceId: "Data Pipeline",
 };

--- a/clients/client-database-migration-service/endpoints.ts
+++ b/clients/client-database-migration-service/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "dms", ...regionInfo });
 };

--- a/clients/client-database-migration-service/runtimeConfig.shared.ts
+++ b/clients/client-database-migration-service/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "dms",
+  serviceId: "Database Migration Service",
 };

--- a/clients/client-databrew/endpoints.ts
+++ b/clients/client-databrew/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "databrew", ...regionInfo });
 };

--- a/clients/client-databrew/runtimeConfig.shared.ts
+++ b/clients/client-databrew/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "databrew",
+  serviceId: "DataBrew",
 };

--- a/clients/client-dataexchange/endpoints.ts
+++ b/clients/client-dataexchange/endpoints.ts
@@ -143,5 +143,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "dataexchange", ...regionInfo });
 };

--- a/clients/client-dataexchange/runtimeConfig.shared.ts
+++ b/clients/client-dataexchange/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "dataexchange",
+  serviceId: "DataExchange",
 };

--- a/clients/client-datasync/endpoints.ts
+++ b/clients/client-datasync/endpoints.ts
@@ -232,5 +232,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "datasync", ...regionInfo });
 };

--- a/clients/client-datasync/runtimeConfig.shared.ts
+++ b/clients/client-datasync/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "datasync",
+  serviceId: "DataSync",
 };

--- a/clients/client-dax/endpoints.ts
+++ b/clients/client-dax/endpoints.ts
@@ -161,5 +161,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "dax", ...regionInfo });
 };

--- a/clients/client-dax/runtimeConfig.shared.ts
+++ b/clients/client-dax/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "dax",
+  serviceId: "DAX",
 };

--- a/clients/client-detective/endpoints.ts
+++ b/clients/client-detective/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "detective", ...regionInfo });
 };

--- a/clients/client-detective/runtimeConfig.shared.ts
+++ b/clients/client-detective/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "detective",
+  serviceId: "Detective",
 };

--- a/clients/client-device-farm/endpoints.ts
+++ b/clients/client-device-farm/endpoints.ts
@@ -83,5 +83,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "devicefarm", ...regionInfo });
 };

--- a/clients/client-device-farm/runtimeConfig.shared.ts
+++ b/clients/client-device-farm/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "devicefarm",
+  serviceId: "Device Farm",
 };

--- a/clients/client-devops-guru/endpoints.ts
+++ b/clients/client-devops-guru/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "devops-guru", ...regionInfo });
 };

--- a/clients/client-devops-guru/runtimeConfig.shared.ts
+++ b/clients/client-devops-guru/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "devops-guru",
+  serviceId: "DevOps Guru",
 };

--- a/clients/client-direct-connect/endpoints.ts
+++ b/clients/client-direct-connect/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "directconnect", ...regionInfo });
 };

--- a/clients/client-direct-connect/runtimeConfig.shared.ts
+++ b/clients/client-direct-connect/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "directconnect",
+  serviceId: "Direct Connect",
 };

--- a/clients/client-directory-service/endpoints.ts
+++ b/clients/client-directory-service/endpoints.ts
@@ -203,5 +203,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ds", ...regionInfo });
 };

--- a/clients/client-directory-service/runtimeConfig.shared.ts
+++ b/clients/client-directory-service/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ds",
+  serviceId: "Directory Service",
 };

--- a/clients/client-dlm/endpoints.ts
+++ b/clients/client-dlm/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "dlm", ...regionInfo });
 };

--- a/clients/client-dlm/runtimeConfig.shared.ts
+++ b/clients/client-dlm/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "dlm",
+  serviceId: "DLM",
 };

--- a/clients/client-docdb/endpoints.ts
+++ b/clients/client-docdb/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "rds", ...regionInfo });
 };

--- a/clients/client-docdb/runtimeConfig.shared.ts
+++ b/clients/client-docdb/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "rds",
+  serviceId: "DocDB",
 };

--- a/clients/client-dynamodb-streams/endpoints.ts
+++ b/clients/client-dynamodb-streams/endpoints.ts
@@ -300,5 +300,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "dynamodb", ...regionInfo });
 };

--- a/clients/client-dynamodb-streams/runtimeConfig.shared.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "dynamodb",
+  serviceId: "DynamoDB Streams",
 };

--- a/clients/client-dynamodb/endpoints.ts
+++ b/clients/client-dynamodb/endpoints.ts
@@ -277,5 +277,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "dynamodb", ...regionInfo });
 };

--- a/clients/client-dynamodb/runtimeConfig.shared.ts
+++ b/clients/client-dynamodb/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "dynamodb",
+  serviceId: "DynamoDB",
 };

--- a/clients/client-ebs/endpoints.ts
+++ b/clients/client-ebs/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ebs", ...regionInfo });
 };

--- a/clients/client-ebs/runtimeConfig.shared.ts
+++ b/clients/client-ebs/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ebs",
+  serviceId: "EBS",
 };

--- a/clients/client-ec2-instance-connect/endpoints.ts
+++ b/clients/client-ec2-instance-connect/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ec2-instance-connect", ...regionInfo });
 };

--- a/clients/client-ec2-instance-connect/runtimeConfig.shared.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ec2-instance-connect",
+  serviceId: "EC2 Instance Connect",
 };

--- a/clients/client-ec2/endpoints.ts
+++ b/clients/client-ec2/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ec2", ...regionInfo });
 };

--- a/clients/client-ec2/runtimeConfig.shared.ts
+++ b/clients/client-ec2/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ec2",
+  serviceId: "EC2",
 };

--- a/clients/client-ecr-public/endpoints.ts
+++ b/clients/client-ecr-public/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ecr-public", ...regionInfo });
 };

--- a/clients/client-ecr-public/runtimeConfig.shared.ts
+++ b/clients/client-ecr-public/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ecr-public",
+  serviceId: "ECR PUBLIC",
 };

--- a/clients/client-ecr/endpoints.ts
+++ b/clients/client-ecr/endpoints.ts
@@ -238,5 +238,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ecr", ...regionInfo });
 };

--- a/clients/client-ecr/runtimeConfig.shared.ts
+++ b/clients/client-ecr/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ecr",
+  serviceId: "ECR",
 };

--- a/clients/client-ecs/endpoints.ts
+++ b/clients/client-ecs/endpoints.ts
@@ -215,5 +215,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ecs", ...regionInfo });
 };

--- a/clients/client-ecs/runtimeConfig.shared.ts
+++ b/clients/client-ecs/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ecs",
+  serviceId: "ECS",
 };

--- a/clients/client-efs/endpoints.ts
+++ b/clients/client-efs/endpoints.ts
@@ -191,5 +191,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "elasticfilesystem", ...regionInfo });
 };

--- a/clients/client-efs/runtimeConfig.shared.ts
+++ b/clients/client-efs/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "elasticfilesystem",
+  serviceId: "EFS",
 };

--- a/clients/client-eks/endpoints.ts
+++ b/clients/client-eks/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "eks", ...regionInfo });
 };

--- a/clients/client-eks/runtimeConfig.shared.ts
+++ b/clients/client-eks/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "eks",
+  serviceId: "EKS",
 };

--- a/clients/client-elastic-beanstalk/endpoints.ts
+++ b/clients/client-elastic-beanstalk/endpoints.ts
@@ -209,5 +209,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "elasticbeanstalk", ...regionInfo });
 };

--- a/clients/client-elastic-beanstalk/runtimeConfig.shared.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "elasticbeanstalk",
+  serviceId: "Elastic Beanstalk",
 };

--- a/clients/client-elastic-inference/endpoints.ts
+++ b/clients/client-elastic-inference/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "elastic-inference", ...regionInfo });
 };

--- a/clients/client-elastic-inference/runtimeConfig.shared.ts
+++ b/clients/client-elastic-inference/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "elastic-inference",
+  serviceId: "Elastic Inference",
 };

--- a/clients/client-elastic-load-balancing-v2/endpoints.ts
+++ b/clients/client-elastic-load-balancing-v2/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "elasticloadbalancing", ...regionInfo });
 };

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.shared.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "elasticloadbalancing",
+  serviceId: "Elastic Load Balancing v2",
 };

--- a/clients/client-elastic-load-balancing/endpoints.ts
+++ b/clients/client-elastic-load-balancing/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "elasticloadbalancing", ...regionInfo });
 };

--- a/clients/client-elastic-load-balancing/runtimeConfig.shared.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "elasticloadbalancing",
+  serviceId: "Elastic Load Balancing",
 };

--- a/clients/client-elastic-transcoder/endpoints.ts
+++ b/clients/client-elastic-transcoder/endpoints.ts
@@ -125,5 +125,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "elastictranscoder", ...regionInfo });
 };

--- a/clients/client-elastic-transcoder/runtimeConfig.shared.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "elastictranscoder",
+  serviceId: "Elastic Transcoder",
 };

--- a/clients/client-elasticache/endpoints.ts
+++ b/clients/client-elasticache/endpoints.ts
@@ -228,5 +228,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "elasticache", ...regionInfo });
 };

--- a/clients/client-elasticache/runtimeConfig.shared.ts
+++ b/clients/client-elasticache/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "elasticache",
+  serviceId: "ElastiCache",
 };

--- a/clients/client-elasticsearch-service/endpoints.ts
+++ b/clients/client-elasticsearch-service/endpoints.ts
@@ -216,5 +216,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "es", ...regionInfo });
 };

--- a/clients/client-elasticsearch-service/runtimeConfig.shared.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "es",
+  serviceId: "Elasticsearch Service",
 };

--- a/clients/client-emr-containers/endpoints.ts
+++ b/clients/client-emr-containers/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "emr-containers", ...regionInfo });
 };

--- a/clients/client-emr-containers/runtimeConfig.shared.ts
+++ b/clients/client-emr-containers/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "emr-containers",
+  serviceId: "EMR containers",
 };

--- a/clients/client-emr/endpoints.ts
+++ b/clients/client-emr/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "elasticmapreduce", ...regionInfo });
 };

--- a/clients/client-emr/runtimeConfig.shared.ts
+++ b/clients/client-emr/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "elasticmapreduce",
+  serviceId: "EMR",
 };

--- a/clients/client-eventbridge/endpoints.ts
+++ b/clients/client-eventbridge/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "events", ...regionInfo });
 };

--- a/clients/client-eventbridge/runtimeConfig.shared.ts
+++ b/clients/client-eventbridge/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "events",
+  serviceId: "EventBridge",
 };

--- a/clients/client-firehose/endpoints.ts
+++ b/clients/client-firehose/endpoints.ts
@@ -209,5 +209,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "firehose", ...regionInfo });
 };

--- a/clients/client-firehose/runtimeConfig.shared.ts
+++ b/clients/client-firehose/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "firehose",
+  serviceId: "Firehose",
 };

--- a/clients/client-fms/endpoints.ts
+++ b/clients/client-fms/endpoints.ts
@@ -173,5 +173,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "fms", ...regionInfo });
 };

--- a/clients/client-fms/runtimeConfig.shared.ts
+++ b/clients/client-fms/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "fms",
+  serviceId: "FMS",
 };

--- a/clients/client-forecast/endpoints.ts
+++ b/clients/client-forecast/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "forecast", ...regionInfo });
 };

--- a/clients/client-forecastquery/endpoints.ts
+++ b/clients/client-forecastquery/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "forecast", ...regionInfo });
 };

--- a/clients/client-forecastquery/runtimeConfig.shared.ts
+++ b/clients/client-forecastquery/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "forecast",
+  serviceId: "forecastquery",
 };

--- a/clients/client-frauddetector/endpoints.ts
+++ b/clients/client-frauddetector/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "frauddetector", ...regionInfo });
 };

--- a/clients/client-frauddetector/runtimeConfig.shared.ts
+++ b/clients/client-frauddetector/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "frauddetector",
+  serviceId: "FraudDetector",
 };

--- a/clients/client-fsx/endpoints.ts
+++ b/clients/client-fsx/endpoints.ts
@@ -143,5 +143,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "fsx", ...regionInfo });
 };

--- a/clients/client-fsx/runtimeConfig.shared.ts
+++ b/clients/client-fsx/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "fsx",
+  serviceId: "FSx",
 };

--- a/clients/client-gamelift/endpoints.ts
+++ b/clients/client-gamelift/endpoints.ts
@@ -167,5 +167,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "gamelift", ...regionInfo });
 };

--- a/clients/client-gamelift/runtimeConfig.shared.ts
+++ b/clients/client-gamelift/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "gamelift",
+  serviceId: "GameLift",
 };

--- a/clients/client-glacier/endpoints.ts
+++ b/clients/client-glacier/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "glacier", ...regionInfo });
 };

--- a/clients/client-glacier/runtimeConfig.shared.ts
+++ b/clients/client-glacier/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "glacier",
+  serviceId: "Glacier",
 };

--- a/clients/client-global-accelerator/endpoints.ts
+++ b/clients/client-global-accelerator/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "globalaccelerator", ...regionInfo });
 };

--- a/clients/client-global-accelerator/runtimeConfig.shared.ts
+++ b/clients/client-global-accelerator/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "globalaccelerator",
+  serviceId: "Global Accelerator",
 };

--- a/clients/client-glue/endpoints.ts
+++ b/clients/client-glue/endpoints.ts
@@ -203,5 +203,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "glue", ...regionInfo });
 };

--- a/clients/client-glue/runtimeConfig.shared.ts
+++ b/clients/client-glue/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "glue",
+  serviceId: "Glue",
 };

--- a/clients/client-greengrass/endpoints.ts
+++ b/clients/client-greengrass/endpoints.ts
@@ -155,5 +155,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "greengrass", ...regionInfo });
 };

--- a/clients/client-greengrass/runtimeConfig.shared.ts
+++ b/clients/client-greengrass/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "greengrass",
+  serviceId: "Greengrass",
 };

--- a/clients/client-groundstation/endpoints.ts
+++ b/clients/client-groundstation/endpoints.ts
@@ -89,5 +89,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "groundstation", ...regionInfo });
 };

--- a/clients/client-groundstation/runtimeConfig.shared.ts
+++ b/clients/client-groundstation/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "groundstation",
+  serviceId: "GroundStation",
 };

--- a/clients/client-guardduty/endpoints.ts
+++ b/clients/client-guardduty/endpoints.ts
@@ -219,5 +219,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "guardduty", ...regionInfo });
 };

--- a/clients/client-guardduty/runtimeConfig.shared.ts
+++ b/clients/client-guardduty/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "guardduty",
+  serviceId: "GuardDuty",
 };

--- a/clients/client-health/endpoints.ts
+++ b/clients/client-health/endpoints.ts
@@ -101,5 +101,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "health", ...regionInfo });
 };

--- a/clients/client-health/runtimeConfig.shared.ts
+++ b/clients/client-health/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "health",
+  serviceId: "Health",
 };

--- a/clients/client-healthlake/endpoints.ts
+++ b/clients/client-healthlake/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "healthlake", ...regionInfo });
 };

--- a/clients/client-healthlake/runtimeConfig.shared.ts
+++ b/clients/client-healthlake/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "healthlake",
+  serviceId: "HealthLake",
 };

--- a/clients/client-honeycode/endpoints.ts
+++ b/clients/client-honeycode/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "honeycode", ...regionInfo });
 };

--- a/clients/client-honeycode/runtimeConfig.shared.ts
+++ b/clients/client-honeycode/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "honeycode",
+  serviceId: "Honeycode",
 };

--- a/clients/client-iam/endpoints.ts
+++ b/clients/client-iam/endpoints.ts
@@ -94,5 +94,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         return defaultRegionInfoProvider("aws-global");
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iam", ...regionInfo });
 };

--- a/clients/client-iam/runtimeConfig.shared.ts
+++ b/clients/client-iam/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iam",
+  serviceId: "IAM",
 };

--- a/clients/client-identitystore/endpoints.ts
+++ b/clients/client-identitystore/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "identitystore", ...regionInfo });
 };

--- a/clients/client-imagebuilder/endpoints.ts
+++ b/clients/client-imagebuilder/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "imagebuilder", ...regionInfo });
 };

--- a/clients/client-inspector/endpoints.ts
+++ b/clients/client-inspector/endpoints.ts
@@ -161,5 +161,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "inspector", ...regionInfo });
 };

--- a/clients/client-inspector/runtimeConfig.shared.ts
+++ b/clients/client-inspector/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "inspector",
+  serviceId: "Inspector",
 };

--- a/clients/client-iot-1click-devices-service/endpoints.ts
+++ b/clients/client-iot-1click-devices-service/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iot1click", ...regionInfo });
 };

--- a/clients/client-iot-1click-devices-service/runtimeConfig.shared.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iot1click",
+  serviceId: "IoT 1Click Devices Service",
 };

--- a/clients/client-iot-1click-projects/endpoints.ts
+++ b/clients/client-iot-1click-projects/endpoints.ts
@@ -119,5 +119,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iot1click", ...regionInfo });
 };

--- a/clients/client-iot-1click-projects/runtimeConfig.shared.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iot1click",
+  serviceId: "IoT 1Click Projects",
 };

--- a/clients/client-iot-data-plane/endpoints.ts
+++ b/clients/client-iot-data-plane/endpoints.ts
@@ -228,5 +228,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iotdata", ...regionInfo });
 };

--- a/clients/client-iot-data-plane/runtimeConfig.shared.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iotdata",
+  serviceId: "IoT Data Plane",
 };

--- a/clients/client-iot-events-data/endpoints.ts
+++ b/clients/client-iot-events-data/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ioteventsdata", ...regionInfo });
 };

--- a/clients/client-iot-events-data/runtimeConfig.shared.ts
+++ b/clients/client-iot-events-data/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ioteventsdata",
+  serviceId: "IoT Events Data",
 };

--- a/clients/client-iot-events/endpoints.ts
+++ b/clients/client-iot-events/endpoints.ts
@@ -137,5 +137,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iotevents", ...regionInfo });
 };

--- a/clients/client-iot-events/runtimeConfig.shared.ts
+++ b/clients/client-iot-events/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iotevents",
+  serviceId: "IoT Events",
 };

--- a/clients/client-iot-jobs-data-plane/endpoints.ts
+++ b/clients/client-iot-jobs-data-plane/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iot-jobs-data", ...regionInfo });
 };

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.shared.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iot-jobs-data",
+  serviceId: "IoT Jobs Data Plane",
 };

--- a/clients/client-iot/endpoints.ts
+++ b/clients/client-iot/endpoints.ts
@@ -228,5 +228,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iot", ...regionInfo });
 };

--- a/clients/client-iot/runtimeConfig.shared.ts
+++ b/clients/client-iot/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iot",
+  serviceId: "IoT",
 };

--- a/clients/client-iotanalytics/endpoints.ts
+++ b/clients/client-iotanalytics/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iotanalytics", ...regionInfo });
 };

--- a/clients/client-iotanalytics/runtimeConfig.shared.ts
+++ b/clients/client-iotanalytics/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iotanalytics",
+  serviceId: "IoTAnalytics",
 };

--- a/clients/client-iotsecuretunneling/endpoints.ts
+++ b/clients/client-iotsecuretunneling/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iotsecuredtunneling", ...regionInfo });
 };

--- a/clients/client-iotsecuretunneling/runtimeConfig.shared.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iotsecuredtunneling",
+  serviceId: "IoTSecureTunneling",
 };

--- a/clients/client-iotsitewise/endpoints.ts
+++ b/clients/client-iotsitewise/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iotsitewise", ...regionInfo });
 };

--- a/clients/client-iotsitewise/runtimeConfig.shared.ts
+++ b/clients/client-iotsitewise/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iotsitewise",
+  serviceId: "IoTSiteWise",
 };

--- a/clients/client-iotthingsgraph/endpoints.ts
+++ b/clients/client-iotthingsgraph/endpoints.ts
@@ -121,5 +121,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "iotthingsgraph", ...regionInfo });
 };

--- a/clients/client-iotthingsgraph/runtimeConfig.shared.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "iotthingsgraph",
+  serviceId: "IoTThingsGraph",
 };

--- a/clients/client-ivs/endpoints.ts
+++ b/clients/client-ivs/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ivs", ...regionInfo });
 };

--- a/clients/client-kafka/endpoints.ts
+++ b/clients/client-kafka/endpoints.ts
@@ -179,5 +179,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "kafka", ...regionInfo });
 };

--- a/clients/client-kafka/runtimeConfig.shared.ts
+++ b/clients/client-kafka/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "kafka",
+  serviceId: "Kafka",
 };

--- a/clients/client-kendra/endpoints.ts
+++ b/clients/client-kendra/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "kendra", ...regionInfo });
 };

--- a/clients/client-kinesis-analytics-v2/endpoints.ts
+++ b/clients/client-kinesis-analytics-v2/endpoints.ts
@@ -155,5 +155,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "kinesisanalytics", ...regionInfo });
 };

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "kinesisanalytics",
+  serviceId: "Kinesis Analytics V2",
 };

--- a/clients/client-kinesis-analytics/endpoints.ts
+++ b/clients/client-kinesis-analytics/endpoints.ts
@@ -155,5 +155,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "kinesisanalytics", ...regionInfo });
 };

--- a/clients/client-kinesis-analytics/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "kinesisanalytics",
+  serviceId: "Kinesis Analytics",
 };

--- a/clients/client-kinesis-video-archived-media/endpoints.ts
+++ b/clients/client-kinesis-video-archived-media/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "kinesisvideo", ...regionInfo });
 };

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "kinesisvideo",
+  serviceId: "Kinesis Video Archived Media",
 };

--- a/clients/client-kinesis-video-media/endpoints.ts
+++ b/clients/client-kinesis-video-media/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "kinesisvideo", ...regionInfo });
 };

--- a/clients/client-kinesis-video-media/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "kinesisvideo",
+  serviceId: "Kinesis Video Media",
 };

--- a/clients/client-kinesis-video-signaling/endpoints.ts
+++ b/clients/client-kinesis-video-signaling/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "kinesisvideo", ...regionInfo });
 };

--- a/clients/client-kinesis-video-signaling/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "kinesisvideo",
+  serviceId: "Kinesis Video Signaling",
 };

--- a/clients/client-kinesis-video/endpoints.ts
+++ b/clients/client-kinesis-video/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "kinesisvideo", ...regionInfo });
 };

--- a/clients/client-kinesis-video/runtimeConfig.shared.ts
+++ b/clients/client-kinesis-video/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "kinesisvideo",
+  serviceId: "Kinesis Video",
 };

--- a/clients/client-kinesis/endpoints.ts
+++ b/clients/client-kinesis/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "kinesis", ...regionInfo });
 };

--- a/clients/client-kinesis/runtimeConfig.shared.ts
+++ b/clients/client-kinesis/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "kinesis",
+  serviceId: "Kinesis",
 };

--- a/clients/client-kms/endpoints.ts
+++ b/clients/client-kms/endpoints.ts
@@ -228,5 +228,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "kms", ...regionInfo });
 };

--- a/clients/client-kms/runtimeConfig.shared.ts
+++ b/clients/client-kms/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "kms",
+  serviceId: "KMS",
 };

--- a/clients/client-lakeformation/endpoints.ts
+++ b/clients/client-lakeformation/endpoints.ts
@@ -155,5 +155,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "lakeformation", ...regionInfo });
 };

--- a/clients/client-lakeformation/runtimeConfig.shared.ts
+++ b/clients/client-lakeformation/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "lakeformation",
+  serviceId: "LakeFormation",
 };

--- a/clients/client-lambda/endpoints.ts
+++ b/clients/client-lambda/endpoints.ts
@@ -215,5 +215,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "lambda", ...regionInfo });
 };

--- a/clients/client-lambda/runtimeConfig.shared.ts
+++ b/clients/client-lambda/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "lambda",
+  serviceId: "Lambda",
 };

--- a/clients/client-lex-model-building-service/endpoints.ts
+++ b/clients/client-lex-model-building-service/endpoints.ts
@@ -100,5 +100,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "lex", ...regionInfo });
 };

--- a/clients/client-lex-model-building-service/runtimeConfig.shared.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "lex",
+  serviceId: "Lex Model Building Service",
 };

--- a/clients/client-lex-runtime-service/endpoints.ts
+++ b/clients/client-lex-runtime-service/endpoints.ts
@@ -100,5 +100,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "lex", ...regionInfo });
 };

--- a/clients/client-lex-runtime-service/runtimeConfig.shared.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "lex",
+  serviceId: "Lex Runtime Service",
 };

--- a/clients/client-license-manager/endpoints.ts
+++ b/clients/client-license-manager/endpoints.ts
@@ -209,5 +209,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "license-manager", ...regionInfo });
 };

--- a/clients/client-license-manager/runtimeConfig.shared.ts
+++ b/clients/client-license-manager/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "license-manager",
+  serviceId: "License Manager",
 };

--- a/clients/client-lightsail/endpoints.ts
+++ b/clients/client-lightsail/endpoints.ts
@@ -155,5 +155,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "lightsail", ...regionInfo });
 };

--- a/clients/client-lightsail/runtimeConfig.shared.ts
+++ b/clients/client-lightsail/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "lightsail",
+  serviceId: "Lightsail",
 };

--- a/clients/client-lookoutvision/endpoints.ts
+++ b/clients/client-lookoutvision/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "lookoutvision", ...regionInfo });
 };

--- a/clients/client-lookoutvision/runtimeConfig.shared.ts
+++ b/clients/client-lookoutvision/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "lookoutvision",
+  serviceId: "LookoutVision",
 };

--- a/clients/client-machine-learning/endpoints.ts
+++ b/clients/client-machine-learning/endpoints.ts
@@ -89,5 +89,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "machinelearning", ...regionInfo });
 };

--- a/clients/client-machine-learning/runtimeConfig.shared.ts
+++ b/clients/client-machine-learning/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "machinelearning",
+  serviceId: "Machine Learning",
 };

--- a/clients/client-macie/endpoints.ts
+++ b/clients/client-macie/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "macie", ...regionInfo });
 };

--- a/clients/client-macie/runtimeConfig.shared.ts
+++ b/clients/client-macie/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "macie",
+  serviceId: "Macie",
 };

--- a/clients/client-macie2/endpoints.ts
+++ b/clients/client-macie2/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "macie2", ...regionInfo });
 };

--- a/clients/client-macie2/runtimeConfig.shared.ts
+++ b/clients/client-macie2/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "macie2",
+  serviceId: "Macie2",
 };

--- a/clients/client-managedblockchain/endpoints.ts
+++ b/clients/client-managedblockchain/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "managedblockchain", ...regionInfo });
 };

--- a/clients/client-managedblockchain/runtimeConfig.shared.ts
+++ b/clients/client-managedblockchain/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "managedblockchain",
+  serviceId: "ManagedBlockchain",
 };

--- a/clients/client-marketplace-catalog/endpoints.ts
+++ b/clients/client-marketplace-catalog/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "aws-marketplace", ...regionInfo });
 };

--- a/clients/client-marketplace-catalog/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "aws-marketplace",
+  serviceId: "Marketplace Catalog",
 };

--- a/clients/client-marketplace-commerce-analytics/endpoints.ts
+++ b/clients/client-marketplace-commerce-analytics/endpoints.ts
@@ -83,5 +83,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "marketplacecommerceanalytics", ...regionInfo });
 };

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "marketplacecommerceanalytics",
+  serviceId: "Marketplace Commerce Analytics",
 };

--- a/clients/client-marketplace-entitlement-service/endpoints.ts
+++ b/clients/client-marketplace-entitlement-service/endpoints.ts
@@ -86,5 +86,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "aws-marketplace", ...regionInfo });
 };

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "aws-marketplace",
+  serviceId: "Marketplace Entitlement Service",
 };

--- a/clients/client-marketplace-metering/endpoints.ts
+++ b/clients/client-marketplace-metering/endpoints.ts
@@ -220,5 +220,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "aws-marketplace", ...regionInfo });
 };

--- a/clients/client-marketplace-metering/runtimeConfig.shared.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "aws-marketplace",
+  serviceId: "Marketplace Metering",
 };

--- a/clients/client-mediaconnect/endpoints.ts
+++ b/clients/client-mediaconnect/endpoints.ts
@@ -167,5 +167,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mediaconnect", ...regionInfo });
 };

--- a/clients/client-mediaconnect/runtimeConfig.shared.ts
+++ b/clients/client-mediaconnect/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mediaconnect",
+  serviceId: "MediaConnect",
 };

--- a/clients/client-mediaconvert/endpoints.ts
+++ b/clients/client-mediaconvert/endpoints.ts
@@ -180,5 +180,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mediaconvert", ...regionInfo });
 };

--- a/clients/client-mediaconvert/runtimeConfig.shared.ts
+++ b/clients/client-mediaconvert/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mediaconvert",
+  serviceId: "MediaConvert",
 };

--- a/clients/client-medialive/endpoints.ts
+++ b/clients/client-medialive/endpoints.ts
@@ -161,5 +161,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "medialive", ...regionInfo });
 };

--- a/clients/client-medialive/runtimeConfig.shared.ts
+++ b/clients/client-medialive/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "medialive",
+  serviceId: "MediaLive",
 };

--- a/clients/client-mediapackage-vod/endpoints.ts
+++ b/clients/client-mediapackage-vod/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mediapackage-vod", ...regionInfo });
 };

--- a/clients/client-mediapackage-vod/runtimeConfig.shared.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mediapackage-vod",
+  serviceId: "MediaPackage Vod",
 };

--- a/clients/client-mediapackage/endpoints.ts
+++ b/clients/client-mediapackage/endpoints.ts
@@ -155,5 +155,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mediapackage", ...regionInfo });
 };

--- a/clients/client-mediapackage/runtimeConfig.shared.ts
+++ b/clients/client-mediapackage/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mediapackage",
+  serviceId: "MediaPackage",
 };

--- a/clients/client-mediastore-data/endpoints.ts
+++ b/clients/client-mediastore-data/endpoints.ts
@@ -125,5 +125,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mediastore", ...regionInfo });
 };

--- a/clients/client-mediastore-data/runtimeConfig.shared.ts
+++ b/clients/client-mediastore-data/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mediastore",
+  serviceId: "MediaStore Data",
 };

--- a/clients/client-mediastore/endpoints.ts
+++ b/clients/client-mediastore/endpoints.ts
@@ -125,5 +125,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mediastore", ...regionInfo });
 };

--- a/clients/client-mediastore/runtimeConfig.shared.ts
+++ b/clients/client-mediastore/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mediastore",
+  serviceId: "MediaStore",
 };

--- a/clients/client-mediatailor/endpoints.ts
+++ b/clients/client-mediatailor/endpoints.ts
@@ -119,5 +119,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mediatailor", ...regionInfo });
 };

--- a/clients/client-mediatailor/runtimeConfig.shared.ts
+++ b/clients/client-mediatailor/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mediatailor",
+  serviceId: "MediaTailor",
 };

--- a/clients/client-migration-hub/endpoints.ts
+++ b/clients/client-migration-hub/endpoints.ts
@@ -89,5 +89,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mgh", ...regionInfo });
 };

--- a/clients/client-migration-hub/runtimeConfig.shared.ts
+++ b/clients/client-migration-hub/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mgh",
+  serviceId: "Migration Hub",
 };

--- a/clients/client-migrationhub-config/endpoints.ts
+++ b/clients/client-migrationhub-config/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mgh", ...regionInfo });
 };

--- a/clients/client-migrationhub-config/runtimeConfig.shared.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mgh",
+  serviceId: "MigrationHub Config",
 };

--- a/clients/client-mobile/endpoints.ts
+++ b/clients/client-mobile/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "awsmobilehubservice", ...regionInfo });
 };

--- a/clients/client-mobile/runtimeConfig.shared.ts
+++ b/clients/client-mobile/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "awsmobilehubservice",
+  serviceId: "Mobile",
 };

--- a/clients/client-mq/endpoints.ts
+++ b/clients/client-mq/endpoints.ts
@@ -189,5 +189,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mq", ...regionInfo });
 };

--- a/clients/client-mturk/endpoints.ts
+++ b/clients/client-mturk/endpoints.ts
@@ -89,5 +89,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mturk-requester", ...regionInfo });
 };

--- a/clients/client-mturk/runtimeConfig.shared.ts
+++ b/clients/client-mturk/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mturk-requester",
+  serviceId: "MTurk",
 };

--- a/clients/client-neptune/endpoints.ts
+++ b/clients/client-neptune/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "rds", ...regionInfo });
 };

--- a/clients/client-neptune/runtimeConfig.shared.ts
+++ b/clients/client-neptune/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "rds",
+  serviceId: "Neptune",
 };

--- a/clients/client-network-firewall/endpoints.ts
+++ b/clients/client-network-firewall/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "network-firewall", ...regionInfo });
 };

--- a/clients/client-network-firewall/runtimeConfig.shared.ts
+++ b/clients/client-network-firewall/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "network-firewall",
+  serviceId: "Network Firewall",
 };

--- a/clients/client-networkmanager/endpoints.ts
+++ b/clients/client-networkmanager/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "networkmanager", ...regionInfo });
 };

--- a/clients/client-networkmanager/runtimeConfig.shared.ts
+++ b/clients/client-networkmanager/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "networkmanager",
+  serviceId: "NetworkManager",
 };

--- a/clients/client-opsworks/endpoints.ts
+++ b/clients/client-opsworks/endpoints.ts
@@ -167,5 +167,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "opsworks", ...regionInfo });
 };

--- a/clients/client-opsworks/runtimeConfig.shared.ts
+++ b/clients/client-opsworks/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "opsworks",
+  serviceId: "OpsWorks",
 };

--- a/clients/client-opsworkscm/endpoints.ts
+++ b/clients/client-opsworkscm/endpoints.ts
@@ -131,5 +131,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "opsworks-cm", ...regionInfo });
 };

--- a/clients/client-opsworkscm/runtimeConfig.shared.ts
+++ b/clients/client-opsworkscm/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "opsworks-cm",
+  serviceId: "OpsWorksCM",
 };

--- a/clients/client-organizations/endpoints.ts
+++ b/clients/client-organizations/endpoints.ts
@@ -82,5 +82,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         return defaultRegionInfoProvider("aws-global");
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "organizations", ...regionInfo });
 };

--- a/clients/client-organizations/runtimeConfig.shared.ts
+++ b/clients/client-organizations/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "organizations",
+  serviceId: "Organizations",
 };

--- a/clients/client-outposts/endpoints.ts
+++ b/clients/client-outposts/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "outposts", ...regionInfo });
 };

--- a/clients/client-outposts/runtimeConfig.shared.ts
+++ b/clients/client-outposts/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "outposts",
+  serviceId: "Outposts",
 };

--- a/clients/client-personalize-events/endpoints.ts
+++ b/clients/client-personalize-events/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "personalize", ...regionInfo });
 };

--- a/clients/client-personalize-events/runtimeConfig.shared.ts
+++ b/clients/client-personalize-events/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "personalize",
+  serviceId: "Personalize Events",
 };

--- a/clients/client-personalize-runtime/endpoints.ts
+++ b/clients/client-personalize-runtime/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "personalize", ...regionInfo });
 };

--- a/clients/client-personalize-runtime/runtimeConfig.shared.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "personalize",
+  serviceId: "Personalize Runtime",
 };

--- a/clients/client-personalize/endpoints.ts
+++ b/clients/client-personalize/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "personalize", ...regionInfo });
 };

--- a/clients/client-personalize/runtimeConfig.shared.ts
+++ b/clients/client-personalize/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "personalize",
+  serviceId: "Personalize",
 };

--- a/clients/client-pi/endpoints.ts
+++ b/clients/client-pi/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "pi", ...regionInfo });
 };

--- a/clients/client-pi/runtimeConfig.shared.ts
+++ b/clients/client-pi/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "pi",
+  serviceId: "PI",
 };

--- a/clients/client-pinpoint-email/endpoints.ts
+++ b/clients/client-pinpoint-email/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ses", ...regionInfo });
 };

--- a/clients/client-pinpoint-email/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ses",
+  serviceId: "Pinpoint Email",
 };

--- a/clients/client-pinpoint-sms-voice/endpoints.ts
+++ b/clients/client-pinpoint-sms-voice/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sms-voice", ...regionInfo });
 };

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sms-voice",
+  serviceId: "Pinpoint SMS Voice",
 };

--- a/clients/client-pinpoint/endpoints.ts
+++ b/clients/client-pinpoint/endpoints.ts
@@ -121,5 +121,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "mobiletargeting", ...regionInfo });
 };

--- a/clients/client-pinpoint/runtimeConfig.shared.ts
+++ b/clients/client-pinpoint/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "mobiletargeting",
+  serviceId: "Pinpoint",
 };

--- a/clients/client-polly/endpoints.ts
+++ b/clients/client-polly/endpoints.ts
@@ -185,5 +185,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "polly", ...regionInfo });
 };

--- a/clients/client-polly/runtimeConfig.shared.ts
+++ b/clients/client-polly/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "polly",
+  serviceId: "Polly",
 };

--- a/clients/client-pricing/endpoints.ts
+++ b/clients/client-pricing/endpoints.ts
@@ -93,5 +93,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "pricing", ...regionInfo });
 };

--- a/clients/client-pricing/runtimeConfig.shared.ts
+++ b/clients/client-pricing/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "pricing",
+  serviceId: "Pricing",
 };

--- a/clients/client-qldb-session/endpoints.ts
+++ b/clients/client-qldb-session/endpoints.ts
@@ -131,5 +131,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "qldb", ...regionInfo });
 };

--- a/clients/client-qldb-session/runtimeConfig.shared.ts
+++ b/clients/client-qldb-session/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "qldb",
+  serviceId: "QLDB Session",
 };

--- a/clients/client-qldb/endpoints.ts
+++ b/clients/client-qldb/endpoints.ts
@@ -131,5 +131,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "qldb", ...regionInfo });
 };

--- a/clients/client-qldb/runtimeConfig.shared.ts
+++ b/clients/client-qldb/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "qldb",
+  serviceId: "QLDB",
 };

--- a/clients/client-quicksight/endpoints.ts
+++ b/clients/client-quicksight/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "quicksight", ...regionInfo });
 };

--- a/clients/client-quicksight/runtimeConfig.shared.ts
+++ b/clients/client-quicksight/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "quicksight",
+  serviceId: "QuickSight",
 };

--- a/clients/client-ram/endpoints.ts
+++ b/clients/client-ram/endpoints.ts
@@ -185,5 +185,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ram", ...regionInfo });
 };

--- a/clients/client-ram/runtimeConfig.shared.ts
+++ b/clients/client-ram/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ram",
+  serviceId: "RAM",
 };

--- a/clients/client-rds-data/endpoints.ts
+++ b/clients/client-rds-data/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "rds-data", ...regionInfo });
 };

--- a/clients/client-rds-data/runtimeConfig.shared.ts
+++ b/clients/client-rds-data/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "rds-data",
+  serviceId: "RDS Data",
 };

--- a/clients/client-rds/endpoints.ts
+++ b/clients/client-rds/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "rds", ...regionInfo });
 };

--- a/clients/client-rds/runtimeConfig.shared.ts
+++ b/clients/client-rds/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "rds",
+  serviceId: "RDS",
 };

--- a/clients/client-redshift-data/endpoints.ts
+++ b/clients/client-redshift-data/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "redshift-data", ...regionInfo });
 };

--- a/clients/client-redshift-data/runtimeConfig.shared.ts
+++ b/clients/client-redshift-data/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "redshift-data",
+  serviceId: "Redshift Data",
 };

--- a/clients/client-redshift/endpoints.ts
+++ b/clients/client-redshift/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "redshift", ...regionInfo });
 };

--- a/clients/client-redshift/runtimeConfig.shared.ts
+++ b/clients/client-redshift/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "redshift",
+  serviceId: "Redshift",
 };

--- a/clients/client-rekognition/endpoints.ts
+++ b/clients/client-rekognition/endpoints.ts
@@ -155,5 +155,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "rekognition", ...regionInfo });
 };

--- a/clients/client-rekognition/runtimeConfig.shared.ts
+++ b/clients/client-rekognition/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "rekognition",
+  serviceId: "Rekognition",
 };

--- a/clients/client-resource-groups-tagging-api/endpoints.ts
+++ b/clients/client-resource-groups-tagging-api/endpoints.ts
@@ -209,5 +209,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "tagging", ...regionInfo });
 };

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.shared.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "tagging",
+  serviceId: "Resource Groups Tagging API",
 };

--- a/clients/client-resource-groups/endpoints.ts
+++ b/clients/client-resource-groups/endpoints.ts
@@ -239,5 +239,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "resource-groups", ...regionInfo });
 };

--- a/clients/client-resource-groups/runtimeConfig.shared.ts
+++ b/clients/client-resource-groups/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "resource-groups",
+  serviceId: "Resource Groups",
 };

--- a/clients/client-robomaker/endpoints.ts
+++ b/clients/client-robomaker/endpoints.ts
@@ -119,5 +119,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "robomaker", ...regionInfo });
 };

--- a/clients/client-robomaker/runtimeConfig.shared.ts
+++ b/clients/client-robomaker/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "robomaker",
+  serviceId: "RoboMaker",
 };

--- a/clients/client-route-53-domains/endpoints.ts
+++ b/clients/client-route-53-domains/endpoints.ts
@@ -83,5 +83,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "route53domains", ...regionInfo });
 };

--- a/clients/client-route-53-domains/runtimeConfig.shared.ts
+++ b/clients/client-route-53-domains/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "route53domains",
+  serviceId: "Route 53 Domains",
 };

--- a/clients/client-route-53/endpoints.ts
+++ b/clients/client-route-53/endpoints.ts
@@ -86,5 +86,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         return defaultRegionInfoProvider("aws-global");
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "route53", ...regionInfo });
 };

--- a/clients/client-route-53/runtimeConfig.shared.ts
+++ b/clients/client-route-53/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "route53",
+  serviceId: "Route 53",
 };

--- a/clients/client-route53resolver/endpoints.ts
+++ b/clients/client-route53resolver/endpoints.ts
@@ -173,5 +173,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "route53resolver", ...regionInfo });
 };

--- a/clients/client-route53resolver/runtimeConfig.shared.ts
+++ b/clients/client-route53resolver/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "route53resolver",
+  serviceId: "Route53Resolver",
 };

--- a/clients/client-s3-control/endpoints.ts
+++ b/clients/client-s3-control/endpoints.ts
@@ -259,5 +259,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "s3", ...regionInfo });
 };

--- a/clients/client-s3-control/runtimeConfig.shared.ts
+++ b/clients/client-s3-control/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "s3",
+  serviceId: "S3 Control",
 };

--- a/clients/client-s3/endpoints.ts
+++ b/clients/client-s3/endpoints.ts
@@ -235,5 +235,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "s3", ...regionInfo });
 };

--- a/clients/client-s3/runtimeConfig.shared.ts
+++ b/clients/client-s3/runtimeConfig.shared.ts
@@ -9,7 +9,7 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "s3",
+  serviceId: "S3",
   signingEscapePath: false,
   useArnRegion: false,
 };

--- a/clients/client-s3outposts/endpoints.ts
+++ b/clients/client-s3outposts/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "s3-outposts", ...regionInfo });
 };

--- a/clients/client-s3outposts/runtimeConfig.shared.ts
+++ b/clients/client-s3outposts/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "s3-outposts",
+  serviceId: "S3Outposts",
 };

--- a/clients/client-sagemaker-a2i-runtime/endpoints.ts
+++ b/clients/client-sagemaker-a2i-runtime/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sagemaker", ...regionInfo });
 };

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sagemaker",
+  serviceId: "SageMaker A2I Runtime",
 };

--- a/clients/client-sagemaker-edge/endpoints.ts
+++ b/clients/client-sagemaker-edge/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sagemaker", ...regionInfo });
 };

--- a/clients/client-sagemaker-edge/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-edge/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sagemaker",
+  serviceId: "Sagemaker Edge",
 };

--- a/clients/client-sagemaker-featurestore-runtime/endpoints.ts
+++ b/clients/client-sagemaker-featurestore-runtime/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sagemaker", ...regionInfo });
 };

--- a/clients/client-sagemaker-featurestore-runtime/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-featurestore-runtime/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sagemaker",
+  serviceId: "SageMaker FeatureStore Runtime",
 };

--- a/clients/client-sagemaker-runtime/endpoints.ts
+++ b/clients/client-sagemaker-runtime/endpoints.ts
@@ -225,5 +225,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sagemaker", ...regionInfo });
 };

--- a/clients/client-sagemaker-runtime/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sagemaker",
+  serviceId: "SageMaker Runtime",
 };

--- a/clients/client-sagemaker/endpoints.ts
+++ b/clients/client-sagemaker/endpoints.ts
@@ -225,5 +225,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sagemaker", ...regionInfo });
 };

--- a/clients/client-sagemaker/runtimeConfig.shared.ts
+++ b/clients/client-sagemaker/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sagemaker",
+  serviceId: "SageMaker",
 };

--- a/clients/client-savingsplans/endpoints.ts
+++ b/clients/client-savingsplans/endpoints.ts
@@ -78,5 +78,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         return defaultRegionInfoProvider("aws-global");
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "savingsplans", ...regionInfo });
 };

--- a/clients/client-schemas/endpoints.ts
+++ b/clients/client-schemas/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "schemas", ...regionInfo });
 };

--- a/clients/client-secrets-manager/endpoints.ts
+++ b/clients/client-secrets-manager/endpoints.ts
@@ -239,5 +239,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "secretsmanager", ...regionInfo });
 };

--- a/clients/client-secrets-manager/runtimeConfig.shared.ts
+++ b/clients/client-secrets-manager/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "secretsmanager",
+  serviceId: "Secrets Manager",
 };

--- a/clients/client-securityhub/endpoints.ts
+++ b/clients/client-securityhub/endpoints.ts
@@ -185,5 +185,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "securityhub", ...regionInfo });
 };

--- a/clients/client-securityhub/runtimeConfig.shared.ts
+++ b/clients/client-securityhub/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "securityhub",
+  serviceId: "SecurityHub",
 };

--- a/clients/client-serverlessapplicationrepository/endpoints.ts
+++ b/clients/client-serverlessapplicationrepository/endpoints.ts
@@ -197,5 +197,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "serverlessrepo", ...regionInfo });
 };

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.shared.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "serverlessrepo",
+  serviceId: "ServerlessApplicationRepository",
 };

--- a/clients/client-service-catalog-appregistry/endpoints.ts
+++ b/clients/client-service-catalog-appregistry/endpoints.ts
@@ -214,5 +214,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "servicecatalog", ...regionInfo });
 };

--- a/clients/client-service-catalog-appregistry/runtimeConfig.shared.ts
+++ b/clients/client-service-catalog-appregistry/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "servicecatalog",
+  serviceId: "Service Catalog AppRegistry",
 };

--- a/clients/client-service-catalog/endpoints.ts
+++ b/clients/client-service-catalog/endpoints.ts
@@ -214,5 +214,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "servicecatalog", ...regionInfo });
 };

--- a/clients/client-service-catalog/runtimeConfig.shared.ts
+++ b/clients/client-service-catalog/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "servicecatalog",
+  serviceId: "Service Catalog",
 };

--- a/clients/client-service-quotas/endpoints.ts
+++ b/clients/client-service-quotas/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "servicequotas", ...regionInfo });
 };

--- a/clients/client-service-quotas/runtimeConfig.shared.ts
+++ b/clients/client-service-quotas/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "servicequotas",
+  serviceId: "Service Quotas",
 };

--- a/clients/client-servicediscovery/endpoints.ts
+++ b/clients/client-servicediscovery/endpoints.ts
@@ -185,5 +185,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "servicediscovery", ...regionInfo });
 };

--- a/clients/client-servicediscovery/runtimeConfig.shared.ts
+++ b/clients/client-servicediscovery/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "servicediscovery",
+  serviceId: "ServiceDiscovery",
 };

--- a/clients/client-ses/endpoints.ts
+++ b/clients/client-ses/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ses", ...regionInfo });
 };

--- a/clients/client-ses/runtimeConfig.shared.ts
+++ b/clients/client-ses/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ses",
+  serviceId: "SES",
 };

--- a/clients/client-sesv2/endpoints.ts
+++ b/clients/client-sesv2/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ses", ...regionInfo });
 };

--- a/clients/client-sesv2/runtimeConfig.shared.ts
+++ b/clients/client-sesv2/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ses",
+  serviceId: "SESv2",
 };

--- a/clients/client-sfn/endpoints.ts
+++ b/clients/client-sfn/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "states", ...regionInfo });
 };

--- a/clients/client-sfn/runtimeConfig.shared.ts
+++ b/clients/client-sfn/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "states",
+  serviceId: "SFN",
 };

--- a/clients/client-shield/endpoints.ts
+++ b/clients/client-shield/endpoints.ts
@@ -83,5 +83,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "shield", ...regionInfo });
 };

--- a/clients/client-shield/runtimeConfig.shared.ts
+++ b/clients/client-shield/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "shield",
+  serviceId: "Shield",
 };

--- a/clients/client-signer/endpoints.ts
+++ b/clients/client-signer/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "signer", ...regionInfo });
 };

--- a/clients/client-sms/endpoints.ts
+++ b/clients/client-sms/endpoints.ts
@@ -209,5 +209,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sms", ...regionInfo });
 };

--- a/clients/client-sms/runtimeConfig.shared.ts
+++ b/clients/client-sms/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sms",
+  serviceId: "SMS",
 };

--- a/clients/client-snowball/endpoints.ts
+++ b/clients/client-snowball/endpoints.ts
@@ -197,5 +197,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "snowball", ...regionInfo });
 };

--- a/clients/client-snowball/runtimeConfig.shared.ts
+++ b/clients/client-snowball/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "snowball",
+  serviceId: "Snowball",
 };

--- a/clients/client-sns/endpoints.ts
+++ b/clients/client-sns/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sns", ...regionInfo });
 };

--- a/clients/client-sns/runtimeConfig.shared.ts
+++ b/clients/client-sns/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sns",
+  serviceId: "SNS",
 };

--- a/clients/client-sqs/endpoints.ts
+++ b/clients/client-sqs/endpoints.ts
@@ -249,5 +249,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sqs", ...regionInfo });
 };

--- a/clients/client-sqs/runtimeConfig.shared.ts
+++ b/clients/client-sqs/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sqs",
+  serviceId: "SQS",
 };

--- a/clients/client-ssm/endpoints.ts
+++ b/clients/client-ssm/endpoints.ts
@@ -209,5 +209,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "ssm", ...regionInfo });
 };

--- a/clients/client-ssm/runtimeConfig.shared.ts
+++ b/clients/client-ssm/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "ssm",
+  serviceId: "SSM",
 };

--- a/clients/client-sso-admin/endpoints.ts
+++ b/clients/client-sso-admin/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sso", ...regionInfo });
 };

--- a/clients/client-sso-admin/runtimeConfig.shared.ts
+++ b/clients/client-sso-admin/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sso",
+  serviceId: "SSO Admin",
 };

--- a/clients/client-sso-oidc/endpoints.ts
+++ b/clients/client-sso-oidc/endpoints.ts
@@ -140,5 +140,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "awsssooidc", ...regionInfo });
 };

--- a/clients/client-sso-oidc/runtimeConfig.shared.ts
+++ b/clients/client-sso-oidc/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "awsssooidc",
+  serviceId: "SSO OIDC",
 };

--- a/clients/client-sso/endpoints.ts
+++ b/clients/client-sso/endpoints.ts
@@ -140,5 +140,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "awsssoportal", ...regionInfo });
 };

--- a/clients/client-sso/models/models_0.ts
+++ b/clients/client-sso/models/models_0.ts
@@ -6,11 +6,6 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  */
 export interface AccountInfo {
   /**
-   * <p>The identifier of the AWS account that is assigned to the user.</p>
-   */
-  accountId?: string;
-
-  /**
    * <p>The display name of the AWS account that is assigned to the user.</p>
    */
   accountName?: string;
@@ -19,6 +14,11 @@ export interface AccountInfo {
    * <p>The email address of the AWS account that is assigned to the user.</p>
    */
   emailAddress?: string;
+
+  /**
+   * <p>The identifier of the AWS account that is assigned to the user.</p>
+   */
+  accountId?: string;
 }
 
 export namespace AccountInfo {
@@ -34,15 +34,15 @@ export interface GetRoleCredentialsRequest {
   roleName: string | undefined;
 
   /**
-   * <p>The identifier for the AWS account that is assigned to the user.</p>
-   */
-  accountId: string | undefined;
-
-  /**
    * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
    *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
    */
   accessToken: string | undefined;
+
+  /**
+   * <p>The identifier for the AWS account that is assigned to the user.</p>
+   */
+  accountId: string | undefined;
 }
 
 export namespace GetRoleCredentialsRequest {
@@ -57,6 +57,17 @@ export namespace GetRoleCredentialsRequest {
  */
 export interface RoleCredentials {
   /**
+   * <p>The date on which temporary security credentials expire.</p>
+   */
+  expiration?: number;
+
+  /**
+   * <p>The token used for temporary credentials. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Security Credentials to Request Access to AWS Resources</a> in the
+   *         <i>AWS IAM User Guide</i>.</p>
+   */
+  sessionToken?: string;
+
+  /**
    * <p>The identifier used for the temporary security credentials. For more information, see
    *         <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Security Credentials to Request Access to AWS Resources</a> in the
    *         <i>AWS IAM User Guide</i>.</p>
@@ -68,24 +79,13 @@ export interface RoleCredentials {
    *         <i>AWS IAM User Guide</i>.</p>
    */
   secretAccessKey?: string;
-
-  /**
-   * <p>The token used for temporary credentials. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Security Credentials to Request Access to AWS Resources</a> in the
-   *         <i>AWS IAM User Guide</i>.</p>
-   */
-  sessionToken?: string;
-
-  /**
-   * <p>The date on which temporary security credentials expire.</p>
-   */
-  expiration?: number;
 }
 
 export namespace RoleCredentials {
   export const filterSensitiveLog = (obj: RoleCredentials): any => ({
     ...obj,
-    ...(obj.secretAccessKey && { secretAccessKey: SENSITIVE_STRING }),
     ...(obj.sessionToken && { sessionToken: SENSITIVE_STRING }),
+    ...(obj.secretAccessKey && { secretAccessKey: SENSITIVE_STRING }),
   });
 }
 
@@ -166,9 +166,10 @@ export namespace UnauthorizedException {
 
 export interface ListAccountRolesRequest {
   /**
-   * <p>The page token from the previous response output when you request subsequent pages.</p>
+   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
+   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
    */
-  nextToken?: string;
+  accessToken: string | undefined;
 
   /**
    * <p>The number of items that clients can request per page.</p>
@@ -176,15 +177,14 @@ export interface ListAccountRolesRequest {
   maxResults?: number;
 
   /**
-   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
-   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
-   */
-  accessToken: string | undefined;
-
-  /**
    * <p>The identifier for the AWS account that is assigned to the user.</p>
    */
   accountId: string | undefined;
+
+  /**
+   * <p>The page token from the previous response output when you request subsequent pages.</p>
+   */
+  nextToken?: string;
 }
 
 export namespace ListAccountRolesRequest {
@@ -199,14 +199,14 @@ export namespace ListAccountRolesRequest {
  */
 export interface RoleInfo {
   /**
-   * <p>The friendly name of the role that is assigned to the user.</p>
-   */
-  roleName?: string;
-
-  /**
    * <p>The identifier of the AWS account assigned to the user.</p>
    */
   accountId?: string;
+
+  /**
+   * <p>The friendly name of the role that is assigned to the user.</p>
+   */
+  roleName?: string;
 }
 
 export namespace RoleInfo {
@@ -217,14 +217,14 @@ export namespace RoleInfo {
 
 export interface ListAccountRolesResponse {
   /**
-   * <p>The page token client that is used to retrieve the list of accounts.</p>
-   */
-  nextToken?: string;
-
-  /**
    * <p>A paginated response with the list of roles and the next token if more results are available.</p>
    */
   roleList?: RoleInfo[];
+
+  /**
+   * <p>The page token client that is used to retrieve the list of accounts.</p>
+   */
+  nextToken?: string;
 }
 
 export namespace ListAccountRolesResponse {
@@ -235,9 +235,10 @@ export namespace ListAccountRolesResponse {
 
 export interface ListAccountsRequest {
   /**
-   * <p>(Optional) When requesting subsequent pages, this is the page token from the previous response output.</p>
+   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
+   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
    */
-  nextToken?: string;
+  accessToken: string | undefined;
 
   /**
    * <p>This is the number of items clients can request per page.</p>
@@ -245,10 +246,9 @@ export interface ListAccountsRequest {
   maxResults?: number;
 
   /**
-   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
-   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
+   * <p>(Optional) When requesting subsequent pages, this is the page token from the previous response output.</p>
    */
-  accessToken: string | undefined;
+  nextToken?: string;
 }
 
 export namespace ListAccountsRequest {
@@ -260,14 +260,14 @@ export namespace ListAccountsRequest {
 
 export interface ListAccountsResponse {
   /**
-   * <p>The page token client that is used to retrieve the list of accounts.</p>
-   */
-  nextToken?: string;
-
-  /**
    * <p>A paginated response with the list of account information and the next token if more results are available.</p>
    */
   accountList?: AccountInfo[];
+
+  /**
+   * <p>The page token client that is used to retrieve the list of accounts.</p>
+   */
+  nextToken?: string;
 }
 
 export namespace ListAccountsResponse {

--- a/clients/client-sso/protocols/Aws_restJson1.ts
+++ b/clients/client-sso/protocols/Aws_restJson1.ts
@@ -58,9 +58,9 @@ export const serializeAws_restJson1ListAccountRolesCommand = async (
   };
   let resolvedPath = "/assignment/roles";
   const query: any = {
-    ...(input.nextToken !== undefined && { next_token: input.nextToken }),
     ...(input.maxResults !== undefined && { max_result: input.maxResults.toString() }),
     ...(input.accountId !== undefined && { account_id: input.accountId }),
+    ...(input.nextToken !== undefined && { next_token: input.nextToken }),
   };
   let body: any;
   const { hostname, protocol = "https", port } = await context.endpoint();
@@ -85,8 +85,8 @@ export const serializeAws_restJson1ListAccountsCommand = async (
   };
   let resolvedPath = "/assignment/accounts";
   const query: any = {
-    ...(input.nextToken !== undefined && { next_token: input.nextToken }),
     ...(input.maxResults !== undefined && { max_result: input.maxResults.toString() }),
+    ...(input.nextToken !== undefined && { next_token: input.nextToken }),
   };
   let body: any;
   const { hostname, protocol = "https", port } = await context.endpoint();

--- a/clients/client-sso/runtimeConfig.shared.ts
+++ b/clients/client-sso/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "awsssoportal",
+  serviceId: "SSO",
 };

--- a/clients/client-storage-gateway/endpoints.ts
+++ b/clients/client-storage-gateway/endpoints.ts
@@ -197,5 +197,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "storagegateway", ...regionInfo });
 };

--- a/clients/client-storage-gateway/runtimeConfig.shared.ts
+++ b/clients/client-storage-gateway/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "storagegateway",
+  serviceId: "Storage Gateway",
 };

--- a/clients/client-sts/endpoints.ts
+++ b/clients/client-sts/endpoints.ts
@@ -256,5 +256,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "sts", ...regionInfo });
 };

--- a/clients/client-sts/runtimeConfig.shared.ts
+++ b/clients/client-sts/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "sts",
+  serviceId: "STS",
 };

--- a/clients/client-support/endpoints.ts
+++ b/clients/client-support/endpoints.ts
@@ -105,5 +105,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "support", ...regionInfo });
 };

--- a/clients/client-support/runtimeConfig.shared.ts
+++ b/clients/client-support/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "support",
+  serviceId: "Support",
 };

--- a/clients/client-swf/endpoints.ts
+++ b/clients/client-swf/endpoints.ts
@@ -221,5 +221,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "swf", ...regionInfo });
 };

--- a/clients/client-swf/runtimeConfig.shared.ts
+++ b/clients/client-swf/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "swf",
+  serviceId: "SWF",
 };

--- a/clients/client-synthetics/endpoints.ts
+++ b/clients/client-synthetics/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "synthetics", ...regionInfo });
 };

--- a/clients/client-textract/endpoints.ts
+++ b/clients/client-textract/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "textract", ...regionInfo });
 };

--- a/clients/client-textract/runtimeConfig.shared.ts
+++ b/clients/client-textract/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "textract",
+  serviceId: "Textract",
 };

--- a/clients/client-timestream-query/endpoints.ts
+++ b/clients/client-timestream-query/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "timestream", ...regionInfo });
 };

--- a/clients/client-timestream-query/runtimeConfig.shared.ts
+++ b/clients/client-timestream-query/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "timestream",
+  serviceId: "Timestream Query",
 };

--- a/clients/client-timestream-write/endpoints.ts
+++ b/clients/client-timestream-write/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "timestream", ...regionInfo });
 };

--- a/clients/client-timestream-write/runtimeConfig.shared.ts
+++ b/clients/client-timestream-write/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "timestream",
+  serviceId: "Timestream Write",
 };

--- a/clients/client-transcribe-streaming/endpoints.ts
+++ b/clients/client-transcribe-streaming/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "transcribe", ...regionInfo });
 };

--- a/clients/client-transcribe-streaming/runtimeConfig.shared.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "transcribe",
+  serviceId: "Transcribe Streaming",
 };

--- a/clients/client-transcribe/endpoints.ts
+++ b/clients/client-transcribe/endpoints.ts
@@ -199,5 +199,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "transcribe", ...regionInfo });
 };

--- a/clients/client-transcribe/runtimeConfig.shared.ts
+++ b/clients/client-transcribe/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "transcribe",
+  serviceId: "Transcribe",
 };

--- a/clients/client-transfer/endpoints.ts
+++ b/clients/client-transfer/endpoints.ts
@@ -173,5 +173,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "transfer", ...regionInfo });
 };

--- a/clients/client-transfer/runtimeConfig.shared.ts
+++ b/clients/client-transfer/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "transfer",
+  serviceId: "Transfer",
 };

--- a/clients/client-translate/endpoints.ts
+++ b/clients/client-translate/endpoints.ts
@@ -171,5 +171,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "translate", ...regionInfo });
 };

--- a/clients/client-translate/runtimeConfig.shared.ts
+++ b/clients/client-translate/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "translate",
+  serviceId: "Translate",
 };

--- a/clients/client-waf-regional/endpoints.ts
+++ b/clients/client-waf-regional/endpoints.ts
@@ -179,5 +179,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "waf-regional", ...regionInfo });
 };

--- a/clients/client-waf-regional/runtimeConfig.shared.ts
+++ b/clients/client-waf-regional/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "waf-regional",
+  serviceId: "WAF Regional",
 };

--- a/clients/client-waf/endpoints.ts
+++ b/clients/client-waf/endpoints.ts
@@ -78,5 +78,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         return defaultRegionInfoProvider("aws-global");
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "waf", ...regionInfo });
 };

--- a/clients/client-waf/runtimeConfig.shared.ts
+++ b/clients/client-waf/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "waf",
+  serviceId: "WAF",
 };

--- a/clients/client-wafv2/endpoints.ts
+++ b/clients/client-wafv2/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "wafv2", ...regionInfo });
 };

--- a/clients/client-wafv2/runtimeConfig.shared.ts
+++ b/clients/client-wafv2/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "wafv2",
+  serviceId: "WAFV2",
 };

--- a/clients/client-workdocs/endpoints.ts
+++ b/clients/client-workdocs/endpoints.ts
@@ -113,5 +113,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "workdocs", ...regionInfo });
 };

--- a/clients/client-workdocs/runtimeConfig.shared.ts
+++ b/clients/client-workdocs/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "workdocs",
+  serviceId: "WorkDocs",
 };

--- a/clients/client-worklink/endpoints.ts
+++ b/clients/client-worklink/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "worklink", ...regionInfo });
 };

--- a/clients/client-worklink/runtimeConfig.shared.ts
+++ b/clients/client-worklink/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "worklink",
+  serviceId: "WorkLink",
 };

--- a/clients/client-workmail/endpoints.ts
+++ b/clients/client-workmail/endpoints.ts
@@ -95,5 +95,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "workmail", ...regionInfo });
 };

--- a/clients/client-workmail/runtimeConfig.shared.ts
+++ b/clients/client-workmail/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "workmail",
+  serviceId: "WorkMail",
 };

--- a/clients/client-workmailmessageflow/endpoints.ts
+++ b/clients/client-workmailmessageflow/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "workmailmessageflow", ...regionInfo });
 };

--- a/clients/client-workmailmessageflow/runtimeConfig.shared.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "workmailmessageflow",
+  serviceId: "WorkMailMessageFlow",
 };

--- a/clients/client-workspaces/endpoints.ts
+++ b/clients/client-workspaces/endpoints.ts
@@ -161,5 +161,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "workspaces", ...regionInfo });
 };

--- a/clients/client-workspaces/runtimeConfig.shared.ts
+++ b/clients/client-workspaces/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "workspaces",
+  serviceId: "WorkSpaces",
 };

--- a/clients/client-xray/endpoints.ts
+++ b/clients/client-xray/endpoints.ts
@@ -185,5 +185,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "xray", ...regionInfo });
 };

--- a/clients/client-xray/runtimeConfig.shared.ts
+++ b/clients/client-xray/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "xray",
+  serviceId: "XRay",
 };

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -113,7 +113,7 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
         Map<String, Consumer<TypeScriptWriter>> runtimeConfigs = new HashMap();
         if (target.equals(LanguageTarget.SHARED)) {
             String serviceId = service.getTrait(ServiceTrait.class)
-                    .map(ServiceTrait::getArnNamespace)
+                    .map(ServiceTrait::getSdkId)
                     .orElse(null);
             if (serviceId != null) {
                 runtimeConfigs.put("serviceId", writer -> {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/EndpointGenerator.java
@@ -161,7 +161,8 @@ final class EndpointGenerator implements Runnable {
                     writePartitionEndpointResolver(partitions.get("aws")); });
                 writer.dedent();
             });
-            writer.write("return Promise.resolve({ signingService: $S, ...regionInfo });", serviceTrait.getArnNamespace());
+            writer.write("return Promise.resolve({ signingService: $S, ...regionInfo });",
+                    serviceTrait.getArnNamespace());
         });
     }
 

--- a/packages/middleware-signing/src/configurations.ts
+++ b/packages/middleware-signing/src/configurations.ts
@@ -60,6 +60,8 @@ export function resolveAwsAuthConfig<T>(input: T & AwsAuthInputConfig & Previous
           //update client's singing region and signing service config if they are resolved.
           //signing region resolving order: user supplied signingRegion -> endpoints.json inferred region -> client region
           input.signingRegion = input.signingRegion || signingRegion || region;
+          //signing name resolving order:
+          //user supplied signingName -> endpoints.json inferred (credential scope -> model arnNamespace) -> model service id
           input.signingName = input.signingName || signingService || input.serviceId;
 
           return new SignatureV4({

--- a/protocol_tests/aws-ec2/endpoints.ts
+++ b/protocol_tests/aws-ec2/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "awsec2", ...regionInfo });
 };

--- a/protocol_tests/aws-ec2/runtimeConfig.shared.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "awsec2",
+  serviceId: "EC2 Protocol",
 };

--- a/protocol_tests/aws-json/endpoints.ts
+++ b/protocol_tests/aws-json/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "jsonprotocol", ...regionInfo });
 };

--- a/protocol_tests/aws-json/runtimeConfig.shared.ts
+++ b/protocol_tests/aws-json/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "jsonprotocol",
+  serviceId: "Json Protocol",
 };

--- a/protocol_tests/aws-query/endpoints.ts
+++ b/protocol_tests/aws-query/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "awsquery", ...regionInfo });
 };

--- a/protocol_tests/aws-query/runtimeConfig.shared.ts
+++ b/protocol_tests/aws-query/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "awsquery",
+  serviceId: "Query Protocol",
 };

--- a/protocol_tests/aws-restjson/endpoints.ts
+++ b/protocol_tests/aws-restjson/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "restjson", ...regionInfo });
 };

--- a/protocol_tests/aws-restjson/runtimeConfig.shared.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "restjson",
+  serviceId: "Rest Json Protocol",
 };

--- a/protocol_tests/aws-restxml/endpoints.ts
+++ b/protocol_tests/aws-restxml/endpoints.ts
@@ -77,5 +77,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve(regionInfo);
+  return Promise.resolve({ signingService: "restxml", ...regionInfo });
 };

--- a/protocol_tests/aws-restxml/runtimeConfig.shared.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.shared.ts
@@ -9,5 +9,5 @@ export const ClientSharedValues = {
   disableHostPrefix: false,
   logger: {} as __Logger,
   regionInfoProvider: defaultRegionInfoProvider,
-  serviceId: "restxml",
+  serviceId: "Rest Xml Protocol",
 };


### PR DESCRIPTION
Follow up to https://github.com/aws/aws-sdk-js-v3/pull/1765
*Description of changes:*
The previous change https://github.com/aws/aws-sdk-js-v3/pull/1765 put arnNamespace in serviceId client config, and use it as fallback when a service doesn't specify a signing name in its `endpoints.json` credentialScope. It fixes the issue but the `serviceId` config is not correct. Right now the `serviceId` is generated from arnNamespace in the Smithy model, but it can be different from the actual service id. It may result unexpected results in metrics. 

This change moves the fallback-to-arnNamespace logic to `endpoints.ts`: every service has `arnNamespace` as default signingName. If they have a different signing name in its `endpoints.json` credentialScope, they will use that instead. Now `serviceId` client config can be changed to actual service id because it doesn't need to provide the signing name information.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
