### PR TITLE
fix: log requestId, extendedRequestId, cfId in $metadata

### DIFF
--- a/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
+++ b/clients/client-accessanalyzer/protocols/Aws_restJson1.ts
@@ -2782,7 +2782,9 @@ const deserializeAws_restJson1ValueList = (output: any, context: __SerdeContext)
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-acm-pca/protocols/Aws_json1_1.ts
+++ b/clients/client-acm-pca/protocols/Aws_json1_1.ts
@@ -3427,7 +3427,9 @@ const deserializeAws_json1_1TooManyTagsException = (output: any, context: __Serd
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-acm/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/protocols/Aws_json1_1.ts
@@ -2101,7 +2101,9 @@ const deserializeAws_json1_1ValidationEmailList = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
@@ -10652,7 +10652,9 @@ const deserializeAws_json1_1UserDataList = (output: any, context: __SerdeContext
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-amplify/protocols/Aws_restJson1.ts
+++ b/clients/client-amplify/protocols/Aws_restJson1.ts
@@ -5484,7 +5484,9 @@ const deserializeAws_restJson1Webhooks = (output: any, context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-amplifybackend/protocols/Aws_restJson1.ts
+++ b/clients/client-amplifybackend/protocols/Aws_restJson1.ts
@@ -4244,7 +4244,9 @@ const deserializeAws_restJson1SocialProviderSettings = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-api-gateway/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1.ts
@@ -18126,7 +18126,9 @@ const deserializeAws_restJson1VpcLink = (output: any, context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewaymanagementapi/protocols/Aws_restJson1.ts
@@ -395,7 +395,9 @@ const deserializeAws_restJson1Identity = (output: any, context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-apigatewayv2/protocols/Aws_restJson1.ts
+++ b/clients/client-apigatewayv2/protocols/Aws_restJson1.ts
@@ -10719,7 +10719,9 @@ const deserializeAws_restJson1VpcLink = (output: any, context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-app-mesh/protocols/Aws_restJson1.ts
+++ b/clients/client-app-mesh/protocols/Aws_restJson1.ts
@@ -8518,7 +8518,9 @@ const deserializeAws_restJson1WeightedTargets = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-appconfig/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1.ts
@@ -4608,7 +4608,9 @@ const deserializeAws_restJson1ValidatorTypeList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-appflow/protocols/Aws_restJson1.ts
+++ b/clients/client-appflow/protocols/Aws_restJson1.ts
@@ -4746,7 +4746,9 @@ const deserializeAws_restJson1ZendeskSourceProperties = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-appintegrations/protocols/Aws_restJson1.ts
+++ b/clients/client-appintegrations/protocols/Aws_restJson1.ts
@@ -1344,7 +1344,9 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
+++ b/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
@@ -1941,7 +1941,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
@@ -4160,7 +4160,9 @@ const deserializeAws_json1_1UpdateApplicationResponse = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-application-insights/protocols/Aws_json1_1.ts
+++ b/clients/client-application-insights/protocols/Aws_json1_1.ts
@@ -3616,7 +3616,9 @@ const deserializeAws_json1_1WorkloadMetaData = (output: any, context: __SerdeCon
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-appstream/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/protocols/Aws_json1_1.ts
@@ -6656,7 +6656,9 @@ const deserializeAws_json1_1VpcConfig = (output: any, context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-appsync/protocols/Aws_restJson1.ts
+++ b/clients/client-appsync/protocols/Aws_restJson1.ts
@@ -6126,7 +6126,9 @@ const deserializeAws_restJson1UserPoolConfig = (output: any, context: __SerdeCon
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-athena/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/protocols/Aws_json1_1.ts
@@ -3585,7 +3585,9 @@ const deserializeAws_json1_1WorkGroupSummary = (output: any, context: __SerdeCon
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-auditmanager/protocols/Aws_restJson1.ts
+++ b/clients/client-auditmanager/protocols/Aws_restJson1.ts
@@ -7292,7 +7292,9 @@ const deserializeAws_restJson1ValidationExceptionFieldList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
+++ b/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
@@ -1487,7 +1487,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-auto-scaling/protocols/Aws_query.ts
+++ b/clients/client-auto-scaling/protocols/Aws_query.ts
@@ -8851,7 +8851,9 @@ const deserializeAws_queryTerminationPolicies = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-backup/protocols/Aws_restJson1.ts
+++ b/clients/client-backup/protocols/Aws_restJson1.ts
@@ -7250,7 +7250,9 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-batch/protocols/Aws_restJson1.ts
+++ b/clients/client-batch/protocols/Aws_restJson1.ts
@@ -3546,7 +3546,9 @@ const deserializeAws_restJson1Volumes = (output: any, context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-braket/protocols/Aws_restJson1.ts
+++ b/clients/client-braket/protocols/Aws_restJson1.ts
@@ -1048,7 +1048,9 @@ const deserializeAws_restJson1QuantumTaskSummaryList = (output: any, context: __
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-budgets/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/protocols/Aws_json1_1.ts
@@ -3737,7 +3737,9 @@ const deserializeAws_json1_1Users = (output: any, context: __SerdeContext): stri
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-chime/protocols/Aws_restJson1.ts
+++ b/clients/client-chime/protocols/Aws_restJson1.ts
@@ -28359,7 +28359,9 @@ const deserializeAws_restJson1VoiceConnectorSettings = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloud9/protocols/Aws_json1_1.ts
+++ b/clients/client-cloud9/protocols/Aws_json1_1.ts
@@ -2096,7 +2096,9 @@ const deserializeAws_json1_1UpdateEnvironmentResult = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-clouddirectory/protocols/Aws_restJson1.ts
+++ b/clients/client-clouddirectory/protocols/Aws_restJson1.ts
@@ -12718,7 +12718,9 @@ const deserializeAws_restJson1TypedLinkSpecifierList = (output: any, context: __
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloudformation/protocols/Aws_query.ts
+++ b/clients/client-cloudformation/protocols/Aws_query.ts
@@ -9541,7 +9541,9 @@ const deserializeAws_queryValidateTemplateOutput = (output: any, context: __Serd
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -17013,7 +17013,9 @@ const deserializeAws_restXmlViewerCertificate = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
@@ -2287,7 +2287,9 @@ const deserializeAws_json1_1UntagResourceResponse = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloudhsm/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm/protocols/Aws_json1_1.ts
@@ -2340,7 +2340,9 @@ const deserializeAws_json1_1TagList = (output: any, context: __SerdeContext): Ta
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloudsearch-domain/protocols/Aws_restJson1.ts
+++ b/clients/client-cloudsearch-domain/protocols/Aws_restJson1.ts
@@ -573,7 +573,9 @@ const deserializeAws_restJson1SuggestStatus = (output: any, context: __SerdeCont
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloudsearch/protocols/Aws_query.ts
+++ b/clients/client-cloudsearch/protocols/Aws_query.ts
@@ -4818,7 +4818,9 @@ const deserializeAws_queryValidationException = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloudtrail/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudtrail/protocols/Aws_json1_1.ts
@@ -4479,7 +4479,9 @@ const deserializeAws_json1_1UpdateTrailResponse = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
@@ -5643,7 +5643,9 @@ const deserializeAws_json1_1UpdateArchiveResponse = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
@@ -5354,7 +5354,9 @@ const deserializeAws_json1_1UnrecognizedClientException = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cloudwatch/protocols/Aws_query.ts
+++ b/clients/client-cloudwatch/protocols/Aws_query.ts
@@ -5416,7 +5416,9 @@ const deserializeAws_queryUntagResourceOutput = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-codeartifact/protocols/Aws_restJson1.ts
+++ b/clients/client-codeartifact/protocols/Aws_restJson1.ts
@@ -4984,7 +4984,9 @@ const deserializeAws_restJson1UpstreamRepositoryInfoList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-codebuild/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/protocols/Aws_json1_1.ts
@@ -6537,7 +6537,9 @@ const deserializeAws_json1_1WebhookFilter = (output: any, context: __SerdeContex
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-codecommit/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/protocols/Aws_json1_1.ts
@@ -21428,7 +21428,9 @@ const deserializeAws_json1_1UserInfo = (output: any, context: __SerdeContext): U
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-codedeploy/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/protocols/Aws_json1_1.ts
@@ -11347,7 +11347,9 @@ const deserializeAws_json1_1UpdateDeploymentGroupOutput = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-codeguru-reviewer/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguru-reviewer/protocols/Aws_restJson1.ts
@@ -2189,7 +2189,9 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
@@ -1967,7 +1967,9 @@ const deserializeAws_restJson1UnprocessedEndTimeMap = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-codepipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/protocols/Aws_json1_1.ts
@@ -6490,7 +6490,9 @@ const deserializeAws_json1_1WebhookNotFoundException = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-codestar-connections/protocols/Aws_json1_0.ts
+++ b/clients/client-codestar-connections/protocols/Aws_json1_0.ts
@@ -1401,7 +1401,9 @@ const deserializeAws_json1_0VpcConfiguration = (output: any, context: __SerdeCon
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-codestar-notifications/protocols/Aws_restJson1.ts
+++ b/clients/client-codestar-notifications/protocols/Aws_restJson1.ts
@@ -1631,7 +1631,9 @@ const deserializeAws_restJson1TargetSummary = (output: any, context: __SerdeCont
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-codestar/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/protocols/Aws_json1_1.ts
@@ -2571,7 +2571,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
@@ -18211,7 +18211,9 @@ const deserializeAws_json1_1VerifyUserAttributeResponse = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cognito-identity/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/protocols/Aws_json1_1.ts
@@ -3477,7 +3477,9 @@ const deserializeAws_json1_1UntagResourceResponse = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cognito-sync/protocols/Aws_restJson1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1.ts
@@ -2814,7 +2814,9 @@ const deserializeAws_restJson1RecordList = (output: any, context: __SerdeContext
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-comprehend/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/protocols/Aws_json1_1.ts
@@ -9513,7 +9513,9 @@ const deserializeAws_json1_1VpcConfig = (output: any, context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
@@ -3195,7 +3195,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
+++ b/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
@@ -2494,7 +2494,9 @@ const deserializeAws_json1_0VolumeRecommendations = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-config-service/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/protocols/Aws_json1_1.ts
@@ -13121,7 +13121,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-connect-contact-lens/protocols/Aws_restJson1.ts
+++ b/clients/client-connect-contact-lens/protocols/Aws_restJson1.ts
@@ -381,7 +381,9 @@ const deserializeAws_restJson1Transcript = (output: any, context: __SerdeContext
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-connect/protocols/Aws_restJson1.ts
+++ b/clients/client-connect/protocols/Aws_restJson1.ts
@@ -12091,7 +12091,9 @@ const deserializeAws_restJson1UserSummaryList = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-connectparticipant/protocols/Aws_restJson1.ts
+++ b/clients/client-connectparticipant/protocols/Aws_restJson1.ts
@@ -710,7 +710,9 @@ const deserializeAws_restJson1Websocket = (output: any, context: __SerdeContext)
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cost-and-usage-report-service/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-and-usage-report-service/protocols/Aws_json1_1.ts
@@ -633,7 +633,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-cost-explorer/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-explorer/protocols/Aws_json1_1.ts
@@ -5589,7 +5589,9 @@ const deserializeAws_json1_1Values = (output: any, context: __SerdeContext): str
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-customer-profiles/protocols/Aws_restJson1.ts
+++ b/clients/client-customer-profiles/protocols/Aws_restJson1.ts
@@ -4341,7 +4341,9 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-data-pipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-data-pipeline/protocols/Aws_json1_1.ts
@@ -2687,7 +2687,9 @@ const deserializeAws_json1_1ValidationWarnings = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-database-migration-service/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/protocols/Aws_json1_1.ts
@@ -9010,7 +9010,9 @@ const deserializeAws_json1_1VpcSecurityGroupMembershipList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-databrew/protocols/Aws_restJson1.ts
+++ b/clients/client-databrew/protocols/Aws_restJson1.ts
@@ -4855,7 +4855,9 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-dataexchange/protocols/Aws_restJson1.ts
+++ b/clients/client-dataexchange/protocols/Aws_restJson1.ts
@@ -3537,7 +3537,9 @@ const deserializeAws_restJson1S3SnapshotAsset = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-datasync/protocols/Aws_json1_1.ts
+++ b/clients/client-datasync/protocols/Aws_json1_1.ts
@@ -3890,7 +3890,9 @@ const deserializeAws_json1_1UpdateTaskResponse = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-dax/protocols/Aws_json1_1.ts
+++ b/clients/client-dax/protocols/Aws_json1_1.ts
@@ -3866,7 +3866,9 @@ const deserializeAws_json1_1UpdateSubnetGroupResponse = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-detective/protocols/Aws_restJson1.ts
+++ b/clients/client-detective/protocols/Aws_restJson1.ts
@@ -1433,7 +1433,9 @@ const deserializeAws_restJson1UnprocessedAccountList = (output: any, context: __
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-device-farm/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/protocols/Aws_json1_1.ts
@@ -10611,7 +10611,9 @@ const deserializeAws_json1_1VPCEConfigurations = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-devops-guru/protocols/Aws_restJson1.ts
+++ b/clients/client-devops-guru/protocols/Aws_restJson1.ts
@@ -3391,7 +3391,9 @@ const deserializeAws_restJson1ValidationExceptionField = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-direct-connect/protocols/Aws_json1_1.ts
+++ b/clients/client-direct-connect/protocols/Aws_json1_1.ts
@@ -6688,7 +6688,9 @@ const deserializeAws_json1_1VirtualInterfaceTestHistoryList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-directory-service/protocols/Aws_json1_1.ts
+++ b/clients/client-directory-service/protocols/Aws_json1_1.ts
@@ -9668,7 +9668,9 @@ const deserializeAws_json1_1VerifyTrustResult = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-dlm/protocols/Aws_restJson1.ts
+++ b/clients/client-dlm/protocols/Aws_restJson1.ts
@@ -1495,7 +1495,9 @@ const deserializeAws_restJson1VariableTagsList = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-docdb/protocols/Aws_query.ts
+++ b/clients/client-docdb/protocols/Aws_query.ts
@@ -8655,7 +8655,9 @@ const deserializeAws_queryVpcSecurityGroupMembershipList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
@@ -853,7 +853,9 @@ const deserializeAws_json1_0TrimmedDataAccessException = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-dynamodb/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/protocols/Aws_json1_0.ts
@@ -10098,7 +10098,9 @@ const deserializeAws_json1_0WriteRequests = (output: any, context: __SerdeContex
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-ebs/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/protocols/Aws_restJson1.ts
@@ -1157,7 +1157,9 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): Tag
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-ec2-instance-connect/protocols/Aws_json1_1.ts
+++ b/clients/client-ec2-instance-connect/protocols/Aws_json1_1.ts
@@ -248,7 +248,9 @@ const deserializeAws_json1_1ThrottlingException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-ec2/protocols/Aws_ec2.ts
+++ b/clients/client-ec2/protocols/Aws_ec2.ts
@@ -70438,7 +70438,9 @@ const deserializeAws_ec2WithdrawByoipCidrResult = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-ecr-public/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr-public/protocols/Aws_json1_1.ts
@@ -3421,7 +3421,9 @@ const deserializeAws_json1_1UploadNotFoundException = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-ecr/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr/protocols/Aws_json1_1.ts
@@ -5612,7 +5612,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-ecs/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/protocols/Aws_json1_1.ts
@@ -10131,7 +10131,9 @@ const deserializeAws_json1_1VolumeList = (output: any, context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-efs/protocols/Aws_restJson1.ts
+++ b/clients/client-efs/protocols/Aws_restJson1.ts
@@ -4075,7 +4075,9 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): Tag
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-eks/protocols/Aws_restJson1.ts
+++ b/clients/client-eks/protocols/Aws_restJson1.ts
@@ -4581,7 +4581,9 @@ const deserializeAws_restJson1VpcConfigResponse = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-elastic-beanstalk/protocols/Aws_query.ts
+++ b/clients/client-elastic-beanstalk/protocols/Aws_query.ts
@@ -8152,7 +8152,9 @@ const deserializeAws_queryVersionLabelsList = (output: any, context: __SerdeCont
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-elastic-inference/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-inference/protocols/Aws_restJson1.ts
@@ -871,7 +871,9 @@ const deserializeAws_restJson1ThroughputInfoList = (output: any, context: __Serd
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing-v2/protocols/Aws_query.ts
@@ -7808,7 +7808,9 @@ const deserializeAws_queryUnsupportedProtocolException = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-elastic-load-balancing/protocols/Aws_query.ts
+++ b/clients/client-elastic-load-balancing/protocols/Aws_query.ts
@@ -5357,7 +5357,9 @@ const deserializeAws_queryUnsupportedProtocolException = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-elastic-transcoder/protocols/Aws_restJson1.ts
+++ b/clients/client-elastic-transcoder/protocols/Aws_restJson1.ts
@@ -3445,7 +3445,9 @@ const deserializeAws_restJson1Warnings = (output: any, context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-elasticache/protocols/Aws_query.ts
+++ b/clients/client-elasticache/protocols/Aws_query.ts
@@ -14327,7 +14327,9 @@ const deserializeAws_queryUserQuotaExceededFault = (output: any, context: __Serd
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
+++ b/clients/client-elasticsearch-service/protocols/Aws_restJson1.ts
@@ -6451,7 +6451,9 @@ const deserializeAws_restJson1ZoneAwarenessConfig = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-emr-containers/protocols/Aws_restJson1.ts
+++ b/clients/client-emr-containers/protocols/Aws_restJson1.ts
@@ -2189,7 +2189,9 @@ const deserializeAws_restJson1VirtualClusters = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-emr/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/protocols/Aws_json1_1.ts
@@ -7319,7 +7319,9 @@ const deserializeAws_json1_1XmlStringMaxLen256List = (output: any, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-eventbridge/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/protocols/Aws_json1_1.ts
@@ -5643,7 +5643,9 @@ const deserializeAws_json1_1UpdateArchiveResponse = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-firehose/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/protocols/Aws_json1_1.ts
@@ -3460,7 +3460,9 @@ const deserializeAws_json1_1VpcConfigurationDescription = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-fms/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/protocols/Aws_json1_1.ts
@@ -4043,7 +4043,9 @@ const deserializeAws_json1_1ViolationDetail = (output: any, context: __SerdeCont
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-forecast/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/protocols/Aws_json1_1.ts
@@ -4981,7 +4981,9 @@ const deserializeAws_json1_1WindowSummary = (output: any, context: __SerdeContex
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-forecastquery/protocols/Aws_json1_1.ts
+++ b/clients/client-forecastquery/protocols/Aws_json1_1.ts
@@ -303,7 +303,9 @@ const deserializeAws_json1_1TimeSeries = (output: any, context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-frauddetector/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/protocols/Aws_json1_1.ts
@@ -7308,7 +7308,9 @@ const deserializeAws_json1_1VariableList = (output: any, context: __SerdeContext
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-fsx/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/protocols/Aws_json1_1.ts
@@ -3685,7 +3685,9 @@ const deserializeAws_json1_1WindowsFileSystemConfiguration = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-gamelift/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/protocols/Aws_json1_1.ts
@@ -13231,7 +13231,9 @@ const deserializeAws_json1_1VpcPeeringConnectionStatus = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-glacier/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1.ts
@@ -5108,7 +5108,9 @@ const deserializeAws_restJson1VaultNotificationConfig = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-global-accelerator/protocols/Aws_json1_1.ts
+++ b/clients/client-global-accelerator/protocols/Aws_json1_1.ts
@@ -6741,7 +6741,9 @@ const deserializeAws_json1_1WithdrawByoipCidrResponse = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-glue/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/protocols/Aws_json1_1.ts
@@ -24256,7 +24256,9 @@ const deserializeAws_json1_1XMLClassifier = (output: any, context: __SerdeContex
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-greengrass/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1.ts
@@ -10535,7 +10535,9 @@ const deserializeAws_restJson1VersionInformation = (output: any, context: __Serd
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-groundstation/protocols/Aws_restJson1.ts
+++ b/clients/client-groundstation/protocols/Aws_restJson1.ts
@@ -3655,7 +3655,9 @@ const deserializeAws_restJson1UplinkSpectrumConfig = (output: any, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-guardduty/protocols/Aws_restJson1.ts
+++ b/clients/client-guardduty/protocols/Aws_restJson1.ts
@@ -7381,7 +7381,9 @@ const deserializeAws_restJson1UsageStatistics = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-health/protocols/Aws_json1_1.ts
+++ b/clients/client-health/protocols/Aws_json1_1.ts
@@ -2039,7 +2039,9 @@ const deserializeAws_json1_1UnsupportedLocale = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-healthlake/protocols/Aws_json1_0.ts
+++ b/clients/client-healthlake/protocols/Aws_json1_0.ts
@@ -997,7 +997,9 @@ const deserializeAws_json1_0ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-honeycode/protocols/Aws_restJson1.ts
+++ b/clients/client-honeycode/protocols/Aws_restJson1.ts
@@ -2687,7 +2687,9 @@ const deserializeAws_restJson1UpsertRowsResultMap = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iam/protocols/Aws_query.ts
+++ b/clients/client-iam/protocols/Aws_query.ts
@@ -19051,7 +19051,9 @@ const deserializeAws_queryvirtualMFADeviceListType = (output: any, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-identitystore/protocols/Aws_json1_1.ts
+++ b/clients/client-identitystore/protocols/Aws_json1_1.ts
@@ -673,7 +673,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-imagebuilder/protocols/Aws_restJson1.ts
+++ b/clients/client-imagebuilder/protocols/Aws_restJson1.ts
@@ -7404,7 +7404,9 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-inspector/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/protocols/Aws_json1_1.ts
@@ -5894,7 +5894,9 @@ const deserializeAws_json1_1UserAttributeList = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iot-1click-devices-service/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-devices-service/protocols/Aws_restJson1.ts
@@ -1700,7 +1700,9 @@ const deserializeAws_restJson1DeviceMethod = (output: any, context: __SerdeConte
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iot-1click-projects/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-1click-projects/protocols/Aws_restJson1.ts
@@ -2176,7 +2176,9 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iot-data-plane/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-data-plane/protocols/Aws_restJson1.ts
@@ -905,7 +905,9 @@ const deserializeAws_restJson1NamedShadowList = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iot-events-data/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events-data/protocols/Aws_restJson1.ts
@@ -846,7 +846,9 @@ const deserializeAws_restJson1Variables = (output: any, context: __SerdeContext)
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iot-events/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-events/protocols/Aws_restJson1.ts
@@ -3179,7 +3179,9 @@ const deserializeAws_restJson1TransitionEvents = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1.ts
+++ b/clients/client-iot-jobs-data-plane/protocols/Aws_restJson1.ts
@@ -785,7 +785,9 @@ const deserializeAws_restJson1JobExecutionSummaryList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iot/protocols/Aws_restJson1.ts
+++ b/clients/client-iot/protocols/Aws_restJson1.ts
@@ -32702,7 +32702,9 @@ const deserializeAws_restJson1ViolationEvents = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iotanalytics/protocols/Aws_restJson1.ts
+++ b/clients/client-iotanalytics/protocols/Aws_restJson1.ts
@@ -5997,7 +5997,9 @@ const deserializeAws_restJson1VersioningConfiguration = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
+++ b/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
@@ -846,7 +846,9 @@ const deserializeAws_json1_1UntagResourceResponse = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iotsitewise/protocols/Aws_restJson1.ts
+++ b/clients/client-iotsitewise/protocols/Aws_restJson1.ts
@@ -9044,7 +9044,9 @@ const deserializeAws_restJson1Variant = (output: any, context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
+++ b/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
@@ -4800,7 +4800,9 @@ const deserializeAws_json1_1UploadEntityDefinitionsResponse = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-ivs/protocols/Aws_restJson1.ts
+++ b/clients/client-ivs/protocols/Aws_restJson1.ts
@@ -2667,7 +2667,9 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-kafka/protocols/Aws_restJson1.ts
+++ b/clients/client-kafka/protocols/Aws_restJson1.ts
@@ -4859,7 +4859,9 @@ const deserializeAws_restJson1ZookeeperNodeInfo = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-kendra/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/protocols/Aws_json1_1.ts
@@ -7116,7 +7116,9 @@ const deserializeAws_json1_1ValueImportanceMap = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
@@ -5915,7 +5915,9 @@ const deserializeAws_json1_1VpcConfigurationDescriptions = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
@@ -3886,7 +3886,9 @@ const deserializeAws_json1_1UpdateApplicationResponse = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-archived-media/protocols/Aws_restJson1.ts
@@ -991,7 +991,9 @@ const deserializeAws_restJson1FragmentList = (output: any, context: __SerdeConte
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-kinesis-video-media/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-media/protocols/Aws_restJson1.ts
@@ -260,7 +260,9 @@ const serializeAws_restJson1StartSelector = (input: StartSelector, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-kinesis-video-signaling/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video-signaling/protocols/Aws_restJson1.ts
@@ -388,7 +388,9 @@ const deserializeAws_restJson1Uris = (output: any, context: __SerdeContext): str
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-kinesis-video/protocols/Aws_restJson1.ts
+++ b/clients/client-kinesis-video/protocols/Aws_restJson1.ts
@@ -2665,7 +2665,9 @@ const deserializeAws_restJson1StreamInfoList = (output: any, context: __SerdeCon
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-kinesis/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/protocols/Aws_json1_1.ts
@@ -3972,7 +3972,9 @@ const deserializeAws_json1_1UpdateShardCountOutput = (output: any, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-kms/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/protocols/Aws_json1_1.ts
@@ -7221,7 +7221,9 @@ const deserializeAws_json1_1VerifyResponse = (output: any, context: __SerdeConte
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-lakeformation/protocols/Aws_json1_1.ts
+++ b/clients/client-lakeformation/protocols/Aws_json1_1.ts
@@ -2175,7 +2175,9 @@ const deserializeAws_json1_1UpdateResourceResponse = (output: any, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-lambda/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1.ts
@@ -10319,7 +10319,9 @@ const deserializeAws_restJson1VpcConfigResponse = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-lex-model-building-service/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-model-building-service/protocols/Aws_restJson1.ts
@@ -6583,7 +6583,9 @@ const deserializeAws_restJson1UtteranceList = (output: any, context: __SerdeCont
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-lex-runtime-service/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/protocols/Aws_restJson1.ts
@@ -1549,7 +1549,9 @@ const deserializeAws_restJson1StringMap = (output: any, context: __SerdeContext)
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-license-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-license-manager/protocols/Aws_json1_1.ts
@@ -7087,7 +7087,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-lightsail/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/protocols/Aws_json1_1.ts
@@ -22766,7 +22766,9 @@ const deserializeAws_json1_1UpdateRelationalDatabaseResult = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-lookoutvision/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutvision/protocols/Aws_restJson1.ts
@@ -2678,7 +2678,9 @@ const deserializeAws_restJson1S3Location = (output: any, context: __SerdeContext
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-machine-learning/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/protocols/Aws_json1_1.ts
@@ -3967,7 +3967,9 @@ const deserializeAws_json1_1UpdateMLModelOutput = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-macie/protocols/Aws_json1_1.ts
+++ b/clients/client-macie/protocols/Aws_json1_1.ts
@@ -1023,7 +1023,9 @@ const deserializeAws_json1_1UpdateS3ResourcesResult = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-macie2/protocols/Aws_restJson1.ts
+++ b/clients/client-macie2/protocols/Aws_restJson1.ts
@@ -8953,7 +8953,9 @@ const deserializeAws_restJson1WeeklySchedule = (output: any, context: __SerdeCon
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-managedblockchain/protocols/Aws_restJson1.ts
+++ b/clients/client-managedblockchain/protocols/Aws_restJson1.ts
@@ -3480,7 +3480,9 @@ const deserializeAws_restJson1VotingPolicy = (output: any, context: __SerdeConte
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-marketplace-catalog/protocols/Aws_restJson1.ts
+++ b/clients/client-marketplace-catalog/protocols/Aws_restJson1.ts
@@ -1125,7 +1125,9 @@ const deserializeAws_restJson1ResourceIdList = (output: any, context: __SerdeCon
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-marketplace-commerce-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-commerce-analytics/protocols/Aws_json1_1.ts
@@ -250,7 +250,9 @@ const deserializeAws_json1_1StartSupportDataExportResult = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
@@ -276,7 +276,9 @@ const deserializeAws_json1_1ThrottlingException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
@@ -1167,7 +1167,9 @@ const deserializeAws_json1_1UsageRecordResultList = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-mediaconnect/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconnect/protocols/Aws_restJson1.ts
@@ -4274,7 +4274,9 @@ const deserializeAws_restJson1VpcInterfaceAttachment = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-mediaconvert/protocols/Aws_restJson1.ts
+++ b/clients/client-mediaconvert/protocols/Aws_restJson1.ts
@@ -9853,7 +9853,9 @@ const deserializeAws_restJson1WavSettings = (output: any, context: __SerdeContex
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-medialive/protocols/Aws_restJson1.ts
+++ b/clients/client-medialive/protocols/Aws_restJson1.ts
@@ -15787,7 +15787,9 @@ const deserializeAws_restJson1WebvttDestinationSettings = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-mediapackage-vod/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage-vod/protocols/Aws_restJson1.ts
@@ -2858,7 +2858,9 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-mediapackage/protocols/Aws_restJson1.ts
+++ b/clients/client-mediapackage/protocols/Aws_restJson1.ts
@@ -3643,7 +3643,9 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-mediastore-data/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/protocols/Aws_restJson1.ts
@@ -684,7 +684,9 @@ const deserializeAws_restJson1ItemList = (output: any, context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-mediastore/protocols/Aws_json1_1.ts
+++ b/clients/client-mediastore/protocols/Aws_json1_1.ts
@@ -2609,7 +2609,9 @@ const deserializeAws_json1_1UntagResourceOutput = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-mediatailor/protocols/Aws_restJson1.ts
+++ b/clients/client-mediatailor/protocols/Aws_restJson1.ts
@@ -1034,7 +1034,9 @@ const deserializeAws_restJson1PlaybackConfiguration = (output: any, context: __S
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-migration-hub/protocols/Aws_json1_1.ts
+++ b/clients/client-migration-hub/protocols/Aws_json1_1.ts
@@ -3099,7 +3099,9 @@ const deserializeAws_json1_1UnauthorizedOperation = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-migrationhub-config/protocols/Aws_json1_1.ts
+++ b/clients/client-migrationhub-config/protocols/Aws_json1_1.ts
@@ -574,7 +574,9 @@ const deserializeAws_json1_1ThrottlingException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-mobile/protocols/Aws_restJson1.ts
+++ b/clients/client-mobile/protocols/Aws_restJson1.ts
@@ -1418,7 +1418,9 @@ const deserializeAws_restJson1Resources = (output: any, context: __SerdeContext)
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-mq/protocols/Aws_restJson1.ts
+++ b/clients/client-mq/protocols/Aws_restJson1.ts
@@ -3501,7 +3501,9 @@ const deserializeAws_restJson1WeeklyStartTime = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-mturk/protocols/Aws_json1_1.ts
+++ b/clients/client-mturk/protocols/Aws_json1_1.ts
@@ -4774,7 +4774,9 @@ const deserializeAws_json1_1WorkerBlockList = (output: any, context: __SerdeCont
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-neptune/protocols/Aws_query.ts
+++ b/clients/client-neptune/protocols/Aws_query.ts
@@ -13121,7 +13121,9 @@ const deserializeAws_queryVpcSecurityGroupMembershipList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-network-firewall/protocols/Aws_json1_0.ts
+++ b/clients/client-network-firewall/protocols/Aws_json1_0.ts
@@ -5314,7 +5314,9 @@ const deserializeAws_json1_0VariableDefinitionList = (output: any, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-networkmanager/protocols/Aws_restJson1.ts
+++ b/clients/client-networkmanager/protocols/Aws_restJson1.ts
@@ -5354,7 +5354,9 @@ const deserializeAws_restJson1ValidationExceptionFieldList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-opsworks/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/protocols/Aws_json1_1.ts
@@ -8635,7 +8635,9 @@ const deserializeAws_json1_1WeeklyAutoScalingSchedule = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-opsworkscm/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworkscm/protocols/Aws_json1_1.ts
@@ -2467,7 +2467,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-organizations/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/protocols/Aws_json1_1.ts
@@ -8916,7 +8916,9 @@ const deserializeAws_json1_1UpdatePolicyResponse = (output: any, context: __Serd
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-outposts/protocols/Aws_restJson1.ts
+++ b/clients/client-outposts/protocols/Aws_restJson1.ts
@@ -972,7 +972,9 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-personalize-events/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-events/protocols/Aws_restJson1.ts
@@ -372,7 +372,9 @@ const serializeAws_restJson1UserList = (input: User[], context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-personalize-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-personalize-runtime/protocols/Aws_restJson1.ts
@@ -300,7 +300,9 @@ const deserializeAws_restJson1PredictedItem = (output: any, context: __SerdeCont
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-personalize/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/protocols/Aws_json1_1.ts
@@ -6012,7 +6012,9 @@ const deserializeAws_json1_1UpdateCampaignResponse = (output: any, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-pi/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/protocols/Aws_json1_1.ts
@@ -545,7 +545,9 @@ const deserializeAws_json1_1ResponseResourceMetricKey = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-email/protocols/Aws_restJson1.ts
@@ -5733,7 +5733,9 @@ const deserializeAws_restJson1VolumeStatistics = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint-sms-voice/protocols/Aws_restJson1.ts
@@ -1241,7 +1241,9 @@ const deserializeAws_restJson1SnsDestination = (output: any, context: __SerdeCon
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-pinpoint/protocols/Aws_restJson1.ts
+++ b/clients/client-pinpoint/protocols/Aws_restJson1.ts
@@ -19955,7 +19955,9 @@ const deserializeAws_restJson1WaitTime = (output: any, context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-polly/protocols/Aws_restJson1.ts
+++ b/clients/client-polly/protocols/Aws_restJson1.ts
@@ -1641,7 +1641,9 @@ const deserializeAws_restJson1VoiceList = (output: any, context: __SerdeContext)
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-pricing/protocols/Aws_json1_1.ts
+++ b/clients/client-pricing/protocols/Aws_json1_1.ts
@@ -591,7 +591,9 @@ const deserializeAws_json1_1ServiceList = (output: any, context: __SerdeContext)
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-qldb-session/protocols/Aws_json1_0.ts
+++ b/clients/client-qldb-session/protocols/Aws_json1_0.ts
@@ -453,7 +453,9 @@ const deserializeAws_json1_0ValueHolders = (output: any, context: __SerdeContext
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-qldb/protocols/Aws_restJson1.ts
+++ b/clients/client-qldb/protocols/Aws_restJson1.ts
@@ -2347,7 +2347,9 @@ const deserializeAws_restJson1ValueHolder = (output: any, context: __SerdeContex
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-quicksight/protocols/Aws_restJson1.ts
+++ b/clients/client-quicksight/protocols/Aws_restJson1.ts
@@ -19379,7 +19379,9 @@ const deserializeAws_restJson1VpcConnectionProperties = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-ram/protocols/Aws_restJson1.ts
+++ b/clients/client-ram/protocols/Aws_restJson1.ts
@@ -4220,7 +4220,9 @@ const deserializeAws_restJson1TagList = (output: any, context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-rds-data/protocols/Aws_restJson1.ts
+++ b/clients/client-rds-data/protocols/Aws_restJson1.ts
@@ -1331,7 +1331,9 @@ const deserializeAws_restJson1Value = (output: any, context: __SerdeContext): Va
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-rds/protocols/Aws_query.ts
+++ b/clients/client-rds/protocols/Aws_query.ts
@@ -27030,7 +27030,9 @@ const deserializeAws_queryVpnDetails = (output: any, context: __SerdeContext): V
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-redshift-data/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-data/protocols/Aws_json1_1.ts
@@ -1230,7 +1230,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-redshift/protocols/Aws_query.ts
+++ b/clients/client-redshift/protocols/Aws_query.ts
@@ -18525,7 +18525,9 @@ const deserializeAws_queryVpcSecurityGroupMembershipList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-rekognition/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/protocols/Aws_json1_1.ts
@@ -9430,7 +9430,9 @@ const deserializeAws_json1_1VideoTooLargeException = (output: any, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
+++ b/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
@@ -1353,7 +1353,9 @@ const deserializeAws_json1_1UntagResourcesOutput = (output: any, context: __Serd
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-resource-groups/protocols/Aws_restJson1.ts
+++ b/clients/client-resource-groups/protocols/Aws_restJson1.ts
@@ -2458,7 +2458,9 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-robomaker/protocols/Aws_restJson1.ts
+++ b/clients/client-robomaker/protocols/Aws_restJson1.ts
@@ -9121,7 +9121,9 @@ const deserializeAws_restJson1WorldSummary = (output: any, context: __SerdeConte
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-route-53-domains/protocols/Aws_json1_1.ts
+++ b/clients/client-route-53-domains/protocols/Aws_json1_1.ts
@@ -3557,7 +3557,9 @@ const deserializeAws_json1_1ViewBillingResponse = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-route-53/protocols/Aws_restXml.ts
+++ b/clients/client-route-53/protocols/Aws_restXml.ts
@@ -8972,7 +8972,9 @@ const deserializeAws_restXmlVPCs = (output: any, context: __SerdeContext): VPC[]
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-route53resolver/protocols/Aws_json1_1.ts
+++ b/clients/client-route53resolver/protocols/Aws_json1_1.ts
@@ -4995,7 +4995,9 @@ const deserializeAws_json1_1UpdateResolverRuleResponse = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-s3-control/protocols/Aws_restXml.ts
+++ b/clients/client-s3-control/protocols/Aws_restXml.ts
@@ -6732,7 +6732,9 @@ const deserializeAws_restXmlVpcConfiguration = (output: any, context: __SerdeCon
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -14269,7 +14269,9 @@ const deserializeAws_restXmlTransitionList = (output: any, context: __SerdeConte
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-s3outposts/protocols/Aws_restJson1.ts
+++ b/clients/client-s3outposts/protocols/Aws_restJson1.ts
@@ -477,7 +477,9 @@ const deserializeAws_restJson1NetworkInterfaces = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-a2i-runtime/protocols/Aws_restJson1.ts
@@ -773,7 +773,9 @@ const deserializeAws_restJson1HumanLoopSummary = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sagemaker-edge/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-edge/protocols/Aws_restJson1.ts
@@ -244,7 +244,9 @@ const serializeAws_restJson1Models = (input: Model[], context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sagemaker-featurestore-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-featurestore-runtime/protocols/Aws_restJson1.ts
@@ -486,7 +486,9 @@ const deserializeAws_restJson1Record = (output: any, context: __SerdeContext): F
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sagemaker-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-runtime/protocols/Aws_restJson1.ts
@@ -224,7 +224,9 @@ const deserializeAws_restJson1ValidationErrorResponse = async (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sagemaker/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/protocols/Aws_json1_1.ts
@@ -34181,7 +34181,9 @@ const deserializeAws_json1_1Workteams = (output: any, context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-savingsplans/protocols/Aws_restJson1.ts
+++ b/clients/client-savingsplans/protocols/Aws_restJson1.ts
@@ -1681,7 +1681,9 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-schemas/protocols/Aws_restJson1.ts
+++ b/clients/client-schemas/protocols/Aws_restJson1.ts
@@ -4626,7 +4626,9 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-secrets-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/protocols/Aws_json1_1.ts
@@ -2863,7 +2863,9 @@ const deserializeAws_json1_1ValidationErrorsType = (output: any, context: __Serd
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-securityhub/protocols/Aws_restJson1.ts
+++ b/clients/client-securityhub/protocols/Aws_restJson1.ts
@@ -16810,7 +16810,9 @@ const deserializeAws_restJson1Workflow = (output: any, context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1.ts
+++ b/clients/client-serverlessapplicationrepository/protocols/Aws_restJson1.ts
@@ -2479,7 +2479,9 @@ const deserializeAws_restJson1VersionSummary = (output: any, context: __SerdeCon
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-service-catalog-appregistry/protocols/Aws_restJson1.ts
+++ b/clients/client-service-catalog-appregistry/protocols/Aws_restJson1.ts
@@ -2351,7 +2351,9 @@ const deserializeAws_restJson1Tags = (output: any, context: __SerdeContext): { [
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-service-catalog/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/protocols/Aws_json1_1.ts
@@ -11238,7 +11238,9 @@ const deserializeAws_json1_1UsageInstructions = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-service-quotas/protocols/Aws_json1_1.ts
+++ b/clients/client-service-quotas/protocols/Aws_json1_1.ts
@@ -2841,7 +2841,9 @@ const deserializeAws_json1_1TooManyRequestsException = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-servicediscovery/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/protocols/Aws_json1_1.ts
@@ -3341,7 +3341,9 @@ const deserializeAws_json1_1UpdateServiceResponse = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-ses/protocols/Aws_query.ts
+++ b/clients/client-ses/protocols/Aws_query.ts
@@ -10267,7 +10267,9 @@ const deserializeAws_queryWorkmailAction = (output: any, context: __SerdeContext
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sesv2/protocols/Aws_restJson1.ts
+++ b/clients/client-sesv2/protocols/Aws_restJson1.ts
@@ -10675,7 +10675,9 @@ const deserializeAws_restJson1VolumeStatistics = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sfn/protocols/Aws_json1_0.ts
+++ b/clients/client-sfn/protocols/Aws_json1_0.ts
@@ -3890,7 +3890,9 @@ const deserializeAws_json1_0UpdateStateMachineOutput = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-shield/protocols/Aws_json1_1.ts
+++ b/clients/client-shield/protocols/Aws_json1_1.ts
@@ -4291,7 +4291,9 @@ const deserializeAws_json1_1ValidationExceptionFieldList = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-signer/protocols/Aws_restJson1.ts
+++ b/clients/client-signer/protocols/Aws_restJson1.ts
@@ -2916,7 +2916,9 @@ const deserializeAws_restJson1TagMap = (output: any, context: __SerdeContext): {
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sms/protocols/Aws_json1_1.ts
+++ b/clients/client-sms/protocols/Aws_json1_1.ts
@@ -5756,7 +5756,9 @@ const deserializeAws_json1_1VmServerAddress = (output: any, context: __SerdeCont
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-snowball/protocols/Aws_json1_1.ts
+++ b/clients/client-snowball/protocols/Aws_json1_1.ts
@@ -3133,7 +3133,9 @@ const deserializeAws_json1_1WirelessConnection = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sns/protocols/Aws_query.ts
+++ b/clients/client-sns/protocols/Aws_query.ts
@@ -5277,7 +5277,9 @@ const deserializeAws_queryUntagResourceResponse = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sqs/protocols/Aws_query.ts
+++ b/clients/client-sqs/protocols/Aws_query.ts
@@ -3088,7 +3088,9 @@ const deserializeAws_queryUnsupportedOperation = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-ssm/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/protocols/Aws_json1_1.ts
@@ -23569,7 +23569,9 @@ const deserializeAws_json1_1ValidNextStepList = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sso-admin/protocols/Aws_json1_1.ts
+++ b/clients/client-sso-admin/protocols/Aws_json1_1.ts
@@ -4659,7 +4659,9 @@ const deserializeAws_json1_1ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sso-oidc/protocols/Aws_restJson1.ts
+++ b/clients/client-sso-oidc/protocols/Aws_restJson1.ts
@@ -734,7 +734,9 @@ const serializeAws_restJson1Scopes = (input: string[], context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sso/models/models_0.ts
+++ b/clients/client-sso/models/models_0.ts
@@ -6,6 +6,11 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  */
 export interface AccountInfo {
   /**
+   * <p>The identifier of the AWS account that is assigned to the user.</p>
+   */
+  accountId?: string;
+
+  /**
    * <p>The display name of the AWS account that is assigned to the user.</p>
    */
   accountName?: string;
@@ -14,11 +19,6 @@ export interface AccountInfo {
    * <p>The email address of the AWS account that is assigned to the user.</p>
    */
   emailAddress?: string;
-
-  /**
-   * <p>The identifier of the AWS account that is assigned to the user.</p>
-   */
-  accountId?: string;
 }
 
 export namespace AccountInfo {
@@ -34,15 +34,15 @@ export interface GetRoleCredentialsRequest {
   roleName: string | undefined;
 
   /**
+   * <p>The identifier for the AWS account that is assigned to the user.</p>
+   */
+  accountId: string | undefined;
+
+  /**
    * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
    *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
    */
   accessToken: string | undefined;
-
-  /**
-   * <p>The identifier for the AWS account that is assigned to the user.</p>
-   */
-  accountId: string | undefined;
 }
 
 export namespace GetRoleCredentialsRequest {
@@ -57,17 +57,6 @@ export namespace GetRoleCredentialsRequest {
  */
 export interface RoleCredentials {
   /**
-   * <p>The date on which temporary security credentials expire.</p>
-   */
-  expiration?: number;
-
-  /**
-   * <p>The token used for temporary credentials. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Security Credentials to Request Access to AWS Resources</a> in the
-   *         <i>AWS IAM User Guide</i>.</p>
-   */
-  sessionToken?: string;
-
-  /**
    * <p>The identifier used for the temporary security credentials. For more information, see
    *         <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Security Credentials to Request Access to AWS Resources</a> in the
    *         <i>AWS IAM User Guide</i>.</p>
@@ -79,13 +68,24 @@ export interface RoleCredentials {
    *         <i>AWS IAM User Guide</i>.</p>
    */
   secretAccessKey?: string;
+
+  /**
+   * <p>The token used for temporary credentials. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Security Credentials to Request Access to AWS Resources</a> in the
+   *         <i>AWS IAM User Guide</i>.</p>
+   */
+  sessionToken?: string;
+
+  /**
+   * <p>The date on which temporary security credentials expire.</p>
+   */
+  expiration?: number;
 }
 
 export namespace RoleCredentials {
   export const filterSensitiveLog = (obj: RoleCredentials): any => ({
     ...obj,
-    ...(obj.sessionToken && { sessionToken: SENSITIVE_STRING }),
     ...(obj.secretAccessKey && { secretAccessKey: SENSITIVE_STRING }),
+    ...(obj.sessionToken && { sessionToken: SENSITIVE_STRING }),
   });
 }
 
@@ -166,10 +166,9 @@ export namespace UnauthorizedException {
 
 export interface ListAccountRolesRequest {
   /**
-   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
-   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
+   * <p>The page token from the previous response output when you request subsequent pages.</p>
    */
-  accessToken: string | undefined;
+  nextToken?: string;
 
   /**
    * <p>The number of items that clients can request per page.</p>
@@ -177,14 +176,15 @@ export interface ListAccountRolesRequest {
   maxResults?: number;
 
   /**
+   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
+   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
+   */
+  accessToken: string | undefined;
+
+  /**
    * <p>The identifier for the AWS account that is assigned to the user.</p>
    */
   accountId: string | undefined;
-
-  /**
-   * <p>The page token from the previous response output when you request subsequent pages.</p>
-   */
-  nextToken?: string;
 }
 
 export namespace ListAccountRolesRequest {
@@ -199,14 +199,14 @@ export namespace ListAccountRolesRequest {
  */
 export interface RoleInfo {
   /**
-   * <p>The identifier of the AWS account assigned to the user.</p>
-   */
-  accountId?: string;
-
-  /**
    * <p>The friendly name of the role that is assigned to the user.</p>
    */
   roleName?: string;
+
+  /**
+   * <p>The identifier of the AWS account assigned to the user.</p>
+   */
+  accountId?: string;
 }
 
 export namespace RoleInfo {
@@ -217,14 +217,14 @@ export namespace RoleInfo {
 
 export interface ListAccountRolesResponse {
   /**
-   * <p>A paginated response with the list of roles and the next token if more results are available.</p>
-   */
-  roleList?: RoleInfo[];
-
-  /**
    * <p>The page token client that is used to retrieve the list of accounts.</p>
    */
   nextToken?: string;
+
+  /**
+   * <p>A paginated response with the list of roles and the next token if more results are available.</p>
+   */
+  roleList?: RoleInfo[];
 }
 
 export namespace ListAccountRolesResponse {
@@ -235,10 +235,9 @@ export namespace ListAccountRolesResponse {
 
 export interface ListAccountsRequest {
   /**
-   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
-   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
+   * <p>(Optional) When requesting subsequent pages, this is the page token from the previous response output.</p>
    */
-  accessToken: string | undefined;
+  nextToken?: string;
 
   /**
    * <p>This is the number of items clients can request per page.</p>
@@ -246,9 +245,10 @@ export interface ListAccountsRequest {
   maxResults?: number;
 
   /**
-   * <p>(Optional) When requesting subsequent pages, this is the page token from the previous response output.</p>
+   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
+   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
    */
-  nextToken?: string;
+  accessToken: string | undefined;
 }
 
 export namespace ListAccountsRequest {
@@ -260,14 +260,14 @@ export namespace ListAccountsRequest {
 
 export interface ListAccountsResponse {
   /**
-   * <p>A paginated response with the list of account information and the next token if more results are available.</p>
-   */
-  accountList?: AccountInfo[];
-
-  /**
    * <p>The page token client that is used to retrieve the list of accounts.</p>
    */
   nextToken?: string;
+
+  /**
+   * <p>A paginated response with the list of account information and the next token if more results are available.</p>
+   */
+  accountList?: AccountInfo[];
 }
 
 export namespace ListAccountsResponse {

--- a/clients/client-sso/protocols/Aws_restJson1.ts
+++ b/clients/client-sso/protocols/Aws_restJson1.ts
@@ -58,9 +58,9 @@ export const serializeAws_restJson1ListAccountRolesCommand = async (
   };
   let resolvedPath = "/assignment/roles";
   const query: any = {
+    ...(input.nextToken !== undefined && { next_token: input.nextToken }),
     ...(input.maxResults !== undefined && { max_result: input.maxResults.toString() }),
     ...(input.accountId !== undefined && { account_id: input.accountId }),
-    ...(input.nextToken !== undefined && { next_token: input.nextToken }),
   };
   let body: any;
   const { hostname, protocol = "https", port } = await context.endpoint();
@@ -85,8 +85,8 @@ export const serializeAws_restJson1ListAccountsCommand = async (
   };
   let resolvedPath = "/assignment/accounts";
   const query: any = {
-    ...(input.maxResults !== undefined && { max_result: input.maxResults.toString() }),
     ...(input.nextToken !== undefined && { next_token: input.nextToken }),
+    ...(input.maxResults !== undefined && { max_result: input.maxResults.toString() }),
   };
   let body: any;
   const { hostname, protocol = "https", port } = await context.endpoint();
@@ -552,7 +552,9 @@ const deserializeAws_restJson1RoleListType = (output: any, context: __SerdeConte
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-storage-gateway/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/protocols/Aws_json1_1.ts
@@ -9818,7 +9818,9 @@ const deserializeAws_json1_1VTLDevices = (output: any, context: __SerdeContext):
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-sts/protocols/Aws_query.ts
+++ b/clients/client-sts/protocols/Aws_query.ts
@@ -1413,7 +1413,9 @@ const deserializeAws_queryRegionDisabledException = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-support/protocols/Aws_json1_1.ts
+++ b/clients/client-support/protocols/Aws_json1_1.ts
@@ -2118,7 +2118,9 @@ const deserializeAws_json1_1TrustedAdvisorResourcesSummary = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-swf/protocols/Aws_json1_0.ts
+++ b/clients/client-swf/protocols/Aws_json1_0.ts
@@ -6123,7 +6123,9 @@ const deserializeAws_json1_0WorkflowTypeInfos = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-synthetics/protocols/Aws_restJson1.ts
+++ b/clients/client-synthetics/protocols/Aws_restJson1.ts
@@ -1801,7 +1801,9 @@ const deserializeAws_restJson1VpcConfigOutput = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-textract/protocols/Aws_json1_1.ts
+++ b/clients/client-textract/protocols/Aws_json1_1.ts
@@ -1696,7 +1696,9 @@ const deserializeAws_json1_1Warnings = (output: any, context: __SerdeContext): W
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-timestream-query/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-query/protocols/Aws_json1_0.ts
@@ -697,7 +697,9 @@ const deserializeAws_json1_0ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-timestream-write/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-write/protocols/Aws_json1_0.ts
@@ -2305,7 +2305,9 @@ const deserializeAws_json1_0ValidationException = (output: any, context: __Serde
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-transcribe-streaming/protocols/Aws_restJson1.ts
+++ b/clients/client-transcribe-streaming/protocols/Aws_restJson1.ts
@@ -884,7 +884,9 @@ const deserializeAws_restJson1TranscriptEvent = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-transcribe/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/protocols/Aws_json1_1.ts
@@ -3896,7 +3896,9 @@ const deserializeAws_json1_1VocabularyInfo = (output: any, context: __SerdeConte
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-transfer/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/protocols/Aws_json1_1.ts
@@ -2992,7 +2992,9 @@ const deserializeAws_json1_1UpdateUserResponse = (output: any, context: __SerdeC
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-translate/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/protocols/Aws_json1_1.ts
@@ -2483,7 +2483,9 @@ const deserializeAws_json1_1UpdateParallelDataResponse = (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-waf-regional/protocols/Aws_json1_1.ts
+++ b/clients/client-waf-regional/protocols/Aws_json1_1.ts
@@ -11706,7 +11706,9 @@ const deserializeAws_json1_1XssMatchTuples = (output: any, context: __SerdeConte
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-waf/protocols/Aws_json1_1.ts
+++ b/clients/client-waf/protocols/Aws_json1_1.ts
@@ -11199,7 +11199,9 @@ const deserializeAws_json1_1XssMatchTuples = (output: any, context: __SerdeConte
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-wafv2/protocols/Aws_json1_1.ts
+++ b/clients/client-wafv2/protocols/Aws_json1_1.ts
@@ -7085,7 +7085,9 @@ const deserializeAws_json1_1XssMatchStatement = (output: any, context: __SerdeCo
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-workdocs/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1.ts
@@ -6600,7 +6600,9 @@ const deserializeAws_restJson1UserStorageMetadata = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-worklink/protocols/Aws_restJson1.ts
+++ b/clients/client-worklink/protocols/Aws_restJson1.ts
@@ -4147,7 +4147,9 @@ const deserializeAws_restJson1WebsiteCaSummaryList = (output: any, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-workmail/protocols/Aws_json1_1.ts
+++ b/clients/client-workmail/protocols/Aws_json1_1.ts
@@ -4892,7 +4892,9 @@ const deserializeAws_json1_1Users = (output: any, context: __SerdeContext): User
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-workmailmessageflow/protocols/Aws_restJson1.ts
+++ b/clients/client-workmailmessageflow/protocols/Aws_restJson1.ts
@@ -115,7 +115,9 @@ const deserializeAws_restJson1ResourceNotFoundExceptionResponse = async (
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-workspaces/protocols/Aws_json1_1.ts
+++ b/clients/client-workspaces/protocols/Aws_json1_1.ts
@@ -7074,7 +7074,9 @@ const deserializeAws_json1_1WorkspacesIpGroupsList = (output: any, context: __Se
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/clients/client-xray/protocols/Aws_restJson1.ts
+++ b/clients/client-xray/protocols/Aws_restJson1.ts
@@ -4273,7 +4273,9 @@ const deserializeAws_restJson1ValueWithServiceIds = (output: any, context: __Ser
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/packages/middleware-logger/src/loggerMiddleware.spec.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.spec.ts
@@ -110,16 +110,7 @@ describe("loggerMiddleware", () => {
         commandName,
         input: mockInputLog,
         output: mockOutputLog,
-        metadata: {
-          statusCode: mockResponse.response.statusCode,
-          requestId: mockResponse.response.headers["x-amzn-requestid"],
-          extendedRequestId: mockResponse.response.headers["x-amz-id-2"],
-          cfId: mockResponse.response.headers["x-amz-cf-id"],
-          retry: {
-            attempts: $metadata.attempts,
-            totalDelay: $metadata.totalRetryDelay,
-          },
-        },
+        metadata: $metadata,
       });
     });
 
@@ -154,16 +145,7 @@ describe("loggerMiddleware", () => {
       expect(logger.info).toHaveBeenCalledWith({
         input: mockArgs.input,
         output: outputWithoutMetadata,
-        metadata: {
-          statusCode: customResponse.response.statusCode,
-          requestId: requestIdBackup,
-          extendedRequestId: undefined,
-          cfId: undefined,
-          retry: {
-            attempts: $metadata.attempts,
-            totalDelay: $metadata.totalRetryDelay,
-          },
-        },
+        metadata: $metadata,
       });
     });
   });

--- a/packages/middleware-logger/src/loggerMiddleware.ts
+++ b/packages/middleware-logger/src/loggerMiddleware.ts
@@ -25,23 +25,13 @@ export const loggerMiddleware = () => <Output extends MetadataBearer = MetadataB
   }
 
   if (typeof logger.info === "function") {
-    const httpResponse = response.response as HttpResponse;
     const { $metadata, ...outputWithoutMetadata } = response.output;
     logger.info({
       clientName,
       commandName,
       input: inputFilterSensitiveLog(args.input),
       output: outputFilterSensitiveLog(outputWithoutMetadata),
-      metadata: {
-        statusCode: httpResponse.statusCode,
-        requestId: httpResponse.headers["x-amzn-requestid"] ?? httpResponse.headers["x-amzn-request-id"],
-        extendedRequestId: httpResponse.headers["x-amz-id-2"],
-        cfId: httpResponse.headers["x-amz-cf-id"],
-        retry: {
-          attempts: $metadata.attempts,
-          totalDelay: $metadata.totalRetryDelay,
-        },
-      },
+      metadata: $metadata,
     });
   }
 

--- a/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
+++ b/protocol_tests/aws-ec2/protocols/Aws_ec2.ts
@@ -1943,7 +1943,9 @@ const deserializeAws_ec2TimestampList = (output: any, context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/protocol_tests/aws-json/protocols/Aws_json1_1.ts
+++ b/protocol_tests/aws-json/protocols/Aws_json1_1.ts
@@ -1481,7 +1481,9 @@ const deserializeAws_json1_1StringMap = (output: any, context: __SerdeContext): 
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/protocol_tests/aws-query/protocols/Aws_query.ts
+++ b/protocol_tests/aws-query/protocols/Aws_query.ts
@@ -2719,7 +2719,9 @@ const deserializeAws_queryTimestampList = (output: any, context: __SerdeContext)
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -4003,7 +4003,9 @@ const deserializeAws_restJson1TimestampList = (output: any, context: __SerdeCont
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -5023,7 +5023,9 @@ const deserializeAws_restXmlTimestampList = (output: any, context: __SerdeContex
 
 const deserializeMetadata = (output: __HttpResponse): __ResponseMetadata => ({
   httpStatusCode: output.statusCode,
-  requestId: output.headers["x-amzn-requestid"],
+  requestId: output.headers["x-amzn-requestid"] ?? output.headers["x-amzn-request-id"],
+  extendedRequestId: output.headers["x-amz-id-2"],
+  cfId: output.headers["x-amz-cf-id"],
 });
 
 // Collect low-level response body stream to Uint8Array.


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1521
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1522
Depends on: https://github.com/awslabs/smithy-typescript/pull/252

*Description of changes:*
fix: log requestId, extendedRequestId, cfId in $metadata

<details>
<summary>Test code</summary>

```js
(async () => {
  const client = new DynamoDB({ region: "us-west-2", logger: console });
  await client.listTables({ Limit: 1 });
})();
```

</details>

<details>
<summary>Test output</summary>

```console
{
  clientName: 'DynamoDBClient',
  commandName: 'ListTablesCommand',
  input: { Limit: 1 },
  output: {
    LastEvaluatedTableName: 'CUSTOMER_LIST',
    TableNames: [ 'CUSTOMER_LIST' ]
  },
  metadata: {
    httpStatusCode: 200,
    requestId: 'B8H6HG1T8PDAL2N4BBHKEBERE3VV4KQNSO5AEMVJF66Q9ASUAAJG',
    extendedRequestId: undefined,
    cfId: undefined,
    attempts: 1,
    totalRetryDelay: 0
  }
}
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
