### PR TITLE
fix(util-waiter): expose minDelay and maxDelay for waiters

### DIFF
--- a/packages/util-waiter/src/createWaiter.spec.ts
+++ b/packages/util-waiter/src/createWaiter.spec.ts
@@ -1,6 +1,6 @@
 import { AbortController } from "@aws-sdk/abort-controller";
 
-import { ResolvedWaiterOptions, WaiterState } from "./waiter";
+import { WaiterOptions, WaiterState } from "./waiter";
 
 const mockValidate = jest.fn();
 jest.mock("./utils/validate", () => ({
@@ -22,7 +22,7 @@ describe("createWaiter", () => {
     maxDelay: 120,
     maxWaitTime: 9999,
     client: "client",
-  } as ResolvedWaiterOptions<any>;
+  } as WaiterOptions<any>;
   const input = "input";
 
   const abortedState = {

--- a/packages/util-waiter/src/poller.spec.ts
+++ b/packages/util-waiter/src/poller.spec.ts
@@ -2,7 +2,7 @@ import { AbortController } from "@aws-sdk/abort-controller";
 
 import { runPolling } from "./poller";
 import { sleep } from "./utils/sleep";
-import { ResolvedWaiterOptions, WaiterState } from "./waiter";
+import { WaiterOptions, WaiterState } from "./waiter";
 
 jest.mock("./utils/sleep");
 
@@ -12,7 +12,7 @@ describe(runPolling.name, () => {
     maxDelay: 30,
     maxWaitTime: 99999,
     client: "mockClient",
-  } as ResolvedWaiterOptions<any>;
+  } as WaiterOptions<any>;
   const input = "mockInput";
   const abortedState = {
     state: WaiterState.ABORTED,

--- a/packages/util-waiter/src/poller.ts
+++ b/packages/util-waiter/src/poller.ts
@@ -1,5 +1,5 @@
 import { sleep } from "./utils/sleep";
-import { ResolvedWaiterOptions, WaiterResult, WaiterState } from "./waiter";
+import { WaiterOptions, WaiterResult, WaiterState } from "./waiter";
 
 /**
  * Reference: https://awslabs.github.io/smithy/1.0/spec/waiters.html#waiter-retries
@@ -20,7 +20,7 @@ const randomInRange = (min: number, max: number) => min + Math.random() * (max -
  * @param stateChecker function that checks the acceptor states on each poll.
  */
 export const runPolling = async <Client, Input>(
-  { minDelay, maxDelay, maxWaitTime, abortController, client }: ResolvedWaiterOptions<Client>,
+  { minDelay, maxDelay, maxWaitTime, abortController, client }: WaiterOptions<Client>,
   input: Input,
   acceptorChecks: (client: Client, input: Input) => Promise<WaiterResult>
 ): Promise<WaiterResult> => {

--- a/packages/util-waiter/src/utils/validate.spec.ts
+++ b/packages/util-waiter/src/utils/validate.spec.ts
@@ -8,9 +8,37 @@ describe(validateWaiterOptions.name, () => {
     waiterOptions = {
       maxWaitTime: 120,
       minDelay: 20,
-      maxDelay: 120,
+      maxDelay: 1200,
       client: "client",
     };
+  });
+
+  it("should not throw an error when maxDelay is proper", (done) => {
+    waiterOptions.maxDelay = 300;
+    waiterOptions.minDelay = 200;
+    waiterOptions.maxWaitTime = 250;
+    try {
+      validateWaiterOptions(waiterOptions);
+      expect(1).toBe(1);
+      done();
+    } catch (e) {
+      expect(e).toBe("SHOULD NOT ERROR HERE");
+    }
+  });
+
+  it("should not throw an error when maxDelay is less than minDelay", (done) => {
+    waiterOptions.maxDelay = 120;
+    waiterOptions.minDelay = 200;
+    waiterOptions.maxWaitTime = 250;
+    try {
+      validateWaiterOptions(waiterOptions);
+      expect(1).toBe("SHOULD NOT GET HERE");
+    } catch (e) {
+      expect(e).toBe(
+        "WaiterConfiguration.maxDelay [120] must be greater than WaiterConfiguration.minDelay [200] for this waiter"
+      );
+      done();
+    }
   });
 
   it("should not throw an error when maxWaitTime is proper", (done) => {
@@ -31,7 +59,7 @@ describe(validateWaiterOptions.name, () => {
     try {
       validateWaiterOptions(waiterOptions);
     } catch (e) {
-      expect(e).toBe("WaiterOptions.maxWaitTime must be greater than 0");
+      expect(e).toBe("WaiterConfiguration.maxWaitTime must be greater than 0");
       done();
     }
   });
@@ -43,7 +71,7 @@ describe(validateWaiterOptions.name, () => {
       validateWaiterOptions(waiterOptions);
     } catch (e) {
       expect(e).toBe(
-        "WaiterOptions.maxWaitTime [150] must be greater than WaiterOptions.minDelay [200] for this waiter"
+        "WaiterConfiguration.maxWaitTime [150] must be greater than WaiterConfiguration.minDelay [200] for this waiter"
       );
       done();
     }
@@ -56,7 +84,7 @@ describe(validateWaiterOptions.name, () => {
       validateWaiterOptions(waiterOptions);
     } catch (e) {
       expect(e).toBe(
-        "WaiterOptions.maxWaitTime [200] must be greater than WaiterOptions.minDelay [200] for this waiter"
+        "WaiterConfiguration.maxWaitTime [200] must be greater than WaiterConfiguration.minDelay [200] for this waiter"
       );
     }
   });

--- a/packages/util-waiter/src/utils/validate.spec.ts
+++ b/packages/util-waiter/src/utils/validate.spec.ts
@@ -1,8 +1,8 @@
-import { ResolvedWaiterOptions } from "../waiter";
+import { WaiterOptions } from "../waiter";
 import { validateWaiterOptions } from "./validate";
 
 describe(validateWaiterOptions.name, () => {
-  let waiterOptions: ResolvedWaiterOptions<any>;
+  let waiterOptions: WaiterOptions<any>;
 
   beforeEach(() => {
     waiterOptions = {

--- a/packages/util-waiter/src/utils/validate.spec.ts
+++ b/packages/util-waiter/src/utils/validate.spec.ts
@@ -34,8 +34,8 @@ describe(validateWaiterOptions.name, () => {
       validateWaiterOptions(waiterOptions);
       expect(1).toBe("SHOULD NOT GET HERE");
     } catch (e) {
-      expect(e).toBe(
-        "WaiterConfiguration.maxDelay [120] must be greater than WaiterConfiguration.minDelay [200] for this waiter"
+      expect(e.toString()).toBe(
+        "Error: WaiterConfiguration.maxDelay [120] must be greater than WaiterConfiguration.minDelay [200] for this waiter"
       );
       done();
     }
@@ -59,7 +59,7 @@ describe(validateWaiterOptions.name, () => {
     try {
       validateWaiterOptions(waiterOptions);
     } catch (e) {
-      expect(e).toBe("WaiterConfiguration.maxWaitTime must be greater than 0");
+      expect(e.toString()).toBe("Error: WaiterConfiguration.maxWaitTime must be greater than 0");
       done();
     }
   });
@@ -70,8 +70,8 @@ describe(validateWaiterOptions.name, () => {
     try {
       validateWaiterOptions(waiterOptions);
     } catch (e) {
-      expect(e).toBe(
-        "WaiterConfiguration.maxWaitTime [150] must be greater than WaiterConfiguration.minDelay [200] for this waiter"
+      expect(e.toString()).toBe(
+        "Error: WaiterConfiguration.maxWaitTime [150] must be greater than WaiterConfiguration.minDelay [200] for this waiter"
       );
       done();
     }
@@ -83,8 +83,8 @@ describe(validateWaiterOptions.name, () => {
     try {
       validateWaiterOptions(waiterOptions);
     } catch (e) {
-      expect(e).toBe(
-        "WaiterConfiguration.maxWaitTime [200] must be greater than WaiterConfiguration.minDelay [200] for this waiter"
+      expect(e.toString()).toBe(
+        "Error: WaiterConfiguration.maxWaitTime [200] must be greater than WaiterConfiguration.minDelay [200] for this waiter"
       );
     }
   });

--- a/packages/util-waiter/src/utils/validate.ts
+++ b/packages/util-waiter/src/utils/validate.ts
@@ -6,10 +6,10 @@ import { WaiterOptions } from "../waiter";
  */
 export const validateWaiterOptions = <Client>(options: WaiterOptions<Client>): void => {
   if (options.maxWaitTime < 1) {
-    throw `WaiterOptions.maxWaitTime must be greater than 0`;
+    throw `WaiterConfiguration.maxWaitTime must be greater than 0`;
   } else if (options.maxWaitTime <= options.minDelay) {
-    throw `WaiterOptions.maxWaitTime [${options.maxWaitTime}] must be greater than WaiterOptions.minDelay [${options.minDelay}] for this waiter`;
+    throw `WaiterConfiguration.maxWaitTime [${options.maxWaitTime}] must be greater than WaiterConfiguration.minDelay [${options.minDelay}] for this waiter`;
   } else if (options.maxDelay < options.minDelay) {
-    throw `WaiterOptions.maxDelay [${options.maxWaitTime}] must be greater than WaiterOptions.minDelay [${options.minDelay}] for this waiter`;
+    throw `WaiterConfiguration.maxDelay [${options.maxDelay}] must be greater than WaiterConfiguration.minDelay [${options.minDelay}] for this waiter`;
   }
 };

--- a/packages/util-waiter/src/utils/validate.ts
+++ b/packages/util-waiter/src/utils/validate.ts
@@ -1,13 +1,15 @@
-import { ResolvedWaiterOptions } from "../waiter";
+import { WaiterOptions } from "../waiter";
 
 /**
  * Validates that waiter options are passed correctly
  * @param options a waiter configuration object
  */
-export const validateWaiterOptions = <Client>(options: ResolvedWaiterOptions<Client>): void => {
+export const validateWaiterOptions = <Client>(options: WaiterOptions<Client>): void => {
   if (options.maxWaitTime < 1) {
     throw `WaiterOptions.maxWaitTime must be greater than 0`;
   } else if (options.maxWaitTime <= options.minDelay) {
     throw `WaiterOptions.maxWaitTime [${options.maxWaitTime}] must be greater than WaiterOptions.minDelay [${options.minDelay}] for this waiter`;
+  } else if (options.maxDelay < options.minDelay) {
+    throw `WaiterOptions.maxDelay [${options.maxWaitTime}] must be greater than WaiterOptions.minDelay [${options.minDelay}] for this waiter`;
   }
 };

--- a/packages/util-waiter/src/utils/validate.ts
+++ b/packages/util-waiter/src/utils/validate.ts
@@ -7,6 +7,10 @@ import { WaiterOptions } from "../waiter";
 export const validateWaiterOptions = <Client>(options: WaiterOptions<Client>): void => {
   if (options.maxWaitTime < 1) {
     throw `WaiterConfiguration.maxWaitTime must be greater than 0`;
+  } else if (options.minDelay < 1) {
+    throw `WaiterConfiguration.minDelay must be greater than 0`;
+  } else if (options.maxDelay < 1) {
+    throw `WaiterConfiguration.maxDelay must be greater than 0`;
   } else if (options.maxWaitTime <= options.minDelay) {
     throw `WaiterConfiguration.maxWaitTime [${options.maxWaitTime}] must be greater than WaiterConfiguration.minDelay [${options.minDelay}] for this waiter`;
   } else if (options.maxDelay < options.minDelay) {

--- a/packages/util-waiter/src/utils/validate.ts
+++ b/packages/util-waiter/src/utils/validate.ts
@@ -6,14 +6,18 @@ import { WaiterOptions } from "../waiter";
  */
 export const validateWaiterOptions = <Client>(options: WaiterOptions<Client>): void => {
   if (options.maxWaitTime < 1) {
-    throw `WaiterConfiguration.maxWaitTime must be greater than 0`;
+    throw new Error(`WaiterConfiguration.maxWaitTime must be greater than 0`);
   } else if (options.minDelay < 1) {
-    throw `WaiterConfiguration.minDelay must be greater than 0`;
+    throw new Error(`WaiterConfiguration.minDelay must be greater than 0`);
   } else if (options.maxDelay < 1) {
-    throw `WaiterConfiguration.maxDelay must be greater than 0`;
+    throw new Error(`WaiterConfiguration.maxDelay must be greater than 0`);
   } else if (options.maxWaitTime <= options.minDelay) {
-    throw `WaiterConfiguration.maxWaitTime [${options.maxWaitTime}] must be greater than WaiterConfiguration.minDelay [${options.minDelay}] for this waiter`;
+    throw new Error(
+      `WaiterConfiguration.maxWaitTime [${options.maxWaitTime}] must be greater than WaiterConfiguration.minDelay [${options.minDelay}] for this waiter`
+    );
   } else if (options.maxDelay < options.minDelay) {
-    throw `WaiterConfiguration.maxDelay [${options.maxDelay}] must be greater than WaiterConfiguration.minDelay [${options.minDelay}] for this waiter`;
+    throw new Error(
+      `WaiterConfiguration.maxDelay [${options.maxDelay}] must be greater than WaiterConfiguration.minDelay [${options.minDelay}] for this waiter`
+    );
   }
 };

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -15,9 +15,7 @@ export interface WaiterConfiguration<Client> {
    * Abort controller. Used for ending the waiter early.
    */
   abortController?: AbortController;
-}
 
-export interface WaiterOptions<Client> extends WaiterConfiguration<Client> {
   /**
    * The minimum amount of time to delay between retries in seconds. This value defaults
    * to 2 if not specified. If specified, this value MUST be greater than or equal to 1
@@ -44,8 +42,8 @@ export const waiterServiceDefaults = {
 /**
  * @private
  */
-export type ResolvedWaiterOptions<Client> = WaiterOptions<Client> &
-  Required<Pick<WaiterOptions<Client>, "minDelay" | "maxDelay">>;
+export type WaiterOptions<Client> = WaiterConfiguration<Client> &
+  Required<Pick<WaiterConfiguration<Client>, "minDelay" | "maxDelay">>;
 
 export enum WaiterState {
   ABORTED = "ABORTED",

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -18,15 +18,15 @@ export interface WaiterConfiguration<Client> {
 
   /**
    * The minimum amount of time to delay between retries in seconds. This value defaults
-   * to 2 if not specified. If specified, this value MUST be greater than or equal to 1
-   * and less than or equal to maxDelay.
+   * to service default if not specified. If specified, this value MUST be greater than
+   * or equal to 1 and less than or equal to maxDelay.
    */
   minDelay?: number;
 
   /**
    * The maximum amount of time to delay between retries in seconds. The maximum amount
-   * of time in seconds to delay between each retry. This value defaults to 120 if not
-   * specified (2 minutes). If specified, this value MUST be greater than or equal to 1.
+   * of time in seconds to delay between each retry. This value defaults to service default
+   * if not specified. If specified, this value MUST be greater than or equal to 1.
    */
   maxDelay?: number;
 }

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -17,15 +17,15 @@ export interface WaiterConfiguration<Client> {
   abortController?: AbortController;
 
   /**
-   * The minimum amount of time to delay between retries in seconds. This value defaults
-   * to service default if not specified. If specified, this value MUST be greater than
+   * The minimum amount of time to delay between retries in seconds. This is the floor of the exponential backoff.
+   * This value defaults  to service default if not specified. If specified, this value MUST be greater than
    * or equal to 1 and less than or equal to maxDelay.
    */
   minDelay?: number;
 
   /**
-   * The maximum amount of time to delay between retries in seconds. The maximum amount
-   * of time in seconds to delay between each retry. This value defaults to service default
+   * The maximum amount of time to delay between retries in seconds. This is the ceiling of the exponential backoff.
+   * The maximum amount of time in seconds to delay between each retry. This value defaults to service default
    * if not specified. If specified, this value MUST be greater than or equal to 1.
    */
   maxDelay?: number;

--- a/packages/util-waiter/src/waiter.ts
+++ b/packages/util-waiter/src/waiter.ts
@@ -17,15 +17,15 @@ export interface WaiterConfiguration<Client> {
   abortController?: AbortController;
 
   /**
-   * The minimum amount of time to delay between retries in seconds. This is the floor of the exponential backoff.
-   * This value defaults  to service default if not specified. If specified, this value MUST be greater than
-   * or equal to 1 and less than or equal to maxDelay.
+   * The minimum amount of time to delay between retries in seconds. This is the
+   * floor of the exponential backoff. This value defaults to service default
+   * if not specified. This value MUST be less than or equal to maxDelay and greater than 0.
    */
   minDelay?: number;
 
   /**
-   * The maximum amount of time to delay between retries in seconds. This is the ceiling of the exponential backoff.
-   * The maximum amount of time in seconds to delay between each retry. This value defaults to service default
+   * The maximum amount of time to delay between retries in seconds. This is the
+   * ceiling of the exponential backoff. This value defaults to service default
    * if not specified. If specified, this value MUST be greater than or equal to 1.
    */
   maxDelay?: number;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Expose the options for minDelay and maxDelay through typescript
```js
import { DynamoDBClient, waitForTableExists } from "@aws-sdk/client-dynamodb"

(async () => {
    const TableName = "MY-TEST-TABLE-1";
  
    const maxWaitTime = 120;
    const client: DynamoDBClient = new DynamoDBClient({});
    let result = await waitForTableExists( { 
        client,
        minDelay: 20,
        maxDelay: 80,
        maxWaitTime: 25 } , { TableName });
    console.log("Table exists", result);
  })();
  
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


Resolves: https://github.com/aws/aws-sdk-js-v3/issues/1806