### PR TITLE
fix(lib-storage): improve performance with stream's readable event

### DIFF
--- a/lib/storage/src/data-chunk/readable-helper.ts
+++ b/lib/storage/src/data-chunk/readable-helper.ts
@@ -37,12 +37,17 @@ function _chunkFromStream(stream: Readable, chunkSize: number, oldBuffer: Buffer
   let currentChunk = oldBuffer;
   return new Promise((resolve, reject) => {
     const cleanupListeners = () => {
-      stream.removeAllListeners("data");
+      stream.removeAllListeners("readable");
       stream.removeAllListeners("error");
       stream.removeAllListeners("end");
     };
 
-    stream.on("data", (chunk) => {
+    stream.on("readable", () => {
+      const chunk = stream.read();
+      if (!chunk) {
+        return;
+      }
+
       currentChunk = Buffer.concat([currentChunk, Buffer.from(chunk)]);
       if (currentChunk.length >= chunkSize) {
         cleanupListeners();


### PR DESCRIPTION
I didn't make an issue for this, since it's hard to make a minimal example recreating the problem; however, I noticed this when attempting to test #1829 in a production use case.

*Description of changes:* For performance reasons, switch from `stream.on("data")` to `stream.on("readable")`. Before making this change, I wasn't able to stream from a large/undetermined-length source. Individual uploads would get stalled which slowed everything else down until it eventually was so slow that the client I was streaming from kills the stream's connection. All of this is fine when switching event listeners.

From [Node's `Stream` docs](https://nodejs.org/api/stream.html#stream_event_readable), it says:
> In general, the `readable.pipe()` and `'data'` event mechanisms are easier to understand than the `'readable'` event. However, handling `'readable'` might result in increased throughput.

This is also what the v2 library uses to stream an upload to S3: https://github.com/aws/aws-sdk-js/blob/v2.817.0/lib/s3/managed_upload.js#L188

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
