### PR TITLE
fix(client-s3): add missing types to GetObjectOutput's Body

### DIFF
--- a/clients/client-s3/models/models_0.ts
+++ b/clients/client-s3/models/models_0.ts
@@ -6557,7 +6557,7 @@ export interface GetObjectOutput {
   /**
    * <p>Object data.</p>
    */
-  Body?: Readable | ReadableStream | Blob;
+  Body?: Readable | ReadableStream | Blob | Buffer | Uint8Array;
 
   /**
    * <p>Specifies whether the object retrieved was (true) or was not (false) a Delete Marker. If


### PR DESCRIPTION
extracted from https://github.com/aws/aws-sdk-js/blob/b2c88d61974996ca218144cbd09f00ba3d666478/clients/s3.d.ts#L941

*Description of changes:*

Added node.js `Buffer` and `Uint8Array`  types to GetObjectOutput's `Body` property.
As the types were missing, it's breaking code when upgrading from v2

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
