### PR TITLE
docs: call out @deprecated in comments for shapes/members

### DIFF
--- a/clients/client-application-discovery-service/ApplicationDiscoveryService.ts
+++ b/clients/client-application-discovery-service/ApplicationDiscoveryService.ts
@@ -567,6 +567,7 @@ export class ApplicationDiscoveryService extends ApplicationDiscoveryServiceClie
 
   /**
    * @deprecated
+   *
    * <p>
    *             <code>DescribeExportConfigurations</code> is deprecated. Use <a href="https://docs.aws.amazon.com/application-discovery/latest/APIReference/API_DescribeExportTasks.html">DescribeImportTasks</a>, instead.</p>
    */
@@ -745,6 +746,7 @@ export class ApplicationDiscoveryService extends ApplicationDiscoveryServiceClie
 
   /**
    * @deprecated
+   *
    * <p>Deprecated. Use <code>StartExportTask</code> instead.</p>
    *          <p>Exports all discovered configuration data to an Amazon S3 bucket or an application that
    *       enables you to view and evaluate the data. Data includes tags and tag associations, processes,

--- a/clients/client-application-discovery-service/ApplicationDiscoveryService.ts
+++ b/clients/client-application-discovery-service/ApplicationDiscoveryService.ts
@@ -566,6 +566,7 @@ export class ApplicationDiscoveryService extends ApplicationDiscoveryServiceClie
   }
 
   /**
+   * @deprecated
    * <p>
    *             <code>DescribeExportConfigurations</code> is deprecated. Use <a href="https://docs.aws.amazon.com/application-discovery/latest/APIReference/API_DescribeExportTasks.html">DescribeImportTasks</a>, instead.</p>
    */
@@ -743,6 +744,7 @@ export class ApplicationDiscoveryService extends ApplicationDiscoveryServiceClie
   }
 
   /**
+   * @deprecated
    * <p>Deprecated. Use <code>StartExportTask</code> instead.</p>
    *          <p>Exports all discovered configuration data to an Amazon S3 bucket or an application that
    *       enables you to view and evaluate the data. Data includes tags and tag associations, processes,

--- a/clients/client-application-discovery-service/commands/DescribeExportConfigurationsCommand.ts
+++ b/clients/client-application-discovery-service/commands/DescribeExportConfigurationsCommand.ts
@@ -26,6 +26,7 @@ export type DescribeExportConfigurationsCommandOutput = DescribeExportConfigurat
 
 /**
  * @deprecated
+ *
  * <p>
  *             <code>DescribeExportConfigurations</code> is deprecated. Use <a href="https://docs.aws.amazon.com/application-discovery/latest/APIReference/API_DescribeExportTasks.html">DescribeImportTasks</a>, instead.</p>
  */

--- a/clients/client-application-discovery-service/commands/DescribeExportConfigurationsCommand.ts
+++ b/clients/client-application-discovery-service/commands/DescribeExportConfigurationsCommand.ts
@@ -25,6 +25,7 @@ export type DescribeExportConfigurationsCommandInput = DescribeExportConfigurati
 export type DescribeExportConfigurationsCommandOutput = DescribeExportConfigurationsResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>
  *             <code>DescribeExportConfigurations</code> is deprecated. Use <a href="https://docs.aws.amazon.com/application-discovery/latest/APIReference/API_DescribeExportTasks.html">DescribeImportTasks</a>, instead.</p>
  */

--- a/clients/client-application-discovery-service/commands/ExportConfigurationsCommand.ts
+++ b/clients/client-application-discovery-service/commands/ExportConfigurationsCommand.ts
@@ -26,6 +26,7 @@ export type ExportConfigurationsCommandOutput = ExportConfigurationsResponse & _
 
 /**
  * @deprecated
+ *
  * <p>Deprecated. Use <code>StartExportTask</code> instead.</p>
  *          <p>Exports all discovered configuration data to an Amazon S3 bucket or an application that
  *       enables you to view and evaluate the data. Data includes tags and tag associations, processes,

--- a/clients/client-application-discovery-service/commands/ExportConfigurationsCommand.ts
+++ b/clients/client-application-discovery-service/commands/ExportConfigurationsCommand.ts
@@ -25,6 +25,7 @@ export type ExportConfigurationsCommandInput = {};
 export type ExportConfigurationsCommandOutput = ExportConfigurationsResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Deprecated. Use <code>StartExportTask</code> instead.</p>
  *          <p>Exports all discovered configuration data to an Amazon S3 bucket or an application that
  *       enables you to view and evaluate the data. Data includes tags and tag associations, processes,

--- a/clients/client-appstream/models/models_0.ts
+++ b/clients/client-appstream/models/models_0.ts
@@ -3786,6 +3786,8 @@ export interface UpdateFleetRequest {
   DisconnectTimeoutInSeconds?: number;
 
   /**
+   * @deprecated
+   *
    * <p>Deletes the VPC association for the specified fleet.</p>
    */
   DeleteVpcConfig?: boolean;
@@ -3935,6 +3937,8 @@ export interface UpdateStackRequest {
   StorageConnectors?: StorageConnector[];
 
   /**
+   * @deprecated
+   *
    * <p>Deletes the storage connectors currently enabled for the stack.</p>
    */
   DeleteStorageConnectors?: boolean;

--- a/clients/client-appstream/models/models_0.ts
+++ b/clients/client-appstream/models/models_0.ts
@@ -3786,7 +3786,6 @@ export interface UpdateFleetRequest {
   DisconnectTimeoutInSeconds?: number;
 
   /**
-   * @deprecated
    * <p>Deletes the VPC association for the specified fleet.</p>
    */
   DeleteVpcConfig?: boolean;
@@ -3936,7 +3935,6 @@ export interface UpdateStackRequest {
   StorageConnectors?: StorageConnector[];
 
   /**
-   * @deprecated
    * <p>Deletes the storage connectors currently enabled for the stack.</p>
    */
   DeleteStorageConnectors?: boolean;

--- a/clients/client-appstream/models/models_0.ts
+++ b/clients/client-appstream/models/models_0.ts
@@ -3786,6 +3786,7 @@ export interface UpdateFleetRequest {
   DisconnectTimeoutInSeconds?: number;
 
   /**
+   * @deprecated
    * <p>Deletes the VPC association for the specified fleet.</p>
    */
   DeleteVpcConfig?: boolean;
@@ -3935,6 +3936,7 @@ export interface UpdateStackRequest {
   StorageConnectors?: StorageConnector[];
 
   /**
+   * @deprecated
    * <p>Deletes the storage connectors currently enabled for the stack.</p>
    */
   DeleteStorageConnectors?: boolean;

--- a/clients/client-auto-scaling/models/models_0.ts
+++ b/clients/client-auto-scaling/models/models_0.ts
@@ -3546,6 +3546,8 @@ export interface ScalingPolicy {
   AdjustmentType?: string;
 
   /**
+   * @deprecated
+   *
    * <p>Available for backward compatibility. Use <code>MinAdjustmentMagnitude</code>
    *             instead.</p>
    */
@@ -4524,6 +4526,8 @@ export interface PutScalingPolicyType {
   AdjustmentType?: string;
 
   /**
+   * @deprecated
+   *
    * <p>Available for backward compatibility. Use <code>MinAdjustmentMagnitude</code>
    *             instead.</p>
    */

--- a/clients/client-auto-scaling/models/models_0.ts
+++ b/clients/client-auto-scaling/models/models_0.ts
@@ -3546,6 +3546,7 @@ export interface ScalingPolicy {
   AdjustmentType?: string;
 
   /**
+   * @deprecated
    * <p>Available for backward compatibility. Use <code>MinAdjustmentMagnitude</code>
    *             instead.</p>
    */
@@ -4524,6 +4525,7 @@ export interface PutScalingPolicyType {
   AdjustmentType?: string;
 
   /**
+   * @deprecated
    * <p>Available for backward compatibility. Use <code>MinAdjustmentMagnitude</code>
    *             instead.</p>
    */

--- a/clients/client-auto-scaling/models/models_0.ts
+++ b/clients/client-auto-scaling/models/models_0.ts
@@ -3546,7 +3546,6 @@ export interface ScalingPolicy {
   AdjustmentType?: string;
 
   /**
-   * @deprecated
    * <p>Available for backward compatibility. Use <code>MinAdjustmentMagnitude</code>
    *             instead.</p>
    */
@@ -4525,7 +4524,6 @@ export interface PutScalingPolicyType {
   AdjustmentType?: string;
 
   /**
-   * @deprecated
    * <p>Available for backward compatibility. Use <code>MinAdjustmentMagnitude</code>
    *             instead.</p>
    */

--- a/clients/client-batch/models/models_0.ts
+++ b/clients/client-batch/models/models_0.ts
@@ -435,6 +435,8 @@ export interface ComputeResource {
   instanceTypes?: string[];
 
   /**
+   * @deprecated
+   *
    * <p>The Amazon Machine Image (AMI) ID used for instances launched in the compute environment. This parameter is
    *    overridden by the <code>imageIdOverride</code> member of the <code>Ec2Configuration</code> structure.</p>
    *          <note>
@@ -1645,6 +1647,8 @@ export interface ContainerProperties {
   image?: string;
 
   /**
+   * @deprecated
+   *
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, see
    *     <code>resourceRequirement</code>. The number of vCPUs reserved for the container. Jobs running on EC2 resources can
    *    specify the vCPU requirement for the job using <code>resourceRequirements</code> but the vCPU requirements can't be
@@ -1661,6 +1665,8 @@ export interface ContainerProperties {
   vcpus?: number;
 
   /**
+   * @deprecated
+   *
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, use
    *     <code>ResourceRequirement</code>. For jobs run on EC2 resources can specify the memory requirement using the
    *     <code>ResourceRequirement</code> structure. The hard limit (in MiB) of memory to present to the container. If your
@@ -2969,6 +2975,8 @@ export namespace RegisterJobDefinitionResponse {
  */
 export interface ContainerOverrides {
   /**
+   * @deprecated
+   *
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, see
    *     <code>resourceRequirement</code>. For jobs run on EC2 resources, the number of vCPUs to reserve for the container.
    *    This value overrides the value set in the job definition. Jobs run on EC2 resources can specify the vCPU requirement
@@ -2985,6 +2993,8 @@ export interface ContainerOverrides {
   vcpus?: number;
 
   /**
+   * @deprecated
+   *
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, use
    *     <code>ResourceRequirement</code>. For jobs run on EC2 resource, the number of MiB of memory reserved for the job.
    *    This value overrides the value set in the job definition.</p>

--- a/clients/client-batch/models/models_0.ts
+++ b/clients/client-batch/models/models_0.ts
@@ -435,7 +435,6 @@ export interface ComputeResource {
   instanceTypes?: string[];
 
   /**
-   * @deprecated
    * <p>The Amazon Machine Image (AMI) ID used for instances launched in the compute environment. This parameter is
    *    overridden by the <code>imageIdOverride</code> member of the <code>Ec2Configuration</code> structure.</p>
    *          <note>
@@ -1646,7 +1645,6 @@ export interface ContainerProperties {
   image?: string;
 
   /**
-   * @deprecated
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, see
    *     <code>resourceRequirement</code>. The number of vCPUs reserved for the container. Jobs running on EC2 resources can
    *    specify the vCPU requirement for the job using <code>resourceRequirements</code> but the vCPU requirements can't be
@@ -1663,7 +1661,6 @@ export interface ContainerProperties {
   vcpus?: number;
 
   /**
-   * @deprecated
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, use
    *     <code>ResourceRequirement</code>. For jobs run on EC2 resources can specify the memory requirement using the
    *     <code>ResourceRequirement</code> structure. The hard limit (in MiB) of memory to present to the container. If your
@@ -2972,7 +2969,6 @@ export namespace RegisterJobDefinitionResponse {
  */
 export interface ContainerOverrides {
   /**
-   * @deprecated
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, see
    *     <code>resourceRequirement</code>. For jobs run on EC2 resources, the number of vCPUs to reserve for the container.
    *    This value overrides the value set in the job definition. Jobs run on EC2 resources can specify the vCPU requirement
@@ -2989,7 +2985,6 @@ export interface ContainerOverrides {
   vcpus?: number;
 
   /**
-   * @deprecated
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, use
    *     <code>ResourceRequirement</code>. For jobs run on EC2 resource, the number of MiB of memory reserved for the job.
    *    This value overrides the value set in the job definition.</p>

--- a/clients/client-batch/models/models_0.ts
+++ b/clients/client-batch/models/models_0.ts
@@ -435,6 +435,7 @@ export interface ComputeResource {
   instanceTypes?: string[];
 
   /**
+   * @deprecated
    * <p>The Amazon Machine Image (AMI) ID used for instances launched in the compute environment. This parameter is
    *    overridden by the <code>imageIdOverride</code> member of the <code>Ec2Configuration</code> structure.</p>
    *          <note>
@@ -1645,6 +1646,7 @@ export interface ContainerProperties {
   image?: string;
 
   /**
+   * @deprecated
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, see
    *     <code>resourceRequirement</code>. The number of vCPUs reserved for the container. Jobs running on EC2 resources can
    *    specify the vCPU requirement for the job using <code>resourceRequirements</code> but the vCPU requirements can't be
@@ -1661,6 +1663,7 @@ export interface ContainerProperties {
   vcpus?: number;
 
   /**
+   * @deprecated
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, use
    *     <code>ResourceRequirement</code>. For jobs run on EC2 resources can specify the memory requirement using the
    *     <code>ResourceRequirement</code> structure. The hard limit (in MiB) of memory to present to the container. If your
@@ -2969,6 +2972,7 @@ export namespace RegisterJobDefinitionResponse {
  */
 export interface ContainerOverrides {
   /**
+   * @deprecated
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, see
    *     <code>resourceRequirement</code>. For jobs run on EC2 resources, the number of vCPUs to reserve for the container.
    *    This value overrides the value set in the job definition. Jobs run on EC2 resources can specify the vCPU requirement
@@ -2985,6 +2989,7 @@ export interface ContainerOverrides {
   vcpus?: number;
 
   /**
+   * @deprecated
    * <p>This parameter is deprecated and not supported for jobs run on Fargate resources, use
    *     <code>ResourceRequirement</code>. For jobs run on EC2 resource, the number of MiB of memory reserved for the job.
    *    This value overrides the value set in the job definition.</p>

--- a/clients/client-cloudfront/models/models_0.ts
+++ b/clients/client-cloudfront/models/models_0.ts
@@ -884,6 +884,8 @@ export interface CacheBehavior {
   OriginRequestPolicyId?: string;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. We recommend that you use a cache policy or an origin
    * 			request policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/working-with-policies.html">Working with policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -898,6 +900,8 @@ export interface CacheBehavior {
   ForwardedValues?: ForwardedValues;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. We recommend that you use the <code>MinTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -913,6 +917,8 @@ export interface CacheBehavior {
   MinTTL?: number;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. We recommend that you use the <code>DefaultTTL</code> field in a
    * 			cache policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -926,6 +932,8 @@ export interface CacheBehavior {
   DefaultTTL?: number;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. We recommend that you use the <code>MaxTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2072,6 +2080,8 @@ export interface DefaultCacheBehavior {
   OriginRequestPolicyId?: string;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. We recommend that you use a cache policy or an origin request
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/working-with-policies.html">Working with policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2086,6 +2096,8 @@ export interface DefaultCacheBehavior {
   ForwardedValues?: ForwardedValues;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. We recommend that you use the <code>MinTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2100,6 +2112,8 @@ export interface DefaultCacheBehavior {
   MinTTL?: number;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. We recommend that you use the <code>DefaultTTL</code> field in a
    * 			cache policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2113,6 +2127,8 @@ export interface DefaultCacheBehavior {
   DefaultTTL?: number;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. We recommend that you use the <code>MaxTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2935,6 +2951,8 @@ export interface ViewerCertificate {
   MinimumProtocolVersion?: MinimumProtocolVersion | string;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. Use one of the following fields instead:</p>
    * 		       <ul>
    *             <li>
@@ -2959,6 +2977,8 @@ export interface ViewerCertificate {
   Certificate?: string;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. Use one of the following fields instead:</p>
    * 		       <ul>
    *             <li>

--- a/clients/client-cloudfront/models/models_0.ts
+++ b/clients/client-cloudfront/models/models_0.ts
@@ -884,7 +884,6 @@ export interface CacheBehavior {
   OriginRequestPolicyId?: string;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. We recommend that you use a cache policy or an origin
    * 			request policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/working-with-policies.html">Working with policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -899,7 +898,6 @@ export interface CacheBehavior {
   ForwardedValues?: ForwardedValues;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>MinTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -915,7 +913,6 @@ export interface CacheBehavior {
   MinTTL?: number;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>DefaultTTL</code> field in a
    * 			cache policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -929,7 +926,6 @@ export interface CacheBehavior {
   DefaultTTL?: number;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>MaxTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2076,7 +2072,6 @@ export interface DefaultCacheBehavior {
   OriginRequestPolicyId?: string;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. We recommend that you use a cache policy or an origin request
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/working-with-policies.html">Working with policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2091,7 +2086,6 @@ export interface DefaultCacheBehavior {
   ForwardedValues?: ForwardedValues;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>MinTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2106,7 +2100,6 @@ export interface DefaultCacheBehavior {
   MinTTL?: number;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>DefaultTTL</code> field in a
    * 			cache policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2120,7 +2113,6 @@ export interface DefaultCacheBehavior {
   DefaultTTL?: number;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>MaxTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2943,7 +2935,6 @@ export interface ViewerCertificate {
   MinimumProtocolVersion?: MinimumProtocolVersion | string;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. Use one of the following fields instead:</p>
    * 		       <ul>
    *             <li>
@@ -2968,7 +2959,6 @@ export interface ViewerCertificate {
   Certificate?: string;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. Use one of the following fields instead:</p>
    * 		       <ul>
    *             <li>

--- a/clients/client-cloudfront/models/models_0.ts
+++ b/clients/client-cloudfront/models/models_0.ts
@@ -884,6 +884,7 @@ export interface CacheBehavior {
   OriginRequestPolicyId?: string;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. We recommend that you use a cache policy or an origin
    * 			request policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/working-with-policies.html">Working with policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -898,6 +899,7 @@ export interface CacheBehavior {
   ForwardedValues?: ForwardedValues;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>MinTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -913,6 +915,7 @@ export interface CacheBehavior {
   MinTTL?: number;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>DefaultTTL</code> field in a
    * 			cache policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -926,6 +929,7 @@ export interface CacheBehavior {
   DefaultTTL?: number;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>MaxTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2072,6 +2076,7 @@ export interface DefaultCacheBehavior {
   OriginRequestPolicyId?: string;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. We recommend that you use a cache policy or an origin request
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/working-with-policies.html">Working with policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2086,6 +2091,7 @@ export interface DefaultCacheBehavior {
   ForwardedValues?: ForwardedValues;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>MinTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2100,6 +2106,7 @@ export interface DefaultCacheBehavior {
   MinTTL?: number;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>DefaultTTL</code> field in a
    * 			cache policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2113,6 +2120,7 @@ export interface DefaultCacheBehavior {
   DefaultTTL?: number;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. We recommend that you use the <code>MaxTTL</code> field in a cache
    * 			policy instead of this field. For more information, see <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/controlling-the-cache-key.html#cache-key-create-cache-policy">Creating cache policies</a> or <a href="https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html">Using the managed cache policies</a> in the
    * 			<i>Amazon CloudFront Developer Guide</i>.</p>
@@ -2935,6 +2943,7 @@ export interface ViewerCertificate {
   MinimumProtocolVersion?: MinimumProtocolVersion | string;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. Use one of the following fields instead:</p>
    * 		       <ul>
    *             <li>
@@ -2959,6 +2968,7 @@ export interface ViewerCertificate {
   Certificate?: string;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. Use one of the following fields instead:</p>
    * 		       <ul>
    *             <li>

--- a/clients/client-cloudtrail/models/models_0.ts
+++ b/clients/client-cloudtrail/models/models_0.ts
@@ -627,6 +627,7 @@ export interface CreateTrailResponse {
   S3KeyPrefix?: string;
 
   /**
+   * @deprecated
    * <p>This field is no longer in use. Use SnsTopicARN.</p>
    */
   SnsTopicName?: string;
@@ -912,6 +913,7 @@ export namespace KmsException {
 }
 
 /**
+ * @deprecated
  * <p>This exception is no longer in use.</p>
  */
 export interface KmsKeyDisabledException extends __SmithyException, $MetadataBearer {
@@ -1188,6 +1190,7 @@ export interface Trail {
   S3KeyPrefix?: string;
 
   /**
+   * @deprecated
    * <p>This field is no longer in use. Use SnsTopicARN.</p>
    */
   SnsTopicName?: string;
@@ -2680,6 +2683,7 @@ export interface UpdateTrailResponse {
   S3KeyPrefix?: string;
 
   /**
+   * @deprecated
    * <p>This field is no longer in use. Use SnsTopicARN.</p>
    */
   SnsTopicName?: string;

--- a/clients/client-cloudtrail/models/models_0.ts
+++ b/clients/client-cloudtrail/models/models_0.ts
@@ -627,7 +627,6 @@ export interface CreateTrailResponse {
   S3KeyPrefix?: string;
 
   /**
-   * @deprecated
    * <p>This field is no longer in use. Use SnsTopicARN.</p>
    */
   SnsTopicName?: string;
@@ -914,6 +913,7 @@ export namespace KmsException {
 
 /**
  * @deprecated
+ *
  * <p>This exception is no longer in use.</p>
  */
 export interface KmsKeyDisabledException extends __SmithyException, $MetadataBearer {
@@ -1190,7 +1190,6 @@ export interface Trail {
   S3KeyPrefix?: string;
 
   /**
-   * @deprecated
    * <p>This field is no longer in use. Use SnsTopicARN.</p>
    */
   SnsTopicName?: string;
@@ -2683,7 +2682,6 @@ export interface UpdateTrailResponse {
   S3KeyPrefix?: string;
 
   /**
-   * @deprecated
    * <p>This field is no longer in use. Use SnsTopicARN.</p>
    */
   SnsTopicName?: string;

--- a/clients/client-cloudtrail/models/models_0.ts
+++ b/clients/client-cloudtrail/models/models_0.ts
@@ -627,6 +627,8 @@ export interface CreateTrailResponse {
   S3KeyPrefix?: string;
 
   /**
+   * @deprecated
+   *
    * <p>This field is no longer in use. Use SnsTopicARN.</p>
    */
   SnsTopicName?: string;
@@ -1190,6 +1192,8 @@ export interface Trail {
   S3KeyPrefix?: string;
 
   /**
+   * @deprecated
+   *
    * <p>This field is no longer in use. Use SnsTopicARN.</p>
    */
   SnsTopicName?: string;
@@ -2682,6 +2686,8 @@ export interface UpdateTrailResponse {
   S3KeyPrefix?: string;
 
   /**
+   * @deprecated
+   *
    * <p>This field is no longer in use. Use SnsTopicARN.</p>
    */
   SnsTopicName?: string;

--- a/clients/client-cloudwatch-logs/models/models_0.ts
+++ b/clients/client-cloudwatch-logs/models/models_0.ts
@@ -831,6 +831,8 @@ export interface LogStream {
   arn?: string;
 
   /**
+   * @deprecated
+   *
    * <p>The number of bytes stored.</p>
    *          <p>
    *             <b>Important:</b> On June 17, 2019, this parameter was
@@ -1434,6 +1436,8 @@ export interface FilterLogEventsRequest {
   limit?: number;
 
   /**
+   * @deprecated
+   *
    * <p>If the value is true, the operation makes a best effort to provide responses that
    *       contain events from multiple log streams within the log group, interleaved in a single
    *       response. If the value is false, all the matched log events in the first log stream are

--- a/clients/client-cloudwatch-logs/models/models_0.ts
+++ b/clients/client-cloudwatch-logs/models/models_0.ts
@@ -831,7 +831,6 @@ export interface LogStream {
   arn?: string;
 
   /**
-   * @deprecated
    * <p>The number of bytes stored.</p>
    *          <p>
    *             <b>Important:</b> On June 17, 2019, this parameter was
@@ -1435,7 +1434,6 @@ export interface FilterLogEventsRequest {
   limit?: number;
 
   /**
-   * @deprecated
    * <p>If the value is true, the operation makes a best effort to provide responses that
    *       contain events from multiple log streams within the log group, interleaved in a single
    *       response. If the value is false, all the matched log events in the first log stream are

--- a/clients/client-cloudwatch-logs/models/models_0.ts
+++ b/clients/client-cloudwatch-logs/models/models_0.ts
@@ -831,6 +831,7 @@ export interface LogStream {
   arn?: string;
 
   /**
+   * @deprecated
    * <p>The number of bytes stored.</p>
    *          <p>
    *             <b>Important:</b> On June 17, 2019, this parameter was
@@ -1434,6 +1435,7 @@ export interface FilterLogEventsRequest {
   limit?: number;
 
   /**
+   * @deprecated
    * <p>If the value is true, the operation makes a best effort to provide responses that
    *       contain events from multiple log streams within the log group, interleaved in a single
    *       response. If the value is false, all the matched log events in the first log stream are

--- a/clients/client-codedeploy/CodeDeploy.ts
+++ b/clients/client-codedeploy/CodeDeploy.ts
@@ -465,6 +465,7 @@ export class CodeDeploy extends CodeDeployClient {
 
   /**
    * @deprecated
+   *
    * <note>
    *             <p> This method works, but is deprecated. Use <code>BatchGetDeploymentTargets</code>
    *                 instead. </p>
@@ -1154,6 +1155,7 @@ export class CodeDeploy extends CodeDeployClient {
 
   /**
    * @deprecated
+   *
    * <p>Gets information about an instance as part of a deployment.</p>
    */
   public getDeploymentInstance(
@@ -1380,6 +1382,7 @@ export class CodeDeploy extends CodeDeployClient {
 
   /**
    * @deprecated
+   *
    * <note>
    *             <p> The newer <code>BatchGetDeploymentTargets</code> should be used instead because
    *                 it works with all compute types. <code>ListDeploymentInstances</code> throws an
@@ -1725,6 +1728,7 @@ export class CodeDeploy extends CodeDeployClient {
 
   /**
    * @deprecated
+   *
    * <p>In a blue/green deployment, overrides any specified wait time and starts terminating
    *             instances immediately after the traffic routing is complete.</p>
    */

--- a/clients/client-codedeploy/CodeDeploy.ts
+++ b/clients/client-codedeploy/CodeDeploy.ts
@@ -464,6 +464,7 @@ export class CodeDeploy extends CodeDeployClient {
   }
 
   /**
+   * @deprecated
    * <note>
    *             <p> This method works, but is deprecated. Use <code>BatchGetDeploymentTargets</code>
    *                 instead. </p>
@@ -1152,6 +1153,7 @@ export class CodeDeploy extends CodeDeployClient {
   }
 
   /**
+   * @deprecated
    * <p>Gets information about an instance as part of a deployment.</p>
    */
   public getDeploymentInstance(
@@ -1377,6 +1379,7 @@ export class CodeDeploy extends CodeDeployClient {
   }
 
   /**
+   * @deprecated
    * <note>
    *             <p> The newer <code>BatchGetDeploymentTargets</code> should be used instead because
    *                 it works with all compute types. <code>ListDeploymentInstances</code> throws an
@@ -1721,6 +1724,7 @@ export class CodeDeploy extends CodeDeployClient {
   }
 
   /**
+   * @deprecated
    * <p>In a blue/green deployment, overrides any specified wait time and starts terminating
    *             instances immediately after the traffic routing is complete.</p>
    */

--- a/clients/client-codedeploy/commands/BatchGetDeploymentInstancesCommand.ts
+++ b/clients/client-codedeploy/commands/BatchGetDeploymentInstancesCommand.ts
@@ -22,6 +22,7 @@ export type BatchGetDeploymentInstancesCommandOutput = BatchGetDeploymentInstanc
 
 /**
  * @deprecated
+ *
  * <note>
  *             <p> This method works, but is deprecated. Use <code>BatchGetDeploymentTargets</code>
  *                 instead. </p>

--- a/clients/client-codedeploy/commands/BatchGetDeploymentInstancesCommand.ts
+++ b/clients/client-codedeploy/commands/BatchGetDeploymentInstancesCommand.ts
@@ -21,6 +21,7 @@ export type BatchGetDeploymentInstancesCommandInput = BatchGetDeploymentInstance
 export type BatchGetDeploymentInstancesCommandOutput = BatchGetDeploymentInstancesOutput & __MetadataBearer;
 
 /**
+ * @deprecated
  * <note>
  *             <p> This method works, but is deprecated. Use <code>BatchGetDeploymentTargets</code>
  *                 instead. </p>

--- a/clients/client-codedeploy/commands/GetDeploymentInstanceCommand.ts
+++ b/clients/client-codedeploy/commands/GetDeploymentInstanceCommand.ts
@@ -21,6 +21,7 @@ export type GetDeploymentInstanceCommandInput = GetDeploymentInstanceInput;
 export type GetDeploymentInstanceCommandOutput = GetDeploymentInstanceOutput & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Gets information about an instance as part of a deployment.</p>
  */
 export class GetDeploymentInstanceCommand extends $Command<

--- a/clients/client-codedeploy/commands/GetDeploymentInstanceCommand.ts
+++ b/clients/client-codedeploy/commands/GetDeploymentInstanceCommand.ts
@@ -22,6 +22,7 @@ export type GetDeploymentInstanceCommandOutput = GetDeploymentInstanceOutput & _
 
 /**
  * @deprecated
+ *
  * <p>Gets information about an instance as part of a deployment.</p>
  */
 export class GetDeploymentInstanceCommand extends $Command<

--- a/clients/client-codedeploy/commands/ListDeploymentInstancesCommand.ts
+++ b/clients/client-codedeploy/commands/ListDeploymentInstancesCommand.ts
@@ -21,6 +21,7 @@ export type ListDeploymentInstancesCommandInput = ListDeploymentInstancesInput;
 export type ListDeploymentInstancesCommandOutput = ListDeploymentInstancesOutput & __MetadataBearer;
 
 /**
+ * @deprecated
  * <note>
  *             <p> The newer <code>BatchGetDeploymentTargets</code> should be used instead because
  *                 it works with all compute types. <code>ListDeploymentInstances</code> throws an

--- a/clients/client-codedeploy/commands/ListDeploymentInstancesCommand.ts
+++ b/clients/client-codedeploy/commands/ListDeploymentInstancesCommand.ts
@@ -22,6 +22,7 @@ export type ListDeploymentInstancesCommandOutput = ListDeploymentInstancesOutput
 
 /**
  * @deprecated
+ *
  * <note>
  *             <p> The newer <code>BatchGetDeploymentTargets</code> should be used instead because
  *                 it works with all compute types. <code>ListDeploymentInstances</code> throws an

--- a/clients/client-codedeploy/commands/SkipWaitTimeForInstanceTerminationCommand.ts
+++ b/clients/client-codedeploy/commands/SkipWaitTimeForInstanceTerminationCommand.ts
@@ -21,6 +21,7 @@ export type SkipWaitTimeForInstanceTerminationCommandInput = SkipWaitTimeForInst
 export type SkipWaitTimeForInstanceTerminationCommandOutput = __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>In a blue/green deployment, overrides any specified wait time and starts terminating
  *             instances immediately after the traffic routing is complete.</p>
  */

--- a/clients/client-codedeploy/commands/SkipWaitTimeForInstanceTerminationCommand.ts
+++ b/clients/client-codedeploy/commands/SkipWaitTimeForInstanceTerminationCommand.ts
@@ -22,6 +22,7 @@ export type SkipWaitTimeForInstanceTerminationCommandOutput = __MetadataBearer;
 
 /**
  * @deprecated
+ *
  * <p>In a blue/green deployment, overrides any specified wait time and starts terminating
  *             instances immediately after the traffic routing is complete.</p>
  */

--- a/clients/client-codedeploy/models/models_0.ts
+++ b/clients/client-codedeploy/models/models_0.ts
@@ -637,6 +637,8 @@ export interface RevisionLocation {
   gitHubLocation?: GitHubLocation;
 
   /**
+   * @deprecated
+   *
    * <p>Information about the location of an AWS Lambda deployment revision stored as a
    *             RawString.</p>
    */
@@ -1832,6 +1834,8 @@ export interface InstanceSummary {
   instanceId?: string;
 
   /**
+   * @deprecated
+   *
    * <p>The deployment status for this instance:</p>
    *         <ul>
    *             <li>
@@ -2430,6 +2434,8 @@ export interface DeploymentInfo {
   loadBalancerInfo?: LoadBalancerInfo;
 
   /**
+   * @deprecated
+   *
    * <p>Provides information about the results of a deployment, such as whether instances in
    *             the original environment in a blue/green deployment were not terminated.</p>
    */
@@ -5081,6 +5087,8 @@ export namespace GetDeploymentInstanceInput {
  */
 export interface GetDeploymentInstanceOutput {
   /**
+   * @deprecated
+   *
    * <p> Information about the instance. </p>
    */
   instanceSummary?: InstanceSummary;

--- a/clients/client-codedeploy/models/models_0.ts
+++ b/clients/client-codedeploy/models/models_0.ts
@@ -574,6 +574,7 @@ export namespace S3Location {
 }
 
 /**
+ * @deprecated
  * <p>A revision for an AWS Lambda deployment that is a YAML-formatted or JSON-formatted
  *             string. For AWS Lambda deployments, the revision is the same as the AppSpec file.</p>
  */
@@ -635,6 +636,7 @@ export interface RevisionLocation {
   gitHubLocation?: GitHubLocation;
 
   /**
+   * @deprecated
    * <p>Information about the location of an AWS Lambda deployment revision stored as a
    *             RawString.</p>
    */
@@ -1814,6 +1816,7 @@ export enum InstanceStatus {
 }
 
 /**
+ * @deprecated
  * <p>Information about an instance in a deployment.</p>
  */
 export interface InstanceSummary {
@@ -1828,6 +1831,7 @@ export interface InstanceSummary {
   instanceId?: string;
 
   /**
+   * @deprecated
    * <p>The deployment status for this instance:</p>
    *         <ul>
    *             <li>
@@ -1950,6 +1954,7 @@ export namespace DeploymentIdRequiredException {
 }
 
 /**
+ * @deprecated
  * <p>The instance ID was not specified.</p>
  */
 export interface InstanceIdRequiredException extends __SmithyException, $MetadataBearer {
@@ -2424,6 +2429,7 @@ export interface DeploymentInfo {
   loadBalancerInfo?: LoadBalancerInfo;
 
   /**
+   * @deprecated
    * <p>Provides information about the results of a deployment, such as whether instances in
    *             the original environment in a blue/green deployment were not terminated.</p>
    */
@@ -3036,6 +3042,7 @@ export namespace DeploymentTargetListSizeExceededException {
 }
 
 /**
+ * @deprecated
  * <p>The specified instance does not exist in the deployment group.</p>
  */
 export interface InstanceDoesNotExistException extends __SmithyException, $MetadataBearer {
@@ -5073,6 +5080,7 @@ export namespace GetDeploymentInstanceInput {
  */
 export interface GetDeploymentInstanceOutput {
   /**
+   * @deprecated
    * <p> Information about the instance. </p>
    */
   instanceSummary?: InstanceSummary;

--- a/clients/client-codedeploy/models/models_0.ts
+++ b/clients/client-codedeploy/models/models_0.ts
@@ -575,6 +575,7 @@ export namespace S3Location {
 
 /**
  * @deprecated
+ *
  * <p>A revision for an AWS Lambda deployment that is a YAML-formatted or JSON-formatted
  *             string. For AWS Lambda deployments, the revision is the same as the AppSpec file.</p>
  */
@@ -636,7 +637,6 @@ export interface RevisionLocation {
   gitHubLocation?: GitHubLocation;
 
   /**
-   * @deprecated
    * <p>Information about the location of an AWS Lambda deployment revision stored as a
    *             RawString.</p>
    */
@@ -1817,6 +1817,7 @@ export enum InstanceStatus {
 
 /**
  * @deprecated
+ *
  * <p>Information about an instance in a deployment.</p>
  */
 export interface InstanceSummary {
@@ -1831,7 +1832,6 @@ export interface InstanceSummary {
   instanceId?: string;
 
   /**
-   * @deprecated
    * <p>The deployment status for this instance:</p>
    *         <ul>
    *             <li>
@@ -1955,6 +1955,7 @@ export namespace DeploymentIdRequiredException {
 
 /**
  * @deprecated
+ *
  * <p>The instance ID was not specified.</p>
  */
 export interface InstanceIdRequiredException extends __SmithyException, $MetadataBearer {
@@ -2429,7 +2430,6 @@ export interface DeploymentInfo {
   loadBalancerInfo?: LoadBalancerInfo;
 
   /**
-   * @deprecated
    * <p>Provides information about the results of a deployment, such as whether instances in
    *             the original environment in a blue/green deployment were not terminated.</p>
    */
@@ -3043,6 +3043,7 @@ export namespace DeploymentTargetListSizeExceededException {
 
 /**
  * @deprecated
+ *
  * <p>The specified instance does not exist in the deployment group.</p>
  */
 export interface InstanceDoesNotExistException extends __SmithyException, $MetadataBearer {
@@ -5080,7 +5081,6 @@ export namespace GetDeploymentInstanceInput {
  */
 export interface GetDeploymentInstanceOutput {
   /**
-   * @deprecated
    * <p> Information about the instance. </p>
    */
   instanceSummary?: InstanceSummary;

--- a/clients/client-comprehendmedical/ComprehendMedical.ts
+++ b/clients/client-comprehendmedical/ComprehendMedical.ts
@@ -236,6 +236,7 @@ export class ComprehendMedical extends ComprehendMedicalClient {
   }
 
   /**
+   * @deprecated
    * <p>The <code>DetectEntities</code> operation is deprecated. You should use the <a>DetectEntitiesV2</a> operation instead.</p>
    *          <p> Inspects the clinical text for a variety of medical entities and returns specific
    *       information about them such as entity category, location, and confidence score on that

--- a/clients/client-comprehendmedical/ComprehendMedical.ts
+++ b/clients/client-comprehendmedical/ComprehendMedical.ts
@@ -237,6 +237,7 @@ export class ComprehendMedical extends ComprehendMedicalClient {
 
   /**
    * @deprecated
+   *
    * <p>The <code>DetectEntities</code> operation is deprecated. You should use the <a>DetectEntitiesV2</a> operation instead.</p>
    *          <p> Inspects the clinical text for a variety of medical entities and returns specific
    *       information about them such as entity category, location, and confidence score on that

--- a/clients/client-comprehendmedical/commands/DetectEntitiesCommand.ts
+++ b/clients/client-comprehendmedical/commands/DetectEntitiesCommand.ts
@@ -26,6 +26,7 @@ export type DetectEntitiesCommandOutput = DetectEntitiesResponse & __MetadataBea
 
 /**
  * @deprecated
+ *
  * <p>The <code>DetectEntities</code> operation is deprecated. You should use the <a>DetectEntitiesV2</a> operation instead.</p>
  *          <p> Inspects the clinical text for a variety of medical entities and returns specific
  *       information about them such as entity category, location, and confidence score on that

--- a/clients/client-comprehendmedical/commands/DetectEntitiesCommand.ts
+++ b/clients/client-comprehendmedical/commands/DetectEntitiesCommand.ts
@@ -25,6 +25,7 @@ export type DetectEntitiesCommandInput = DetectEntitiesRequest;
 export type DetectEntitiesCommandOutput = DetectEntitiesResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>The <code>DetectEntities</code> operation is deprecated. You should use the <a>DetectEntitiesV2</a> operation instead.</p>
  *          <p> Inspects the clinical text for a variety of medical entities and returns specific
  *       information about them such as entity category, location, and confidence score on that

--- a/clients/client-database-migration-service/models/models_0.ts
+++ b/clients/client-database-migration-service/models/models_0.ts
@@ -3726,11 +3726,15 @@ export interface ReplicationInstance {
   ReplicationInstanceArn?: string;
 
   /**
+   * @deprecated
+   *
    * <p>The public IP address of the replication instance.</p>
    */
   ReplicationInstancePublicIpAddress?: string;
 
   /**
+   * @deprecated
+   *
    * <p>The private IP address of the replication instance.</p>
    */
   ReplicationInstancePrivateIpAddress?: string;

--- a/clients/client-database-migration-service/models/models_0.ts
+++ b/clients/client-database-migration-service/models/models_0.ts
@@ -3726,11 +3726,13 @@ export interface ReplicationInstance {
   ReplicationInstanceArn?: string;
 
   /**
+   * @deprecated
    * <p>The public IP address of the replication instance.</p>
    */
   ReplicationInstancePublicIpAddress?: string;
 
   /**
+   * @deprecated
    * <p>The private IP address of the replication instance.</p>
    */
   ReplicationInstancePrivateIpAddress?: string;

--- a/clients/client-database-migration-service/models/models_0.ts
+++ b/clients/client-database-migration-service/models/models_0.ts
@@ -3726,13 +3726,11 @@ export interface ReplicationInstance {
   ReplicationInstanceArn?: string;
 
   /**
-   * @deprecated
    * <p>The public IP address of the replication instance.</p>
    */
   ReplicationInstancePublicIpAddress?: string;
 
   /**
-   * @deprecated
    * <p>The private IP address of the replication instance.</p>
    */
   ReplicationInstancePrivateIpAddress?: string;

--- a/clients/client-direct-connect/DirectConnect.ts
+++ b/clients/client-direct-connect/DirectConnect.ts
@@ -306,6 +306,7 @@ export class DirectConnect extends DirectConnectClient {
 
   /**
    * @deprecated
+   *
    * <p>Deprecated. Use <a>AllocateHostedConnection</a> instead.</p>
    *          <p>Creates a hosted connection on an interconnect.</p>
    *          <p>Allocates a VLAN number and a specified amount of bandwidth for use by a hosted connection on the specified interconnect.</p>
@@ -1406,6 +1407,7 @@ export class DirectConnect extends DirectConnectClient {
 
   /**
    * @deprecated
+   *
    * <p>Deprecated. Use <a>DescribeLoa</a> instead.</p>
    *          <p>Gets the LOA-CFA for a connection.</p>
    *          <p>The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is a document that your APN partner or
@@ -1476,6 +1478,7 @@ export class DirectConnect extends DirectConnectClient {
 
   /**
    * @deprecated
+   *
    * <p>Deprecated. Use <a>DescribeHostedConnections</a> instead.</p>
    *          <p>Lists the connections that have been provisioned on the specified interconnect.</p>
    *          <note>
@@ -1693,6 +1696,7 @@ export class DirectConnect extends DirectConnectClient {
 
   /**
    * @deprecated
+   *
    * <p>Deprecated. Use <a>DescribeLoa</a> instead.</p>
    *          <p>Gets the LOA-CFA for the specified interconnect.</p>
    *          <p>The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is a document that is used when establishing your cross connect to AWS at the colocation facility.

--- a/clients/client-direct-connect/DirectConnect.ts
+++ b/clients/client-direct-connect/DirectConnect.ts
@@ -305,6 +305,7 @@ export class DirectConnect extends DirectConnectClient {
   }
 
   /**
+   * @deprecated
    * <p>Deprecated. Use <a>AllocateHostedConnection</a> instead.</p>
    *          <p>Creates a hosted connection on an interconnect.</p>
    *          <p>Allocates a VLAN number and a specified amount of bandwidth for use by a hosted connection on the specified interconnect.</p>
@@ -1404,6 +1405,7 @@ export class DirectConnect extends DirectConnectClient {
   }
 
   /**
+   * @deprecated
    * <p>Deprecated. Use <a>DescribeLoa</a> instead.</p>
    *          <p>Gets the LOA-CFA for a connection.</p>
    *          <p>The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is a document that your APN partner or
@@ -1473,6 +1475,7 @@ export class DirectConnect extends DirectConnectClient {
   }
 
   /**
+   * @deprecated
    * <p>Deprecated. Use <a>DescribeHostedConnections</a> instead.</p>
    *          <p>Lists the connections that have been provisioned on the specified interconnect.</p>
    *          <note>
@@ -1689,6 +1692,7 @@ export class DirectConnect extends DirectConnectClient {
   }
 
   /**
+   * @deprecated
    * <p>Deprecated. Use <a>DescribeLoa</a> instead.</p>
    *          <p>Gets the LOA-CFA for the specified interconnect.</p>
    *          <p>The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is a document that is used when establishing your cross connect to AWS at the colocation facility.

--- a/clients/client-direct-connect/commands/AllocateConnectionOnInterconnectCommand.ts
+++ b/clients/client-direct-connect/commands/AllocateConnectionOnInterconnectCommand.ts
@@ -22,6 +22,7 @@ export type AllocateConnectionOnInterconnectCommandOutput = Connection & __Metad
 
 /**
  * @deprecated
+ *
  * <p>Deprecated. Use <a>AllocateHostedConnection</a> instead.</p>
  *          <p>Creates a hosted connection on an interconnect.</p>
  *          <p>Allocates a VLAN number and a specified amount of bandwidth for use by a hosted connection on the specified interconnect.</p>

--- a/clients/client-direct-connect/commands/AllocateConnectionOnInterconnectCommand.ts
+++ b/clients/client-direct-connect/commands/AllocateConnectionOnInterconnectCommand.ts
@@ -21,6 +21,7 @@ export type AllocateConnectionOnInterconnectCommandInput = AllocateConnectionOnI
 export type AllocateConnectionOnInterconnectCommandOutput = Connection & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Deprecated. Use <a>AllocateHostedConnection</a> instead.</p>
  *          <p>Creates a hosted connection on an interconnect.</p>
  *          <p>Allocates a VLAN number and a specified amount of bandwidth for use by a hosted connection on the specified interconnect.</p>

--- a/clients/client-direct-connect/commands/DescribeConnectionLoaCommand.ts
+++ b/clients/client-direct-connect/commands/DescribeConnectionLoaCommand.ts
@@ -22,6 +22,7 @@ export type DescribeConnectionLoaCommandOutput = DescribeConnectionLoaResponse &
 
 /**
  * @deprecated
+ *
  * <p>Deprecated. Use <a>DescribeLoa</a> instead.</p>
  *          <p>Gets the LOA-CFA for a connection.</p>
  *          <p>The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is a document that your APN partner or

--- a/clients/client-direct-connect/commands/DescribeConnectionLoaCommand.ts
+++ b/clients/client-direct-connect/commands/DescribeConnectionLoaCommand.ts
@@ -21,6 +21,7 @@ export type DescribeConnectionLoaCommandInput = DescribeConnectionLoaRequest;
 export type DescribeConnectionLoaCommandOutput = DescribeConnectionLoaResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Deprecated. Use <a>DescribeLoa</a> instead.</p>
  *          <p>Gets the LOA-CFA for a connection.</p>
  *          <p>The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is a document that your APN partner or

--- a/clients/client-direct-connect/commands/DescribeConnectionsOnInterconnectCommand.ts
+++ b/clients/client-direct-connect/commands/DescribeConnectionsOnInterconnectCommand.ts
@@ -22,6 +22,7 @@ export type DescribeConnectionsOnInterconnectCommandOutput = Connections & __Met
 
 /**
  * @deprecated
+ *
  * <p>Deprecated. Use <a>DescribeHostedConnections</a> instead.</p>
  *          <p>Lists the connections that have been provisioned on the specified interconnect.</p>
  *          <note>

--- a/clients/client-direct-connect/commands/DescribeConnectionsOnInterconnectCommand.ts
+++ b/clients/client-direct-connect/commands/DescribeConnectionsOnInterconnectCommand.ts
@@ -21,6 +21,7 @@ export type DescribeConnectionsOnInterconnectCommandInput = DescribeConnectionsO
 export type DescribeConnectionsOnInterconnectCommandOutput = Connections & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Deprecated. Use <a>DescribeHostedConnections</a> instead.</p>
  *          <p>Lists the connections that have been provisioned on the specified interconnect.</p>
  *          <note>

--- a/clients/client-direct-connect/commands/DescribeInterconnectLoaCommand.ts
+++ b/clients/client-direct-connect/commands/DescribeInterconnectLoaCommand.ts
@@ -22,6 +22,7 @@ export type DescribeInterconnectLoaCommandOutput = DescribeInterconnectLoaRespon
 
 /**
  * @deprecated
+ *
  * <p>Deprecated. Use <a>DescribeLoa</a> instead.</p>
  *          <p>Gets the LOA-CFA for the specified interconnect.</p>
  *          <p>The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is a document that is used when establishing your cross connect to AWS at the colocation facility.

--- a/clients/client-direct-connect/commands/DescribeInterconnectLoaCommand.ts
+++ b/clients/client-direct-connect/commands/DescribeInterconnectLoaCommand.ts
@@ -21,6 +21,7 @@ export type DescribeInterconnectLoaCommandInput = DescribeInterconnectLoaRequest
 export type DescribeInterconnectLoaCommandOutput = DescribeInterconnectLoaResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Deprecated. Use <a>DescribeLoa</a> instead.</p>
  *          <p>Gets the LOA-CFA for the specified interconnect.</p>
  *          <p>The Letter of Authorization - Connecting Facility Assignment (LOA-CFA) is a document that is used when establishing your cross connect to AWS at the colocation facility.

--- a/clients/client-direct-connect/models/models_0.ts
+++ b/clients/client-direct-connect/models/models_0.ts
@@ -153,6 +153,8 @@ export interface DirectConnectGatewayAssociation {
   virtualGatewayId?: string;
 
   /**
+   * @deprecated
+   *
    * <p>The AWS Region where the virtual private gateway is located.</p>
    */
   virtualGatewayRegion?: string;
@@ -389,6 +391,8 @@ export interface Connection {
   lagId?: string;
 
   /**
+   * @deprecated
+   *
    * <p>The Direct Connect endpoint on which the physical connection terminates.</p>
    */
   awsDevice?: string;
@@ -1839,6 +1843,8 @@ export interface Interconnect {
   lagId?: string;
 
   /**
+   * @deprecated
+   *
    * <p>The Direct Connect endpoint on which the physical connection terminates.</p>
    */
   awsDevice?: string;
@@ -2009,6 +2015,8 @@ export interface Lag {
   minimumLinks?: number;
 
   /**
+   * @deprecated
+   *
    * <p>The AWS Direct Connect endpoint that hosts the LAG.</p>
    */
   awsDevice?: string;

--- a/clients/client-direct-connect/models/models_0.ts
+++ b/clients/client-direct-connect/models/models_0.ts
@@ -153,7 +153,6 @@ export interface DirectConnectGatewayAssociation {
   virtualGatewayId?: string;
 
   /**
-   * @deprecated
    * <p>The AWS Region where the virtual private gateway is located.</p>
    */
   virtualGatewayRegion?: string;
@@ -390,7 +389,6 @@ export interface Connection {
   lagId?: string;
 
   /**
-   * @deprecated
    * <p>The Direct Connect endpoint on which the physical connection terminates.</p>
    */
   awsDevice?: string;
@@ -1841,7 +1839,6 @@ export interface Interconnect {
   lagId?: string;
 
   /**
-   * @deprecated
    * <p>The Direct Connect endpoint on which the physical connection terminates.</p>
    */
   awsDevice?: string;
@@ -2012,7 +2009,6 @@ export interface Lag {
   minimumLinks?: number;
 
   /**
-   * @deprecated
    * <p>The AWS Direct Connect endpoint that hosts the LAG.</p>
    */
   awsDevice?: string;

--- a/clients/client-direct-connect/models/models_0.ts
+++ b/clients/client-direct-connect/models/models_0.ts
@@ -153,6 +153,7 @@ export interface DirectConnectGatewayAssociation {
   virtualGatewayId?: string;
 
   /**
+   * @deprecated
    * <p>The AWS Region where the virtual private gateway is located.</p>
    */
   virtualGatewayRegion?: string;
@@ -389,6 +390,7 @@ export interface Connection {
   lagId?: string;
 
   /**
+   * @deprecated
    * <p>The Direct Connect endpoint on which the physical connection terminates.</p>
    */
   awsDevice?: string;
@@ -1839,6 +1841,7 @@ export interface Interconnect {
   lagId?: string;
 
   /**
+   * @deprecated
    * <p>The Direct Connect endpoint on which the physical connection terminates.</p>
    */
   awsDevice?: string;
@@ -2009,6 +2012,7 @@ export interface Lag {
   minimumLinks?: number;
 
   /**
+   * @deprecated
    * <p>The AWS Direct Connect endpoint that hosts the LAG.</p>
    */
   awsDevice?: string;

--- a/clients/client-ec2/models/models_2.ts
+++ b/clients/client-ec2/models/models_2.ts
@@ -2975,6 +2975,8 @@ export interface ClientVpnEndpoint {
   VpnPort?: number;
 
   /**
+   * @deprecated
+   *
    * <p>Information about the associated target networks. A target network is a subnet in a VPC.</p>
    */
   AssociatedTargetNetworks?: AssociatedTargetNetwork[];

--- a/clients/client-ec2/models/models_2.ts
+++ b/clients/client-ec2/models/models_2.ts
@@ -2975,6 +2975,7 @@ export interface ClientVpnEndpoint {
   VpnPort?: number;
 
   /**
+   * @deprecated
    * <p>Information about the associated target networks. A target network is a subnet in a VPC.</p>
    */
   AssociatedTargetNetworks?: AssociatedTargetNetwork[];

--- a/clients/client-ec2/models/models_2.ts
+++ b/clients/client-ec2/models/models_2.ts
@@ -2975,7 +2975,6 @@ export interface ClientVpnEndpoint {
   VpnPort?: number;
 
   /**
-   * @deprecated
    * <p>Information about the associated target networks. A target network is a subnet in a VPC.</p>
    */
   AssociatedTargetNetworks?: AssociatedTargetNetwork[];

--- a/clients/client-ecr/models/models_0.ts
+++ b/clients/client-ecr/models/models_0.ts
@@ -1647,6 +1647,8 @@ export namespace DescribeRepositoriesResponse {
 
 export interface GetAuthorizationTokenRequest {
   /**
+   * @deprecated
+   *
    * <p>A list of AWS account IDs that are associated with the registries for which to get
    *             AuthorizationData objects. If you do not specify a registry, the default registry is assumed.</p>
    */

--- a/clients/client-ecr/models/models_0.ts
+++ b/clients/client-ecr/models/models_0.ts
@@ -1647,7 +1647,6 @@ export namespace DescribeRepositoriesResponse {
 
 export interface GetAuthorizationTokenRequest {
   /**
-   * @deprecated
    * <p>A list of AWS account IDs that are associated with the registries for which to get
    *             AuthorizationData objects. If you do not specify a registry, the default registry is assumed.</p>
    */

--- a/clients/client-ecr/models/models_0.ts
+++ b/clients/client-ecr/models/models_0.ts
@@ -1647,6 +1647,7 @@ export namespace DescribeRepositoriesResponse {
 
 export interface GetAuthorizationTokenRequest {
   /**
+   * @deprecated
    * <p>A list of AWS account IDs that are associated with the registries for which to get
    *             AuthorizationData objects. If you do not specify a registry, the default registry is assumed.</p>
    */

--- a/clients/client-efs/EFS.ts
+++ b/clients/client-efs/EFS.ts
@@ -400,6 +400,7 @@ export class EFS extends EFSClient {
 
   /**
    * @deprecated
+   *
    * <p>Creates or overwrites tags associated with a file system. Each tag is a key-value pair. If
    *       a tag key specified in the request already exists on the file system, this operation
    *       overwrites its value with the value provided in the request. If you add the <code>Name</code>
@@ -613,6 +614,7 @@ export class EFS extends EFSClient {
 
   /**
    * @deprecated
+   *
    * <p>Deletes the specified tags from a file system. If the <code>DeleteTags</code> request
    *       includes a tag key that doesn't exist, Amazon EFS ignores it and doesn't cause an
    *       error. For more information about tags and related restrictions, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html">Tag Restrictions</a> in the
@@ -924,6 +926,7 @@ export class EFS extends EFSClient {
 
   /**
    * @deprecated
+   *
    * <p>Returns the tags associated with a file system. The order of tags returned in the
    *       response of one <code>DescribeTags</code> call and the order of tags returned across the
    *       responses of a multiple-call iteration (when using pagination) is unspecified. </p>

--- a/clients/client-efs/EFS.ts
+++ b/clients/client-efs/EFS.ts
@@ -399,6 +399,7 @@ export class EFS extends EFSClient {
   }
 
   /**
+   * @deprecated
    * <p>Creates or overwrites tags associated with a file system. Each tag is a key-value pair. If
    *       a tag key specified in the request already exists on the file system, this operation
    *       overwrites its value with the value provided in the request. If you add the <code>Name</code>
@@ -611,6 +612,7 @@ export class EFS extends EFSClient {
   }
 
   /**
+   * @deprecated
    * <p>Deletes the specified tags from a file system. If the <code>DeleteTags</code> request
    *       includes a tag key that doesn't exist, Amazon EFS ignores it and doesn't cause an
    *       error. For more information about tags and related restrictions, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html">Tag Restrictions</a> in the
@@ -921,6 +923,7 @@ export class EFS extends EFSClient {
   }
 
   /**
+   * @deprecated
    * <p>Returns the tags associated with a file system. The order of tags returned in the
    *       response of one <code>DescribeTags</code> call and the order of tags returned across the
    *       responses of a multiple-call iteration (when using pagination) is unspecified. </p>

--- a/clients/client-efs/commands/CreateTagsCommand.ts
+++ b/clients/client-efs/commands/CreateTagsCommand.ts
@@ -21,6 +21,7 @@ export type CreateTagsCommandInput = CreateTagsRequest;
 export type CreateTagsCommandOutput = __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Creates or overwrites tags associated with a file system. Each tag is a key-value pair. If
  *       a tag key specified in the request already exists on the file system, this operation
  *       overwrites its value with the value provided in the request. If you add the <code>Name</code>

--- a/clients/client-efs/commands/CreateTagsCommand.ts
+++ b/clients/client-efs/commands/CreateTagsCommand.ts
@@ -22,6 +22,7 @@ export type CreateTagsCommandOutput = __MetadataBearer;
 
 /**
  * @deprecated
+ *
  * <p>Creates or overwrites tags associated with a file system. Each tag is a key-value pair. If
  *       a tag key specified in the request already exists on the file system, this operation
  *       overwrites its value with the value provided in the request. If you add the <code>Name</code>

--- a/clients/client-efs/commands/DeleteTagsCommand.ts
+++ b/clients/client-efs/commands/DeleteTagsCommand.ts
@@ -21,6 +21,7 @@ export type DeleteTagsCommandInput = DeleteTagsRequest;
 export type DeleteTagsCommandOutput = __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Deletes the specified tags from a file system. If the <code>DeleteTags</code> request
  *       includes a tag key that doesn't exist, Amazon EFS ignores it and doesn't cause an
  *       error. For more information about tags and related restrictions, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html">Tag Restrictions</a> in the

--- a/clients/client-efs/commands/DeleteTagsCommand.ts
+++ b/clients/client-efs/commands/DeleteTagsCommand.ts
@@ -22,6 +22,7 @@ export type DeleteTagsCommandOutput = __MetadataBearer;
 
 /**
  * @deprecated
+ *
  * <p>Deletes the specified tags from a file system. If the <code>DeleteTags</code> request
  *       includes a tag key that doesn't exist, Amazon EFS ignores it and doesn't cause an
  *       error. For more information about tags and related restrictions, see <a href="https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/cost-alloc-tags.html">Tag Restrictions</a> in the

--- a/clients/client-efs/commands/DescribeTagsCommand.ts
+++ b/clients/client-efs/commands/DescribeTagsCommand.ts
@@ -22,6 +22,7 @@ export type DescribeTagsCommandOutput = DescribeTagsResponse & __MetadataBearer;
 
 /**
  * @deprecated
+ *
  * <p>Returns the tags associated with a file system. The order of tags returned in the
  *       response of one <code>DescribeTags</code> call and the order of tags returned across the
  *       responses of a multiple-call iteration (when using pagination) is unspecified. </p>

--- a/clients/client-efs/commands/DescribeTagsCommand.ts
+++ b/clients/client-efs/commands/DescribeTagsCommand.ts
@@ -21,6 +21,7 @@ export type DescribeTagsCommandInput = DescribeTagsRequest;
 export type DescribeTagsCommandOutput = DescribeTagsResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Returns the tags associated with a file system. The order of tags returned in the
  *       response of one <code>DescribeTags</code> call and the order of tags returned across the
  *       responses of a multiple-call iteration (when using pagination) is unspecified. </p>

--- a/clients/client-elastic-transcoder/ElasticTranscoder.ts
+++ b/clients/client-elastic-transcoder/ElasticTranscoder.ts
@@ -478,6 +478,7 @@ export class ElasticTranscoder extends ElasticTranscoderClient {
 
   /**
    * @deprecated
+   *
    * <p>The TestRole operation tests the IAM role used to create the pipeline.</p>
    *         <p>The <code>TestRole</code> action lets you determine whether the IAM role you are using
    *             has sufficient permissions to let Elastic Transcoder perform tasks associated with the transcoding

--- a/clients/client-elastic-transcoder/ElasticTranscoder.ts
+++ b/clients/client-elastic-transcoder/ElasticTranscoder.ts
@@ -477,6 +477,7 @@ export class ElasticTranscoder extends ElasticTranscoderClient {
   }
 
   /**
+   * @deprecated
    * <p>The TestRole operation tests the IAM role used to create the pipeline.</p>
    *         <p>The <code>TestRole</code> action lets you determine whether the IAM role you are using
    *             has sufficient permissions to let Elastic Transcoder perform tasks associated with the transcoding

--- a/clients/client-elastic-transcoder/commands/TestRoleCommand.ts
+++ b/clients/client-elastic-transcoder/commands/TestRoleCommand.ts
@@ -25,6 +25,7 @@ export type TestRoleCommandInput = TestRoleRequest;
 export type TestRoleCommandOutput = TestRoleResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>The TestRole operation tests the IAM role used to create the pipeline.</p>
  *         <p>The <code>TestRole</code> action lets you determine whether the IAM role you are using
  *             has sufficient permissions to let Elastic Transcoder perform tasks associated with the transcoding

--- a/clients/client-elastic-transcoder/commands/TestRoleCommand.ts
+++ b/clients/client-elastic-transcoder/commands/TestRoleCommand.ts
@@ -26,6 +26,7 @@ export type TestRoleCommandOutput = TestRoleResponse & __MetadataBearer;
 
 /**
  * @deprecated
+ *
  * <p>The TestRole operation tests the IAM role used to create the pipeline.</p>
  *         <p>The <code>TestRole</code> action lets you determine whether the IAM role you are using
  *             has sufficient permissions to let Elastic Transcoder perform tasks associated with the transcoding

--- a/clients/client-elastic-transcoder/models/models_0.ts
+++ b/clients/client-elastic-transcoder/models/models_0.ts
@@ -818,6 +818,8 @@ export namespace CaptionSource {
  */
 export interface Captions {
   /**
+   * @deprecated
+   *
    * <p>A policy that determines how Elastic Transcoder handles the existence of multiple captions.</p>
    *          <ul>
    *             <li>
@@ -847,6 +849,8 @@ export interface Captions {
   MergePolicy?: string;
 
   /**
+   * @deprecated
+   *
    * <p>Source files for the input sidecar captions used during the transcoding
    *          process. To omit all sidecar captions, leave <code>CaptionSources</code> blank.</p>
    */
@@ -1320,6 +1324,8 @@ export interface CreateJobOutput {
   AlbumArt?: JobAlbumArt;
 
   /**
+   * @deprecated
+   *
    * <p>You can create an output file that contains an excerpt from the input file. This excerpt, called a
    *             clip, can come from the beginning, middle, or end of the file. The Composition object contains settings
    *             for the clips that make up an output file. For the current release, you can only specify settings for a
@@ -1862,6 +1868,8 @@ export interface JobOutput {
   AlbumArt?: JobAlbumArt;
 
   /**
+   * @deprecated
+   *
    * <p>You can create an output file that contains an excerpt from the input file. This excerpt, called
    *             a clip, can come from the beginning, middle, or end of the file. The Composition object contains settings
    *             for the clips that make up an output file. For the current release, you can only specify settings for a

--- a/clients/client-elastic-transcoder/models/models_0.ts
+++ b/clients/client-elastic-transcoder/models/models_0.ts
@@ -818,7 +818,6 @@ export namespace CaptionSource {
  */
 export interface Captions {
   /**
-   * @deprecated
    * <p>A policy that determines how Elastic Transcoder handles the existence of multiple captions.</p>
    *          <ul>
    *             <li>
@@ -848,7 +847,6 @@ export interface Captions {
   MergePolicy?: string;
 
   /**
-   * @deprecated
    * <p>Source files for the input sidecar captions used during the transcoding
    *          process. To omit all sidecar captions, leave <code>CaptionSources</code> blank.</p>
    */
@@ -896,6 +894,7 @@ export namespace TimeSpan {
 
 /**
  * @deprecated
+ *
  * <p>Settings for one clip in a composition. All jobs in a playlist must have the same clip settings.</p>
  */
 export interface Clip {
@@ -1321,7 +1320,6 @@ export interface CreateJobOutput {
   AlbumArt?: JobAlbumArt;
 
   /**
-   * @deprecated
    * <p>You can create an output file that contains an excerpt from the input file. This excerpt, called a
    *             clip, can come from the beginning, middle, or end of the file. The Composition object contains settings
    *             for the clips that make up an output file. For the current release, you can only specify settings for a
@@ -1864,7 +1862,6 @@ export interface JobOutput {
   AlbumArt?: JobAlbumArt;
 
   /**
-   * @deprecated
    * <p>You can create an output file that contains an excerpt from the input file. This excerpt, called
    *             a clip, can come from the beginning, middle, or end of the file. The Composition object contains settings
    *             for the clips that make up an output file. For the current release, you can only specify settings for a
@@ -4460,6 +4457,7 @@ export namespace ReadPresetResponse {
 
 /**
  * @deprecated
+ *
  * <p> The <code>TestRoleRequest</code> structure. </p>
  */
 export interface TestRoleRequest {
@@ -4492,6 +4490,7 @@ export namespace TestRoleRequest {
 
 /**
  * @deprecated
+ *
  * <p>The <code>TestRoleResponse</code> structure.</p>
  */
 export interface TestRoleResponse {

--- a/clients/client-elastic-transcoder/models/models_0.ts
+++ b/clients/client-elastic-transcoder/models/models_0.ts
@@ -818,6 +818,7 @@ export namespace CaptionSource {
  */
 export interface Captions {
   /**
+   * @deprecated
    * <p>A policy that determines how Elastic Transcoder handles the existence of multiple captions.</p>
    *          <ul>
    *             <li>
@@ -847,6 +848,7 @@ export interface Captions {
   MergePolicy?: string;
 
   /**
+   * @deprecated
    * <p>Source files for the input sidecar captions used during the transcoding
    *          process. To omit all sidecar captions, leave <code>CaptionSources</code> blank.</p>
    */
@@ -893,6 +895,7 @@ export namespace TimeSpan {
 }
 
 /**
+ * @deprecated
  * <p>Settings for one clip in a composition. All jobs in a playlist must have the same clip settings.</p>
  */
 export interface Clip {
@@ -1318,6 +1321,7 @@ export interface CreateJobOutput {
   AlbumArt?: JobAlbumArt;
 
   /**
+   * @deprecated
    * <p>You can create an output file that contains an excerpt from the input file. This excerpt, called a
    *             clip, can come from the beginning, middle, or end of the file. The Composition object contains settings
    *             for the clips that make up an output file. For the current release, you can only specify settings for a
@@ -1860,6 +1864,7 @@ export interface JobOutput {
   AlbumArt?: JobAlbumArt;
 
   /**
+   * @deprecated
    * <p>You can create an output file that contains an excerpt from the input file. This excerpt, called
    *             a clip, can come from the beginning, middle, or end of the file. The Composition object contains settings
    *             for the clips that make up an output file. For the current release, you can only specify settings for a
@@ -4454,6 +4459,7 @@ export namespace ReadPresetResponse {
 }
 
 /**
+ * @deprecated
  * <p> The <code>TestRoleRequest</code> structure. </p>
  */
 export interface TestRoleRequest {
@@ -4485,6 +4491,7 @@ export namespace TestRoleRequest {
 }
 
 /**
+ * @deprecated
  * <p>The <code>TestRoleResponse</code> structure.</p>
  */
 export interface TestRoleResponse {

--- a/clients/client-elasticache/models/models_0.ts
+++ b/clients/client-elasticache/models/models_0.ts
@@ -9086,6 +9086,8 @@ export interface ModifyReplicationGroupMessage {
   MultiAZEnabled?: boolean;
 
   /**
+   * @deprecated
+   *
    * <p>Deprecated. This parameter is not used.</p>
    */
   NodeGroupId?: string;

--- a/clients/client-elasticache/models/models_0.ts
+++ b/clients/client-elasticache/models/models_0.ts
@@ -9086,6 +9086,7 @@ export interface ModifyReplicationGroupMessage {
   MultiAZEnabled?: boolean;
 
   /**
+   * @deprecated
    * <p>Deprecated. This parameter is not used.</p>
    */
   NodeGroupId?: string;

--- a/clients/client-elasticache/models/models_0.ts
+++ b/clients/client-elasticache/models/models_0.ts
@@ -9086,7 +9086,6 @@ export interface ModifyReplicationGroupMessage {
   MultiAZEnabled?: boolean;
 
   /**
-   * @deprecated
    * <p>Deprecated. This parameter is not used.</p>
    */
   NodeGroupId?: string;

--- a/clients/client-emr/EMR.ts
+++ b/clients/client-emr/EMR.ts
@@ -626,6 +626,7 @@ export class EMR extends EMRClient {
   }
 
   /**
+   * @deprecated
    * <p>This API is no longer supported and will eventually be removed. We recommend you use
    *             <a>ListClusters</a>, <a>DescribeCluster</a>, <a>ListSteps</a>, <a>ListInstanceGroups</a> and <a>ListBootstrapActions</a> instead.</p>
    *          <p>DescribeJobFlows returns a list of job flows that match all of the supplied parameters.

--- a/clients/client-emr/EMR.ts
+++ b/clients/client-emr/EMR.ts
@@ -627,6 +627,7 @@ export class EMR extends EMRClient {
 
   /**
    * @deprecated
+   *
    * <p>This API is no longer supported and will eventually be removed. We recommend you use
    *             <a>ListClusters</a>, <a>DescribeCluster</a>, <a>ListSteps</a>, <a>ListInstanceGroups</a> and <a>ListBootstrapActions</a> instead.</p>
    *          <p>DescribeJobFlows returns a list of job flows that match all of the supplied parameters.

--- a/clients/client-emr/commands/DescribeJobFlowsCommand.ts
+++ b/clients/client-emr/commands/DescribeJobFlowsCommand.ts
@@ -21,6 +21,7 @@ export type DescribeJobFlowsCommandInput = DescribeJobFlowsInput;
 export type DescribeJobFlowsCommandOutput = DescribeJobFlowsOutput & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>This API is no longer supported and will eventually be removed. We recommend you use
  *             <a>ListClusters</a>, <a>DescribeCluster</a>, <a>ListSteps</a>, <a>ListInstanceGroups</a> and <a>ListBootstrapActions</a> instead.</p>
  *          <p>DescribeJobFlows returns a list of job flows that match all of the supplied parameters.

--- a/clients/client-emr/commands/DescribeJobFlowsCommand.ts
+++ b/clients/client-emr/commands/DescribeJobFlowsCommand.ts
@@ -22,6 +22,7 @@ export type DescribeJobFlowsCommandOutput = DescribeJobFlowsOutput & __MetadataB
 
 /**
  * @deprecated
+ *
  * <p>This API is no longer supported and will eventually be removed. We recommend you use
  *             <a>ListClusters</a>, <a>DescribeCluster</a>, <a>ListSteps</a>, <a>ListInstanceGroups</a> and <a>ListBootstrapActions</a> instead.</p>
  *          <p>DescribeJobFlows returns a list of job flows that match all of the supplied parameters.

--- a/clients/client-firehose/models/models_0.ts
+++ b/clients/client-firehose/models/models_0.ts
@@ -1587,6 +1587,8 @@ export interface CreateDeliveryStreamInput {
   DeliveryStreamEncryptionConfigurationInput?: DeliveryStreamEncryptionConfigurationInput;
 
   /**
+   * @deprecated
+   *
    * <p>[Deprecated]
    *          The destination in Amazon S3. You can specify only one destination.</p>
    */
@@ -3503,6 +3505,8 @@ export interface UpdateDestinationInput {
   DestinationId: string | undefined;
 
   /**
+   * @deprecated
+   *
    * <p>[Deprecated] Describes an update for a destination in Amazon S3.</p>
    */
   S3DestinationUpdate?: S3DestinationUpdate;

--- a/clients/client-firehose/models/models_0.ts
+++ b/clients/client-firehose/models/models_0.ts
@@ -1587,6 +1587,7 @@ export interface CreateDeliveryStreamInput {
   DeliveryStreamEncryptionConfigurationInput?: DeliveryStreamEncryptionConfigurationInput;
 
   /**
+   * @deprecated
    * <p>[Deprecated]
    *          The destination in Amazon S3. You can specify only one destination.</p>
    */
@@ -3503,6 +3504,7 @@ export interface UpdateDestinationInput {
   DestinationId: string | undefined;
 
   /**
+   * @deprecated
    * <p>[Deprecated] Describes an update for a destination in Amazon S3.</p>
    */
   S3DestinationUpdate?: S3DestinationUpdate;

--- a/clients/client-firehose/models/models_0.ts
+++ b/clients/client-firehose/models/models_0.ts
@@ -1587,7 +1587,6 @@ export interface CreateDeliveryStreamInput {
   DeliveryStreamEncryptionConfigurationInput?: DeliveryStreamEncryptionConfigurationInput;
 
   /**
-   * @deprecated
    * <p>[Deprecated]
    *          The destination in Amazon S3. You can specify only one destination.</p>
    */
@@ -3504,7 +3503,6 @@ export interface UpdateDestinationInput {
   DestinationId: string | undefined;
 
   /**
-   * @deprecated
    * <p>[Deprecated] Describes an update for a destination in Amazon S3.</p>
    */
   S3DestinationUpdate?: S3DestinationUpdate;

--- a/clients/client-forecast/models/models_0.ts
+++ b/clients/client-forecast/models/models_0.ts
@@ -2712,6 +2712,8 @@ export namespace WeightedQuantileLoss {
  */
 export interface Metrics {
   /**
+   * @deprecated
+   *
    * <p>The root-mean-square error (RMSE).</p>
    */
   RMSE?: number;

--- a/clients/client-forecast/models/models_0.ts
+++ b/clients/client-forecast/models/models_0.ts
@@ -2712,6 +2712,7 @@ export namespace WeightedQuantileLoss {
  */
 export interface Metrics {
   /**
+   * @deprecated
    * <p>The root-mean-square error (RMSE).</p>
    */
   RMSE?: number;

--- a/clients/client-forecast/models/models_0.ts
+++ b/clients/client-forecast/models/models_0.ts
@@ -2712,7 +2712,6 @@ export namespace WeightedQuantileLoss {
  */
 export interface Metrics {
   /**
-   * @deprecated
    * <p>The root-mean-square error (RMSE).</p>
    */
   RMSE?: number;

--- a/clients/client-glue/models/models_0.ts
+++ b/clients/client-glue/models/models_0.ts
@@ -1672,6 +1672,8 @@ export interface Job {
   MaxRetries?: number;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) allocated to runs of this job. You can
@@ -2271,6 +2273,8 @@ export interface JobRun {
   PredecessorRuns?: Predecessor[];
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) allocated to this JobRun.
@@ -3850,6 +3854,8 @@ export interface CreateJobRequest {
   MaxRetries?: number;
 
   /**
+   * @deprecated
+   *
    * <p>This parameter is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) to allocate to this Job. You can

--- a/clients/client-glue/models/models_0.ts
+++ b/clients/client-glue/models/models_0.ts
@@ -1672,6 +1672,7 @@ export interface Job {
   MaxRetries?: number;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) allocated to runs of this job. You can
@@ -2271,6 +2272,7 @@ export interface JobRun {
   PredecessorRuns?: Predecessor[];
 
   /**
+   * @deprecated
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) allocated to this JobRun.
@@ -3850,6 +3852,7 @@ export interface CreateJobRequest {
   MaxRetries?: number;
 
   /**
+   * @deprecated
    * <p>This parameter is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) to allocate to this Job. You can

--- a/clients/client-glue/models/models_0.ts
+++ b/clients/client-glue/models/models_0.ts
@@ -1672,7 +1672,6 @@ export interface Job {
   MaxRetries?: number;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) allocated to runs of this job. You can
@@ -2272,7 +2271,6 @@ export interface JobRun {
   PredecessorRuns?: Predecessor[];
 
   /**
-   * @deprecated
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) allocated to this JobRun.
@@ -3852,7 +3850,6 @@ export interface CreateJobRequest {
   MaxRetries?: number;
 
   /**
-   * @deprecated
    * <p>This parameter is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) to allocate to this Job. You can

--- a/clients/client-glue/models/models_1.ts
+++ b/clients/client-glue/models/models_1.ts
@@ -4366,6 +4366,8 @@ export interface StartJobRunRequest {
   Arguments?: { [key: string]: string };
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) to allocate to this JobRun.
@@ -5440,6 +5442,8 @@ export interface JobUpdate {
   MaxRetries?: number;
 
   /**
+   * @deprecated
+   *
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) to allocate to this job. You can

--- a/clients/client-glue/models/models_1.ts
+++ b/clients/client-glue/models/models_1.ts
@@ -4366,6 +4366,7 @@ export interface StartJobRunRequest {
   Arguments?: { [key: string]: string };
 
   /**
+   * @deprecated
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) to allocate to this JobRun.
@@ -5440,6 +5441,7 @@ export interface JobUpdate {
   MaxRetries?: number;
 
   /**
+   * @deprecated
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) to allocate to this job. You can

--- a/clients/client-glue/models/models_1.ts
+++ b/clients/client-glue/models/models_1.ts
@@ -4366,7 +4366,6 @@ export interface StartJobRunRequest {
   Arguments?: { [key: string]: string };
 
   /**
-   * @deprecated
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) to allocate to this JobRun.
@@ -5441,7 +5440,6 @@ export interface JobUpdate {
   MaxRetries?: number;
 
   /**
-   * @deprecated
    * <p>This field is deprecated. Use <code>MaxCapacity</code> instead.</p>
    *
    *          <p>The number of AWS Glue data processing units (DPUs) to allocate to this job. You can

--- a/clients/client-guardduty/models/models_0.ts
+++ b/clients/client-guardduty/models/models_0.ts
@@ -718,36 +718,48 @@ export namespace CloudTrailConfigurationResult {
  */
 export interface Condition {
   /**
+   * @deprecated
+   *
    * <p>Represents the <i>equal</i> condition to be applied to a single field when
    *       querying for findings.</p>
    */
   Eq?: string[];
 
   /**
+   * @deprecated
+   *
    * <p>Represents the <i>not equal</i> condition to be applied to a single field
    *       when querying for findings.</p>
    */
   Neq?: string[];
 
   /**
+   * @deprecated
+   *
    * <p>Represents a <i>greater than</i> condition to be applied to a single field
    *       when querying for findings.</p>
    */
   Gt?: number;
 
   /**
+   * @deprecated
+   *
    * <p>Represents a <i>greater than or equal</i> condition to be applied to a
    *       single field when querying for findings.</p>
    */
   Gte?: number;
 
   /**
+   * @deprecated
+   *
    * <p>Represents a <i>less than</i> condition to be applied to a single field when
    *       querying for findings.</p>
    */
   Lt?: number;
 
   /**
+   * @deprecated
+   *
    * <p>Represents a <i>less than or equal</i> condition to be applied to a single
    *       field when querying for findings.</p>
    */

--- a/clients/client-guardduty/models/models_0.ts
+++ b/clients/client-guardduty/models/models_0.ts
@@ -718,42 +718,36 @@ export namespace CloudTrailConfigurationResult {
  */
 export interface Condition {
   /**
-   * @deprecated
    * <p>Represents the <i>equal</i> condition to be applied to a single field when
    *       querying for findings.</p>
    */
   Eq?: string[];
 
   /**
-   * @deprecated
    * <p>Represents the <i>not equal</i> condition to be applied to a single field
    *       when querying for findings.</p>
    */
   Neq?: string[];
 
   /**
-   * @deprecated
    * <p>Represents a <i>greater than</i> condition to be applied to a single field
    *       when querying for findings.</p>
    */
   Gt?: number;
 
   /**
-   * @deprecated
    * <p>Represents a <i>greater than or equal</i> condition to be applied to a
    *       single field when querying for findings.</p>
    */
   Gte?: number;
 
   /**
-   * @deprecated
    * <p>Represents a <i>less than</i> condition to be applied to a single field when
    *       querying for findings.</p>
    */
   Lt?: number;
 
   /**
-   * @deprecated
    * <p>Represents a <i>less than or equal</i> condition to be applied to a single
    *       field when querying for findings.</p>
    */

--- a/clients/client-guardduty/models/models_0.ts
+++ b/clients/client-guardduty/models/models_0.ts
@@ -718,36 +718,42 @@ export namespace CloudTrailConfigurationResult {
  */
 export interface Condition {
   /**
+   * @deprecated
    * <p>Represents the <i>equal</i> condition to be applied to a single field when
    *       querying for findings.</p>
    */
   Eq?: string[];
 
   /**
+   * @deprecated
    * <p>Represents the <i>not equal</i> condition to be applied to a single field
    *       when querying for findings.</p>
    */
   Neq?: string[];
 
   /**
+   * @deprecated
    * <p>Represents a <i>greater than</i> condition to be applied to a single field
    *       when querying for findings.</p>
    */
   Gt?: number;
 
   /**
+   * @deprecated
    * <p>Represents a <i>greater than or equal</i> condition to be applied to a
    *       single field when querying for findings.</p>
    */
   Gte?: number;
 
   /**
+   * @deprecated
    * <p>Represents a <i>less than</i> condition to be applied to a single field when
    *       querying for findings.</p>
    */
   Lt?: number;
 
   /**
+   * @deprecated
    * <p>Represents a <i>less than or equal</i> condition to be applied to a single
    *       field when querying for findings.</p>
    */

--- a/clients/client-iot-events/models/models_0.ts
+++ b/clients/client-iot-events/models/models_0.ts
@@ -537,6 +537,8 @@ export interface SetTimerAction {
   timerName: string | undefined;
 
   /**
+   * @deprecated
+   *
    * <p>The number of seconds until the timer expires. The minimum value is 60 seconds to ensure
    *       accuracy. The maximum value is 31622400 seconds. </p>
    */

--- a/clients/client-iot-events/models/models_0.ts
+++ b/clients/client-iot-events/models/models_0.ts
@@ -537,6 +537,7 @@ export interface SetTimerAction {
   timerName: string | undefined;
 
   /**
+   * @deprecated
    * <p>The number of seconds until the timer expires. The minimum value is 60 seconds to ensure
    *       accuracy. The maximum value is 31622400 seconds. </p>
    */

--- a/clients/client-iot-events/models/models_0.ts
+++ b/clients/client-iot-events/models/models_0.ts
@@ -537,7 +537,6 @@ export interface SetTimerAction {
   timerName: string | undefined;
 
   /**
-   * @deprecated
    * <p>The number of seconds until the timer expires. The minimum value is 60 seconds to ensure
    *       accuracy. The maximum value is 31622400 seconds. </p>
    */

--- a/clients/client-iot/IoT.ts
+++ b/clients/client-iot/IoT.ts
@@ -1194,6 +1194,7 @@ export class IoT extends IoTClient {
 
   /**
    * @deprecated
+   *
    * <p>Attaches the specified policy to the specified principal (certificate or other
    *          credential).</p>
    *          <p>
@@ -4242,6 +4243,7 @@ export class IoT extends IoTClient {
 
   /**
    * @deprecated
+   *
    * <p>Removes the specified policy from the specified certificate.</p>
    *          <p>
    *             <b>Note:</b> This API is deprecated. Please use <a>DetachPolicy</a> instead.</p>
@@ -5561,6 +5563,7 @@ export class IoT extends IoTClient {
 
   /**
    * @deprecated
+   *
    * <p>Lists the principals associated with the specified policy.</p>
    *          <p>
    *             <b>Note:</b> This API is deprecated. Please use <a>ListTargetsForPolicy</a> instead.</p>
@@ -5629,6 +5632,7 @@ export class IoT extends IoTClient {
 
   /**
    * @deprecated
+   *
    * <p>Lists the policies attached to the specified principal. If you use an Cognito
    *          identity, the ID must be in <a href="https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html#API_GetCredentialsForIdentity_RequestSyntax">AmazonCognito Identity format</a>.</p>
    *          <p>

--- a/clients/client-iot/IoT.ts
+++ b/clients/client-iot/IoT.ts
@@ -1193,6 +1193,7 @@ export class IoT extends IoTClient {
   }
 
   /**
+   * @deprecated
    * <p>Attaches the specified policy to the specified principal (certificate or other
    *          credential).</p>
    *          <p>
@@ -4240,6 +4241,7 @@ export class IoT extends IoTClient {
   }
 
   /**
+   * @deprecated
    * <p>Removes the specified policy from the specified certificate.</p>
    *          <p>
    *             <b>Note:</b> This API is deprecated. Please use <a>DetachPolicy</a> instead.</p>
@@ -5558,6 +5560,7 @@ export class IoT extends IoTClient {
   }
 
   /**
+   * @deprecated
    * <p>Lists the principals associated with the specified policy.</p>
    *          <p>
    *             <b>Note:</b> This API is deprecated. Please use <a>ListTargetsForPolicy</a> instead.</p>
@@ -5625,6 +5628,7 @@ export class IoT extends IoTClient {
   }
 
   /**
+   * @deprecated
    * <p>Lists the policies attached to the specified principal. If you use an Cognito
    *          identity, the ID must be in <a href="https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html#API_GetCredentialsForIdentity_RequestSyntax">AmazonCognito Identity format</a>.</p>
    *          <p>

--- a/clients/client-iot/commands/AttachPrincipalPolicyCommand.ts
+++ b/clients/client-iot/commands/AttachPrincipalPolicyCommand.ts
@@ -21,6 +21,7 @@ export type AttachPrincipalPolicyCommandInput = AttachPrincipalPolicyRequest;
 export type AttachPrincipalPolicyCommandOutput = __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Attaches the specified policy to the specified principal (certificate or other
  *          credential).</p>
  *          <p>

--- a/clients/client-iot/commands/AttachPrincipalPolicyCommand.ts
+++ b/clients/client-iot/commands/AttachPrincipalPolicyCommand.ts
@@ -22,6 +22,7 @@ export type AttachPrincipalPolicyCommandOutput = __MetadataBearer;
 
 /**
  * @deprecated
+ *
  * <p>Attaches the specified policy to the specified principal (certificate or other
  *          credential).</p>
  *          <p>

--- a/clients/client-iot/commands/DetachPrincipalPolicyCommand.ts
+++ b/clients/client-iot/commands/DetachPrincipalPolicyCommand.ts
@@ -21,6 +21,7 @@ export type DetachPrincipalPolicyCommandInput = DetachPrincipalPolicyRequest;
 export type DetachPrincipalPolicyCommandOutput = __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Removes the specified policy from the specified certificate.</p>
  *          <p>
  *             <b>Note:</b> This API is deprecated. Please use <a>DetachPolicy</a> instead.</p>

--- a/clients/client-iot/commands/DetachPrincipalPolicyCommand.ts
+++ b/clients/client-iot/commands/DetachPrincipalPolicyCommand.ts
@@ -22,6 +22,7 @@ export type DetachPrincipalPolicyCommandOutput = __MetadataBearer;
 
 /**
  * @deprecated
+ *
  * <p>Removes the specified policy from the specified certificate.</p>
  *          <p>
  *             <b>Note:</b> This API is deprecated. Please use <a>DetachPolicy</a> instead.</p>

--- a/clients/client-iot/commands/ListPolicyPrincipalsCommand.ts
+++ b/clients/client-iot/commands/ListPolicyPrincipalsCommand.ts
@@ -21,6 +21,7 @@ export type ListPolicyPrincipalsCommandInput = ListPolicyPrincipalsRequest;
 export type ListPolicyPrincipalsCommandOutput = ListPolicyPrincipalsResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Lists the principals associated with the specified policy.</p>
  *          <p>
  *             <b>Note:</b> This API is deprecated. Please use <a>ListTargetsForPolicy</a> instead.</p>

--- a/clients/client-iot/commands/ListPolicyPrincipalsCommand.ts
+++ b/clients/client-iot/commands/ListPolicyPrincipalsCommand.ts
@@ -22,6 +22,7 @@ export type ListPolicyPrincipalsCommandOutput = ListPolicyPrincipalsResponse & _
 
 /**
  * @deprecated
+ *
  * <p>Lists the principals associated with the specified policy.</p>
  *          <p>
  *             <b>Note:</b> This API is deprecated. Please use <a>ListTargetsForPolicy</a> instead.</p>

--- a/clients/client-iot/commands/ListPrincipalPoliciesCommand.ts
+++ b/clients/client-iot/commands/ListPrincipalPoliciesCommand.ts
@@ -22,6 +22,7 @@ export type ListPrincipalPoliciesCommandOutput = ListPrincipalPoliciesResponse &
 
 /**
  * @deprecated
+ *
  * <p>Lists the policies attached to the specified principal. If you use an Cognito
  *          identity, the ID must be in <a href="https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html#API_GetCredentialsForIdentity_RequestSyntax">AmazonCognito Identity format</a>.</p>
  *          <p>

--- a/clients/client-iot/commands/ListPrincipalPoliciesCommand.ts
+++ b/clients/client-iot/commands/ListPrincipalPoliciesCommand.ts
@@ -21,6 +21,7 @@ export type ListPrincipalPoliciesCommandInput = ListPrincipalPoliciesRequest;
 export type ListPrincipalPoliciesCommandOutput = ListPrincipalPoliciesResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Lists the policies attached to the specified principal. If you use an Cognito
  *          identity, the ID must be in <a href="https://docs.aws.amazon.com/cognitoidentity/latest/APIReference/API_GetCredentialsForIdentity.html#API_GetCredentialsForIdentity_RequestSyntax">AmazonCognito Identity format</a>.</p>
  *          <p>

--- a/clients/client-iot/models/models_0.ts
+++ b/clients/client-iot/models/models_0.ts
@@ -5208,6 +5208,8 @@ export interface CreateSecurityProfileRequest {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
+   * @deprecated
+   *
    * <p>
    *             <i>Please use <a>CreateSecurityProfileRequest$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>

--- a/clients/client-iot/models/models_0.ts
+++ b/clients/client-iot/models/models_0.ts
@@ -5208,7 +5208,6 @@ export interface CreateSecurityProfileRequest {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
-   * @deprecated
    * <p>
    *             <i>Please use <a>CreateSecurityProfileRequest$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>

--- a/clients/client-iot/models/models_0.ts
+++ b/clients/client-iot/models/models_0.ts
@@ -5208,6 +5208,7 @@ export interface CreateSecurityProfileRequest {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
+   * @deprecated
    * <p>
    *             <i>Please use <a>CreateSecurityProfileRequest$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>

--- a/clients/client-iot/models/models_1.ts
+++ b/clients/client-iot/models/models_1.ts
@@ -1575,6 +1575,8 @@ export interface DescribeSecurityProfileResponse {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
+   * @deprecated
+   *
    * <p>
    *             <i>Please use <a>DescribeSecurityProfileResponse$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>
@@ -6486,6 +6488,8 @@ export interface RegisterCertificateRequest {
   caCertificatePem?: string;
 
   /**
+   * @deprecated
+   *
    * <p>A boolean value that specifies if the certificate is set to active.</p>
    */
   setAsActive?: boolean;

--- a/clients/client-iot/models/models_1.ts
+++ b/clients/client-iot/models/models_1.ts
@@ -1575,7 +1575,6 @@ export interface DescribeSecurityProfileResponse {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
-   * @deprecated
    * <p>
    *             <i>Please use <a>DescribeSecurityProfileResponse$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>
@@ -6487,7 +6486,6 @@ export interface RegisterCertificateRequest {
   caCertificatePem?: string;
 
   /**
-   * @deprecated
    * <p>A boolean value that specifies if the certificate is set to active.</p>
    */
   setAsActive?: boolean;

--- a/clients/client-iot/models/models_1.ts
+++ b/clients/client-iot/models/models_1.ts
@@ -1575,6 +1575,7 @@ export interface DescribeSecurityProfileResponse {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
+   * @deprecated
    * <p>
    *             <i>Please use <a>DescribeSecurityProfileResponse$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>
@@ -6486,6 +6487,7 @@ export interface RegisterCertificateRequest {
   caCertificatePem?: string;
 
   /**
+   * @deprecated
    * <p>A boolean value that specifies if the certificate is set to active.</p>
    */
   setAsActive?: boolean;

--- a/clients/client-iot/models/models_2.ts
+++ b/clients/client-iot/models/models_2.ts
@@ -934,6 +934,8 @@ export interface UpdateSecurityProfileRequest {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
+   * @deprecated
+   *
    * <p>
    *             <i>Please use <a>UpdateSecurityProfileRequest$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>
@@ -1008,6 +1010,8 @@ export interface UpdateSecurityProfileResponse {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
+   * @deprecated
+   *
    * <p>
    *             <i>Please use <a>UpdateSecurityProfileResponse$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>

--- a/clients/client-iot/models/models_2.ts
+++ b/clients/client-iot/models/models_2.ts
@@ -934,7 +934,6 @@ export interface UpdateSecurityProfileRequest {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
-   * @deprecated
    * <p>
    *             <i>Please use <a>UpdateSecurityProfileRequest$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>
@@ -1009,7 +1008,6 @@ export interface UpdateSecurityProfileResponse {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
-   * @deprecated
    * <p>
    *             <i>Please use <a>UpdateSecurityProfileResponse$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>

--- a/clients/client-iot/models/models_2.ts
+++ b/clients/client-iot/models/models_2.ts
@@ -934,6 +934,7 @@ export interface UpdateSecurityProfileRequest {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
+   * @deprecated
    * <p>
    *             <i>Please use <a>UpdateSecurityProfileRequest$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>
@@ -1008,6 +1009,7 @@ export interface UpdateSecurityProfileResponse {
   alertTargets?: { [key: string]: AlertTarget };
 
   /**
+   * @deprecated
    * <p>
    *             <i>Please use <a>UpdateSecurityProfileResponse$additionalMetricsToRetainV2</a> instead.</i>
    *          </p>

--- a/clients/client-lambda/Lambda.ts
+++ b/clients/client-lambda/Lambda.ts
@@ -1343,6 +1343,7 @@ export class Lambda extends LambdaClient {
 
   /**
    * @deprecated
+   *
    * <important>
    *             <p>For asynchronous function invocation, use <a>Invoke</a>.</p>
    *          </important>

--- a/clients/client-lambda/Lambda.ts
+++ b/clients/client-lambda/Lambda.ts
@@ -1342,6 +1342,7 @@ export class Lambda extends LambdaClient {
   }
 
   /**
+   * @deprecated
    * <important>
    *             <p>For asynchronous function invocation, use <a>Invoke</a>.</p>
    *          </important>

--- a/clients/client-lambda/commands/InvokeAsyncCommand.ts
+++ b/clients/client-lambda/commands/InvokeAsyncCommand.ts
@@ -24,6 +24,7 @@ export type InvokeAsyncCommandOutput = InvokeAsyncResponse & __MetadataBearer;
 
 /**
  * @deprecated
+ *
  * <important>
  *             <p>For asynchronous function invocation, use <a>Invoke</a>.</p>
  *          </important>

--- a/clients/client-lambda/commands/InvokeAsyncCommand.ts
+++ b/clients/client-lambda/commands/InvokeAsyncCommand.ts
@@ -23,6 +23,7 @@ export type InvokeAsyncCommandInput = Omit<InvokeAsyncRequest, "InvokeArgs"> & {
 export type InvokeAsyncCommandOutput = InvokeAsyncResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <important>
  *             <p>For asynchronous function invocation, use <a>Invoke</a>.</p>
  *          </important>

--- a/clients/client-lambda/models/models_0.ts
+++ b/clients/client-lambda/models/models_0.ts
@@ -3353,6 +3353,7 @@ export namespace InvokeAsyncRequest {
 
 /**
  * @deprecated
+ *
  * <p>A success response (<code>202 Accepted</code>) indicates that the request is queued for invocation. </p>
  */
 export interface InvokeAsyncResponse {

--- a/clients/client-lambda/models/models_0.ts
+++ b/clients/client-lambda/models/models_0.ts
@@ -3352,6 +3352,7 @@ export namespace InvokeAsyncRequest {
 }
 
 /**
+ * @deprecated
  * <p>A success response (<code>202 Accepted</code>) indicates that the request is queued for invocation. </p>
  */
 export interface InvokeAsyncResponse {

--- a/clients/client-lightsail/models/models_0.ts
+++ b/clients/client-lightsail/models/models_0.ts
@@ -4088,6 +4088,8 @@ export interface DomainEntry {
   type?: string;
 
   /**
+   * @deprecated
+   *
    * <p>(Deprecated) The options for the domain entry.</p>
    *          <note>
    *             <p>In releases prior to November 29, 2017, this parameter was not included in the API
@@ -4155,6 +4157,8 @@ export interface CreateInstancesRequest {
   availabilityZone: string | undefined;
 
   /**
+   * @deprecated
+   *
    * <p>(Deprecated) The name for your custom image.</p>
    *          <note>
    *             <p>In releases prior to June 12, 2017, this parameter was ignored by the API. It is now
@@ -5815,6 +5819,8 @@ export interface Disk {
   isAttached?: boolean;
 
   /**
+   * @deprecated
+   *
    * <p>(Deprecated) The attachment state of the disk.</p>
    *          <note>
    *             <p>In releases prior to November 14, 2017, this parameter returned <code>attached</code>
@@ -5825,6 +5831,8 @@ export interface Disk {
   attachmentState?: string;
 
   /**
+   * @deprecated
+   *
    * <p>(Deprecated) The number of GB in use by the disk.</p>
    *          <note>
    *             <p>In releases prior to November 14, 2017, this parameter was not included in the API

--- a/clients/client-lightsail/models/models_0.ts
+++ b/clients/client-lightsail/models/models_0.ts
@@ -4088,6 +4088,7 @@ export interface DomainEntry {
   type?: string;
 
   /**
+   * @deprecated
    * <p>(Deprecated) The options for the domain entry.</p>
    *          <note>
    *             <p>In releases prior to November 29, 2017, this parameter was not included in the API
@@ -4155,6 +4156,7 @@ export interface CreateInstancesRequest {
   availabilityZone: string | undefined;
 
   /**
+   * @deprecated
    * <p>(Deprecated) The name for your custom image.</p>
    *          <note>
    *             <p>In releases prior to June 12, 2017, this parameter was ignored by the API. It is now
@@ -5815,6 +5817,7 @@ export interface Disk {
   isAttached?: boolean;
 
   /**
+   * @deprecated
    * <p>(Deprecated) The attachment state of the disk.</p>
    *          <note>
    *             <p>In releases prior to November 14, 2017, this parameter returned <code>attached</code>
@@ -5825,6 +5828,7 @@ export interface Disk {
   attachmentState?: string;
 
   /**
+   * @deprecated
    * <p>(Deprecated) The number of GB in use by the disk.</p>
    *          <note>
    *             <p>In releases prior to November 14, 2017, this parameter was not included in the API

--- a/clients/client-lightsail/models/models_0.ts
+++ b/clients/client-lightsail/models/models_0.ts
@@ -4088,7 +4088,6 @@ export interface DomainEntry {
   type?: string;
 
   /**
-   * @deprecated
    * <p>(Deprecated) The options for the domain entry.</p>
    *          <note>
    *             <p>In releases prior to November 29, 2017, this parameter was not included in the API
@@ -4156,7 +4155,6 @@ export interface CreateInstancesRequest {
   availabilityZone: string | undefined;
 
   /**
-   * @deprecated
    * <p>(Deprecated) The name for your custom image.</p>
    *          <note>
    *             <p>In releases prior to June 12, 2017, this parameter was ignored by the API. It is now
@@ -5817,7 +5815,6 @@ export interface Disk {
   isAttached?: boolean;
 
   /**
-   * @deprecated
    * <p>(Deprecated) The attachment state of the disk.</p>
    *          <note>
    *             <p>In releases prior to November 14, 2017, this parameter returned <code>attached</code>
@@ -5828,7 +5825,6 @@ export interface Disk {
   attachmentState?: string;
 
   /**
-   * @deprecated
    * <p>(Deprecated) The number of GB in use by the disk.</p>
    *          <note>
    *             <p>In releases prior to November 14, 2017, this parameter was not included in the API

--- a/clients/client-lightsail/models/models_1.ts
+++ b/clients/client-lightsail/models/models_1.ts
@@ -1310,6 +1310,8 @@ export interface GetOperationsForResourceResult {
   operations?: Operation[];
 
   /**
+   * @deprecated
+   *
    * <p>(Deprecated) Returns the number of pages of results that remain.</p>
    *          <note>
    *             <p>In releases prior to June 12, 2017, this parameter returned <code>null</code> by the

--- a/clients/client-lightsail/models/models_1.ts
+++ b/clients/client-lightsail/models/models_1.ts
@@ -1310,6 +1310,7 @@ export interface GetOperationsForResourceResult {
   operations?: Operation[];
 
   /**
+   * @deprecated
    * <p>(Deprecated) Returns the number of pages of results that remain.</p>
    *          <note>
    *             <p>In releases prior to June 12, 2017, this parameter returned <code>null</code> by the

--- a/clients/client-lightsail/models/models_1.ts
+++ b/clients/client-lightsail/models/models_1.ts
@@ -1310,7 +1310,6 @@ export interface GetOperationsForResourceResult {
   operations?: Operation[];
 
   /**
-   * @deprecated
    * <p>(Deprecated) Returns the number of pages of results that remain.</p>
    *          <note>
    *             <p>In releases prior to June 12, 2017, this parameter returned <code>null</code> by the

--- a/clients/client-medialive/models/models_1.ts
+++ b/clients/client-medialive/models/models_1.ts
@@ -3076,6 +3076,8 @@ export interface CreateChannelRequest {
   RequestId?: string;
 
   /**
+   * @deprecated
+   *
    * Deprecated field that's only usable by whitelisted customers.
    */
   Reserved?: string;

--- a/clients/client-medialive/models/models_1.ts
+++ b/clients/client-medialive/models/models_1.ts
@@ -3076,7 +3076,6 @@ export interface CreateChannelRequest {
   RequestId?: string;
 
   /**
-   * @deprecated
    * Deprecated field that's only usable by whitelisted customers.
    */
   Reserved?: string;

--- a/clients/client-medialive/models/models_1.ts
+++ b/clients/client-medialive/models/models_1.ts
@@ -3076,6 +3076,7 @@ export interface CreateChannelRequest {
   RequestId?: string;
 
   /**
+   * @deprecated
    * Deprecated field that's only usable by whitelisted customers.
    */
   Reserved?: string;

--- a/clients/client-mediapackage/MediaPackage.ts
+++ b/clients/client-mediapackage/MediaPackage.ts
@@ -507,6 +507,7 @@ export class MediaPackage extends MediaPackageClient {
   }
 
   /**
+   * @deprecated
    * Changes the Channel's first IngestEndpoint's username and password. WARNING - This API is deprecated. Please use RotateIngestEndpointCredentials instead
    */
   public rotateChannelCredentials(

--- a/clients/client-mediapackage/MediaPackage.ts
+++ b/clients/client-mediapackage/MediaPackage.ts
@@ -508,6 +508,7 @@ export class MediaPackage extends MediaPackageClient {
 
   /**
    * @deprecated
+   *
    * Changes the Channel's first IngestEndpoint's username and password. WARNING - This API is deprecated. Please use RotateIngestEndpointCredentials instead
    */
   public rotateChannelCredentials(

--- a/clients/client-mediapackage/commands/RotateChannelCredentialsCommand.ts
+++ b/clients/client-mediapackage/commands/RotateChannelCredentialsCommand.ts
@@ -22,6 +22,7 @@ export type RotateChannelCredentialsCommandOutput = RotateChannelCredentialsResp
 
 /**
  * @deprecated
+ *
  * Changes the Channel's first IngestEndpoint's username and password. WARNING - This API is deprecated. Please use RotateIngestEndpointCredentials instead
  */
 export class RotateChannelCredentialsCommand extends $Command<

--- a/clients/client-mediapackage/commands/RotateChannelCredentialsCommand.ts
+++ b/clients/client-mediapackage/commands/RotateChannelCredentialsCommand.ts
@@ -21,6 +21,7 @@ export type RotateChannelCredentialsCommandInput = RotateChannelCredentialsReque
 export type RotateChannelCredentialsCommandOutput = RotateChannelCredentialsResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * Changes the Channel's first IngestEndpoint's username and password. WARNING - This API is deprecated. Please use RotateIngestEndpointCredentials instead
  */
 export class RotateChannelCredentialsCommand extends $Command<

--- a/clients/client-mturk/models/models_0.ts
+++ b/clients/client-mturk/models/models_0.ts
@@ -530,6 +530,8 @@ export interface QualificationRequirement {
   LocaleValues?: Locale[];
 
   /**
+   * @deprecated
+   *
    * <p> DEPRECATED: Use the <code>ActionsGuarded</code> field instead.
    *             If RequiredToPreview is true, the question data for the HIT will not be shown
    *             when a Worker whose Qualifications do not meet this requirement tries

--- a/clients/client-mturk/models/models_0.ts
+++ b/clients/client-mturk/models/models_0.ts
@@ -530,7 +530,6 @@ export interface QualificationRequirement {
   LocaleValues?: Locale[];
 
   /**
-   * @deprecated
    * <p> DEPRECATED: Use the <code>ActionsGuarded</code> field instead.
    *             If RequiredToPreview is true, the question data for the HIT will not be shown
    *             when a Worker whose Qualifications do not meet this requirement tries

--- a/clients/client-mturk/models/models_0.ts
+++ b/clients/client-mturk/models/models_0.ts
@@ -530,6 +530,7 @@ export interface QualificationRequirement {
   LocaleValues?: Locale[];
 
   /**
+   * @deprecated
    * <p> DEPRECATED: Use the <code>ActionsGuarded</code> field instead.
    *             If RequiredToPreview is true, the question data for the HIT will not be shown
    *             when a Worker whose Qualifications do not meet this requirement tries

--- a/clients/client-neptune/models/models_0.ts
+++ b/clients/client-neptune/models/models_0.ts
@@ -2399,6 +2399,8 @@ export interface CreateDBInstanceMessage {
   CharacterSetName?: string;
 
   /**
+   * @deprecated
+   *
    * <p>This flag should no longer be used.</p>
    */
   PubliclyAccessible?: boolean;
@@ -3104,6 +3106,8 @@ export interface DBInstance {
   SecondaryAvailabilityZone?: string;
 
   /**
+   * @deprecated
+   *
    * <p>This flag should no longer be used.</p>
    */
   PubliclyAccessible?: boolean;
@@ -7072,6 +7076,8 @@ export interface ModifyDBInstanceMessage {
   DBPortNumber?: number;
 
   /**
+   * @deprecated
+   *
    * <p>This flag should no longer be used.</p>
    */
   PubliclyAccessible?: boolean;

--- a/clients/client-neptune/models/models_0.ts
+++ b/clients/client-neptune/models/models_0.ts
@@ -2399,6 +2399,7 @@ export interface CreateDBInstanceMessage {
   CharacterSetName?: string;
 
   /**
+   * @deprecated
    * <p>This flag should no longer be used.</p>
    */
   PubliclyAccessible?: boolean;
@@ -3104,6 +3105,7 @@ export interface DBInstance {
   SecondaryAvailabilityZone?: string;
 
   /**
+   * @deprecated
    * <p>This flag should no longer be used.</p>
    */
   PubliclyAccessible?: boolean;
@@ -7072,6 +7074,7 @@ export interface ModifyDBInstanceMessage {
   DBPortNumber?: number;
 
   /**
+   * @deprecated
    * <p>This flag should no longer be used.</p>
    */
   PubliclyAccessible?: boolean;

--- a/clients/client-neptune/models/models_0.ts
+++ b/clients/client-neptune/models/models_0.ts
@@ -2399,7 +2399,6 @@ export interface CreateDBInstanceMessage {
   CharacterSetName?: string;
 
   /**
-   * @deprecated
    * <p>This flag should no longer be used.</p>
    */
   PubliclyAccessible?: boolean;
@@ -3105,7 +3104,6 @@ export interface DBInstance {
   SecondaryAvailabilityZone?: string;
 
   /**
-   * @deprecated
    * <p>This flag should no longer be used.</p>
    */
   PubliclyAccessible?: boolean;
@@ -7074,7 +7072,6 @@ export interface ModifyDBInstanceMessage {
   DBPortNumber?: number;
 
   /**
-   * @deprecated
    * <p>This flag should no longer be used.</p>
    */
   PubliclyAccessible?: boolean;

--- a/clients/client-opsworkscm/models/models_0.ts
+++ b/clients/client-opsworkscm/models/models_0.ts
@@ -312,6 +312,8 @@ export interface Backup {
   PreferredMaintenanceWindow?: string;
 
   /**
+   * @deprecated
+   *
    * <p>
    *       This field is deprecated and is no longer used.
    *     </p>
@@ -319,6 +321,8 @@ export interface Backup {
   S3DataSize?: number;
 
   /**
+   * @deprecated
+   *
    * <p>
    *       This field is deprecated and is no longer used.
    *     </p>

--- a/clients/client-opsworkscm/models/models_0.ts
+++ b/clients/client-opsworkscm/models/models_0.ts
@@ -312,7 +312,6 @@ export interface Backup {
   PreferredMaintenanceWindow?: string;
 
   /**
-   * @deprecated
    * <p>
    *       This field is deprecated and is no longer used.
    *     </p>
@@ -320,7 +319,6 @@ export interface Backup {
   S3DataSize?: number;
 
   /**
-   * @deprecated
    * <p>
    *       This field is deprecated and is no longer used.
    *     </p>

--- a/clients/client-opsworkscm/models/models_0.ts
+++ b/clients/client-opsworkscm/models/models_0.ts
@@ -312,6 +312,7 @@ export interface Backup {
   PreferredMaintenanceWindow?: string;
 
   /**
+   * @deprecated
    * <p>
    *       This field is deprecated and is no longer used.
    *     </p>
@@ -319,6 +320,7 @@ export interface Backup {
   S3DataSize?: number;
 
   /**
+   * @deprecated
    * <p>
    *       This field is deprecated and is no longer used.
    *     </p>

--- a/clients/client-ram/models/models_0.ts
+++ b/clients/client-ram/models/models_0.ts
@@ -128,6 +128,8 @@ export interface ResourceShareInvitation {
   status?: ResourceShareInvitationStatus | string;
 
   /**
+   * @deprecated
+   *
    * <p>To view the resources associated with a pending resource share invitation, use
    *       	<a href="https://docs.aws.amazon.com/ram/latest/APIReference/API_ListPendingInvitationResources.html">
    *       		ListPendingInvitationResources</a>.</p>

--- a/clients/client-ram/models/models_0.ts
+++ b/clients/client-ram/models/models_0.ts
@@ -128,6 +128,7 @@ export interface ResourceShareInvitation {
   status?: ResourceShareInvitationStatus | string;
 
   /**
+   * @deprecated
    * <p>To view the resources associated with a pending resource share invitation, use
    *       	<a href="https://docs.aws.amazon.com/ram/latest/APIReference/API_ListPendingInvitationResources.html">
    *       		ListPendingInvitationResources</a>.</p>

--- a/clients/client-ram/models/models_0.ts
+++ b/clients/client-ram/models/models_0.ts
@@ -128,7 +128,6 @@ export interface ResourceShareInvitation {
   status?: ResourceShareInvitationStatus | string;
 
   /**
-   * @deprecated
    * <p>To view the resources associated with a pending resource share invitation, use
    *       	<a href="https://docs.aws.amazon.com/ram/latest/APIReference/API_ListPendingInvitationResources.html">
    *       		ListPendingInvitationResources</a>.</p>

--- a/clients/client-rds-data/RDSData.ts
+++ b/clients/client-rds-data/RDSData.ts
@@ -157,6 +157,7 @@ export class RDSData extends RDSDataClient {
   }
 
   /**
+   * @deprecated
    * <p>Runs one or more SQL statements.</p>
    *         <important>
    *             <p>This operation is deprecated. Use the <code>BatchExecuteStatement</code> or

--- a/clients/client-rds-data/RDSData.ts
+++ b/clients/client-rds-data/RDSData.ts
@@ -158,6 +158,7 @@ export class RDSData extends RDSDataClient {
 
   /**
    * @deprecated
+   *
    * <p>Runs one or more SQL statements.</p>
    *         <important>
    *             <p>This operation is deprecated. Use the <code>BatchExecuteStatement</code> or

--- a/clients/client-rds-data/commands/ExecuteSqlCommand.ts
+++ b/clients/client-rds-data/commands/ExecuteSqlCommand.ts
@@ -22,6 +22,7 @@ export type ExecuteSqlCommandOutput = ExecuteSqlResponse & __MetadataBearer;
 
 /**
  * @deprecated
+ *
  * <p>Runs one or more SQL statements.</p>
  *         <important>
  *             <p>This operation is deprecated. Use the <code>BatchExecuteStatement</code> or

--- a/clients/client-rds-data/commands/ExecuteSqlCommand.ts
+++ b/clients/client-rds-data/commands/ExecuteSqlCommand.ts
@@ -21,6 +21,7 @@ export type ExecuteSqlCommandInput = ExecuteSqlRequest;
 export type ExecuteSqlCommandOutput = ExecuteSqlResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Runs one or more SQL statements.</p>
  *         <important>
  *             <p>This operation is deprecated. Use the <code>BatchExecuteStatement</code> or

--- a/clients/client-resource-groups/models/models_0.ts
+++ b/clients/client-resource-groups/models/models_0.ts
@@ -538,6 +538,8 @@ export namespace TooManyRequestsException {
 
 export interface DeleteGroupInput {
   /**
+   * @deprecated
+   *
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -584,6 +586,8 @@ export namespace NotFoundException {
 
 export interface GetGroupInput {
   /**
+   * @deprecated
+   *
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -641,6 +645,8 @@ export namespace GetGroupConfigurationOutput {
 
 export interface GetGroupQueryInput {
   /**
+   * @deprecated
+   *
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -818,6 +824,8 @@ export namespace ResourceFilter {
 
 export interface ListGroupResourcesInput {
   /**
+   * @deprecated
+   *
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -1103,6 +1111,8 @@ export interface ListGroupsOutput {
   GroupIdentifiers?: GroupIdentifier[];
 
   /**
+   * @deprecated
+   *
    * <p>This output element is deprecated and shouldn't be used. Refer to
    *                 <code>GroupIdentifiers</code> instead.</p>
    */
@@ -1299,6 +1309,8 @@ export namespace UntagOutput {
 
 export interface UpdateGroupInput {
   /**
+   * @deprecated
+   *
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -1336,6 +1348,8 @@ export namespace UpdateGroupOutput {
 
 export interface UpdateGroupQueryInput {
   /**
+   * @deprecated
+   *
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;

--- a/clients/client-resource-groups/models/models_0.ts
+++ b/clients/client-resource-groups/models/models_0.ts
@@ -538,7 +538,6 @@ export namespace TooManyRequestsException {
 
 export interface DeleteGroupInput {
   /**
-   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -585,7 +584,6 @@ export namespace NotFoundException {
 
 export interface GetGroupInput {
   /**
-   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -643,7 +641,6 @@ export namespace GetGroupConfigurationOutput {
 
 export interface GetGroupQueryInput {
   /**
-   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -821,7 +818,6 @@ export namespace ResourceFilter {
 
 export interface ListGroupResourcesInput {
   /**
-   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -1107,7 +1103,6 @@ export interface ListGroupsOutput {
   GroupIdentifiers?: GroupIdentifier[];
 
   /**
-   * @deprecated
    * <p>This output element is deprecated and shouldn't be used. Refer to
    *                 <code>GroupIdentifiers</code> instead.</p>
    */
@@ -1304,7 +1299,6 @@ export namespace UntagOutput {
 
 export interface UpdateGroupInput {
   /**
-   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -1342,7 +1336,6 @@ export namespace UpdateGroupOutput {
 
 export interface UpdateGroupQueryInput {
   /**
-   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;

--- a/clients/client-resource-groups/models/models_0.ts
+++ b/clients/client-resource-groups/models/models_0.ts
@@ -538,6 +538,7 @@ export namespace TooManyRequestsException {
 
 export interface DeleteGroupInput {
   /**
+   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -584,6 +585,7 @@ export namespace NotFoundException {
 
 export interface GetGroupInput {
   /**
+   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -641,6 +643,7 @@ export namespace GetGroupConfigurationOutput {
 
 export interface GetGroupQueryInput {
   /**
+   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -818,6 +821,7 @@ export namespace ResourceFilter {
 
 export interface ListGroupResourcesInput {
   /**
+   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -1103,6 +1107,7 @@ export interface ListGroupsOutput {
   GroupIdentifiers?: GroupIdentifier[];
 
   /**
+   * @deprecated
    * <p>This output element is deprecated and shouldn't be used. Refer to
    *                 <code>GroupIdentifiers</code> instead.</p>
    */
@@ -1299,6 +1304,7 @@ export namespace UntagOutput {
 
 export interface UpdateGroupInput {
   /**
+   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;
@@ -1336,6 +1342,7 @@ export namespace UpdateGroupOutput {
 
 export interface UpdateGroupQueryInput {
   /**
+   * @deprecated
    * <p>Don't use this parameter. Use <code>Group</code> instead.</p>
    */
   GroupName?: string;

--- a/clients/client-route-53-domains/models/models_0.ts
+++ b/clients/client-route-53-domains/models/models_0.ts
@@ -2978,6 +2978,8 @@ export interface UpdateDomainNameserversRequest {
   DomainName: string | undefined;
 
   /**
+   * @deprecated
+   *
    * <p>The authorization key for .fi domains</p>
    */
   FIAuthKey?: string;

--- a/clients/client-route-53-domains/models/models_0.ts
+++ b/clients/client-route-53-domains/models/models_0.ts
@@ -2978,6 +2978,7 @@ export interface UpdateDomainNameserversRequest {
   DomainName: string | undefined;
 
   /**
+   * @deprecated
    * <p>The authorization key for .fi domains</p>
    */
   FIAuthKey?: string;

--- a/clients/client-route-53-domains/models/models_0.ts
+++ b/clients/client-route-53-domains/models/models_0.ts
@@ -2978,7 +2978,6 @@ export interface UpdateDomainNameserversRequest {
   DomainName: string | undefined;
 
   /**
-   * @deprecated
    * <p>The authorization key for .fi domains</p>
    */
   FIAuthKey?: string;

--- a/clients/client-route-53/models/models_0.ts
+++ b/clients/client-route-53/models/models_0.ts
@@ -3412,6 +3412,7 @@ export namespace DeleteHealthCheckResponse {
 
 /**
  * @deprecated
+ *
  * <p>This error code is not in use.</p>
  */
 export interface HealthCheckInUse extends __SmithyException, $MetadataBearer {

--- a/clients/client-route-53/models/models_0.ts
+++ b/clients/client-route-53/models/models_0.ts
@@ -3411,6 +3411,7 @@ export namespace DeleteHealthCheckResponse {
 }
 
 /**
+ * @deprecated
  * <p>This error code is not in use.</p>
  */
 export interface HealthCheckInUse extends __SmithyException, $MetadataBearer {

--- a/clients/client-s3/models/models_0.ts
+++ b/clients/client-s3/models/models_0.ts
@@ -4904,6 +4904,8 @@ export interface LifecycleRule {
   ID?: string;
 
   /**
+   * @deprecated
+   *
    * <p>Prefix identifying one or more objects to which the rule applies. This is
    *          No longer used; use <code>Filter</code> instead.</p>
    */
@@ -6105,6 +6107,8 @@ export interface ReplicationRule {
   Priority?: number;
 
   /**
+   * @deprecated
+   *
    * <p>An object key name prefix that identifies the object or objects to which the rule
    *          applies. The maximum prefix length is 1,024 characters. To include all objects in a bucket,
    *          specify an empty string. </p>

--- a/clients/client-s3/models/models_0.ts
+++ b/clients/client-s3/models/models_0.ts
@@ -4904,7 +4904,6 @@ export interface LifecycleRule {
   ID?: string;
 
   /**
-   * @deprecated
    * <p>Prefix identifying one or more objects to which the rule applies. This is
    *          No longer used; use <code>Filter</code> instead.</p>
    */
@@ -6106,7 +6105,6 @@ export interface ReplicationRule {
   Priority?: number;
 
   /**
-   * @deprecated
    * <p>An object key name prefix that identifies the object or objects to which the rule
    *          applies. The maximum prefix length is 1,024 characters. To include all objects in a bucket,
    *          specify an empty string. </p>

--- a/clients/client-s3/models/models_0.ts
+++ b/clients/client-s3/models/models_0.ts
@@ -4904,6 +4904,7 @@ export interface LifecycleRule {
   ID?: string;
 
   /**
+   * @deprecated
    * <p>Prefix identifying one or more objects to which the rule applies. This is
    *          No longer used; use <code>Filter</code> instead.</p>
    */
@@ -6105,6 +6106,7 @@ export interface ReplicationRule {
   Priority?: number;
 
   /**
+   * @deprecated
    * <p>An object key name prefix that identifies the object or objects to which the rule
    *          applies. The maximum prefix length is 1,024 characters. To include all objects in a bucket,
    *          specify an empty string. </p>

--- a/clients/client-sagemaker/models/models_0.ts
+++ b/clients/client-sagemaker/models/models_0.ts
@@ -7047,6 +7047,8 @@ export interface CreateDomainRequest {
   AppNetworkAccessType?: AppNetworkAccessType | string;
 
   /**
+   * @deprecated
+   *
    * <p>This member is deprecated and replaced with <code>KmsKeyId</code>.</p>
    */
   HomeEfsFileSystemKmsKeyId?: string;

--- a/clients/client-sagemaker/models/models_0.ts
+++ b/clients/client-sagemaker/models/models_0.ts
@@ -7047,7 +7047,6 @@ export interface CreateDomainRequest {
   AppNetworkAccessType?: AppNetworkAccessType | string;
 
   /**
-   * @deprecated
    * <p>This member is deprecated and replaced with <code>KmsKeyId</code>.</p>
    */
   HomeEfsFileSystemKmsKeyId?: string;

--- a/clients/client-sagemaker/models/models_0.ts
+++ b/clients/client-sagemaker/models/models_0.ts
@@ -7047,6 +7047,7 @@ export interface CreateDomainRequest {
   AppNetworkAccessType?: AppNetworkAccessType | string;
 
   /**
+   * @deprecated
    * <p>This member is deprecated and replaced with <code>KmsKeyId</code>.</p>
    */
   HomeEfsFileSystemKmsKeyId?: string;

--- a/clients/client-sagemaker/models/models_1.ts
+++ b/clients/client-sagemaker/models/models_1.ts
@@ -4868,6 +4868,8 @@ export interface DescribeDomainResponse {
   AppNetworkAccessType?: AppNetworkAccessType | string;
 
   /**
+   * @deprecated
+   *
    * <p>This member is deprecated and replaced with <code>KmsKeyId</code>.</p>
    */
   HomeEfsFileSystemKmsKeyId?: string;

--- a/clients/client-sagemaker/models/models_1.ts
+++ b/clients/client-sagemaker/models/models_1.ts
@@ -4868,6 +4868,7 @@ export interface DescribeDomainResponse {
   AppNetworkAccessType?: AppNetworkAccessType | string;
 
   /**
+   * @deprecated
    * <p>This member is deprecated and replaced with <code>KmsKeyId</code>.</p>
    */
   HomeEfsFileSystemKmsKeyId?: string;

--- a/clients/client-sagemaker/models/models_1.ts
+++ b/clients/client-sagemaker/models/models_1.ts
@@ -4868,7 +4868,6 @@ export interface DescribeDomainResponse {
   AppNetworkAccessType?: AppNetworkAccessType | string;
 
   /**
-   * @deprecated
    * <p>This member is deprecated and replaced with <code>KmsKeyId</code>.</p>
    */
   HomeEfsFileSystemKmsKeyId?: string;

--- a/clients/client-securityhub/models/models_0.ts
+++ b/clients/client-securityhub/models/models_0.ts
@@ -3845,6 +3845,8 @@ export enum AwsIamAccessKeyStatus {
  */
 export interface AwsIamAccessKeyDetails {
   /**
+   * @deprecated
+   *
    * <p>The user associated with the IAM access key related to a finding.</p>
    *          <p>The <code>UserName</code> parameter has been replaced with the
    *             <code>PrincipalName</code> parameter because access keys can also be assigned to
@@ -8646,6 +8648,8 @@ export interface AwsSecurityFinding {
   VerificationState?: VerificationState | string;
 
   /**
+   * @deprecated
+   *
    * <p>The workflow state of a finding. </p>
    */
   WorkflowState?: WorkflowState | string;

--- a/clients/client-securityhub/models/models_0.ts
+++ b/clients/client-securityhub/models/models_0.ts
@@ -3845,7 +3845,6 @@ export enum AwsIamAccessKeyStatus {
  */
 export interface AwsIamAccessKeyDetails {
   /**
-   * @deprecated
    * <p>The user associated with the IAM access key related to a finding.</p>
    *          <p>The <code>UserName</code> parameter has been replaced with the
    *             <code>PrincipalName</code> parameter because access keys can also be assigned to
@@ -8647,7 +8646,6 @@ export interface AwsSecurityFinding {
   VerificationState?: VerificationState | string;
 
   /**
-   * @deprecated
    * <p>The workflow state of a finding. </p>
    */
   WorkflowState?: WorkflowState | string;

--- a/clients/client-securityhub/models/models_0.ts
+++ b/clients/client-securityhub/models/models_0.ts
@@ -3845,6 +3845,7 @@ export enum AwsIamAccessKeyStatus {
  */
 export interface AwsIamAccessKeyDetails {
   /**
+   * @deprecated
    * <p>The user associated with the IAM access key related to a finding.</p>
    *          <p>The <code>UserName</code> parameter has been replaced with the
    *             <code>PrincipalName</code> parameter because access keys can also be assigned to
@@ -8646,6 +8647,7 @@ export interface AwsSecurityFinding {
   VerificationState?: VerificationState | string;
 
   /**
+   * @deprecated
    * <p>The workflow state of a finding. </p>
    */
   WorkflowState?: WorkflowState | string;

--- a/clients/client-servicediscovery/models/models_0.ts
+++ b/clients/client-servicediscovery/models/models_0.ts
@@ -427,6 +427,8 @@ export enum RoutingPolicy {
  */
 export interface DnsConfig {
   /**
+   * @deprecated
+   *
    * <p>The ID of the namespace to use for DNS configuration.</p>
    */
   NamespaceId?: string;

--- a/clients/client-servicediscovery/models/models_0.ts
+++ b/clients/client-servicediscovery/models/models_0.ts
@@ -427,6 +427,7 @@ export enum RoutingPolicy {
  */
 export interface DnsConfig {
   /**
+   * @deprecated
    * <p>The ID of the namespace to use for DNS configuration.</p>
    */
   NamespaceId?: string;

--- a/clients/client-servicediscovery/models/models_0.ts
+++ b/clients/client-servicediscovery/models/models_0.ts
@@ -427,7 +427,6 @@ export enum RoutingPolicy {
  */
 export interface DnsConfig {
   /**
-   * @deprecated
    * <p>The ID of the namespace to use for DNS configuration.</p>
    */
   NamespaceId?: string;

--- a/clients/client-shield/Shield.ts
+++ b/clients/client-shield/Shield.ts
@@ -460,6 +460,7 @@ export class Shield extends ShieldClient {
   }
 
   /**
+   * @deprecated
    * <p>Removes AWS Shield Advanced from an account. AWS Shield Advanced requires a 1-year subscription commitment. You cannot delete a subscription prior to the completion of that commitment. </p>
    */
   public deleteSubscription(

--- a/clients/client-shield/Shield.ts
+++ b/clients/client-shield/Shield.ts
@@ -461,6 +461,7 @@ export class Shield extends ShieldClient {
 
   /**
    * @deprecated
+   *
    * <p>Removes AWS Shield Advanced from an account. AWS Shield Advanced requires a 1-year subscription commitment. You cannot delete a subscription prior to the completion of that commitment. </p>
    */
   public deleteSubscription(

--- a/clients/client-shield/commands/DeleteSubscriptionCommand.ts
+++ b/clients/client-shield/commands/DeleteSubscriptionCommand.ts
@@ -22,6 +22,7 @@ export type DeleteSubscriptionCommandOutput = DeleteSubscriptionResponse & __Met
 
 /**
  * @deprecated
+ *
  * <p>Removes AWS Shield Advanced from an account. AWS Shield Advanced requires a 1-year subscription commitment. You cannot delete a subscription prior to the completion of that commitment. </p>
  */
 export class DeleteSubscriptionCommand extends $Command<

--- a/clients/client-shield/commands/DeleteSubscriptionCommand.ts
+++ b/clients/client-shield/commands/DeleteSubscriptionCommand.ts
@@ -21,6 +21,7 @@ export type DeleteSubscriptionCommandInput = DeleteSubscriptionRequest;
 export type DeleteSubscriptionCommandOutput = DeleteSubscriptionResponse & __MetadataBearer;
 
 /**
+ * @deprecated
  * <p>Removes AWS Shield Advanced from an account. AWS Shield Advanced requires a 1-year subscription commitment. You cannot delete a subscription prior to the completion of that commitment. </p>
  */
 export class DeleteSubscriptionCommand extends $Command<

--- a/clients/client-signer/models/models_0.ts
+++ b/clients/client-signer/models/models_0.ts
@@ -1579,6 +1579,7 @@ export namespace StartSigningJobResponse {
 
 /**
  * @deprecated
+ *
  * <p>The request was denied due to request throttling.</p>
  *         <p>Instead of this error, <code>TooManyRequestsException</code> should be used.</p>
  */

--- a/clients/client-signer/models/models_0.ts
+++ b/clients/client-signer/models/models_0.ts
@@ -1578,6 +1578,7 @@ export namespace StartSigningJobResponse {
 }
 
 /**
+ * @deprecated
  * <p>The request was denied due to request throttling.</p>
  *         <p>Instead of this error, <code>TooManyRequestsException</code> should be used.</p>
  */

--- a/clients/client-workdocs/models/models_0.ts
+++ b/clients/client-workdocs/models/models_0.ts
@@ -2350,6 +2350,8 @@ export interface DescribeUsersResponse {
   Users?: User[];
 
   /**
+   * @deprecated
+   *
    * <p>The total number of users included in the results.</p>
    */
   TotalNumberOfUsers?: number;

--- a/clients/client-workdocs/models/models_0.ts
+++ b/clients/client-workdocs/models/models_0.ts
@@ -2350,7 +2350,6 @@ export interface DescribeUsersResponse {
   Users?: User[];
 
   /**
-   * @deprecated
    * <p>The total number of users included in the results.</p>
    */
   TotalNumberOfUsers?: number;

--- a/clients/client-workdocs/models/models_0.ts
+++ b/clients/client-workdocs/models/models_0.ts
@@ -2350,6 +2350,7 @@ export interface DescribeUsersResponse {
   Users?: User[];
 
   /**
+   * @deprecated
    * <p>The total number of users included in the results.</p>
    */
   TotalNumberOfUsers?: number;


### PR DESCRIPTION
*Issue #, if available:*
Generated code for https://github.com/awslabs/smithy-typescript/pull/258

*Description of changes:*
add @deprecated in doc comments for deprecated shapes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
