### PR TITLE
feat(util-dynamodb): enable undefined values removal in marshall

### DIFF
--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -10,6 +10,12 @@ describe("convertToAttr", () => {
     });
   });
 
+  describe("undefined", () => {
+    it(`returns for undefined when options.removeUndefinedValues=true`, () => {
+      expect(convertToAttr(undefined, { removeUndefinedValues: true })).toEqual(undefined);
+    });
+  });
+
   describe("boolean", () => {
     [true, false].forEach((bool) => {
       it(`returns for boolean: ${bool}`, () => {

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -10,12 +10,6 @@ describe("convertToAttr", () => {
     });
   });
 
-  describe("undefined", () => {
-    it(`returns for undefined when options.removeUndefinedValues=true`, () => {
-      expect(convertToAttr(undefined, { removeUndefinedValues: true })).toEqual(undefined);
-    });
-  });
-
   describe("boolean", () => {
     [true, false].forEach((bool) => {
       it(`returns for boolean: ${bool}`, () => {
@@ -284,6 +278,22 @@ describe("convertToAttr", () => {
         M: { stringKey: { NULL: true }, binaryKey: { NULL: true }, setKey: { NULL: true } },
       });
     });
+
+    describe(`testing map with options.removeUndefinedValues`, () => {
+      it(`throws when options.removeUndefinedValues=false`, () => {
+        const input = { definedKey: "definedKey", undefinedKey: undefined };
+        expect(() => {
+          convertToAttr(input, { removeUndefinedValues: false });
+        }).toThrowError(`Please set removeUndefinedValues to true to remove undefined values.`);
+      });
+
+      it(`returns when options.removeUndefinedValues=true`, () => {
+        const input = { definedKey: "definedKey", undefinedKey: undefined };
+        expect(convertToAttr(input, { removeUndefinedValues: true })).toEqual({
+          M: { definedKey: { S: "definedKey" } },
+        });
+      });
+    });
   });
 
   describe("string", () => {
@@ -303,8 +313,14 @@ describe("convertToAttr", () => {
       constructor(private readonly foo: string) {}
     }
 
+    it(`throws for: undefined`, () => {
+      expect(() => {
+        convertToAttr(undefined);
+      }).toThrowError(`Please set removeUndefinedValues to true to remove undefined values.`);
+    });
+
     // ToDo: Serialize ES6 class objects as string https://github.com/aws/aws-sdk-js-v3/issues/1535
-    [undefined, new Date(), new FooObj("foo")].forEach((data) => {
+    [new Date(), new FooObj("foo")].forEach((data) => {
       it(`throws for: ${String(data)}`, () => {
         expect(() => {
           // @ts-expect-error Argument is not assignable to parameter of type 'NativeAttributeValue'

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -182,16 +182,25 @@ describe("convertToAttr", () => {
     });
 
     describe(`testing list with options.removeUndefinedValues`, () => {
-      it(`throws when options.removeUndefinedValues=false`, () => {
-        const input = ["defined", undefined];
-        expect(() => {
-          convertToAttr(input, { removeUndefinedValues: false });
-        }).toThrowError(`Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.`);
+      describe("throws error", () => {
+        const testErrorListWithUndefinedValues = (options?: marshallOptions) => {
+          expect(() => {
+            convertToAttr(["defined", undefined], options);
+          }).toThrowError(`Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.`);
+        };
+
+        [undefined, {}, { convertEmptyValues: false }].forEach((options) => {
+          it(`when options=${options}`, () => {
+            testErrorListWithUndefinedValues(options);
+          });
+        });
       });
 
       it(`returns when options.removeUndefinedValues=true`, () => {
-        const input = ["defined", undefined];
-        expect(convertToAttr(input, { removeUndefinedValues: true })).toEqual({
+        expect(convertToAttr(["defined", undefined], { removeUndefinedValues: true })).toEqual({
+          L: [{ S: "defined" }],
+        });
+        expect(convertToAttr([undefined, "defined", undefined], { removeUndefinedValues: true })).toEqual({
           L: [{ S: "defined" }],
         });
       });
@@ -329,11 +338,18 @@ describe("convertToAttr", () => {
     });
 
     describe(`testing map with options.removeUndefinedValues`, () => {
-      it(`throws when options.removeUndefinedValues=false`, () => {
-        const input = { definedKey: "definedKey", undefinedKey: undefined };
-        expect(() => {
-          convertToAttr(input, { removeUndefinedValues: false });
-        }).toThrowError(`Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.`);
+      describe("throws error", () => {
+        const testErrorMapWithUndefinedValues = (options?: marshallOptions) => {
+          expect(() => {
+            convertToAttr({ definedKey: "definedKey", undefinedKey: undefined }, options);
+          }).toThrowError(`Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.`);
+        };
+
+        [undefined, {}, { convertEmptyValues: false }].forEach((options) => {
+          it(`when options=${options}`, () => {
+            testErrorMapWithUndefinedValues(options);
+          });
+        });
       });
 
       it(`returns when options.removeUndefinedValues=true`, () => {

--- a/packages/util-dynamodb/src/convertToAttr.spec.ts
+++ b/packages/util-dynamodb/src/convertToAttr.spec.ts
@@ -179,6 +179,22 @@ describe("convertToAttr", () => {
         L: [{ NULL: true }, { NULL: true }, { NULL: true }],
       });
     });
+
+    describe(`testing list with options.removeUndefinedValues`, () => {
+      it(`throws when options.removeUndefinedValues=false`, () => {
+        const input = ["defined", undefined];
+        expect(() => {
+          convertToAttr(input, { removeUndefinedValues: false });
+        }).toThrowError(`Please set removeUndefinedValues to true to remove undefined values from map/array/set.`);
+      });
+
+      it(`returns when options.removeUndefinedValues=true`, () => {
+        const input = ["defined", undefined];
+        expect(convertToAttr(input, { removeUndefinedValues: true })).toEqual({
+          L: [{ S: "defined" }],
+        });
+      });
+    });
   });
 
   describe("set", () => {
@@ -284,7 +300,7 @@ describe("convertToAttr", () => {
         const input = { definedKey: "definedKey", undefinedKey: undefined };
         expect(() => {
           convertToAttr(input, { removeUndefinedValues: false });
-        }).toThrowError(`Please set removeUndefinedValues to true to remove undefined values.`);
+        }).toThrowError(`Please set removeUndefinedValues to true to remove undefined values from map/array/set.`);
       });
 
       it(`returns when options.removeUndefinedValues=true`, () => {
@@ -316,7 +332,7 @@ describe("convertToAttr", () => {
     it(`throws for: undefined`, () => {
       expect(() => {
         convertToAttr(undefined);
-      }).toThrowError(`Please set removeUndefinedValues to true to remove undefined values.`);
+      }).toThrowError(`Please set removeUndefinedValues to true to remove undefined values from map/array/set.`);
     });
 
     // ToDo: Serialize ES6 class objects as string https://github.com/aws/aws-sdk-js-v3/issues/1535

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -22,7 +22,9 @@ export const convertToAttr = (data: NativeAttributeValue, options?: marshallOpti
 };
 
 const convertToListAttr = (data: NativeAttributeValue[], options?: marshallOptions): { L: AttributeValue[] } => ({
-  L: data.map((item) => convertToAttr(item, options)),
+  L: data
+    .filter((item) => !options?.removeUndefinedValues || (options?.removeUndefinedValues && item !== undefined))
+    .map((item) => convertToAttr(item, options)),
 });
 
 const convertToSetAttr = (
@@ -88,7 +90,7 @@ const convertToMapAttr = (
 
 const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: marshallOptions): AttributeValue => {
   if (data === undefined) {
-    throw new Error(`Please set removeUndefinedValues to true to remove undefined values.`);
+    throw new Error(`Please set removeUndefinedValues to true to remove undefined values from map/array/set.`);
   } else if (data === null && typeof data === "object") {
     return convertToNullAttr();
   } else if (typeof data === "boolean") {

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -31,29 +31,35 @@ const convertToSetAttr = (
   set: Set<any>,
   options?: marshallOptions
 ): { NS: string[] } | { BS: Uint8Array[] } | { SS: string[] } | { NULL: true } => {
-  if (set.size === 0) {
+  const setToOperate = options?.removeUndefinedValues ? new Set([...set].filter((value) => value !== undefined)) : set;
+
+  if (!options?.removeUndefinedValues && setToOperate.has(undefined)) {
+    throw new Error(`Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.`);
+  }
+
+  if (setToOperate.size === 0) {
     if (options?.convertEmptyValues) {
       return convertToNullAttr();
     }
-    throw new Error(`Please pass a non-empty set, or set convertEmptyValues to true.`);
+    throw new Error(`Pass a non-empty set, or options.convertEmptyValues=true.`);
   }
 
-  const item = set.values().next().value;
+  const item = setToOperate.values().next().value;
   if (typeof item === "number") {
     return {
-      NS: Array.from(set)
+      NS: Array.from(setToOperate)
         .map(convertToNumberAttr)
         .map((item) => item.N),
     };
   } else if (typeof item === "bigint") {
     return {
-      NS: Array.from(set)
+      NS: Array.from(setToOperate)
         .map(convertToBigIntAttr)
         .map((item) => item.N),
     };
   } else if (typeof item === "string") {
     return {
-      SS: Array.from(set)
+      SS: Array.from(setToOperate)
         .map(convertToStringAttr)
         .map((item) => item.S),
     };
@@ -61,7 +67,7 @@ const convertToSetAttr = (
     return {
       // Do not alter binary data passed https://github.com/aws/aws-sdk-js-v3/issues/1530
       // @ts-expect-error Type 'ArrayBuffer' is not assignable to type 'Uint8Array'
-      BS: Array.from(set)
+      BS: Array.from(setToOperate)
         .map(convertToBinaryAttr)
         .map((item) => item.B),
     };
@@ -90,7 +96,7 @@ const convertToMapAttr = (
 
 const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: marshallOptions): AttributeValue => {
   if (data === undefined) {
-    throw new Error(`Please set removeUndefinedValues to true to remove undefined values from map/array/set.`);
+    throw new Error(`Pass options.removeUndefinedValues=true to remove undefined values from map/array/set.`);
   } else if (data === null && typeof data === "object") {
     return convertToNullAttr();
   } else if (typeof data === "boolean") {

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -72,19 +72,23 @@ const convertToMapAttr = (
   data: { [key: string]: NativeAttributeValue },
   options?: marshallOptions
 ): { M: { [key: string]: AttributeValue } } => ({
-  M: Object.entries(data).reduce(
-    (acc: { [key: string]: AttributeValue }, [key, value]: [string, NativeAttributeValue]) => ({
-      ...acc,
-      [key]: convertToAttr(value, options),
-    }),
-    {}
-  ),
+  M: Object.entries(data)
+    .filter(
+      ([key, value]: [string, NativeAttributeValue]) =>
+        !options?.removeUndefinedValues || (options?.removeUndefinedValues && value !== undefined)
+    )
+    .reduce(
+      (acc: { [key: string]: AttributeValue }, [key, value]: [string, NativeAttributeValue]) => ({
+        ...acc,
+        [key]: convertToAttr(value, options),
+      }),
+      {}
+    ),
 });
 
 const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: marshallOptions): AttributeValue => {
-  if (data === undefined && options?.removeUndefinedValues) {
-    // @ts-ignore To support removal of undefined values
-    return undefined;
+  if (data === undefined) {
+    throw new Error(`Please set removeUndefinedValues to true to remove undefined values.`);
   } else if (data === null && typeof data === "object") {
     return convertToNullAttr();
   } else if (typeof data === "boolean") {

--- a/packages/util-dynamodb/src/convertToAttr.ts
+++ b/packages/util-dynamodb/src/convertToAttr.ts
@@ -82,7 +82,10 @@ const convertToMapAttr = (
 });
 
 const convertToScalarAttr = (data: NativeScalarAttributeValue, options?: marshallOptions): AttributeValue => {
-  if (data === null && typeof data === "object") {
+  if (data === undefined && options?.removeUndefinedValues) {
+    // @ts-ignore To support removal of undefined values
+    return undefined;
+  } else if (data === null && typeof data === "object") {
     return convertToNullAttr();
   } else if (typeof data === "boolean") {
     return { BOOL: data };

--- a/packages/util-dynamodb/src/marshall.spec.ts
+++ b/packages/util-dynamodb/src/marshall.spec.ts
@@ -15,18 +15,20 @@ describe("marshall", () => {
   });
 
   it("calls convertToAttr", () => {
-    // @ts-ignore output mocked for testing
     expect(marshall(input)).toEqual(input);
     expect(convertToAttr).toHaveBeenCalledTimes(1);
     expect(convertToAttr).toHaveBeenCalledWith(input, undefined);
   });
 
-  [false, true].forEach((convertEmptyValues) => {
-    it(`passes convertEmptyValues=${convertEmptyValues} to convertToAttr`, () => {
-      // @ts-ignore output mocked for testing
-      expect(marshall(input, { convertEmptyValues })).toEqual(input);
-      expect(convertToAttr).toHaveBeenCalledTimes(1);
-      expect(convertToAttr).toHaveBeenCalledWith(input, { convertEmptyValues });
+  ["convertEmptyValues", "removeUndefinedValues"].forEach((option) => {
+    describe(`options.${option}`, () => {
+      [false, true].forEach((value) => {
+        it(`passes ${value} to convertToAttr`, () => {
+          expect(marshall(input, { [option]: value })).toEqual(input);
+          expect(convertToAttr).toHaveBeenCalledTimes(1);
+          expect(convertToAttr).toHaveBeenCalledWith(input, { [option]: value });
+        });
+      });
     });
   });
 });

--- a/packages/util-dynamodb/src/marshall.ts
+++ b/packages/util-dynamodb/src/marshall.ts
@@ -11,6 +11,10 @@ export interface marshallOptions {
    * Whether to automatically convert empty strings, blobs, and sets to `null`
    */
   convertEmptyValues?: boolean;
+  /**
+   * Whether to remove undefined values while marshalling.
+   */
+  removeUndefinedValues?: boolean;
 }
 
 /**

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -14,7 +14,7 @@ export type NativeAttributeValue =
   | NativeScalarAttributeValue
   | { [key: string]: NativeAttributeValue }
   | NativeAttributeValue[]
-  | Set<number | bigint | NumberValue | string | NativeAttributeBinary>;
+  | Set<number | bigint | NumberValue | string | NativeAttributeBinary | undefined>;
 
 export type NativeScalarAttributeValue =
   | null

--- a/packages/util-dynamodb/src/models.ts
+++ b/packages/util-dynamodb/src/models.ts
@@ -18,6 +18,7 @@ export type NativeAttributeValue =
 
 export type NativeScalarAttributeValue =
   | null
+  | undefined
   | boolean
   | number
   | NumberValue


### PR DESCRIPTION
*Issue #, if available:*
Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1816

*Description of changes:*
Enables removal of undefined values in marshall by setting `removeUndefinedValues=true`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
