### PR TITLE
fix(clients): use signing name from auth sigv4 trait

### DIFF
--- a/clients/client-apigatewaymanagementapi/endpoints.ts
+++ b/clients/client-apigatewaymanagementapi/endpoints.ts
@@ -79,5 +79,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve({ signingService: "apigateway", ...regionInfo });
+  return Promise.resolve({ signingService: "execute-api", ...regionInfo });
 };

--- a/clients/client-codeguruprofiler/endpoints.ts
+++ b/clients/client-codeguruprofiler/endpoints.ts
@@ -79,5 +79,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve({ signingService: "codeguru-profiler", ...regionInfo });
+  return Promise.resolve({ signingService: "codeguruprofiler", ...regionInfo });
 };

--- a/clients/client-connectparticipant/endpoints.ts
+++ b/clients/client-connectparticipant/endpoints.ts
@@ -79,5 +79,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve({ signingService: "connect", ...regionInfo });
+  return Promise.resolve({ signingService: "execute-api", ...regionInfo });
 };

--- a/clients/client-iot/endpoints.ts
+++ b/clients/client-iot/endpoints.ts
@@ -237,5 +237,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve({ signingService: "iot", ...regionInfo });
+  return Promise.resolve({ signingService: "execute-api", ...regionInfo });
 };

--- a/protocol_tests/aws-json/endpoints.ts
+++ b/protocol_tests/aws-json/endpoints.ts
@@ -79,5 +79,5 @@ export const defaultRegionInfoProvider: RegionInfoProvider = (region: string, op
         };
       }
   }
-  return Promise.resolve({ signingService: "jsonprotocol", ...regionInfo });
+  return Promise.resolve({ signingService: "foo", ...regionInfo });
 };


### PR DESCRIPTION
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1831

*Description of changes:*
The code generator ignores the [aws.auth#sigv4 trait](https://github.com/aws/aws-sdk-js-v3/blob/54e87151877dd5cf9a5f256698c088cc7a856225/codegen%2Fsdk-codegen%2Faws-models%2Fapigatewaymanagementapi.2018-11-29.json#L55) when inferring the signing name. With this change, SDK will use the trait and fall back to `arnNamespace`(for non-AWS clients).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
