### PR TITLE
feat(middleware-logger): log clientName, commandName, input, output

### DIFF
--- a/packages/middleware-logger/src/loggerMiddleware.spec.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.spec.ts
@@ -35,6 +35,8 @@ describe("loggerMiddleware", () => {
     $metadata: {
       statusCode: 200,
       requestId: "requestId",
+      attempts: 2,
+      totalRetryDelay: 350,
     },
     outputKey: "outputValue",
   };
@@ -108,6 +110,10 @@ describe("loggerMiddleware", () => {
         commandName,
         input: mockInputLog,
         output: mockOutputLog,
+        retry: {
+          attempts: $metadata.attempts,
+          totalDelay: $metadata.totalRetryDelay,
+        },
         metadata: {
           statusCode: mockResponse.response.statusCode,
           requestId: mockResponse.response.headers["x-amzn-requestid"],
@@ -148,6 +154,10 @@ describe("loggerMiddleware", () => {
       expect(logger.info).toHaveBeenCalledWith({
         input: mockArgs.input,
         output: outputWithoutMetadata,
+        retry: {
+          attempts: $metadata.attempts,
+          totalDelay: $metadata.totalRetryDelay,
+        },
         metadata: {
           statusCode: customResponse.response.statusCode,
           requestId: requestIdBackup,

--- a/packages/middleware-logger/src/loggerMiddleware.spec.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.spec.ts
@@ -110,15 +110,15 @@ describe("loggerMiddleware", () => {
         commandName,
         input: mockInputLog,
         output: mockOutputLog,
-        retry: {
-          attempts: $metadata.attempts,
-          totalDelay: $metadata.totalRetryDelay,
-        },
         metadata: {
           statusCode: mockResponse.response.statusCode,
           requestId: mockResponse.response.headers["x-amzn-requestid"],
           extendedRequestId: mockResponse.response.headers["x-amz-id-2"],
           cfId: mockResponse.response.headers["x-amz-cf-id"],
+          retry: {
+            attempts: $metadata.attempts,
+            totalDelay: $metadata.totalRetryDelay,
+          },
         },
       });
     });
@@ -154,15 +154,15 @@ describe("loggerMiddleware", () => {
       expect(logger.info).toHaveBeenCalledWith({
         input: mockArgs.input,
         output: outputWithoutMetadata,
-        retry: {
-          attempts: $metadata.attempts,
-          totalDelay: $metadata.totalRetryDelay,
-        },
         metadata: {
           statusCode: customResponse.response.statusCode,
           requestId: requestIdBackup,
           extendedRequestId: undefined,
           cfId: undefined,
+          retry: {
+            attempts: $metadata.attempts,
+            totalDelay: $metadata.totalRetryDelay,
+          },
         },
       });
     });

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -16,7 +16,7 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
 ): InitializeHandler<any, Output> => async (
   args: InitializeHandlerArguments<any>
 ): Promise<InitializeHandlerOutput<Output>> => {
-  const { logger } = context;
+  const { clientName, commandName, logger } = context;
 
   const response = await next(args);
 
@@ -28,6 +28,8 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
 
   if (typeof logger.info === "function") {
     logger.info({
+      clientName,
+      commandName,
       metadata: {
         statusCode: httpResponse.statusCode,
         requestId: httpResponse.headers["x-amzn-requestid"] ?? httpResponse.headers["x-amzn-request-id"],

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -32,6 +32,10 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
       commandName,
       input: inputFilterSensitiveLog(args.input),
       output: outputFilterSensitiveLog(outputWithoutMetadata),
+      retry: {
+        attempts: $metadata.attempts,
+        totalDelay: $metadata.totalRetryDelay,
+      },
       metadata: {
         statusCode: httpResponse.statusCode,
         requestId: httpResponse.headers["x-amzn-requestid"] ?? httpResponse.headers["x-amzn-request-id"],

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -32,15 +32,15 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
       commandName,
       input: inputFilterSensitiveLog(args.input),
       output: outputFilterSensitiveLog(outputWithoutMetadata),
-      retry: {
-        attempts: $metadata.attempts,
-        totalDelay: $metadata.totalRetryDelay,
-      },
       metadata: {
         statusCode: httpResponse.statusCode,
         requestId: httpResponse.headers["x-amzn-requestid"] ?? httpResponse.headers["x-amzn-request-id"],
         extendedRequestId: httpResponse.headers["x-amz-id-2"],
         cfId: httpResponse.headers["x-amz-cf-id"],
+        retry: {
+          attempts: $metadata.attempts,
+          totalDelay: $metadata.totalRetryDelay,
+        },
       },
     });
   }

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -16,7 +16,7 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
 ): InitializeHandler<any, Output> => async (
   args: InitializeHandlerArguments<any>
 ): Promise<InitializeHandlerOutput<Output>> => {
-  const { clientName, commandName, inputFilterSensitiveLog, logger } = context;
+  const { clientName, commandName, inputFilterSensitiveLog, logger, outputFilterSensitiveLog } = context;
 
   const response = await next(args);
 
@@ -24,13 +24,14 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
     return response;
   }
 
-  const httpResponse = response.response as HttpResponse;
-
   if (typeof logger.info === "function") {
+    const httpResponse = response.response as HttpResponse;
+    const { $metadata, ...outputWithoutMetadata } = response.output;
     logger.info({
       clientName,
       commandName,
       input: inputFilterSensitiveLog(args.input),
+      output: outputFilterSensitiveLog(outputWithoutMetadata),
       metadata: {
         statusCode: httpResponse.statusCode,
         requestId: httpResponse.headers["x-amzn-requestid"] ?? httpResponse.headers["x-amzn-request-id"],

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -16,7 +16,7 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
 ): InitializeHandler<any, Output> => async (
   args: InitializeHandlerArguments<any>
 ): Promise<InitializeHandlerOutput<Output>> => {
-  const { clientName, commandName, logger } = context;
+  const { clientName, commandName, inputFilterSensitiveLog, logger } = context;
 
   const response = await next(args);
 
@@ -30,6 +30,7 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
     logger.info({
       clientName,
       commandName,
+      input: inputFilterSensitiveLog(args.input),
       metadata: {
         statusCode: httpResponse.statusCode,
         requestId: httpResponse.headers["x-amzn-requestid"] ?? httpResponse.headers["x-amzn-request-id"],

--- a/packages/middleware-serde/src/deserializerMiddleware.spec.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.spec.ts
@@ -1,5 +1,3 @@
-import { Logger } from "@aws-sdk/types";
-
 import { deserializerMiddleware } from "./deserializerMiddleware";
 
 describe("deserializerMiddleware", () => {
@@ -51,38 +49,17 @@ describe("deserializerMiddleware", () => {
   });
 
   afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("calls deserializer and populates response object", async () => {
+    await expect(deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, {})(mockArgs)).resolves.toStrictEqual(
+      mockResponse
+    );
+
     expect(mockNext).toHaveBeenCalledTimes(1);
     expect(mockNext).toHaveBeenCalledWith(mockArgs);
     expect(mockDeserializer).toHaveBeenCalledTimes(1);
     expect(mockDeserializer).toHaveBeenCalledWith(mockNextResponse.response, mockOptions);
-    jest.clearAllMocks();
-  });
-
-  it("returns without logging if context.logger is not defined", async () => {
-    const response = await deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, {})(mockArgs);
-    expect(response).toStrictEqual(mockResponse);
-  });
-
-  it("returns without logging if context.logger doesn't have debug/info function", async () => {
-    const logger = {} as Logger;
-    const response = await deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, { logger })(mockArgs);
-    expect(response).toStrictEqual(mockResponse);
-  });
-
-  it("logs output if context.logger has info function", async () => {
-    const logger = ({ info: jest.fn() } as unknown) as Logger;
-
-    const outputFilterSensitiveLog = jest.fn().mockImplementationOnce((output) => output);
-    const response = await deserializerMiddleware(mockOptions, mockDeserializer)(mockNext, {
-      logger,
-      outputFilterSensitiveLog: outputFilterSensitiveLog,
-    })(mockArgs);
-
-    const { $metadata, ...outputWithoutMetadata } = mockOutput;
-    expect(response).toStrictEqual(mockResponse);
-    expect(outputFilterSensitiveLog).toHaveBeenCalledTimes(1);
-    expect(outputFilterSensitiveLog).toHaveBeenCalledWith(outputWithoutMetadata);
-    expect(logger.info).toHaveBeenCalledTimes(1);
-    expect(logger.info).toHaveBeenCalledWith({ output: outputWithoutMetadata });
   });
 });

--- a/packages/middleware-serde/src/deserializerMiddleware.ts
+++ b/packages/middleware-serde/src/deserializerMiddleware.ts
@@ -16,21 +16,8 @@ export const deserializerMiddleware = <Input extends object, Output extends obje
 ): DeserializeHandler<Input, Output> => async (
   args: DeserializeHandlerArguments<Input>
 ): Promise<DeserializeHandlerOutput<Output>> => {
-  const { logger, outputFilterSensitiveLog } = context;
-
   const { response } = await next(args);
-
   const parsed = await deserializer(response, options);
-
-  // Log parsed after $metadata is removed in https://github.com/aws/aws-sdk-js-v3/issues/1490
-  const { $metadata, ...outputWithoutMetadata } = parsed;
-
-  if (typeof logger?.info === "function") {
-    logger.info({
-      output: outputFilterSensitiveLog(outputWithoutMetadata),
-    });
-  }
-
   return {
     response,
     output: parsed as Output,

--- a/packages/middleware-serde/src/serializerMiddleware.ts
+++ b/packages/middleware-serde/src/serializerMiddleware.ts
@@ -17,16 +17,7 @@ export const serializerMiddleware = <Input extends object, Output extends object
 ): SerializeHandler<Input, Output> => async (
   args: SerializeHandlerArguments<Input>
 ): Promise<SerializeHandlerOutput<Output>> => {
-  const { logger, inputFilterSensitiveLog } = context;
-
-  if (typeof logger?.info === "function") {
-    logger.info({
-      input: inputFilterSensitiveLog(args.input),
-    });
-  }
-
   const request = await serializer(args.input, options);
-
   return next({
     ...args,
     request,


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1785

Removal of logging clientName and commandName is tracked in:
* https://github.com/awslabs/smithy-typescript/pull/249
* https://github.com/aws/aws-sdk-js-v3/pull/1787

*Description of changes:*
log clientName, commandName, input, output in addition to metadata

<details>
<summary>Test Code</summary>

```js
const { DynamoDB } = require("../aws-sdk-js-v3/clients/client-dynamodb");

(async () => {
  const region = "us-east-1";
  const logger = console;
  const client = new DynamoDB({ region, logger });

  await client.listTables({ Limit: 1 });
})();

```

</details>

<details>
<summary>Test output</summary>

```console
{
  clientName: 'DynamoDBClient',
  commandName: 'ListTablesCommand',
  input: { Limit: 1 },
  output: {
    LastEvaluatedTableName: undefined,
    TableNames: [ 'aws-js-sdk-workshop-notes' ]
  },
  metadata: {
    statusCode: 200,
    requestId: 'CQETJIBBCE0Q84EA4SDIC06JQBVV4KQNSO5AEMVJF66Q9ASUAAJG',
    extendedRequestId: undefined,
    cfId: undefined,
    retry: { attempts: 1, totalDelay: 0 },
  }
}
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
