### PR TITLE
fix(util-user-agent-*): move @aws-sdk/types to devDependencies

### DIFF
--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -21,11 +21,11 @@
     "./index": "./index.native"
   },
   "dependencies": {
-    "@aws-sdk/types": "3.1.0",
     "bowser": "^2.11.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/protocol-http": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/node-config-provider": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/protocol-http": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",


### PR DESCRIPTION
Types module existing in runtime dependency causes the types to be pinned
in lock file. It will cause problem when they are not up-to-date in users 
node_modules.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
