### PR TITLE
chore(clients): retain structure members' iteration order

### DIFF
--- a/clients/client-sso/models/models_0.ts
+++ b/clients/client-sso/models/models_0.ts
@@ -6,6 +6,11 @@ import { MetadataBearer as $MetadataBearer } from "@aws-sdk/types";
  */
 export interface AccountInfo {
   /**
+   * <p>The identifier of the AWS account that is assigned to the user.</p>
+   */
+  accountId?: string;
+
+  /**
    * <p>The display name of the AWS account that is assigned to the user.</p>
    */
   accountName?: string;
@@ -14,11 +19,6 @@ export interface AccountInfo {
    * <p>The email address of the AWS account that is assigned to the user.</p>
    */
   emailAddress?: string;
-
-  /**
-   * <p>The identifier of the AWS account that is assigned to the user.</p>
-   */
-  accountId?: string;
 }
 
 export namespace AccountInfo {
@@ -34,15 +34,15 @@ export interface GetRoleCredentialsRequest {
   roleName: string | undefined;
 
   /**
+   * <p>The identifier for the AWS account that is assigned to the user.</p>
+   */
+  accountId: string | undefined;
+
+  /**
    * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
    *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
    */
   accessToken: string | undefined;
-
-  /**
-   * <p>The identifier for the AWS account that is assigned to the user.</p>
-   */
-  accountId: string | undefined;
 }
 
 export namespace GetRoleCredentialsRequest {
@@ -57,17 +57,6 @@ export namespace GetRoleCredentialsRequest {
  */
 export interface RoleCredentials {
   /**
-   * <p>The date on which temporary security credentials expire.</p>
-   */
-  expiration?: number;
-
-  /**
-   * <p>The token used for temporary credentials. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Security Credentials to Request Access to AWS Resources</a> in the
-   *         <i>AWS IAM User Guide</i>.</p>
-   */
-  sessionToken?: string;
-
-  /**
    * <p>The identifier used for the temporary security credentials. For more information, see
    *         <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Security Credentials to Request Access to AWS Resources</a> in the
    *         <i>AWS IAM User Guide</i>.</p>
@@ -79,13 +68,24 @@ export interface RoleCredentials {
    *         <i>AWS IAM User Guide</i>.</p>
    */
   secretAccessKey?: string;
+
+  /**
+   * <p>The token used for temporary credentials. For more information, see <a href="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_use-resources.html">Using Temporary Security Credentials to Request Access to AWS Resources</a> in the
+   *         <i>AWS IAM User Guide</i>.</p>
+   */
+  sessionToken?: string;
+
+  /**
+   * <p>The date on which temporary security credentials expire.</p>
+   */
+  expiration?: number;
 }
 
 export namespace RoleCredentials {
   export const filterSensitiveLog = (obj: RoleCredentials): any => ({
     ...obj,
-    ...(obj.sessionToken && { sessionToken: SENSITIVE_STRING }),
     ...(obj.secretAccessKey && { secretAccessKey: SENSITIVE_STRING }),
+    ...(obj.sessionToken && { sessionToken: SENSITIVE_STRING }),
   });
 }
 
@@ -166,10 +166,9 @@ export namespace UnauthorizedException {
 
 export interface ListAccountRolesRequest {
   /**
-   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
-   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
+   * <p>The page token from the previous response output when you request subsequent pages.</p>
    */
-  accessToken: string | undefined;
+  nextToken?: string;
 
   /**
    * <p>The number of items that clients can request per page.</p>
@@ -177,14 +176,15 @@ export interface ListAccountRolesRequest {
   maxResults?: number;
 
   /**
+   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
+   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
+   */
+  accessToken: string | undefined;
+
+  /**
    * <p>The identifier for the AWS account that is assigned to the user.</p>
    */
   accountId: string | undefined;
-
-  /**
-   * <p>The page token from the previous response output when you request subsequent pages.</p>
-   */
-  nextToken?: string;
 }
 
 export namespace ListAccountRolesRequest {
@@ -199,14 +199,14 @@ export namespace ListAccountRolesRequest {
  */
 export interface RoleInfo {
   /**
-   * <p>The identifier of the AWS account assigned to the user.</p>
-   */
-  accountId?: string;
-
-  /**
    * <p>The friendly name of the role that is assigned to the user.</p>
    */
   roleName?: string;
+
+  /**
+   * <p>The identifier of the AWS account assigned to the user.</p>
+   */
+  accountId?: string;
 }
 
 export namespace RoleInfo {
@@ -217,14 +217,14 @@ export namespace RoleInfo {
 
 export interface ListAccountRolesResponse {
   /**
-   * <p>A paginated response with the list of roles and the next token if more results are available.</p>
-   */
-  roleList?: RoleInfo[];
-
-  /**
    * <p>The page token client that is used to retrieve the list of accounts.</p>
    */
   nextToken?: string;
+
+  /**
+   * <p>A paginated response with the list of roles and the next token if more results are available.</p>
+   */
+  roleList?: RoleInfo[];
 }
 
 export namespace ListAccountRolesResponse {
@@ -235,10 +235,9 @@ export namespace ListAccountRolesResponse {
 
 export interface ListAccountsRequest {
   /**
-   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
-   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
+   * <p>(Optional) When requesting subsequent pages, this is the page token from the previous response output.</p>
    */
-  accessToken: string | undefined;
+  nextToken?: string;
 
   /**
    * <p>This is the number of items clients can request per page.</p>
@@ -246,9 +245,10 @@ export interface ListAccountsRequest {
   maxResults?: number;
 
   /**
-   * <p>(Optional) When requesting subsequent pages, this is the page token from the previous response output.</p>
+   * <p>The token issued by the <code>CreateToken</code> API call. For more information, see
+   *         <a href="https://docs.aws.amazon.com/singlesignon/latest/OIDCAPIReference/API_CreateToken.html">CreateToken</a> in the <i>AWS SSO OIDC API Reference Guide</i>.</p>
    */
-  nextToken?: string;
+  accessToken: string | undefined;
 }
 
 export namespace ListAccountsRequest {
@@ -260,14 +260,14 @@ export namespace ListAccountsRequest {
 
 export interface ListAccountsResponse {
   /**
-   * <p>A paginated response with the list of account information and the next token if more results are available.</p>
-   */
-  accountList?: AccountInfo[];
-
-  /**
    * <p>The page token client that is used to retrieve the list of accounts.</p>
    */
   nextToken?: string;
+
+  /**
+   * <p>A paginated response with the list of account information and the next token if more results are available.</p>
+   */
+  accountList?: AccountInfo[];
 }
 
 export namespace ListAccountsResponse {

--- a/clients/client-sso/protocols/Aws_restJson1.ts
+++ b/clients/client-sso/protocols/Aws_restJson1.ts
@@ -58,9 +58,9 @@ export const serializeAws_restJson1ListAccountRolesCommand = async (
   };
   let resolvedPath = "/assignment/roles";
   const query: any = {
+    ...(input.nextToken !== undefined && { next_token: input.nextToken }),
     ...(input.maxResults !== undefined && { max_result: input.maxResults.toString() }),
     ...(input.accountId !== undefined && { account_id: input.accountId }),
-    ...(input.nextToken !== undefined && { next_token: input.nextToken }),
   };
   let body: any;
   const { hostname, protocol = "https", port } = await context.endpoint();
@@ -85,8 +85,8 @@ export const serializeAws_restJson1ListAccountsCommand = async (
   };
   let resolvedPath = "/assignment/accounts";
   const query: any = {
-    ...(input.maxResults !== undefined && { max_result: input.maxResults.toString() }),
     ...(input.nextToken !== undefined && { next_token: input.nextToken }),
+    ...(input.maxResults !== undefined && { max_result: input.maxResults.toString() }),
   };
   let body: any;
   const { hostname, protocol = "https", port } = await context.endpoint();


### PR DESCRIPTION
*Issue #, if available:*
Depends on https://github.com/awslabs/smithy-typescript/pull/254

*Description of changes:*
retain structure members' iteration order.

The codegen was run five times, and the Structure members' order was not updated.
```
$ yarn generate-clients
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
