### PR TITLE
fix(s3-request-presigner): not to throw when presign concurrently

### DIFF
--- a/packages/s3-request-presigner/src/getSignedUrl.spec.ts
+++ b/packages/s3-request-presigner/src/getSignedUrl.spec.ts
@@ -99,4 +99,16 @@ describe("getSignedUrl", () => {
     expect(mockPresign).toBeCalled();
     expect(mockPresign.mock.calls[0][1]).toMatchObject(options);
   });
+
+  it("should not throw if it's called concurrently", async () => {
+    const mockPresigned = "a presigned url";
+    mockPresign.mockReturnValue(mockPresigned);
+    const client = new S3Client(clientParams);
+    const command = new GetObjectCommand({
+      Bucket: "Bucket",
+      Key: "Key",
+    });
+    const commands = [command, command];
+    return expect(Promise.all(commands.map((command) => getSignedUrl(client, command)))).resolves.toBeInstanceOf(Array);
+  });
 });


### PR DESCRIPTION
Fixes #1857 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
