### PR TITLE
fix(clients): default region and credential provider

### DIFF
--- a/clients/client-accessanalyzer/runtimeConfig.browser.ts
+++ b/clients/client-accessanalyzer/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-acm-pca/runtimeConfig.browser.ts
+++ b/clients/client-acm-pca/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-acm/runtimeConfig.browser.ts
+++ b/clients/client-acm/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-alexa-for-business/runtimeConfig.browser.ts
+++ b/clients/client-alexa-for-business/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-amplify/runtimeConfig.browser.ts
+++ b/clients/client-amplify/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-amplifybackend/runtimeConfig.browser.ts
+++ b/clients/client-amplifybackend/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-api-gateway/runtimeConfig.browser.ts
+++ b/clients/client-api-gateway/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-apigatewaymanagementapi/runtimeConfig.browser.ts
+++ b/clients/client-apigatewaymanagementapi/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-apigatewayv2/runtimeConfig.browser.ts
+++ b/clients/client-apigatewayv2/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-app-mesh/runtimeConfig.browser.ts
+++ b/clients/client-app-mesh/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-appconfig/runtimeConfig.browser.ts
+++ b/clients/client-appconfig/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-appflow/runtimeConfig.browser.ts
+++ b/clients/client-appflow/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-appintegrations/runtimeConfig.browser.ts
+++ b/clients/client-appintegrations/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-application-auto-scaling/runtimeConfig.browser.ts
+++ b/clients/client-application-auto-scaling/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-application-discovery-service/runtimeConfig.browser.ts
+++ b/clients/client-application-discovery-service/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-application-insights/runtimeConfig.browser.ts
+++ b/clients/client-application-insights/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-appstream/runtimeConfig.browser.ts
+++ b/clients/client-appstream/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-appsync/runtimeConfig.browser.ts
+++ b/clients/client-appsync/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-athena/runtimeConfig.browser.ts
+++ b/clients/client-athena/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-auditmanager/runtimeConfig.browser.ts
+++ b/clients/client-auditmanager/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-auto-scaling-plans/runtimeConfig.browser.ts
+++ b/clients/client-auto-scaling-plans/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-auto-scaling/runtimeConfig.browser.ts
+++ b/clients/client-auto-scaling/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-backup/runtimeConfig.browser.ts
+++ b/clients/client-backup/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-batch/runtimeConfig.browser.ts
+++ b/clients/client-batch/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-braket/runtimeConfig.browser.ts
+++ b/clients/client-braket/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-budgets/runtimeConfig.browser.ts
+++ b/clients/client-budgets/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-chime/runtimeConfig.browser.ts
+++ b/clients/client-chime/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloud9/runtimeConfig.browser.ts
+++ b/clients/client-cloud9/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-clouddirectory/runtimeConfig.browser.ts
+++ b/clients/client-clouddirectory/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloudformation/runtimeConfig.browser.ts
+++ b/clients/client-cloudformation/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloudfront/runtimeConfig.browser.ts
+++ b/clients/client-cloudfront/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloudhsm-v2/runtimeConfig.browser.ts
+++ b/clients/client-cloudhsm-v2/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloudhsm/runtimeConfig.browser.ts
+++ b/clients/client-cloudhsm/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloudsearch-domain/runtimeConfig.browser.ts
+++ b/clients/client-cloudsearch-domain/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloudsearch/runtimeConfig.browser.ts
+++ b/clients/client-cloudsearch/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloudtrail/runtimeConfig.browser.ts
+++ b/clients/client-cloudtrail/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloudwatch-events/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch-events/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloudwatch-logs/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch-logs/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cloudwatch/runtimeConfig.browser.ts
+++ b/clients/client-cloudwatch/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-codeartifact/runtimeConfig.browser.ts
+++ b/clients/client-codeartifact/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-codebuild/runtimeConfig.browser.ts
+++ b/clients/client-codebuild/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-codecommit/runtimeConfig.browser.ts
+++ b/clients/client-codecommit/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-codedeploy/runtimeConfig.browser.ts
+++ b/clients/client-codedeploy/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-codeguru-reviewer/runtimeConfig.browser.ts
+++ b/clients/client-codeguru-reviewer/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-codeguruprofiler/runtimeConfig.browser.ts
+++ b/clients/client-codeguruprofiler/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-codepipeline/runtimeConfig.browser.ts
+++ b/clients/client-codepipeline/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-codestar-connections/runtimeConfig.browser.ts
+++ b/clients/client-codestar-connections/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-codestar-notifications/runtimeConfig.browser.ts
+++ b/clients/client-codestar-notifications/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-codestar/runtimeConfig.browser.ts
+++ b/clients/client-codestar/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cognito-identity-provider/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity-provider/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cognito-identity/runtimeConfig.browser.ts
+++ b/clients/client-cognito-identity/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cognito-sync/runtimeConfig.browser.ts
+++ b/clients/client-cognito-sync/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-comprehend/runtimeConfig.browser.ts
+++ b/clients/client-comprehend/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-comprehendmedical/runtimeConfig.browser.ts
+++ b/clients/client-comprehendmedical/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-compute-optimizer/runtimeConfig.browser.ts
+++ b/clients/client-compute-optimizer/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-config-service/runtimeConfig.browser.ts
+++ b/clients/client-config-service/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-connect-contact-lens/runtimeConfig.browser.ts
+++ b/clients/client-connect-contact-lens/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-connect/runtimeConfig.browser.ts
+++ b/clients/client-connect/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-connectparticipant/runtimeConfig.browser.ts
+++ b/clients/client-connectparticipant/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cost-and-usage-report-service/runtimeConfig.browser.ts
+++ b/clients/client-cost-and-usage-report-service/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-cost-explorer/runtimeConfig.browser.ts
+++ b/clients/client-cost-explorer/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-customer-profiles/runtimeConfig.browser.ts
+++ b/clients/client-customer-profiles/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-data-pipeline/runtimeConfig.browser.ts
+++ b/clients/client-data-pipeline/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-database-migration-service/runtimeConfig.browser.ts
+++ b/clients/client-database-migration-service/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-databrew/runtimeConfig.browser.ts
+++ b/clients/client-databrew/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-dataexchange/runtimeConfig.browser.ts
+++ b/clients/client-dataexchange/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-datasync/runtimeConfig.browser.ts
+++ b/clients/client-datasync/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-dax/runtimeConfig.browser.ts
+++ b/clients/client-dax/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-detective/runtimeConfig.browser.ts
+++ b/clients/client-detective/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-device-farm/runtimeConfig.browser.ts
+++ b/clients/client-device-farm/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-devops-guru/runtimeConfig.browser.ts
+++ b/clients/client-devops-guru/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-direct-connect/runtimeConfig.browser.ts
+++ b/clients/client-direct-connect/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-directory-service/runtimeConfig.browser.ts
+++ b/clients/client-directory-service/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-dlm/runtimeConfig.browser.ts
+++ b/clients/client-dlm/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-docdb/runtimeConfig.browser.ts
+++ b/clients/client-docdb/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-dynamodb-streams/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb-streams/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-dynamodb/runtimeConfig.browser.ts
+++ b/clients/client-dynamodb/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-ebs/runtimeConfig.browser.ts
+++ b/clients/client-ebs/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-ec2-instance-connect/runtimeConfig.browser.ts
+++ b/clients/client-ec2-instance-connect/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-ec2/runtimeConfig.browser.ts
+++ b/clients/client-ec2/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-ecr-public/runtimeConfig.browser.ts
+++ b/clients/client-ecr-public/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-ecr/runtimeConfig.browser.ts
+++ b/clients/client-ecr/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-ecs/runtimeConfig.browser.ts
+++ b/clients/client-ecs/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-efs/runtimeConfig.browser.ts
+++ b/clients/client-efs/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-eks/runtimeConfig.browser.ts
+++ b/clients/client-eks/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-elastic-beanstalk/runtimeConfig.browser.ts
+++ b/clients/client-elastic-beanstalk/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-elastic-inference/runtimeConfig.browser.ts
+++ b/clients/client-elastic-inference/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-elastic-load-balancing-v2/runtimeConfig.browser.ts
+++ b/clients/client-elastic-load-balancing-v2/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-elastic-load-balancing/runtimeConfig.browser.ts
+++ b/clients/client-elastic-load-balancing/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-elastic-transcoder/runtimeConfig.browser.ts
+++ b/clients/client-elastic-transcoder/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-elasticache/runtimeConfig.browser.ts
+++ b/clients/client-elasticache/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-elasticsearch-service/runtimeConfig.browser.ts
+++ b/clients/client-elasticsearch-service/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-emr-containers/runtimeConfig.browser.ts
+++ b/clients/client-emr-containers/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-emr/runtimeConfig.browser.ts
+++ b/clients/client-emr/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-eventbridge/runtimeConfig.browser.ts
+++ b/clients/client-eventbridge/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-firehose/runtimeConfig.browser.ts
+++ b/clients/client-firehose/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-fms/runtimeConfig.browser.ts
+++ b/clients/client-fms/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-forecast/runtimeConfig.browser.ts
+++ b/clients/client-forecast/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-forecastquery/runtimeConfig.browser.ts
+++ b/clients/client-forecastquery/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-frauddetector/runtimeConfig.browser.ts
+++ b/clients/client-frauddetector/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-fsx/runtimeConfig.browser.ts
+++ b/clients/client-fsx/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-gamelift/runtimeConfig.browser.ts
+++ b/clients/client-gamelift/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-glacier/runtimeConfig.browser.ts
+++ b/clients/client-glacier/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { bodyChecksumGenerator } from "@aws-sdk/body-checksum-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -23,13 +23,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Encoder: toBase64,
   bodyChecksumGenerator,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-global-accelerator/runtimeConfig.browser.ts
+++ b/clients/client-global-accelerator/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-glue/runtimeConfig.browser.ts
+++ b/clients/client-glue/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-greengrass/runtimeConfig.browser.ts
+++ b/clients/client-greengrass/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-groundstation/runtimeConfig.browser.ts
+++ b/clients/client-groundstation/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-guardduty/runtimeConfig.browser.ts
+++ b/clients/client-guardduty/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-health/runtimeConfig.browser.ts
+++ b/clients/client-health/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-healthlake/runtimeConfig.browser.ts
+++ b/clients/client-healthlake/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-honeycode/runtimeConfig.browser.ts
+++ b/clients/client-honeycode/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iam/runtimeConfig.browser.ts
+++ b/clients/client-iam/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-identitystore/runtimeConfig.browser.ts
+++ b/clients/client-identitystore/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-imagebuilder/runtimeConfig.browser.ts
+++ b/clients/client-imagebuilder/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-inspector/runtimeConfig.browser.ts
+++ b/clients/client-inspector/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iot-1click-devices-service/runtimeConfig.browser.ts
+++ b/clients/client-iot-1click-devices-service/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iot-1click-projects/runtimeConfig.browser.ts
+++ b/clients/client-iot-1click-projects/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iot-data-plane/runtimeConfig.browser.ts
+++ b/clients/client-iot-data-plane/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iot-events-data/runtimeConfig.browser.ts
+++ b/clients/client-iot-events-data/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iot-events/runtimeConfig.browser.ts
+++ b/clients/client-iot-events/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iot-jobs-data-plane/runtimeConfig.browser.ts
+++ b/clients/client-iot-jobs-data-plane/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iot/runtimeConfig.browser.ts
+++ b/clients/client-iot/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iotanalytics/runtimeConfig.browser.ts
+++ b/clients/client-iotanalytics/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iotsecuretunneling/runtimeConfig.browser.ts
+++ b/clients/client-iotsecuretunneling/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iotsitewise/runtimeConfig.browser.ts
+++ b/clients/client-iotsitewise/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-iotthingsgraph/runtimeConfig.browser.ts
+++ b/clients/client-iotthingsgraph/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-ivs/runtimeConfig.browser.ts
+++ b/clients/client-ivs/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-kafka/runtimeConfig.browser.ts
+++ b/clients/client-kafka/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-kendra/runtimeConfig.browser.ts
+++ b/clients/client-kendra/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-kinesis-analytics-v2/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-analytics-v2/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-kinesis-analytics/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-analytics/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-kinesis-video-archived-media/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-archived-media/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-kinesis-video-media/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-media/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-kinesis-video-signaling/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video-signaling/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-kinesis-video/runtimeConfig.browser.ts
+++ b/clients/client-kinesis-video/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-kinesis/runtimeConfig.browser.ts
+++ b/clients/client-kinesis/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -22,14 +22,14 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   eventStreamSerdeProvider,
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-kms/runtimeConfig.browser.ts
+++ b/clients/client-kms/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-lakeformation/runtimeConfig.browser.ts
+++ b/clients/client-lakeformation/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-lambda/runtimeConfig.browser.ts
+++ b/clients/client-lambda/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-lex-model-building-service/runtimeConfig.browser.ts
+++ b/clients/client-lex-model-building-service/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-lex-runtime-service/runtimeConfig.browser.ts
+++ b/clients/client-lex-runtime-service/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-license-manager/runtimeConfig.browser.ts
+++ b/clients/client-license-manager/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-lightsail/runtimeConfig.browser.ts
+++ b/clients/client-lightsail/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-lookoutvision/runtimeConfig.browser.ts
+++ b/clients/client-lookoutvision/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-machine-learning/runtimeConfig.browser.ts
+++ b/clients/client-machine-learning/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-macie/runtimeConfig.browser.ts
+++ b/clients/client-macie/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-macie2/runtimeConfig.browser.ts
+++ b/clients/client-macie2/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-managedblockchain/runtimeConfig.browser.ts
+++ b/clients/client-managedblockchain/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-marketplace-catalog/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-catalog/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-marketplace-commerce-analytics/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-commerce-analytics/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-marketplace-entitlement-service/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-entitlement-service/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-marketplace-metering/runtimeConfig.browser.ts
+++ b/clients/client-marketplace-metering/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-mediaconnect/runtimeConfig.browser.ts
+++ b/clients/client-mediaconnect/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-mediaconvert/runtimeConfig.browser.ts
+++ b/clients/client-mediaconvert/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-medialive/runtimeConfig.browser.ts
+++ b/clients/client-medialive/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-mediapackage-vod/runtimeConfig.browser.ts
+++ b/clients/client-mediapackage-vod/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-mediapackage/runtimeConfig.browser.ts
+++ b/clients/client-mediapackage/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-mediastore-data/runtimeConfig.browser.ts
+++ b/clients/client-mediastore-data/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-mediastore/runtimeConfig.browser.ts
+++ b/clients/client-mediastore/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-mediatailor/runtimeConfig.browser.ts
+++ b/clients/client-mediatailor/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-migration-hub/runtimeConfig.browser.ts
+++ b/clients/client-migration-hub/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-migrationhub-config/runtimeConfig.browser.ts
+++ b/clients/client-migrationhub-config/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-mobile/runtimeConfig.browser.ts
+++ b/clients/client-mobile/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-mq/runtimeConfig.browser.ts
+++ b/clients/client-mq/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-mturk/runtimeConfig.browser.ts
+++ b/clients/client-mturk/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-neptune/runtimeConfig.browser.ts
+++ b/clients/client-neptune/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-network-firewall/runtimeConfig.browser.ts
+++ b/clients/client-network-firewall/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-networkmanager/runtimeConfig.browser.ts
+++ b/clients/client-networkmanager/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-opsworks/runtimeConfig.browser.ts
+++ b/clients/client-opsworks/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-opsworkscm/runtimeConfig.browser.ts
+++ b/clients/client-opsworkscm/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-organizations/runtimeConfig.browser.ts
+++ b/clients/client-organizations/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-outposts/runtimeConfig.browser.ts
+++ b/clients/client-outposts/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-personalize-events/runtimeConfig.browser.ts
+++ b/clients/client-personalize-events/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-personalize-runtime/runtimeConfig.browser.ts
+++ b/clients/client-personalize-runtime/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-personalize/runtimeConfig.browser.ts
+++ b/clients/client-personalize/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-pi/runtimeConfig.browser.ts
+++ b/clients/client-pi/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-pinpoint-email/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint-email/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-pinpoint-sms-voice/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint-sms-voice/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-pinpoint/runtimeConfig.browser.ts
+++ b/clients/client-pinpoint/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-polly/runtimeConfig.browser.ts
+++ b/clients/client-polly/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-pricing/runtimeConfig.browser.ts
+++ b/clients/client-pricing/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-qldb-session/runtimeConfig.browser.ts
+++ b/clients/client-qldb-session/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-qldb/runtimeConfig.browser.ts
+++ b/clients/client-qldb/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-quicksight/runtimeConfig.browser.ts
+++ b/clients/client-quicksight/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-ram/runtimeConfig.browser.ts
+++ b/clients/client-ram/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-rds-data/runtimeConfig.browser.ts
+++ b/clients/client-rds-data/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-rds/runtimeConfig.browser.ts
+++ b/clients/client-rds/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-redshift-data/runtimeConfig.browser.ts
+++ b/clients/client-redshift-data/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-redshift/runtimeConfig.browser.ts
+++ b/clients/client-redshift/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-rekognition/runtimeConfig.browser.ts
+++ b/clients/client-rekognition/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-resource-groups-tagging-api/runtimeConfig.browser.ts
+++ b/clients/client-resource-groups-tagging-api/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-resource-groups/runtimeConfig.browser.ts
+++ b/clients/client-resource-groups/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-robomaker/runtimeConfig.browser.ts
+++ b/clients/client-robomaker/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-route-53-domains/runtimeConfig.browser.ts
+++ b/clients/client-route-53-domains/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-route-53/runtimeConfig.browser.ts
+++ b/clients/client-route-53/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-route53resolver/runtimeConfig.browser.ts
+++ b/clients/client-route53resolver/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-s3-control/runtimeConfig.browser.ts
+++ b/clients/client-s3-control/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-s3/runtimeConfig.browser.ts
+++ b/clients/client-s3/runtimeConfig.browser.ts
@@ -4,7 +4,7 @@ import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
 import { blobHasher as streamHasher } from "@aws-sdk/hash-blob-browser";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { Md5 } from "@aws-sdk/md5-js";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
@@ -24,7 +24,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
@@ -32,7 +32,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   eventStreamSerdeProvider,
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   md5: Md5,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-s3outposts/runtimeConfig.browser.ts
+++ b/clients/client-s3outposts/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sagemaker-a2i-runtime/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-a2i-runtime/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sagemaker-edge/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-edge/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sagemaker-featurestore-runtime/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-featurestore-runtime/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sagemaker-runtime/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker-runtime/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sagemaker/runtimeConfig.browser.ts
+++ b/clients/client-sagemaker/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-savingsplans/runtimeConfig.browser.ts
+++ b/clients/client-savingsplans/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-schemas/runtimeConfig.browser.ts
+++ b/clients/client-schemas/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-secrets-manager/runtimeConfig.browser.ts
+++ b/clients/client-secrets-manager/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-securityhub/runtimeConfig.browser.ts
+++ b/clients/client-securityhub/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-serverlessapplicationrepository/runtimeConfig.browser.ts
+++ b/clients/client-serverlessapplicationrepository/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-service-catalog-appregistry/runtimeConfig.browser.ts
+++ b/clients/client-service-catalog-appregistry/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-service-catalog/runtimeConfig.browser.ts
+++ b/clients/client-service-catalog/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-service-quotas/runtimeConfig.browser.ts
+++ b/clients/client-service-quotas/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-servicediscovery/runtimeConfig.browser.ts
+++ b/clients/client-servicediscovery/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-ses/runtimeConfig.browser.ts
+++ b/clients/client-ses/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sesv2/runtimeConfig.browser.ts
+++ b/clients/client-sesv2/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sfn/runtimeConfig.browser.ts
+++ b/clients/client-sfn/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-shield/runtimeConfig.browser.ts
+++ b/clients/client-shield/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-signer/runtimeConfig.browser.ts
+++ b/clients/client-signer/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sms/runtimeConfig.browser.ts
+++ b/clients/client-sms/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-snowball/runtimeConfig.browser.ts
+++ b/clients/client-snowball/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sns/runtimeConfig.browser.ts
+++ b/clients/client-sns/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sqs/runtimeConfig.browser.ts
+++ b/clients/client-sqs/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { Md5 } from "@aws-sdk/md5-js";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
@@ -22,14 +22,14 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
   md5: Md5,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-ssm/runtimeConfig.browser.ts
+++ b/clients/client-ssm/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sso-admin/runtimeConfig.browser.ts
+++ b/clients/client-sso-admin/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sso-oidc/runtimeConfig.browser.ts
+++ b/clients/client-sso-oidc/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sso/runtimeConfig.browser.ts
+++ b/clients/client-sso/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-storage-gateway/runtimeConfig.browser.ts
+++ b/clients/client-storage-gateway/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-sts/runtimeConfig.browser.ts
+++ b/clients/client-sts/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-support/runtimeConfig.browser.ts
+++ b/clients/client-support/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-swf/runtimeConfig.browser.ts
+++ b/clients/client-swf/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-synthetics/runtimeConfig.browser.ts
+++ b/clients/client-synthetics/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-textract/runtimeConfig.browser.ts
+++ b/clients/client-textract/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-timestream-query/runtimeConfig.browser.ts
+++ b/clients/client-timestream-query/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-timestream-write/runtimeConfig.browser.ts
+++ b/clients/client-timestream-write/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-transcribe-streaming/runtimeConfig.browser.ts
+++ b/clients/client-transcribe-streaming/runtimeConfig.browser.ts
@@ -3,7 +3,7 @@ import packageInfo from "./package.json";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { eventStreamSerdeProvider } from "@aws-sdk/eventstream-serde-browser";
 import { streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { WebSocketHandler, eventStreamPayloadHandler } from "@aws-sdk/middleware-sdk-transcribe-streaming";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
@@ -23,7 +23,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
@@ -31,7 +31,7 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   eventStreamPayloadHandlerProvider: () => eventStreamPayloadHandler,
   eventStreamSerdeProvider,
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new WebSocketHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-transcribe/runtimeConfig.browser.ts
+++ b/clients/client-transcribe/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-transfer/runtimeConfig.browser.ts
+++ b/clients/client-transfer/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-translate/runtimeConfig.browser.ts
+++ b/clients/client-translate/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-waf-regional/runtimeConfig.browser.ts
+++ b/clients/client-waf-regional/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-waf/runtimeConfig.browser.ts
+++ b/clients/client-waf/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-wafv2/runtimeConfig.browser.ts
+++ b/clients/client-wafv2/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-workdocs/runtimeConfig.browser.ts
+++ b/clients/client-workdocs/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-worklink/runtimeConfig.browser.ts
+++ b/clients/client-worklink/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-workmail/runtimeConfig.browser.ts
+++ b/clients/client-workmail/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-workmailmessageflow/runtimeConfig.browser.ts
+++ b/clients/client-workmailmessageflow/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-workspaces/runtimeConfig.browser.ts
+++ b/clients/client-workspaces/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/clients/client-xray/runtimeConfig.browser.ts
+++ b/clients/client-xray/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfig.java
@@ -141,17 +141,14 @@ public final class AddAwsRuntimeConfig implements TypeScriptIntegration {
                 return MapUtils.of(
                         "region", writer -> {
                             writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
-                            writer.addImport("invalidAsyncFunction", "invalidAsyncFunction",
+                            writer.addImport("invalidProvider", "invalidProvider",
                                     TypeScriptDependency.INVALID_DEPENDENCY.packageName);
-                            writer.write("region: invalidAsyncFunction(\"Region is missing\") as any,");
+                            writer.write("region: invalidProvider(\"Region is missing\"),");
                         },
                         "credentialDefaultProvider", writer -> {
-                            writer.addDependency(TypeScriptDependency.INVALID_DEPENDENCY);
-                            writer.addImport("invalidAsyncFunction", "invalidAsyncFunction",
-                                    TypeScriptDependency.INVALID_DEPENDENCY.packageName);
                             writer.write(
-                                    "credentialDefaultProvider: invalidAsyncFunction(\"Credential"
-                                    + "is missing\") as any,");
+                                    "credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("
+                                        + "\"Credential is missing\")),");
                         },
                         "maxAttempts", writer -> {
                             writer.addDependency(TypeScriptDependency.MIDDLEWARE_RETRY);

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddBuiltinPlugins.java
@@ -180,7 +180,7 @@ public class AddBuiltinPlugins implements TypeScriptIntegration {
     }
 
     private static boolean hasOptionalAuthOperation(Model model, ServiceShape service) {
-        TopDownIndex topDownIndex = model.getKnowledge(TopDownIndex.class);
+        TopDownIndex topDownIndex = TopDownIndex.of(model);
         Set<OperationShape> operations = topDownIndex.getContainedOperations(service);
         for (OperationShape operation : operations) {
             if (operation.getTrait(OptionalAuthTrait.class).isPresent()) {

--- a/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
+++ b/codegen/smithy-aws-typescript-codegen/src/test/java/software/amazon/smithy/aws/typescript/codegen/AddAwsRuntimeConfigTest.java
@@ -37,7 +37,7 @@ public class AddAwsRuntimeConfigTest {
 
         // Check that both the config files were updated.
         assertThat(manifest.getFileString("runtimeConfig.ts").get(), containsString("credentialDefaultProvider"));
-        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("invalidAsyncFunction"));
+        assertThat(manifest.getFileString("runtimeConfig.browser.ts").get(), containsString("invalidProvider"));
 
         // Check that the dependency interface was updated.
         assertThat(manifest.getFileString("NotSameClient.ts").get(), containsString("credentialDefaultProvider?"));

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -21,6 +21,7 @@
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/types": "3.0.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/invalid-dependency/src/index.ts
+++ b/packages/invalid-dependency/src/index.ts
@@ -1,2 +1,2 @@
 export * from "./invalidFunction";
-export * from "./invalidAsyncFunction";
+export * from "./invalidProvider";

--- a/packages/invalid-dependency/src/invalidAsyncFunction.spec.ts
+++ b/packages/invalid-dependency/src/invalidAsyncFunction.spec.ts
@@ -1,8 +1,0 @@
-import { invalidAsyncFunction } from "./invalidAsyncFunction";
-
-describe("invalidAsyncFunction", () => {
-  it("rejects with error containing message", async () => {
-    const message = "Error";
-    await expect(invalidAsyncFunction(message)).rejects.toThrow(new Error(message));
-  });
-});

--- a/packages/invalid-dependency/src/invalidAsyncFunction.ts
+++ b/packages/invalid-dependency/src/invalidAsyncFunction.ts
@@ -1,1 +1,0 @@
-export const invalidAsyncFunction = (message: string) => () => Promise.reject(new Error(message));

--- a/packages/invalid-dependency/src/invalidProvider.spec.ts
+++ b/packages/invalid-dependency/src/invalidProvider.spec.ts
@@ -1,0 +1,10 @@
+import { invalidProvider } from "./invalidProvider";
+
+describe("invalidProvider", () => {
+  it("rejects with error containing message", async () => {
+    const message = "Error";
+    const provider = invalidProvider(message);
+    //@ts-ignore
+    await expect(provider()).rejects.toEqual(message);
+  });
+});

--- a/packages/invalid-dependency/src/invalidProvider.ts
+++ b/packages/invalid-dependency/src/invalidProvider.ts
@@ -1,0 +1,2 @@
+import { Provider } from "@aws-sdk/types";
+export const invalidProvider: (message: string) => Provider<any> = (message: string) => () => Promise.reject(message);

--- a/protocol_tests/aws-ec2/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-ec2/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/protocol_tests/aws-json/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-json/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/protocol_tests/aws-query/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-query/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/protocol_tests/aws-restjson/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-restjson/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,

--- a/protocol_tests/aws-restxml/runtimeConfig.browser.ts
+++ b/protocol_tests/aws-restxml/runtimeConfig.browser.ts
@@ -2,7 +2,7 @@ import packageInfo from "./package.json";
 
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { FetchHttpHandler, streamCollector } from "@aws-sdk/fetch-http-handler";
-import { invalidAsyncFunction } from "@aws-sdk/invalid-dependency";
+import { invalidProvider } from "@aws-sdk/invalid-dependency";
 import { DEFAULT_MAX_ATTEMPTS } from "@aws-sdk/middleware-retry";
 import { parseUrl } from "@aws-sdk/url-parser-browser";
 import { fromBase64, toBase64 } from "@aws-sdk/util-base64-browser";
@@ -21,13 +21,13 @@ export const ClientDefaultValues: Required<ClientDefaults> = {
   base64Decoder: fromBase64,
   base64Encoder: toBase64,
   bodyLengthChecker: calculateBodyLength,
-  credentialDefaultProvider: invalidAsyncFunction("Credentialis missing") as any,
+  credentialDefaultProvider: (_: unknown) => () => Promise.reject(new Error("Credential is missing")),
   defaultUserAgentProvider: defaultUserAgent({
     serviceId: ClientSharedValues.serviceId,
     clientVersion: packageInfo.version,
   }),
   maxAttempts: DEFAULT_MAX_ATTEMPTS,
-  region: invalidAsyncFunction("Region is missing") as any,
+  region: invalidProvider("Region is missing"),
   requestHandler: new FetchHttpHandler(),
   sha256: Sha256,
   streamCollector,


### PR DESCRIPTION
This change makes default credential only resolves at signer signing a request. So that it won't resolve at client instantiation. It fixes the issues that the default credentials provider resolves when credentials is not required for given operations, like `CognitoIdentity.getId()`.

Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1798

Example stack trace for missing credentials in browsers: 
```console
Error: Credential is missing
    at SignatureV4.credentialProvider (/home/ec2-user/workspace/aws-sdk-js-v3/clients/client-cognito-identity/runtimeConfig.browser.ts:24:67)
    at SignatureV4.signRequest (/home/ec2-user/workspace/aws-sdk-js-v3/packages/signature-v4/src/SignatureV4.ts:220:36)
    at SignatureV4.sign (/home/ec2-user/workspace/aws-sdk-js-v3/packages/signature-v4/src/SignatureV4.ts:171:19)
    at /home/ec2-user/workspace/aws-sdk-js-v3/packages/middleware-signing/src/middleware.ts:28:31
    at StandardRetryStrategy.retry (/home/ec2-user/workspace/aws-sdk-js-v3/packages/middleware-retry/src/defaultStrategy.ts:125:38)
    at /home/ec2-user/workspace/aws-sdk-js-v3/packages/middleware-logger/src/loggerMiddleware.ts:21:20 {
  '$metadata': { attempts: 1, totalRetryDelay: 0 }
}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
