### PR TITLE
fix(middleware-logger): remove $metadata from response.output

### DIFF
--- a/packages/middleware-logger/src/loggerMiddleware.spec.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.spec.ts
@@ -116,8 +116,8 @@ describe("loggerMiddleware", () => {
           extendedRequestId: mockResponse.response.headers["x-amz-id-2"],
           cfId: mockResponse.response.headers["x-amz-cf-id"],
           retry: {
-            attempts: $metadata.attempts,
-            totalDelay: $metadata.totalRetryDelay,
+            attempts: $metadata?.attempts,
+            totalDelay: $metadata?.totalRetryDelay,
           },
         },
       });
@@ -160,8 +160,8 @@ describe("loggerMiddleware", () => {
           extendedRequestId: undefined,
           cfId: undefined,
           retry: {
-            attempts: $metadata.attempts,
-            totalDelay: $metadata.totalRetryDelay,
+            attempts: $metadata?.attempts,
+            totalDelay: $metadata?.totalRetryDelay,
           },
         },
       });

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -45,6 +45,9 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
     });
   }
 
+  // ToDo: remove $metadata altogether from output and log it in logger.
+  delete response.output.$metadata;
+
   return response;
 };
 

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -38,8 +38,8 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
         extendedRequestId: httpResponse.headers["x-amz-id-2"],
         cfId: httpResponse.headers["x-amz-cf-id"],
         retry: {
-          attempts: $metadata.attempts,
-          totalDelay: $metadata.totalRetryDelay,
+          attempts: $metadata?.attempts,
+          totalDelay: $metadata?.totalRetryDelay,
         },
       },
     });

--- a/packages/middleware-retry/src/defaultStrategy.spec.ts
+++ b/packages/middleware-retry/src/defaultStrategy.spec.ts
@@ -213,7 +213,7 @@ describe("defaultStrategy", () => {
 
       const maxAttempts = 3;
       const error = await mockFailedOperation(maxAttempts);
-      expect(error.$metadata.totalRetryDelay).toEqual(FIRST_DELAY + SECOND_DELAY);
+      expect(error.$metadata?.totalRetryDelay).toEqual(FIRST_DELAY + SECOND_DELAY);
 
       expect(defaultDelayDecider as jest.Mock).toHaveBeenCalledTimes(maxAttempts - 1);
       expect(setTimeout).toHaveBeenCalledTimes(maxAttempts - 1);
@@ -310,8 +310,8 @@ describe("defaultStrategy", () => {
       });
 
       expect(response).toStrictEqual(mockResponse);
-      expect(output.$metadata.attempts).toBe(1);
-      expect(output.$metadata.totalRetryDelay).toBe(0);
+      expect(output.$metadata?.attempts).toBe(1);
+      expect(output.$metadata?.totalRetryDelay).toBe(0);
       expect(defaultRetryDecider as jest.Mock).not.toHaveBeenCalled();
       expect(defaultDelayDecider as jest.Mock).not.toHaveBeenCalled();
     });

--- a/packages/middleware-retry/src/defaultStrategy.ts
+++ b/packages/middleware-retry/src/defaultStrategy.ts
@@ -118,8 +118,8 @@ export class StandardRetryStrategy implements RetryStrategy {
         const { response, output } = await next(args);
 
         this.retryQuota.releaseRetryTokens(retryTokenAmount);
-        output.$metadata.attempts = attempts + 1;
-        output.$metadata.totalRetryDelay = totalDelay;
+        output.$metadata!.attempts = attempts + 1;
+        output.$metadata!.totalRetryDelay = totalDelay;
 
         return { response, output };
       } catch (err) {
@@ -140,8 +140,8 @@ export class StandardRetryStrategy implements RetryStrategy {
           err.$metadata = {};
         }
 
-        err.$metadata.attempts = attempts;
-        err.$metadata.totalRetryDelay = totalDelay;
+        err.$metadata!.attempts = attempts;
+        err.$metadata!.totalRetryDelay = totalDelay;
         throw err;
       }
     }

--- a/packages/types/src/response.ts
+++ b/packages/types/src/response.ts
@@ -43,5 +43,5 @@ export interface MetadataBearer {
   /**
    * Metadata pertaining to this request.
    */
-  $metadata: ResponseMetadata;
+  $metadata?: ResponseMetadata;
 }


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1490

*Description of changes:*
remove $metadata from response.output

<details>
<summary>Test code</summary>

```js
const { DynamoDB } = require("../aws-sdk-js-v3/clients/client-dynamodb");

(async () => {
  const region = "us-east-1";
  const client = new DynamoDB({ region });

  console.log(await client.listTables({ Limit: 1 }));
})();
```

</details>

<details>
<summary>Output before</summary>

```console
{
  '$metadata': {
    httpStatusCode: 200,
    httpHeaders: {
      server: 'Server',
      date: 'Mon, 14 Dec 2020 20:40:57 GMT',
      'content-type': 'application/x-amz-json-1.0',
      'content-length': '44',
      connection: 'keep-alive',
      'x-amzn-requestid': 'M7HOMU8M8R280SCB6QD266MOC3VV4KQNSO5AEMVJF66Q9ASUAAJG',
      'x-amz-crc32': '2729330041'
    },
    requestId: 'M7HOMU8M8R280SCB6QD266MOC3VV4KQNSO5AEMVJF66Q9ASUAAJG',
    attempts: 1,
    totalRetryDelay: 0
  },
  LastEvaluatedTableName: undefined,
  TableNames: [ 'aws-js-sdk-workshop-notes' ]
}
```

</details>

<details>
<summary>Output after</summary>

```console
{
  LastEvaluatedTableName: undefined,
  TableNames: [ 'aws-js-sdk-workshop-notes' ]
}
```

</details>

The metadata is logged by middleware-logger in https://github.com/aws/aws-sdk-js-v3/pull/1788

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
