### PR TITLE
fix(readme): use latest for npm version badge in template

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
@@ -1,6 +1,6 @@
 # ${packageName}
 
-[![NPM version](https://img.shields.io/npm/v/${packageName}.svg)](https://www.npmjs.com/package/${packageName})
+[![NPM version](https://img.shields.io/npm/v/${packageName}/latest.svg)](https://www.npmjs.com/package/${packageName})
 [![NPM downloads](https://img.shields.io/npm/dm/${packageName}.svg)](https://www.npmjs.com/package/${packageName})
 
 For SDK usage, please step to [SDK readme](https://github.com/aws/aws-sdk-js-v3).

--- a/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
+++ b/codegen/smithy-aws-typescript-codegen/src/main/resources/software/amazon/smithy/aws/typescript/codegen/README.md.template
@@ -1,6 +1,6 @@
 # ${packageName}
 
-[![NPM version](https://img.shields.io/npm/v/${packageName}/rc.svg)](https://www.npmjs.com/package/${packageName})
+[![NPM version](https://img.shields.io/npm/v/${packageName}.svg)](https://www.npmjs.com/package/${packageName})
 [![NPM downloads](https://img.shields.io/npm/dm/${packageName}.svg)](https://www.npmjs.com/package/${packageName})
 
 For SDK usage, please step to [SDK readme](https://github.com/aws/aws-sdk-js-v3).


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/1794

*Description of changes:*
The badge was updated in client README files in https://github.com/aws/aws-sdk-js-v3/pull/1794, but template was missed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
