### PR TITLE
fix(clients): lowercase all header names in serializer

### DIFF
--- a/clients/client-acm-pca/protocols/Aws_json1_1.ts
+++ b/clients/client-acm-pca/protocols/Aws_json1_1.ts
@@ -141,7 +141,7 @@ export const serializeAws_json1_1CreateCertificateAuthorityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.CreateCertificateAuthority",
+    "x-amz-target": "ACMPrivateCA.CreateCertificateAuthority",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCertificateAuthorityRequest(input, context));
@@ -154,7 +154,7 @@ export const serializeAws_json1_1CreateCertificateAuthorityAuditReportCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.CreateCertificateAuthorityAuditReport",
+    "x-amz-target": "ACMPrivateCA.CreateCertificateAuthorityAuditReport",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCertificateAuthorityAuditReportRequest(input, context));
@@ -167,7 +167,7 @@ export const serializeAws_json1_1CreatePermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.CreatePermission",
+    "x-amz-target": "ACMPrivateCA.CreatePermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePermissionRequest(input, context));
@@ -180,7 +180,7 @@ export const serializeAws_json1_1DeleteCertificateAuthorityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.DeleteCertificateAuthority",
+    "x-amz-target": "ACMPrivateCA.DeleteCertificateAuthority",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCertificateAuthorityRequest(input, context));
@@ -193,7 +193,7 @@ export const serializeAws_json1_1DeletePermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.DeletePermission",
+    "x-amz-target": "ACMPrivateCA.DeletePermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePermissionRequest(input, context));
@@ -206,7 +206,7 @@ export const serializeAws_json1_1DeletePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.DeletePolicy",
+    "x-amz-target": "ACMPrivateCA.DeletePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePolicyRequest(input, context));
@@ -219,7 +219,7 @@ export const serializeAws_json1_1DescribeCertificateAuthorityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.DescribeCertificateAuthority",
+    "x-amz-target": "ACMPrivateCA.DescribeCertificateAuthority",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCertificateAuthorityRequest(input, context));
@@ -232,7 +232,7 @@ export const serializeAws_json1_1DescribeCertificateAuthorityAuditReportCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.DescribeCertificateAuthorityAuditReport",
+    "x-amz-target": "ACMPrivateCA.DescribeCertificateAuthorityAuditReport",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCertificateAuthorityAuditReportRequest(input, context));
@@ -245,7 +245,7 @@ export const serializeAws_json1_1GetCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.GetCertificate",
+    "x-amz-target": "ACMPrivateCA.GetCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCertificateRequest(input, context));
@@ -258,7 +258,7 @@ export const serializeAws_json1_1GetCertificateAuthorityCertificateCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.GetCertificateAuthorityCertificate",
+    "x-amz-target": "ACMPrivateCA.GetCertificateAuthorityCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCertificateAuthorityCertificateRequest(input, context));
@@ -271,7 +271,7 @@ export const serializeAws_json1_1GetCertificateAuthorityCsrCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.GetCertificateAuthorityCsr",
+    "x-amz-target": "ACMPrivateCA.GetCertificateAuthorityCsr",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCertificateAuthorityCsrRequest(input, context));
@@ -284,7 +284,7 @@ export const serializeAws_json1_1GetPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.GetPolicy",
+    "x-amz-target": "ACMPrivateCA.GetPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPolicyRequest(input, context));
@@ -297,7 +297,7 @@ export const serializeAws_json1_1ImportCertificateAuthorityCertificateCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.ImportCertificateAuthorityCertificate",
+    "x-amz-target": "ACMPrivateCA.ImportCertificateAuthorityCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportCertificateAuthorityCertificateRequest(input, context));
@@ -310,7 +310,7 @@ export const serializeAws_json1_1IssueCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.IssueCertificate",
+    "x-amz-target": "ACMPrivateCA.IssueCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1IssueCertificateRequest(input, context));
@@ -323,7 +323,7 @@ export const serializeAws_json1_1ListCertificateAuthoritiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.ListCertificateAuthorities",
+    "x-amz-target": "ACMPrivateCA.ListCertificateAuthorities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCertificateAuthoritiesRequest(input, context));
@@ -336,7 +336,7 @@ export const serializeAws_json1_1ListPermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.ListPermissions",
+    "x-amz-target": "ACMPrivateCA.ListPermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPermissionsRequest(input, context));
@@ -349,7 +349,7 @@ export const serializeAws_json1_1ListTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.ListTags",
+    "x-amz-target": "ACMPrivateCA.ListTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsRequest(input, context));
@@ -362,7 +362,7 @@ export const serializeAws_json1_1PutPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.PutPolicy",
+    "x-amz-target": "ACMPrivateCA.PutPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutPolicyRequest(input, context));
@@ -375,7 +375,7 @@ export const serializeAws_json1_1RestoreCertificateAuthorityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.RestoreCertificateAuthority",
+    "x-amz-target": "ACMPrivateCA.RestoreCertificateAuthority",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RestoreCertificateAuthorityRequest(input, context));
@@ -388,7 +388,7 @@ export const serializeAws_json1_1RevokeCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.RevokeCertificate",
+    "x-amz-target": "ACMPrivateCA.RevokeCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RevokeCertificateRequest(input, context));
@@ -401,7 +401,7 @@ export const serializeAws_json1_1TagCertificateAuthorityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.TagCertificateAuthority",
+    "x-amz-target": "ACMPrivateCA.TagCertificateAuthority",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagCertificateAuthorityRequest(input, context));
@@ -414,7 +414,7 @@ export const serializeAws_json1_1UntagCertificateAuthorityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.UntagCertificateAuthority",
+    "x-amz-target": "ACMPrivateCA.UntagCertificateAuthority",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagCertificateAuthorityRequest(input, context));
@@ -427,7 +427,7 @@ export const serializeAws_json1_1UpdateCertificateAuthorityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ACMPrivateCA.UpdateCertificateAuthority",
+    "x-amz-target": "ACMPrivateCA.UpdateCertificateAuthority",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCertificateAuthorityRequest(input, context));

--- a/clients/client-acm/protocols/Aws_json1_1.ts
+++ b/clients/client-acm/protocols/Aws_json1_1.ts
@@ -94,7 +94,7 @@ export const serializeAws_json1_1AddTagsToCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.AddTagsToCertificate",
+    "x-amz-target": "CertificateManager.AddTagsToCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsToCertificateRequest(input, context));
@@ -107,7 +107,7 @@ export const serializeAws_json1_1DeleteCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.DeleteCertificate",
+    "x-amz-target": "CertificateManager.DeleteCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCertificateRequest(input, context));
@@ -120,7 +120,7 @@ export const serializeAws_json1_1DescribeCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.DescribeCertificate",
+    "x-amz-target": "CertificateManager.DescribeCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCertificateRequest(input, context));
@@ -133,7 +133,7 @@ export const serializeAws_json1_1ExportCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.ExportCertificate",
+    "x-amz-target": "CertificateManager.ExportCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ExportCertificateRequest(input, context));
@@ -146,7 +146,7 @@ export const serializeAws_json1_1GetCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.GetCertificate",
+    "x-amz-target": "CertificateManager.GetCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCertificateRequest(input, context));
@@ -159,7 +159,7 @@ export const serializeAws_json1_1ImportCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.ImportCertificate",
+    "x-amz-target": "CertificateManager.ImportCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportCertificateRequest(input, context));
@@ -172,7 +172,7 @@ export const serializeAws_json1_1ListCertificatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.ListCertificates",
+    "x-amz-target": "CertificateManager.ListCertificates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCertificatesRequest(input, context));
@@ -185,7 +185,7 @@ export const serializeAws_json1_1ListTagsForCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.ListTagsForCertificate",
+    "x-amz-target": "CertificateManager.ListTagsForCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForCertificateRequest(input, context));
@@ -198,7 +198,7 @@ export const serializeAws_json1_1RemoveTagsFromCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.RemoveTagsFromCertificate",
+    "x-amz-target": "CertificateManager.RemoveTagsFromCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsFromCertificateRequest(input, context));
@@ -211,7 +211,7 @@ export const serializeAws_json1_1RenewCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.RenewCertificate",
+    "x-amz-target": "CertificateManager.RenewCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RenewCertificateRequest(input, context));
@@ -224,7 +224,7 @@ export const serializeAws_json1_1RequestCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.RequestCertificate",
+    "x-amz-target": "CertificateManager.RequestCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RequestCertificateRequest(input, context));
@@ -237,7 +237,7 @@ export const serializeAws_json1_1ResendValidationEmailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.ResendValidationEmail",
+    "x-amz-target": "CertificateManager.ResendValidationEmail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResendValidationEmailRequest(input, context));
@@ -250,7 +250,7 @@ export const serializeAws_json1_1UpdateCertificateOptionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CertificateManager.UpdateCertificateOptions",
+    "x-amz-target": "CertificateManager.UpdateCertificateOptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCertificateOptionsRequest(input, context));

--- a/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
+++ b/clients/client-alexa-for-business/protocols/Aws_json1_1.ts
@@ -490,7 +490,7 @@ export const serializeAws_json1_1ApproveSkillCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ApproveSkill",
+    "x-amz-target": "AlexaForBusiness.ApproveSkill",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ApproveSkillRequest(input, context));
@@ -503,7 +503,7 @@ export const serializeAws_json1_1AssociateContactWithAddressBookCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.AssociateContactWithAddressBook",
+    "x-amz-target": "AlexaForBusiness.AssociateContactWithAddressBook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateContactWithAddressBookRequest(input, context));
@@ -516,7 +516,7 @@ export const serializeAws_json1_1AssociateDeviceWithNetworkProfileCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.AssociateDeviceWithNetworkProfile",
+    "x-amz-target": "AlexaForBusiness.AssociateDeviceWithNetworkProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateDeviceWithNetworkProfileRequest(input, context));
@@ -529,7 +529,7 @@ export const serializeAws_json1_1AssociateDeviceWithRoomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.AssociateDeviceWithRoom",
+    "x-amz-target": "AlexaForBusiness.AssociateDeviceWithRoom",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateDeviceWithRoomRequest(input, context));
@@ -542,7 +542,7 @@ export const serializeAws_json1_1AssociateSkillGroupWithRoomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.AssociateSkillGroupWithRoom",
+    "x-amz-target": "AlexaForBusiness.AssociateSkillGroupWithRoom",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateSkillGroupWithRoomRequest(input, context));
@@ -555,7 +555,7 @@ export const serializeAws_json1_1AssociateSkillWithSkillGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.AssociateSkillWithSkillGroup",
+    "x-amz-target": "AlexaForBusiness.AssociateSkillWithSkillGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateSkillWithSkillGroupRequest(input, context));
@@ -568,7 +568,7 @@ export const serializeAws_json1_1AssociateSkillWithUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.AssociateSkillWithUsers",
+    "x-amz-target": "AlexaForBusiness.AssociateSkillWithUsers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateSkillWithUsersRequest(input, context));
@@ -581,7 +581,7 @@ export const serializeAws_json1_1CreateAddressBookCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.CreateAddressBook",
+    "x-amz-target": "AlexaForBusiness.CreateAddressBook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAddressBookRequest(input, context));
@@ -594,7 +594,7 @@ export const serializeAws_json1_1CreateBusinessReportScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.CreateBusinessReportSchedule",
+    "x-amz-target": "AlexaForBusiness.CreateBusinessReportSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateBusinessReportScheduleRequest(input, context));
@@ -607,7 +607,7 @@ export const serializeAws_json1_1CreateConferenceProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.CreateConferenceProvider",
+    "x-amz-target": "AlexaForBusiness.CreateConferenceProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateConferenceProviderRequest(input, context));
@@ -620,7 +620,7 @@ export const serializeAws_json1_1CreateContactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.CreateContact",
+    "x-amz-target": "AlexaForBusiness.CreateContact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateContactRequest(input, context));
@@ -633,7 +633,7 @@ export const serializeAws_json1_1CreateGatewayGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.CreateGatewayGroup",
+    "x-amz-target": "AlexaForBusiness.CreateGatewayGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGatewayGroupRequest(input, context));
@@ -646,7 +646,7 @@ export const serializeAws_json1_1CreateNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.CreateNetworkProfile",
+    "x-amz-target": "AlexaForBusiness.CreateNetworkProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateNetworkProfileRequest(input, context));
@@ -659,7 +659,7 @@ export const serializeAws_json1_1CreateProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.CreateProfile",
+    "x-amz-target": "AlexaForBusiness.CreateProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProfileRequest(input, context));
@@ -672,7 +672,7 @@ export const serializeAws_json1_1CreateRoomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.CreateRoom",
+    "x-amz-target": "AlexaForBusiness.CreateRoom",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRoomRequest(input, context));
@@ -685,7 +685,7 @@ export const serializeAws_json1_1CreateSkillGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.CreateSkillGroup",
+    "x-amz-target": "AlexaForBusiness.CreateSkillGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSkillGroupRequest(input, context));
@@ -698,7 +698,7 @@ export const serializeAws_json1_1CreateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.CreateUser",
+    "x-amz-target": "AlexaForBusiness.CreateUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserRequest(input, context));
@@ -711,7 +711,7 @@ export const serializeAws_json1_1DeleteAddressBookCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteAddressBook",
+    "x-amz-target": "AlexaForBusiness.DeleteAddressBook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAddressBookRequest(input, context));
@@ -724,7 +724,7 @@ export const serializeAws_json1_1DeleteBusinessReportScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteBusinessReportSchedule",
+    "x-amz-target": "AlexaForBusiness.DeleteBusinessReportSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBusinessReportScheduleRequest(input, context));
@@ -737,7 +737,7 @@ export const serializeAws_json1_1DeleteConferenceProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteConferenceProvider",
+    "x-amz-target": "AlexaForBusiness.DeleteConferenceProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConferenceProviderRequest(input, context));
@@ -750,7 +750,7 @@ export const serializeAws_json1_1DeleteContactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteContact",
+    "x-amz-target": "AlexaForBusiness.DeleteContact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteContactRequest(input, context));
@@ -763,7 +763,7 @@ export const serializeAws_json1_1DeleteDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteDevice",
+    "x-amz-target": "AlexaForBusiness.DeleteDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDeviceRequest(input, context));
@@ -776,7 +776,7 @@ export const serializeAws_json1_1DeleteDeviceUsageDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteDeviceUsageData",
+    "x-amz-target": "AlexaForBusiness.DeleteDeviceUsageData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDeviceUsageDataRequest(input, context));
@@ -789,7 +789,7 @@ export const serializeAws_json1_1DeleteGatewayGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteGatewayGroup",
+    "x-amz-target": "AlexaForBusiness.DeleteGatewayGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteGatewayGroupRequest(input, context));
@@ -802,7 +802,7 @@ export const serializeAws_json1_1DeleteNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteNetworkProfile",
+    "x-amz-target": "AlexaForBusiness.DeleteNetworkProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteNetworkProfileRequest(input, context));
@@ -815,7 +815,7 @@ export const serializeAws_json1_1DeleteProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteProfile",
+    "x-amz-target": "AlexaForBusiness.DeleteProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProfileRequest(input, context));
@@ -828,7 +828,7 @@ export const serializeAws_json1_1DeleteRoomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteRoom",
+    "x-amz-target": "AlexaForBusiness.DeleteRoom",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRoomRequest(input, context));
@@ -841,7 +841,7 @@ export const serializeAws_json1_1DeleteRoomSkillParameterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteRoomSkillParameter",
+    "x-amz-target": "AlexaForBusiness.DeleteRoomSkillParameter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRoomSkillParameterRequest(input, context));
@@ -854,7 +854,7 @@ export const serializeAws_json1_1DeleteSkillAuthorizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteSkillAuthorization",
+    "x-amz-target": "AlexaForBusiness.DeleteSkillAuthorization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSkillAuthorizationRequest(input, context));
@@ -867,7 +867,7 @@ export const serializeAws_json1_1DeleteSkillGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteSkillGroup",
+    "x-amz-target": "AlexaForBusiness.DeleteSkillGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSkillGroupRequest(input, context));
@@ -880,7 +880,7 @@ export const serializeAws_json1_1DeleteUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DeleteUser",
+    "x-amz-target": "AlexaForBusiness.DeleteUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserRequest(input, context));
@@ -893,7 +893,7 @@ export const serializeAws_json1_1DisassociateContactFromAddressBookCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DisassociateContactFromAddressBook",
+    "x-amz-target": "AlexaForBusiness.DisassociateContactFromAddressBook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateContactFromAddressBookRequest(input, context));
@@ -906,7 +906,7 @@ export const serializeAws_json1_1DisassociateDeviceFromRoomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DisassociateDeviceFromRoom",
+    "x-amz-target": "AlexaForBusiness.DisassociateDeviceFromRoom",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateDeviceFromRoomRequest(input, context));
@@ -919,7 +919,7 @@ export const serializeAws_json1_1DisassociateSkillFromSkillGroupCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DisassociateSkillFromSkillGroup",
+    "x-amz-target": "AlexaForBusiness.DisassociateSkillFromSkillGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateSkillFromSkillGroupRequest(input, context));
@@ -932,7 +932,7 @@ export const serializeAws_json1_1DisassociateSkillFromUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DisassociateSkillFromUsers",
+    "x-amz-target": "AlexaForBusiness.DisassociateSkillFromUsers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateSkillFromUsersRequest(input, context));
@@ -945,7 +945,7 @@ export const serializeAws_json1_1DisassociateSkillGroupFromRoomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.DisassociateSkillGroupFromRoom",
+    "x-amz-target": "AlexaForBusiness.DisassociateSkillGroupFromRoom",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateSkillGroupFromRoomRequest(input, context));
@@ -958,7 +958,7 @@ export const serializeAws_json1_1ForgetSmartHomeAppliancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ForgetSmartHomeAppliances",
+    "x-amz-target": "AlexaForBusiness.ForgetSmartHomeAppliances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ForgetSmartHomeAppliancesRequest(input, context));
@@ -971,7 +971,7 @@ export const serializeAws_json1_1GetAddressBookCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetAddressBook",
+    "x-amz-target": "AlexaForBusiness.GetAddressBook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAddressBookRequest(input, context));
@@ -984,7 +984,7 @@ export const serializeAws_json1_1GetConferencePreferenceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetConferencePreference",
+    "x-amz-target": "AlexaForBusiness.GetConferencePreference",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetConferencePreferenceRequest(input, context));
@@ -997,7 +997,7 @@ export const serializeAws_json1_1GetConferenceProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetConferenceProvider",
+    "x-amz-target": "AlexaForBusiness.GetConferenceProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetConferenceProviderRequest(input, context));
@@ -1010,7 +1010,7 @@ export const serializeAws_json1_1GetContactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetContact",
+    "x-amz-target": "AlexaForBusiness.GetContact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContactRequest(input, context));
@@ -1023,7 +1023,7 @@ export const serializeAws_json1_1GetDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetDevice",
+    "x-amz-target": "AlexaForBusiness.GetDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeviceRequest(input, context));
@@ -1036,7 +1036,7 @@ export const serializeAws_json1_1GetGatewayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetGateway",
+    "x-amz-target": "AlexaForBusiness.GetGateway",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetGatewayRequest(input, context));
@@ -1049,7 +1049,7 @@ export const serializeAws_json1_1GetGatewayGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetGatewayGroup",
+    "x-amz-target": "AlexaForBusiness.GetGatewayGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetGatewayGroupRequest(input, context));
@@ -1062,7 +1062,7 @@ export const serializeAws_json1_1GetInvitationConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetInvitationConfiguration",
+    "x-amz-target": "AlexaForBusiness.GetInvitationConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInvitationConfigurationRequest(input, context));
@@ -1075,7 +1075,7 @@ export const serializeAws_json1_1GetNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetNetworkProfile",
+    "x-amz-target": "AlexaForBusiness.GetNetworkProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetNetworkProfileRequest(input, context));
@@ -1088,7 +1088,7 @@ export const serializeAws_json1_1GetProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetProfile",
+    "x-amz-target": "AlexaForBusiness.GetProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetProfileRequest(input, context));
@@ -1101,7 +1101,7 @@ export const serializeAws_json1_1GetRoomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetRoom",
+    "x-amz-target": "AlexaForBusiness.GetRoom",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRoomRequest(input, context));
@@ -1114,7 +1114,7 @@ export const serializeAws_json1_1GetRoomSkillParameterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetRoomSkillParameter",
+    "x-amz-target": "AlexaForBusiness.GetRoomSkillParameter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRoomSkillParameterRequest(input, context));
@@ -1127,7 +1127,7 @@ export const serializeAws_json1_1GetSkillGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.GetSkillGroup",
+    "x-amz-target": "AlexaForBusiness.GetSkillGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSkillGroupRequest(input, context));
@@ -1140,7 +1140,7 @@ export const serializeAws_json1_1ListBusinessReportSchedulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ListBusinessReportSchedules",
+    "x-amz-target": "AlexaForBusiness.ListBusinessReportSchedules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBusinessReportSchedulesRequest(input, context));
@@ -1153,7 +1153,7 @@ export const serializeAws_json1_1ListConferenceProvidersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ListConferenceProviders",
+    "x-amz-target": "AlexaForBusiness.ListConferenceProviders",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListConferenceProvidersRequest(input, context));
@@ -1166,7 +1166,7 @@ export const serializeAws_json1_1ListDeviceEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ListDeviceEvents",
+    "x-amz-target": "AlexaForBusiness.ListDeviceEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDeviceEventsRequest(input, context));
@@ -1179,7 +1179,7 @@ export const serializeAws_json1_1ListGatewayGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ListGatewayGroups",
+    "x-amz-target": "AlexaForBusiness.ListGatewayGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGatewayGroupsRequest(input, context));
@@ -1192,7 +1192,7 @@ export const serializeAws_json1_1ListGatewaysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ListGateways",
+    "x-amz-target": "AlexaForBusiness.ListGateways",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGatewaysRequest(input, context));
@@ -1205,7 +1205,7 @@ export const serializeAws_json1_1ListSkillsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ListSkills",
+    "x-amz-target": "AlexaForBusiness.ListSkills",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSkillsRequest(input, context));
@@ -1218,7 +1218,7 @@ export const serializeAws_json1_1ListSkillsStoreCategoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ListSkillsStoreCategories",
+    "x-amz-target": "AlexaForBusiness.ListSkillsStoreCategories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSkillsStoreCategoriesRequest(input, context));
@@ -1231,7 +1231,7 @@ export const serializeAws_json1_1ListSkillsStoreSkillsByCategoryCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ListSkillsStoreSkillsByCategory",
+    "x-amz-target": "AlexaForBusiness.ListSkillsStoreSkillsByCategory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSkillsStoreSkillsByCategoryRequest(input, context));
@@ -1244,7 +1244,7 @@ export const serializeAws_json1_1ListSmartHomeAppliancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ListSmartHomeAppliances",
+    "x-amz-target": "AlexaForBusiness.ListSmartHomeAppliances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSmartHomeAppliancesRequest(input, context));
@@ -1257,7 +1257,7 @@ export const serializeAws_json1_1ListTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ListTags",
+    "x-amz-target": "AlexaForBusiness.ListTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsRequest(input, context));
@@ -1270,7 +1270,7 @@ export const serializeAws_json1_1PutConferencePreferenceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.PutConferencePreference",
+    "x-amz-target": "AlexaForBusiness.PutConferencePreference",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutConferencePreferenceRequest(input, context));
@@ -1283,7 +1283,7 @@ export const serializeAws_json1_1PutInvitationConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.PutInvitationConfiguration",
+    "x-amz-target": "AlexaForBusiness.PutInvitationConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutInvitationConfigurationRequest(input, context));
@@ -1296,7 +1296,7 @@ export const serializeAws_json1_1PutRoomSkillParameterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.PutRoomSkillParameter",
+    "x-amz-target": "AlexaForBusiness.PutRoomSkillParameter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRoomSkillParameterRequest(input, context));
@@ -1309,7 +1309,7 @@ export const serializeAws_json1_1PutSkillAuthorizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.PutSkillAuthorization",
+    "x-amz-target": "AlexaForBusiness.PutSkillAuthorization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutSkillAuthorizationRequest(input, context));
@@ -1322,7 +1322,7 @@ export const serializeAws_json1_1RegisterAVSDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.RegisterAVSDevice",
+    "x-amz-target": "AlexaForBusiness.RegisterAVSDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterAVSDeviceRequest(input, context));
@@ -1335,7 +1335,7 @@ export const serializeAws_json1_1RejectSkillCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.RejectSkill",
+    "x-amz-target": "AlexaForBusiness.RejectSkill",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RejectSkillRequest(input, context));
@@ -1348,7 +1348,7 @@ export const serializeAws_json1_1ResolveRoomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.ResolveRoom",
+    "x-amz-target": "AlexaForBusiness.ResolveRoom",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResolveRoomRequest(input, context));
@@ -1361,7 +1361,7 @@ export const serializeAws_json1_1RevokeInvitationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.RevokeInvitation",
+    "x-amz-target": "AlexaForBusiness.RevokeInvitation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RevokeInvitationRequest(input, context));
@@ -1374,7 +1374,7 @@ export const serializeAws_json1_1SearchAddressBooksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.SearchAddressBooks",
+    "x-amz-target": "AlexaForBusiness.SearchAddressBooks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchAddressBooksRequest(input, context));
@@ -1387,7 +1387,7 @@ export const serializeAws_json1_1SearchContactsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.SearchContacts",
+    "x-amz-target": "AlexaForBusiness.SearchContacts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchContactsRequest(input, context));
@@ -1400,7 +1400,7 @@ export const serializeAws_json1_1SearchDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.SearchDevices",
+    "x-amz-target": "AlexaForBusiness.SearchDevices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchDevicesRequest(input, context));
@@ -1413,7 +1413,7 @@ export const serializeAws_json1_1SearchNetworkProfilesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.SearchNetworkProfiles",
+    "x-amz-target": "AlexaForBusiness.SearchNetworkProfiles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchNetworkProfilesRequest(input, context));
@@ -1426,7 +1426,7 @@ export const serializeAws_json1_1SearchProfilesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.SearchProfiles",
+    "x-amz-target": "AlexaForBusiness.SearchProfiles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchProfilesRequest(input, context));
@@ -1439,7 +1439,7 @@ export const serializeAws_json1_1SearchRoomsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.SearchRooms",
+    "x-amz-target": "AlexaForBusiness.SearchRooms",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchRoomsRequest(input, context));
@@ -1452,7 +1452,7 @@ export const serializeAws_json1_1SearchSkillGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.SearchSkillGroups",
+    "x-amz-target": "AlexaForBusiness.SearchSkillGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchSkillGroupsRequest(input, context));
@@ -1465,7 +1465,7 @@ export const serializeAws_json1_1SearchUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.SearchUsers",
+    "x-amz-target": "AlexaForBusiness.SearchUsers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchUsersRequest(input, context));
@@ -1478,7 +1478,7 @@ export const serializeAws_json1_1SendAnnouncementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.SendAnnouncement",
+    "x-amz-target": "AlexaForBusiness.SendAnnouncement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SendAnnouncementRequest(input, context));
@@ -1491,7 +1491,7 @@ export const serializeAws_json1_1SendInvitationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.SendInvitation",
+    "x-amz-target": "AlexaForBusiness.SendInvitation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SendInvitationRequest(input, context));
@@ -1504,7 +1504,7 @@ export const serializeAws_json1_1StartDeviceSyncCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.StartDeviceSync",
+    "x-amz-target": "AlexaForBusiness.StartDeviceSync",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartDeviceSyncRequest(input, context));
@@ -1517,7 +1517,7 @@ export const serializeAws_json1_1StartSmartHomeApplianceDiscoveryCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.StartSmartHomeApplianceDiscovery",
+    "x-amz-target": "AlexaForBusiness.StartSmartHomeApplianceDiscovery",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartSmartHomeApplianceDiscoveryRequest(input, context));
@@ -1530,7 +1530,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.TagResource",
+    "x-amz-target": "AlexaForBusiness.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -1543,7 +1543,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UntagResource",
+    "x-amz-target": "AlexaForBusiness.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -1556,7 +1556,7 @@ export const serializeAws_json1_1UpdateAddressBookCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateAddressBook",
+    "x-amz-target": "AlexaForBusiness.UpdateAddressBook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAddressBookRequest(input, context));
@@ -1569,7 +1569,7 @@ export const serializeAws_json1_1UpdateBusinessReportScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateBusinessReportSchedule",
+    "x-amz-target": "AlexaForBusiness.UpdateBusinessReportSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateBusinessReportScheduleRequest(input, context));
@@ -1582,7 +1582,7 @@ export const serializeAws_json1_1UpdateConferenceProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateConferenceProvider",
+    "x-amz-target": "AlexaForBusiness.UpdateConferenceProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateConferenceProviderRequest(input, context));
@@ -1595,7 +1595,7 @@ export const serializeAws_json1_1UpdateContactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateContact",
+    "x-amz-target": "AlexaForBusiness.UpdateContact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateContactRequest(input, context));
@@ -1608,7 +1608,7 @@ export const serializeAws_json1_1UpdateDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateDevice",
+    "x-amz-target": "AlexaForBusiness.UpdateDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDeviceRequest(input, context));
@@ -1621,7 +1621,7 @@ export const serializeAws_json1_1UpdateGatewayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateGateway",
+    "x-amz-target": "AlexaForBusiness.UpdateGateway",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGatewayRequest(input, context));
@@ -1634,7 +1634,7 @@ export const serializeAws_json1_1UpdateGatewayGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateGatewayGroup",
+    "x-amz-target": "AlexaForBusiness.UpdateGatewayGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGatewayGroupRequest(input, context));
@@ -1647,7 +1647,7 @@ export const serializeAws_json1_1UpdateNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateNetworkProfile",
+    "x-amz-target": "AlexaForBusiness.UpdateNetworkProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateNetworkProfileRequest(input, context));
@@ -1660,7 +1660,7 @@ export const serializeAws_json1_1UpdateProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateProfile",
+    "x-amz-target": "AlexaForBusiness.UpdateProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateProfileRequest(input, context));
@@ -1673,7 +1673,7 @@ export const serializeAws_json1_1UpdateRoomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateRoom",
+    "x-amz-target": "AlexaForBusiness.UpdateRoom",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRoomRequest(input, context));
@@ -1686,7 +1686,7 @@ export const serializeAws_json1_1UpdateSkillGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AlexaForBusiness.UpdateSkillGroup",
+    "x-amz-target": "AlexaForBusiness.UpdateSkillGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSkillGroupRequest(input, context));

--- a/clients/client-api-gateway/protocols/Aws_restJson1.ts
+++ b/clients/client-api-gateway/protocols/Aws_restJson1.ts
@@ -2309,7 +2309,7 @@ export const serializeAws_restJson1GetExportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.accepts) && { Accept: input.accepts! }),
+    ...(isSerializableHeaderValue(input.accepts) && { accept: input.accepts! }),
   };
   let resolvedPath = "/restapis/{restApiId}/stages/{stageName}/exports/{exportType}";
   if (input.restApiId !== undefined) {

--- a/clients/client-appconfig/protocols/Aws_restJson1.ts
+++ b/clients/client-appconfig/protocols/Aws_restJson1.ts
@@ -251,10 +251,10 @@ export const serializeAws_restJson1CreateHostedConfigurationVersionCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/octet-stream",
-    ...(isSerializableHeaderValue(input.Description) && { Description: input.Description! }),
-    ...(isSerializableHeaderValue(input.ContentType) && { "Content-Type": input.ContentType! }),
+    ...(isSerializableHeaderValue(input.Description) && { description: input.Description! }),
+    ...(isSerializableHeaderValue(input.ContentType) && { "content-type": input.ContentType! }),
     ...(isSerializableHeaderValue(input.LatestVersionNumber) && {
-      "Latest-Version-Number": input.LatestVersionNumber!.toString(),
+      "latest-version-number": input.LatestVersionNumber!.toString(),
     }),
   };
   let resolvedPath =

--- a/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
+++ b/clients/client-application-auto-scaling/protocols/Aws_json1_1.ts
@@ -90,7 +90,7 @@ export const serializeAws_json1_1DeleteScalingPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleFrontendService.DeleteScalingPolicy",
+    "x-amz-target": "AnyScaleFrontendService.DeleteScalingPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteScalingPolicyRequest(input, context));
@@ -103,7 +103,7 @@ export const serializeAws_json1_1DeleteScheduledActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleFrontendService.DeleteScheduledAction",
+    "x-amz-target": "AnyScaleFrontendService.DeleteScheduledAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteScheduledActionRequest(input, context));
@@ -116,7 +116,7 @@ export const serializeAws_json1_1DeregisterScalableTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleFrontendService.DeregisterScalableTarget",
+    "x-amz-target": "AnyScaleFrontendService.DeregisterScalableTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterScalableTargetRequest(input, context));
@@ -129,7 +129,7 @@ export const serializeAws_json1_1DescribeScalableTargetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleFrontendService.DescribeScalableTargets",
+    "x-amz-target": "AnyScaleFrontendService.DescribeScalableTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeScalableTargetsRequest(input, context));
@@ -142,7 +142,7 @@ export const serializeAws_json1_1DescribeScalingActivitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleFrontendService.DescribeScalingActivities",
+    "x-amz-target": "AnyScaleFrontendService.DescribeScalingActivities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeScalingActivitiesRequest(input, context));
@@ -155,7 +155,7 @@ export const serializeAws_json1_1DescribeScalingPoliciesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleFrontendService.DescribeScalingPolicies",
+    "x-amz-target": "AnyScaleFrontendService.DescribeScalingPolicies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeScalingPoliciesRequest(input, context));
@@ -168,7 +168,7 @@ export const serializeAws_json1_1DescribeScheduledActionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleFrontendService.DescribeScheduledActions",
+    "x-amz-target": "AnyScaleFrontendService.DescribeScheduledActions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeScheduledActionsRequest(input, context));
@@ -181,7 +181,7 @@ export const serializeAws_json1_1PutScalingPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleFrontendService.PutScalingPolicy",
+    "x-amz-target": "AnyScaleFrontendService.PutScalingPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutScalingPolicyRequest(input, context));
@@ -194,7 +194,7 @@ export const serializeAws_json1_1PutScheduledActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleFrontendService.PutScheduledAction",
+    "x-amz-target": "AnyScaleFrontendService.PutScheduledAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutScheduledActionRequest(input, context));
@@ -207,7 +207,7 @@ export const serializeAws_json1_1RegisterScalableTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleFrontendService.RegisterScalableTarget",
+    "x-amz-target": "AnyScaleFrontendService.RegisterScalableTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterScalableTargetRequest(input, context));

--- a/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
+++ b/clients/client-application-discovery-service/protocols/Aws_json1_1.ts
@@ -163,7 +163,7 @@ export const serializeAws_json1_1AssociateConfigurationItemsToApplicationCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.AssociateConfigurationItemsToApplication",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.AssociateConfigurationItemsToApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateConfigurationItemsToApplicationRequest(input, context));
@@ -176,7 +176,7 @@ export const serializeAws_json1_1BatchDeleteImportDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.BatchDeleteImportData",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.BatchDeleteImportData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDeleteImportDataRequest(input, context));
@@ -189,7 +189,7 @@ export const serializeAws_json1_1CreateApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.CreateApplication",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.CreateApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateApplicationRequest(input, context));
@@ -202,7 +202,7 @@ export const serializeAws_json1_1CreateTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.CreateTags",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.CreateTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTagsRequest(input, context));
@@ -215,7 +215,7 @@ export const serializeAws_json1_1DeleteApplicationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.DeleteApplications",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.DeleteApplications",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationsRequest(input, context));
@@ -228,7 +228,7 @@ export const serializeAws_json1_1DeleteTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.DeleteTags",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.DeleteTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTagsRequest(input, context));
@@ -241,7 +241,7 @@ export const serializeAws_json1_1DescribeAgentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.DescribeAgents",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeAgents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAgentsRequest(input, context));
@@ -254,7 +254,7 @@ export const serializeAws_json1_1DescribeConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.DescribeConfigurations",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConfigurationsRequest(input, context));
@@ -267,7 +267,7 @@ export const serializeAws_json1_1DescribeContinuousExportsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.DescribeContinuousExports",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeContinuousExports",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeContinuousExportsRequest(input, context));
@@ -280,7 +280,7 @@ export const serializeAws_json1_1DescribeExportConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.DescribeExportConfigurations",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeExportConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeExportConfigurationsRequest(input, context));
@@ -293,7 +293,7 @@ export const serializeAws_json1_1DescribeExportTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.DescribeExportTasks",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeExportTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeExportTasksRequest(input, context));
@@ -306,7 +306,7 @@ export const serializeAws_json1_1DescribeImportTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.DescribeImportTasks",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeImportTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeImportTasksRequest(input, context));
@@ -319,7 +319,7 @@ export const serializeAws_json1_1DescribeTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.DescribeTags",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.DescribeTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTagsRequest(input, context));
@@ -332,7 +332,7 @@ export const serializeAws_json1_1DisassociateConfigurationItemsFromApplicationCo
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.DisassociateConfigurationItemsFromApplication",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.DisassociateConfigurationItemsFromApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateConfigurationItemsFromApplicationRequest(input, context));
@@ -345,7 +345,7 @@ export const serializeAws_json1_1ExportConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.ExportConfigurations",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.ExportConfigurations",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -356,7 +356,7 @@ export const serializeAws_json1_1GetDiscoverySummaryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.GetDiscoverySummary",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.GetDiscoverySummary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDiscoverySummaryRequest(input, context));
@@ -369,7 +369,7 @@ export const serializeAws_json1_1ListConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.ListConfigurations",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.ListConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListConfigurationsRequest(input, context));
@@ -382,7 +382,7 @@ export const serializeAws_json1_1ListServerNeighborsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.ListServerNeighbors",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.ListServerNeighbors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListServerNeighborsRequest(input, context));
@@ -395,7 +395,7 @@ export const serializeAws_json1_1StartContinuousExportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.StartContinuousExport",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.StartContinuousExport",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartContinuousExportRequest(input, context));
@@ -408,7 +408,7 @@ export const serializeAws_json1_1StartDataCollectionByAgentIdsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.StartDataCollectionByAgentIds",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.StartDataCollectionByAgentIds",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartDataCollectionByAgentIdsRequest(input, context));
@@ -421,7 +421,7 @@ export const serializeAws_json1_1StartExportTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.StartExportTask",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.StartExportTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartExportTaskRequest(input, context));
@@ -434,7 +434,7 @@ export const serializeAws_json1_1StartImportTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.StartImportTask",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.StartImportTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartImportTaskRequest(input, context));
@@ -447,7 +447,7 @@ export const serializeAws_json1_1StopContinuousExportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.StopContinuousExport",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.StopContinuousExport",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopContinuousExportRequest(input, context));
@@ -460,7 +460,7 @@ export const serializeAws_json1_1StopDataCollectionByAgentIdsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.StopDataCollectionByAgentIds",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.StopDataCollectionByAgentIds",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopDataCollectionByAgentIdsRequest(input, context));
@@ -473,7 +473,7 @@ export const serializeAws_json1_1UpdateApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPoseidonService_V2015_11_01.UpdateApplication",
+    "x-amz-target": "AWSPoseidonService_V2015_11_01.UpdateApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateApplicationRequest(input, context));

--- a/clients/client-application-insights/protocols/Aws_json1_1.ts
+++ b/clients/client-application-insights/protocols/Aws_json1_1.ts
@@ -140,7 +140,7 @@ export const serializeAws_json1_1CreateApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.CreateApplication",
+    "x-amz-target": "EC2WindowsBarleyService.CreateApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateApplicationRequest(input, context));
@@ -153,7 +153,7 @@ export const serializeAws_json1_1CreateComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.CreateComponent",
+    "x-amz-target": "EC2WindowsBarleyService.CreateComponent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateComponentRequest(input, context));
@@ -166,7 +166,7 @@ export const serializeAws_json1_1CreateLogPatternCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.CreateLogPattern",
+    "x-amz-target": "EC2WindowsBarleyService.CreateLogPattern",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLogPatternRequest(input, context));
@@ -179,7 +179,7 @@ export const serializeAws_json1_1DeleteApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DeleteApplication",
+    "x-amz-target": "EC2WindowsBarleyService.DeleteApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationRequest(input, context));
@@ -192,7 +192,7 @@ export const serializeAws_json1_1DeleteComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DeleteComponent",
+    "x-amz-target": "EC2WindowsBarleyService.DeleteComponent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteComponentRequest(input, context));
@@ -205,7 +205,7 @@ export const serializeAws_json1_1DeleteLogPatternCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DeleteLogPattern",
+    "x-amz-target": "EC2WindowsBarleyService.DeleteLogPattern",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLogPatternRequest(input, context));
@@ -218,7 +218,7 @@ export const serializeAws_json1_1DescribeApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DescribeApplication",
+    "x-amz-target": "EC2WindowsBarleyService.DescribeApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeApplicationRequest(input, context));
@@ -231,7 +231,7 @@ export const serializeAws_json1_1DescribeComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DescribeComponent",
+    "x-amz-target": "EC2WindowsBarleyService.DescribeComponent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeComponentRequest(input, context));
@@ -244,7 +244,7 @@ export const serializeAws_json1_1DescribeComponentConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DescribeComponentConfiguration",
+    "x-amz-target": "EC2WindowsBarleyService.DescribeComponentConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeComponentConfigurationRequest(input, context));
@@ -257,7 +257,7 @@ export const serializeAws_json1_1DescribeComponentConfigurationRecommendationCom
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DescribeComponentConfigurationRecommendation",
+    "x-amz-target": "EC2WindowsBarleyService.DescribeComponentConfigurationRecommendation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeComponentConfigurationRecommendationRequest(input, context));
@@ -270,7 +270,7 @@ export const serializeAws_json1_1DescribeLogPatternCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DescribeLogPattern",
+    "x-amz-target": "EC2WindowsBarleyService.DescribeLogPattern",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLogPatternRequest(input, context));
@@ -283,7 +283,7 @@ export const serializeAws_json1_1DescribeObservationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DescribeObservation",
+    "x-amz-target": "EC2WindowsBarleyService.DescribeObservation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeObservationRequest(input, context));
@@ -296,7 +296,7 @@ export const serializeAws_json1_1DescribeProblemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DescribeProblem",
+    "x-amz-target": "EC2WindowsBarleyService.DescribeProblem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProblemRequest(input, context));
@@ -309,7 +309,7 @@ export const serializeAws_json1_1DescribeProblemObservationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.DescribeProblemObservations",
+    "x-amz-target": "EC2WindowsBarleyService.DescribeProblemObservations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProblemObservationsRequest(input, context));
@@ -322,7 +322,7 @@ export const serializeAws_json1_1ListApplicationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.ListApplications",
+    "x-amz-target": "EC2WindowsBarleyService.ListApplications",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListApplicationsRequest(input, context));
@@ -335,7 +335,7 @@ export const serializeAws_json1_1ListComponentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.ListComponents",
+    "x-amz-target": "EC2WindowsBarleyService.ListComponents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListComponentsRequest(input, context));
@@ -348,7 +348,7 @@ export const serializeAws_json1_1ListConfigurationHistoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.ListConfigurationHistory",
+    "x-amz-target": "EC2WindowsBarleyService.ListConfigurationHistory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListConfigurationHistoryRequest(input, context));
@@ -361,7 +361,7 @@ export const serializeAws_json1_1ListLogPatternsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.ListLogPatterns",
+    "x-amz-target": "EC2WindowsBarleyService.ListLogPatterns",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLogPatternsRequest(input, context));
@@ -374,7 +374,7 @@ export const serializeAws_json1_1ListLogPatternSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.ListLogPatternSets",
+    "x-amz-target": "EC2WindowsBarleyService.ListLogPatternSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLogPatternSetsRequest(input, context));
@@ -387,7 +387,7 @@ export const serializeAws_json1_1ListProblemsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.ListProblems",
+    "x-amz-target": "EC2WindowsBarleyService.ListProblems",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProblemsRequest(input, context));
@@ -400,7 +400,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.ListTagsForResource",
+    "x-amz-target": "EC2WindowsBarleyService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -413,7 +413,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.TagResource",
+    "x-amz-target": "EC2WindowsBarleyService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -426,7 +426,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.UntagResource",
+    "x-amz-target": "EC2WindowsBarleyService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -439,7 +439,7 @@ export const serializeAws_json1_1UpdateApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.UpdateApplication",
+    "x-amz-target": "EC2WindowsBarleyService.UpdateApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateApplicationRequest(input, context));
@@ -452,7 +452,7 @@ export const serializeAws_json1_1UpdateComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.UpdateComponent",
+    "x-amz-target": "EC2WindowsBarleyService.UpdateComponent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateComponentRequest(input, context));
@@ -465,7 +465,7 @@ export const serializeAws_json1_1UpdateComponentConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.UpdateComponentConfiguration",
+    "x-amz-target": "EC2WindowsBarleyService.UpdateComponentConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateComponentConfigurationRequest(input, context));
@@ -478,7 +478,7 @@ export const serializeAws_json1_1UpdateLogPatternCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "EC2WindowsBarleyService.UpdateLogPattern",
+    "x-amz-target": "EC2WindowsBarleyService.UpdateLogPattern",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateLogPatternRequest(input, context));

--- a/clients/client-appstream/protocols/Aws_json1_1.ts
+++ b/clients/client-appstream/protocols/Aws_json1_1.ts
@@ -255,7 +255,7 @@ export const serializeAws_json1_1AssociateFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.AssociateFleet",
+    "x-amz-target": "PhotonAdminProxyService.AssociateFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateFleetRequest(input, context));
@@ -268,7 +268,7 @@ export const serializeAws_json1_1BatchAssociateUserStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.BatchAssociateUserStack",
+    "x-amz-target": "PhotonAdminProxyService.BatchAssociateUserStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchAssociateUserStackRequest(input, context));
@@ -281,7 +281,7 @@ export const serializeAws_json1_1BatchDisassociateUserStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.BatchDisassociateUserStack",
+    "x-amz-target": "PhotonAdminProxyService.BatchDisassociateUserStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDisassociateUserStackRequest(input, context));
@@ -294,7 +294,7 @@ export const serializeAws_json1_1CopyImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.CopyImage",
+    "x-amz-target": "PhotonAdminProxyService.CopyImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CopyImageRequest(input, context));
@@ -307,7 +307,7 @@ export const serializeAws_json1_1CreateDirectoryConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.CreateDirectoryConfig",
+    "x-amz-target": "PhotonAdminProxyService.CreateDirectoryConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDirectoryConfigRequest(input, context));
@@ -320,7 +320,7 @@ export const serializeAws_json1_1CreateFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.CreateFleet",
+    "x-amz-target": "PhotonAdminProxyService.CreateFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateFleetRequest(input, context));
@@ -333,7 +333,7 @@ export const serializeAws_json1_1CreateImageBuilderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.CreateImageBuilder",
+    "x-amz-target": "PhotonAdminProxyService.CreateImageBuilder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateImageBuilderRequest(input, context));
@@ -346,7 +346,7 @@ export const serializeAws_json1_1CreateImageBuilderStreamingURLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.CreateImageBuilderStreamingURL",
+    "x-amz-target": "PhotonAdminProxyService.CreateImageBuilderStreamingURL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateImageBuilderStreamingURLRequest(input, context));
@@ -359,7 +359,7 @@ export const serializeAws_json1_1CreateStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.CreateStack",
+    "x-amz-target": "PhotonAdminProxyService.CreateStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateStackRequest(input, context));
@@ -372,7 +372,7 @@ export const serializeAws_json1_1CreateStreamingURLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.CreateStreamingURL",
+    "x-amz-target": "PhotonAdminProxyService.CreateStreamingURL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateStreamingURLRequest(input, context));
@@ -385,7 +385,7 @@ export const serializeAws_json1_1CreateUsageReportSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.CreateUsageReportSubscription",
+    "x-amz-target": "PhotonAdminProxyService.CreateUsageReportSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUsageReportSubscriptionRequest(input, context));
@@ -398,7 +398,7 @@ export const serializeAws_json1_1CreateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.CreateUser",
+    "x-amz-target": "PhotonAdminProxyService.CreateUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserRequest(input, context));
@@ -411,7 +411,7 @@ export const serializeAws_json1_1DeleteDirectoryConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DeleteDirectoryConfig",
+    "x-amz-target": "PhotonAdminProxyService.DeleteDirectoryConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDirectoryConfigRequest(input, context));
@@ -424,7 +424,7 @@ export const serializeAws_json1_1DeleteFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DeleteFleet",
+    "x-amz-target": "PhotonAdminProxyService.DeleteFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFleetRequest(input, context));
@@ -437,7 +437,7 @@ export const serializeAws_json1_1DeleteImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DeleteImage",
+    "x-amz-target": "PhotonAdminProxyService.DeleteImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteImageRequest(input, context));
@@ -450,7 +450,7 @@ export const serializeAws_json1_1DeleteImageBuilderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DeleteImageBuilder",
+    "x-amz-target": "PhotonAdminProxyService.DeleteImageBuilder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteImageBuilderRequest(input, context));
@@ -463,7 +463,7 @@ export const serializeAws_json1_1DeleteImagePermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DeleteImagePermissions",
+    "x-amz-target": "PhotonAdminProxyService.DeleteImagePermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteImagePermissionsRequest(input, context));
@@ -476,7 +476,7 @@ export const serializeAws_json1_1DeleteStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DeleteStack",
+    "x-amz-target": "PhotonAdminProxyService.DeleteStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteStackRequest(input, context));
@@ -489,7 +489,7 @@ export const serializeAws_json1_1DeleteUsageReportSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DeleteUsageReportSubscription",
+    "x-amz-target": "PhotonAdminProxyService.DeleteUsageReportSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUsageReportSubscriptionRequest(input, context));
@@ -502,7 +502,7 @@ export const serializeAws_json1_1DeleteUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DeleteUser",
+    "x-amz-target": "PhotonAdminProxyService.DeleteUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserRequest(input, context));
@@ -515,7 +515,7 @@ export const serializeAws_json1_1DescribeDirectoryConfigsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DescribeDirectoryConfigs",
+    "x-amz-target": "PhotonAdminProxyService.DescribeDirectoryConfigs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDirectoryConfigsRequest(input, context));
@@ -528,7 +528,7 @@ export const serializeAws_json1_1DescribeFleetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DescribeFleets",
+    "x-amz-target": "PhotonAdminProxyService.DescribeFleets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFleetsRequest(input, context));
@@ -541,7 +541,7 @@ export const serializeAws_json1_1DescribeImageBuildersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DescribeImageBuilders",
+    "x-amz-target": "PhotonAdminProxyService.DescribeImageBuilders",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeImageBuildersRequest(input, context));
@@ -554,7 +554,7 @@ export const serializeAws_json1_1DescribeImagePermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DescribeImagePermissions",
+    "x-amz-target": "PhotonAdminProxyService.DescribeImagePermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeImagePermissionsRequest(input, context));
@@ -567,7 +567,7 @@ export const serializeAws_json1_1DescribeImagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DescribeImages",
+    "x-amz-target": "PhotonAdminProxyService.DescribeImages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeImagesRequest(input, context));
@@ -580,7 +580,7 @@ export const serializeAws_json1_1DescribeSessionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DescribeSessions",
+    "x-amz-target": "PhotonAdminProxyService.DescribeSessions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSessionsRequest(input, context));
@@ -593,7 +593,7 @@ export const serializeAws_json1_1DescribeStacksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DescribeStacks",
+    "x-amz-target": "PhotonAdminProxyService.DescribeStacks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStacksRequest(input, context));
@@ -606,7 +606,7 @@ export const serializeAws_json1_1DescribeUsageReportSubscriptionsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DescribeUsageReportSubscriptions",
+    "x-amz-target": "PhotonAdminProxyService.DescribeUsageReportSubscriptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUsageReportSubscriptionsRequest(input, context));
@@ -619,7 +619,7 @@ export const serializeAws_json1_1DescribeUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DescribeUsers",
+    "x-amz-target": "PhotonAdminProxyService.DescribeUsers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUsersRequest(input, context));
@@ -632,7 +632,7 @@ export const serializeAws_json1_1DescribeUserStackAssociationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DescribeUserStackAssociations",
+    "x-amz-target": "PhotonAdminProxyService.DescribeUserStackAssociations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserStackAssociationsRequest(input, context));
@@ -645,7 +645,7 @@ export const serializeAws_json1_1DisableUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DisableUser",
+    "x-amz-target": "PhotonAdminProxyService.DisableUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableUserRequest(input, context));
@@ -658,7 +658,7 @@ export const serializeAws_json1_1DisassociateFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.DisassociateFleet",
+    "x-amz-target": "PhotonAdminProxyService.DisassociateFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateFleetRequest(input, context));
@@ -671,7 +671,7 @@ export const serializeAws_json1_1EnableUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.EnableUser",
+    "x-amz-target": "PhotonAdminProxyService.EnableUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableUserRequest(input, context));
@@ -684,7 +684,7 @@ export const serializeAws_json1_1ExpireSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.ExpireSession",
+    "x-amz-target": "PhotonAdminProxyService.ExpireSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ExpireSessionRequest(input, context));
@@ -697,7 +697,7 @@ export const serializeAws_json1_1ListAssociatedFleetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.ListAssociatedFleets",
+    "x-amz-target": "PhotonAdminProxyService.ListAssociatedFleets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssociatedFleetsRequest(input, context));
@@ -710,7 +710,7 @@ export const serializeAws_json1_1ListAssociatedStacksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.ListAssociatedStacks",
+    "x-amz-target": "PhotonAdminProxyService.ListAssociatedStacks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssociatedStacksRequest(input, context));
@@ -723,7 +723,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.ListTagsForResource",
+    "x-amz-target": "PhotonAdminProxyService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -736,7 +736,7 @@ export const serializeAws_json1_1StartFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.StartFleet",
+    "x-amz-target": "PhotonAdminProxyService.StartFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartFleetRequest(input, context));
@@ -749,7 +749,7 @@ export const serializeAws_json1_1StartImageBuilderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.StartImageBuilder",
+    "x-amz-target": "PhotonAdminProxyService.StartImageBuilder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartImageBuilderRequest(input, context));
@@ -762,7 +762,7 @@ export const serializeAws_json1_1StopFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.StopFleet",
+    "x-amz-target": "PhotonAdminProxyService.StopFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopFleetRequest(input, context));
@@ -775,7 +775,7 @@ export const serializeAws_json1_1StopImageBuilderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.StopImageBuilder",
+    "x-amz-target": "PhotonAdminProxyService.StopImageBuilder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopImageBuilderRequest(input, context));
@@ -788,7 +788,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.TagResource",
+    "x-amz-target": "PhotonAdminProxyService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -801,7 +801,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.UntagResource",
+    "x-amz-target": "PhotonAdminProxyService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -814,7 +814,7 @@ export const serializeAws_json1_1UpdateDirectoryConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.UpdateDirectoryConfig",
+    "x-amz-target": "PhotonAdminProxyService.UpdateDirectoryConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDirectoryConfigRequest(input, context));
@@ -827,7 +827,7 @@ export const serializeAws_json1_1UpdateFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.UpdateFleet",
+    "x-amz-target": "PhotonAdminProxyService.UpdateFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateFleetRequest(input, context));
@@ -840,7 +840,7 @@ export const serializeAws_json1_1UpdateImagePermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.UpdateImagePermissions",
+    "x-amz-target": "PhotonAdminProxyService.UpdateImagePermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateImagePermissionsRequest(input, context));
@@ -853,7 +853,7 @@ export const serializeAws_json1_1UpdateStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PhotonAdminProxyService.UpdateStack",
+    "x-amz-target": "PhotonAdminProxyService.UpdateStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateStackRequest(input, context));

--- a/clients/client-athena/protocols/Aws_json1_1.ts
+++ b/clients/client-athena/protocols/Aws_json1_1.ts
@@ -143,7 +143,7 @@ export const serializeAws_json1_1BatchGetNamedQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.BatchGetNamedQuery",
+    "x-amz-target": "AmazonAthena.BatchGetNamedQuery",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetNamedQueryInput(input, context));
@@ -156,7 +156,7 @@ export const serializeAws_json1_1BatchGetQueryExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.BatchGetQueryExecution",
+    "x-amz-target": "AmazonAthena.BatchGetQueryExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetQueryExecutionInput(input, context));
@@ -169,7 +169,7 @@ export const serializeAws_json1_1CreateDataCatalogCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.CreateDataCatalog",
+    "x-amz-target": "AmazonAthena.CreateDataCatalog",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDataCatalogInput(input, context));
@@ -182,7 +182,7 @@ export const serializeAws_json1_1CreateNamedQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.CreateNamedQuery",
+    "x-amz-target": "AmazonAthena.CreateNamedQuery",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateNamedQueryInput(input, context));
@@ -195,7 +195,7 @@ export const serializeAws_json1_1CreateWorkGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.CreateWorkGroup",
+    "x-amz-target": "AmazonAthena.CreateWorkGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWorkGroupInput(input, context));
@@ -208,7 +208,7 @@ export const serializeAws_json1_1DeleteDataCatalogCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.DeleteDataCatalog",
+    "x-amz-target": "AmazonAthena.DeleteDataCatalog",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDataCatalogInput(input, context));
@@ -221,7 +221,7 @@ export const serializeAws_json1_1DeleteNamedQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.DeleteNamedQuery",
+    "x-amz-target": "AmazonAthena.DeleteNamedQuery",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteNamedQueryInput(input, context));
@@ -234,7 +234,7 @@ export const serializeAws_json1_1DeleteWorkGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.DeleteWorkGroup",
+    "x-amz-target": "AmazonAthena.DeleteWorkGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWorkGroupInput(input, context));
@@ -247,7 +247,7 @@ export const serializeAws_json1_1GetDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.GetDatabase",
+    "x-amz-target": "AmazonAthena.GetDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDatabaseInput(input, context));
@@ -260,7 +260,7 @@ export const serializeAws_json1_1GetDataCatalogCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.GetDataCatalog",
+    "x-amz-target": "AmazonAthena.GetDataCatalog",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDataCatalogInput(input, context));
@@ -273,7 +273,7 @@ export const serializeAws_json1_1GetNamedQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.GetNamedQuery",
+    "x-amz-target": "AmazonAthena.GetNamedQuery",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetNamedQueryInput(input, context));
@@ -286,7 +286,7 @@ export const serializeAws_json1_1GetQueryExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.GetQueryExecution",
+    "x-amz-target": "AmazonAthena.GetQueryExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetQueryExecutionInput(input, context));
@@ -299,7 +299,7 @@ export const serializeAws_json1_1GetQueryResultsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.GetQueryResults",
+    "x-amz-target": "AmazonAthena.GetQueryResults",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetQueryResultsInput(input, context));
@@ -312,7 +312,7 @@ export const serializeAws_json1_1GetTableMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.GetTableMetadata",
+    "x-amz-target": "AmazonAthena.GetTableMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTableMetadataInput(input, context));
@@ -325,7 +325,7 @@ export const serializeAws_json1_1GetWorkGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.GetWorkGroup",
+    "x-amz-target": "AmazonAthena.GetWorkGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetWorkGroupInput(input, context));
@@ -338,7 +338,7 @@ export const serializeAws_json1_1ListDatabasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.ListDatabases",
+    "x-amz-target": "AmazonAthena.ListDatabases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDatabasesInput(input, context));
@@ -351,7 +351,7 @@ export const serializeAws_json1_1ListDataCatalogsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.ListDataCatalogs",
+    "x-amz-target": "AmazonAthena.ListDataCatalogs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDataCatalogsInput(input, context));
@@ -364,7 +364,7 @@ export const serializeAws_json1_1ListNamedQueriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.ListNamedQueries",
+    "x-amz-target": "AmazonAthena.ListNamedQueries",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListNamedQueriesInput(input, context));
@@ -377,7 +377,7 @@ export const serializeAws_json1_1ListQueryExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.ListQueryExecutions",
+    "x-amz-target": "AmazonAthena.ListQueryExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListQueryExecutionsInput(input, context));
@@ -390,7 +390,7 @@ export const serializeAws_json1_1ListTableMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.ListTableMetadata",
+    "x-amz-target": "AmazonAthena.ListTableMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTableMetadataInput(input, context));
@@ -403,7 +403,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.ListTagsForResource",
+    "x-amz-target": "AmazonAthena.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceInput(input, context));
@@ -416,7 +416,7 @@ export const serializeAws_json1_1ListWorkGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.ListWorkGroups",
+    "x-amz-target": "AmazonAthena.ListWorkGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListWorkGroupsInput(input, context));
@@ -429,7 +429,7 @@ export const serializeAws_json1_1StartQueryExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.StartQueryExecution",
+    "x-amz-target": "AmazonAthena.StartQueryExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartQueryExecutionInput(input, context));
@@ -442,7 +442,7 @@ export const serializeAws_json1_1StopQueryExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.StopQueryExecution",
+    "x-amz-target": "AmazonAthena.StopQueryExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopQueryExecutionInput(input, context));
@@ -455,7 +455,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.TagResource",
+    "x-amz-target": "AmazonAthena.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceInput(input, context));
@@ -468,7 +468,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.UntagResource",
+    "x-amz-target": "AmazonAthena.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceInput(input, context));
@@ -481,7 +481,7 @@ export const serializeAws_json1_1UpdateDataCatalogCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.UpdateDataCatalog",
+    "x-amz-target": "AmazonAthena.UpdateDataCatalog",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDataCatalogInput(input, context));
@@ -494,7 +494,7 @@ export const serializeAws_json1_1UpdateWorkGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonAthena.UpdateWorkGroup",
+    "x-amz-target": "AmazonAthena.UpdateWorkGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateWorkGroupInput(input, context));

--- a/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
+++ b/clients/client-auto-scaling-plans/protocols/Aws_json1_1.ts
@@ -62,7 +62,7 @@ export const serializeAws_json1_1CreateScalingPlanCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleScalingPlannerFrontendService.CreateScalingPlan",
+    "x-amz-target": "AnyScaleScalingPlannerFrontendService.CreateScalingPlan",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateScalingPlanRequest(input, context));
@@ -75,7 +75,7 @@ export const serializeAws_json1_1DeleteScalingPlanCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleScalingPlannerFrontendService.DeleteScalingPlan",
+    "x-amz-target": "AnyScaleScalingPlannerFrontendService.DeleteScalingPlan",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteScalingPlanRequest(input, context));
@@ -88,7 +88,7 @@ export const serializeAws_json1_1DescribeScalingPlanResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleScalingPlannerFrontendService.DescribeScalingPlanResources",
+    "x-amz-target": "AnyScaleScalingPlannerFrontendService.DescribeScalingPlanResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeScalingPlanResourcesRequest(input, context));
@@ -101,7 +101,7 @@ export const serializeAws_json1_1DescribeScalingPlansCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleScalingPlannerFrontendService.DescribeScalingPlans",
+    "x-amz-target": "AnyScaleScalingPlannerFrontendService.DescribeScalingPlans",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeScalingPlansRequest(input, context));
@@ -114,7 +114,7 @@ export const serializeAws_json1_1GetScalingPlanResourceForecastDataCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleScalingPlannerFrontendService.GetScalingPlanResourceForecastData",
+    "x-amz-target": "AnyScaleScalingPlannerFrontendService.GetScalingPlanResourceForecastData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetScalingPlanResourceForecastDataRequest(input, context));
@@ -127,7 +127,7 @@ export const serializeAws_json1_1UpdateScalingPlanCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AnyScaleScalingPlannerFrontendService.UpdateScalingPlan",
+    "x-amz-target": "AnyScaleScalingPlannerFrontendService.UpdateScalingPlan",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateScalingPlanRequest(input, context));

--- a/clients/client-budgets/protocols/Aws_json1_1.ts
+++ b/clients/client-budgets/protocols/Aws_json1_1.ts
@@ -133,7 +133,7 @@ export const serializeAws_json1_1CreateBudgetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.CreateBudget",
+    "x-amz-target": "AWSBudgetServiceGateway.CreateBudget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateBudgetRequest(input, context));
@@ -146,7 +146,7 @@ export const serializeAws_json1_1CreateBudgetActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.CreateBudgetAction",
+    "x-amz-target": "AWSBudgetServiceGateway.CreateBudgetAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateBudgetActionRequest(input, context));
@@ -159,7 +159,7 @@ export const serializeAws_json1_1CreateNotificationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.CreateNotification",
+    "x-amz-target": "AWSBudgetServiceGateway.CreateNotification",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateNotificationRequest(input, context));
@@ -172,7 +172,7 @@ export const serializeAws_json1_1CreateSubscriberCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.CreateSubscriber",
+    "x-amz-target": "AWSBudgetServiceGateway.CreateSubscriber",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSubscriberRequest(input, context));
@@ -185,7 +185,7 @@ export const serializeAws_json1_1DeleteBudgetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DeleteBudget",
+    "x-amz-target": "AWSBudgetServiceGateway.DeleteBudget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBudgetRequest(input, context));
@@ -198,7 +198,7 @@ export const serializeAws_json1_1DeleteBudgetActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DeleteBudgetAction",
+    "x-amz-target": "AWSBudgetServiceGateway.DeleteBudgetAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBudgetActionRequest(input, context));
@@ -211,7 +211,7 @@ export const serializeAws_json1_1DeleteNotificationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DeleteNotification",
+    "x-amz-target": "AWSBudgetServiceGateway.DeleteNotification",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteNotificationRequest(input, context));
@@ -224,7 +224,7 @@ export const serializeAws_json1_1DeleteSubscriberCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DeleteSubscriber",
+    "x-amz-target": "AWSBudgetServiceGateway.DeleteSubscriber",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSubscriberRequest(input, context));
@@ -237,7 +237,7 @@ export const serializeAws_json1_1DescribeBudgetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DescribeBudget",
+    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBudgetRequest(input, context));
@@ -250,7 +250,7 @@ export const serializeAws_json1_1DescribeBudgetActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DescribeBudgetAction",
+    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBudgetActionRequest(input, context));
@@ -263,7 +263,7 @@ export const serializeAws_json1_1DescribeBudgetActionHistoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DescribeBudgetActionHistories",
+    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetActionHistories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBudgetActionHistoriesRequest(input, context));
@@ -276,7 +276,7 @@ export const serializeAws_json1_1DescribeBudgetActionsForAccountCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DescribeBudgetActionsForAccount",
+    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetActionsForAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBudgetActionsForAccountRequest(input, context));
@@ -289,7 +289,7 @@ export const serializeAws_json1_1DescribeBudgetActionsForBudgetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DescribeBudgetActionsForBudget",
+    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetActionsForBudget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBudgetActionsForBudgetRequest(input, context));
@@ -302,7 +302,7 @@ export const serializeAws_json1_1DescribeBudgetPerformanceHistoryCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DescribeBudgetPerformanceHistory",
+    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgetPerformanceHistory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBudgetPerformanceHistoryRequest(input, context));
@@ -315,7 +315,7 @@ export const serializeAws_json1_1DescribeBudgetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DescribeBudgets",
+    "x-amz-target": "AWSBudgetServiceGateway.DescribeBudgets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBudgetsRequest(input, context));
@@ -328,7 +328,7 @@ export const serializeAws_json1_1DescribeNotificationsForBudgetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DescribeNotificationsForBudget",
+    "x-amz-target": "AWSBudgetServiceGateway.DescribeNotificationsForBudget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeNotificationsForBudgetRequest(input, context));
@@ -341,7 +341,7 @@ export const serializeAws_json1_1DescribeSubscribersForNotificationCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.DescribeSubscribersForNotification",
+    "x-amz-target": "AWSBudgetServiceGateway.DescribeSubscribersForNotification",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSubscribersForNotificationRequest(input, context));
@@ -354,7 +354,7 @@ export const serializeAws_json1_1ExecuteBudgetActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.ExecuteBudgetAction",
+    "x-amz-target": "AWSBudgetServiceGateway.ExecuteBudgetAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ExecuteBudgetActionRequest(input, context));
@@ -367,7 +367,7 @@ export const serializeAws_json1_1UpdateBudgetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.UpdateBudget",
+    "x-amz-target": "AWSBudgetServiceGateway.UpdateBudget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateBudgetRequest(input, context));
@@ -380,7 +380,7 @@ export const serializeAws_json1_1UpdateBudgetActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.UpdateBudgetAction",
+    "x-amz-target": "AWSBudgetServiceGateway.UpdateBudgetAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateBudgetActionRequest(input, context));
@@ -393,7 +393,7 @@ export const serializeAws_json1_1UpdateNotificationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.UpdateNotification",
+    "x-amz-target": "AWSBudgetServiceGateway.UpdateNotification",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateNotificationRequest(input, context));
@@ -406,7 +406,7 @@ export const serializeAws_json1_1UpdateSubscriberCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSBudgetServiceGateway.UpdateSubscriber",
+    "x-amz-target": "AWSBudgetServiceGateway.UpdateSubscriber",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSubscriberRequest(input, context));

--- a/clients/client-cloud9/protocols/Aws_json1_1.ts
+++ b/clients/client-cloud9/protocols/Aws_json1_1.ts
@@ -92,7 +92,7 @@ export const serializeAws_json1_1CreateEnvironmentEC2Command = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.CreateEnvironmentEC2",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.CreateEnvironmentEC2",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEnvironmentEC2Request(input, context));
@@ -105,7 +105,7 @@ export const serializeAws_json1_1CreateEnvironmentMembershipCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.CreateEnvironmentMembership",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.CreateEnvironmentMembership",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEnvironmentMembershipRequest(input, context));
@@ -118,7 +118,7 @@ export const serializeAws_json1_1DeleteEnvironmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.DeleteEnvironment",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.DeleteEnvironment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEnvironmentRequest(input, context));
@@ -131,7 +131,7 @@ export const serializeAws_json1_1DeleteEnvironmentMembershipCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.DeleteEnvironmentMembership",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.DeleteEnvironmentMembership",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEnvironmentMembershipRequest(input, context));
@@ -144,7 +144,7 @@ export const serializeAws_json1_1DescribeEnvironmentMembershipsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.DescribeEnvironmentMemberships",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.DescribeEnvironmentMemberships",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEnvironmentMembershipsRequest(input, context));
@@ -157,7 +157,7 @@ export const serializeAws_json1_1DescribeEnvironmentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.DescribeEnvironments",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.DescribeEnvironments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEnvironmentsRequest(input, context));
@@ -170,7 +170,7 @@ export const serializeAws_json1_1DescribeEnvironmentStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.DescribeEnvironmentStatus",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.DescribeEnvironmentStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEnvironmentStatusRequest(input, context));
@@ -183,7 +183,7 @@ export const serializeAws_json1_1ListEnvironmentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.ListEnvironments",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.ListEnvironments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEnvironmentsRequest(input, context));
@@ -196,7 +196,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.ListTagsForResource",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -209,7 +209,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.TagResource",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -222,7 +222,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.UntagResource",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -235,7 +235,7 @@ export const serializeAws_json1_1UpdateEnvironmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.UpdateEnvironment",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.UpdateEnvironment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateEnvironmentRequest(input, context));
@@ -248,7 +248,7 @@ export const serializeAws_json1_1UpdateEnvironmentMembershipCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCloud9WorkspaceManagementService.UpdateEnvironmentMembership",
+    "x-amz-target": "AWSCloud9WorkspaceManagementService.UpdateEnvironmentMembership",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateEnvironmentMembershipRequest(input, context));

--- a/clients/client-cloudfront/protocols/Aws_restXml.ts
+++ b/clients/client-cloudfront/protocols/Aws_restXml.ts
@@ -912,7 +912,7 @@ export const serializeAws_restXmlDeleteCachePolicyCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/cache-policy/{Id}";
   if (input.Id !== undefined) {
@@ -942,7 +942,7 @@ export const serializeAws_restXmlDeleteCloudFrontOriginAccessIdentityCommand = a
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/origin-access-identity/cloudfront/{Id}";
   if (input.Id !== undefined) {
@@ -972,7 +972,7 @@ export const serializeAws_restXmlDeleteDistributionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/distribution/{Id}";
   if (input.Id !== undefined) {
@@ -1002,7 +1002,7 @@ export const serializeAws_restXmlDeleteFieldLevelEncryptionConfigCommand = async
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/field-level-encryption/{Id}";
   if (input.Id !== undefined) {
@@ -1032,7 +1032,7 @@ export const serializeAws_restXmlDeleteFieldLevelEncryptionProfileCommand = asyn
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/field-level-encryption-profile/{Id}";
   if (input.Id !== undefined) {
@@ -1062,7 +1062,7 @@ export const serializeAws_restXmlDeleteKeyGroupCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/key-group/{Id}";
   if (input.Id !== undefined) {
@@ -1120,7 +1120,7 @@ export const serializeAws_restXmlDeleteOriginRequestPolicyCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/origin-request-policy/{Id}";
   if (input.Id !== undefined) {
@@ -1150,7 +1150,7 @@ export const serializeAws_restXmlDeletePublicKeyCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/public-key/{Id}";
   if (input.Id !== undefined) {
@@ -1213,7 +1213,7 @@ export const serializeAws_restXmlDeleteStreamingDistributionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/streaming-distribution/{Id}";
   if (input.Id !== undefined) {
@@ -2387,7 +2387,7 @@ export const serializeAws_restXmlUpdateCachePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/cache-policy/{Id}";
   if (input.Id !== undefined) {
@@ -2425,7 +2425,7 @@ export const serializeAws_restXmlUpdateCloudFrontOriginAccessIdentityCommand = a
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/origin-access-identity/cloudfront/{Id}/config";
   if (input.Id !== undefined) {
@@ -2466,7 +2466,7 @@ export const serializeAws_restXmlUpdateDistributionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/distribution/{Id}/config";
   if (input.Id !== undefined) {
@@ -2504,7 +2504,7 @@ export const serializeAws_restXmlUpdateFieldLevelEncryptionConfigCommand = async
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/field-level-encryption/{Id}/config";
   if (input.Id !== undefined) {
@@ -2542,7 +2542,7 @@ export const serializeAws_restXmlUpdateFieldLevelEncryptionProfileCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/field-level-encryption-profile/{Id}/config";
   if (input.Id !== undefined) {
@@ -2580,7 +2580,7 @@ export const serializeAws_restXmlUpdateKeyGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/key-group/{Id}";
   if (input.Id !== undefined) {
@@ -2618,7 +2618,7 @@ export const serializeAws_restXmlUpdateOriginRequestPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/origin-request-policy/{Id}";
   if (input.Id !== undefined) {
@@ -2656,7 +2656,7 @@ export const serializeAws_restXmlUpdatePublicKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/public-key/{Id}/config";
   if (input.Id !== undefined) {
@@ -2747,7 +2747,7 @@ export const serializeAws_restXmlUpdateStreamingDistributionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
   };
   let resolvedPath = "/2020-05-31/streaming-distribution/{Id}/config";
   if (input.Id !== undefined) {

--- a/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm-v2/protocols/Aws_json1_1.ts
@@ -77,7 +77,7 @@ export const serializeAws_json1_1CopyBackupToRegionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.CopyBackupToRegion",
+    "x-amz-target": "BaldrApiService.CopyBackupToRegion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CopyBackupToRegionRequest(input, context));
@@ -90,7 +90,7 @@ export const serializeAws_json1_1CreateClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.CreateCluster",
+    "x-amz-target": "BaldrApiService.CreateCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateClusterRequest(input, context));
@@ -103,7 +103,7 @@ export const serializeAws_json1_1CreateHsmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.CreateHsm",
+    "x-amz-target": "BaldrApiService.CreateHsm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateHsmRequest(input, context));
@@ -116,7 +116,7 @@ export const serializeAws_json1_1DeleteBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.DeleteBackup",
+    "x-amz-target": "BaldrApiService.DeleteBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBackupRequest(input, context));
@@ -129,7 +129,7 @@ export const serializeAws_json1_1DeleteClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.DeleteCluster",
+    "x-amz-target": "BaldrApiService.DeleteCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteClusterRequest(input, context));
@@ -142,7 +142,7 @@ export const serializeAws_json1_1DeleteHsmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.DeleteHsm",
+    "x-amz-target": "BaldrApiService.DeleteHsm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteHsmRequest(input, context));
@@ -155,7 +155,7 @@ export const serializeAws_json1_1DescribeBackupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.DescribeBackups",
+    "x-amz-target": "BaldrApiService.DescribeBackups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBackupsRequest(input, context));
@@ -168,7 +168,7 @@ export const serializeAws_json1_1DescribeClustersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.DescribeClusters",
+    "x-amz-target": "BaldrApiService.DescribeClusters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeClustersRequest(input, context));
@@ -181,7 +181,7 @@ export const serializeAws_json1_1InitializeClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.InitializeCluster",
+    "x-amz-target": "BaldrApiService.InitializeCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1InitializeClusterRequest(input, context));
@@ -194,7 +194,7 @@ export const serializeAws_json1_1ListTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.ListTags",
+    "x-amz-target": "BaldrApiService.ListTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsRequest(input, context));
@@ -207,7 +207,7 @@ export const serializeAws_json1_1ModifyBackupAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.ModifyBackupAttributes",
+    "x-amz-target": "BaldrApiService.ModifyBackupAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyBackupAttributesRequest(input, context));
@@ -220,7 +220,7 @@ export const serializeAws_json1_1ModifyClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.ModifyCluster",
+    "x-amz-target": "BaldrApiService.ModifyCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyClusterRequest(input, context));
@@ -233,7 +233,7 @@ export const serializeAws_json1_1RestoreBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.RestoreBackup",
+    "x-amz-target": "BaldrApiService.RestoreBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RestoreBackupRequest(input, context));
@@ -246,7 +246,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.TagResource",
+    "x-amz-target": "BaldrApiService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -259,7 +259,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "BaldrApiService.UntagResource",
+    "x-amz-target": "BaldrApiService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));

--- a/clients/client-cloudhsm/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudhsm/protocols/Aws_json1_1.ts
@@ -86,7 +86,7 @@ export const serializeAws_json1_1AddTagsToResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.AddTagsToResource",
+    "x-amz-target": "CloudHsmFrontendService.AddTagsToResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsToResourceRequest(input, context));
@@ -99,7 +99,7 @@ export const serializeAws_json1_1CreateHapgCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.CreateHapg",
+    "x-amz-target": "CloudHsmFrontendService.CreateHapg",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateHapgRequest(input, context));
@@ -112,7 +112,7 @@ export const serializeAws_json1_1CreateHsmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.CreateHsm",
+    "x-amz-target": "CloudHsmFrontendService.CreateHsm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateHsmRequest(input, context));
@@ -125,7 +125,7 @@ export const serializeAws_json1_1CreateLunaClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.CreateLunaClient",
+    "x-amz-target": "CloudHsmFrontendService.CreateLunaClient",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLunaClientRequest(input, context));
@@ -138,7 +138,7 @@ export const serializeAws_json1_1DeleteHapgCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.DeleteHapg",
+    "x-amz-target": "CloudHsmFrontendService.DeleteHapg",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteHapgRequest(input, context));
@@ -151,7 +151,7 @@ export const serializeAws_json1_1DeleteHsmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.DeleteHsm",
+    "x-amz-target": "CloudHsmFrontendService.DeleteHsm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteHsmRequest(input, context));
@@ -164,7 +164,7 @@ export const serializeAws_json1_1DeleteLunaClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.DeleteLunaClient",
+    "x-amz-target": "CloudHsmFrontendService.DeleteLunaClient",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLunaClientRequest(input, context));
@@ -177,7 +177,7 @@ export const serializeAws_json1_1DescribeHapgCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.DescribeHapg",
+    "x-amz-target": "CloudHsmFrontendService.DescribeHapg",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeHapgRequest(input, context));
@@ -190,7 +190,7 @@ export const serializeAws_json1_1DescribeHsmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.DescribeHsm",
+    "x-amz-target": "CloudHsmFrontendService.DescribeHsm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeHsmRequest(input, context));
@@ -203,7 +203,7 @@ export const serializeAws_json1_1DescribeLunaClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.DescribeLunaClient",
+    "x-amz-target": "CloudHsmFrontendService.DescribeLunaClient",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLunaClientRequest(input, context));
@@ -216,7 +216,7 @@ export const serializeAws_json1_1GetConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.GetConfig",
+    "x-amz-target": "CloudHsmFrontendService.GetConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetConfigRequest(input, context));
@@ -229,7 +229,7 @@ export const serializeAws_json1_1ListAvailableZonesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.ListAvailableZones",
+    "x-amz-target": "CloudHsmFrontendService.ListAvailableZones",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAvailableZonesRequest(input, context));
@@ -242,7 +242,7 @@ export const serializeAws_json1_1ListHapgsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.ListHapgs",
+    "x-amz-target": "CloudHsmFrontendService.ListHapgs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListHapgsRequest(input, context));
@@ -255,7 +255,7 @@ export const serializeAws_json1_1ListHsmsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.ListHsms",
+    "x-amz-target": "CloudHsmFrontendService.ListHsms",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListHsmsRequest(input, context));
@@ -268,7 +268,7 @@ export const serializeAws_json1_1ListLunaClientsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.ListLunaClients",
+    "x-amz-target": "CloudHsmFrontendService.ListLunaClients",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLunaClientsRequest(input, context));
@@ -281,7 +281,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.ListTagsForResource",
+    "x-amz-target": "CloudHsmFrontendService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -294,7 +294,7 @@ export const serializeAws_json1_1ModifyHapgCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.ModifyHapg",
+    "x-amz-target": "CloudHsmFrontendService.ModifyHapg",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyHapgRequest(input, context));
@@ -307,7 +307,7 @@ export const serializeAws_json1_1ModifyHsmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.ModifyHsm",
+    "x-amz-target": "CloudHsmFrontendService.ModifyHsm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyHsmRequest(input, context));
@@ -320,7 +320,7 @@ export const serializeAws_json1_1ModifyLunaClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.ModifyLunaClient",
+    "x-amz-target": "CloudHsmFrontendService.ModifyLunaClient",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyLunaClientRequest(input, context));
@@ -333,7 +333,7 @@ export const serializeAws_json1_1RemoveTagsFromResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudHsmFrontendService.RemoveTagsFromResource",
+    "x-amz-target": "CloudHsmFrontendService.RemoveTagsFromResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsFromResourceRequest(input, context));

--- a/clients/client-cloudsearch-domain/protocols/Aws_restJson1.ts
+++ b/clients/client-cloudsearch-domain/protocols/Aws_restJson1.ts
@@ -98,7 +98,7 @@ export const serializeAws_restJson1UploadDocumentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/octet-stream",
-    ...(isSerializableHeaderValue(input.contentType) && { "Content-Type": input.contentType! }),
+    ...(isSerializableHeaderValue(input.contentType) && { "content-type": input.contentType! }),
   };
   let resolvedPath = "/2013-01-01/documents/batch";
   const query: any = {

--- a/clients/client-cloudtrail/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudtrail/protocols/Aws_json1_1.ts
@@ -132,7 +132,7 @@ export const serializeAws_json1_1AddTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.AddTags",
+    "x-amz-target": "CloudTrail_20131101.AddTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsRequest(input, context));
@@ -145,7 +145,7 @@ export const serializeAws_json1_1CreateTrailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.CreateTrail",
+    "x-amz-target": "CloudTrail_20131101.CreateTrail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTrailRequest(input, context));
@@ -158,7 +158,7 @@ export const serializeAws_json1_1DeleteTrailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.DeleteTrail",
+    "x-amz-target": "CloudTrail_20131101.DeleteTrail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTrailRequest(input, context));
@@ -171,7 +171,7 @@ export const serializeAws_json1_1DescribeTrailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.DescribeTrails",
+    "x-amz-target": "CloudTrail_20131101.DescribeTrails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTrailsRequest(input, context));
@@ -184,7 +184,7 @@ export const serializeAws_json1_1GetEventSelectorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.GetEventSelectors",
+    "x-amz-target": "CloudTrail_20131101.GetEventSelectors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetEventSelectorsRequest(input, context));
@@ -197,7 +197,7 @@ export const serializeAws_json1_1GetInsightSelectorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.GetInsightSelectors",
+    "x-amz-target": "CloudTrail_20131101.GetInsightSelectors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInsightSelectorsRequest(input, context));
@@ -210,7 +210,7 @@ export const serializeAws_json1_1GetTrailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.GetTrail",
+    "x-amz-target": "CloudTrail_20131101.GetTrail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTrailRequest(input, context));
@@ -223,7 +223,7 @@ export const serializeAws_json1_1GetTrailStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.GetTrailStatus",
+    "x-amz-target": "CloudTrail_20131101.GetTrailStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTrailStatusRequest(input, context));
@@ -236,7 +236,7 @@ export const serializeAws_json1_1ListPublicKeysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.ListPublicKeys",
+    "x-amz-target": "CloudTrail_20131101.ListPublicKeys",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPublicKeysRequest(input, context));
@@ -249,7 +249,7 @@ export const serializeAws_json1_1ListTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.ListTags",
+    "x-amz-target": "CloudTrail_20131101.ListTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsRequest(input, context));
@@ -262,7 +262,7 @@ export const serializeAws_json1_1ListTrailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.ListTrails",
+    "x-amz-target": "CloudTrail_20131101.ListTrails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTrailsRequest(input, context));
@@ -275,7 +275,7 @@ export const serializeAws_json1_1LookupEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.LookupEvents",
+    "x-amz-target": "CloudTrail_20131101.LookupEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1LookupEventsRequest(input, context));
@@ -288,7 +288,7 @@ export const serializeAws_json1_1PutEventSelectorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.PutEventSelectors",
+    "x-amz-target": "CloudTrail_20131101.PutEventSelectors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutEventSelectorsRequest(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_1PutInsightSelectorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.PutInsightSelectors",
+    "x-amz-target": "CloudTrail_20131101.PutInsightSelectors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutInsightSelectorsRequest(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_1RemoveTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.RemoveTags",
+    "x-amz-target": "CloudTrail_20131101.RemoveTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsRequest(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1StartLoggingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.StartLogging",
+    "x-amz-target": "CloudTrail_20131101.StartLogging",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartLoggingRequest(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1StopLoggingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.StopLogging",
+    "x-amz-target": "CloudTrail_20131101.StopLogging",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopLoggingRequest(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1UpdateTrailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CloudTrail_20131101.UpdateTrail",
+    "x-amz-target": "CloudTrail_20131101.UpdateTrail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTrailRequest(input, context));

--- a/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-events/protocols/Aws_json1_1.ts
@@ -200,7 +200,7 @@ export const serializeAws_json1_1ActivateEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ActivateEventSource",
+    "x-amz-target": "AWSEvents.ActivateEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ActivateEventSourceRequest(input, context));
@@ -213,7 +213,7 @@ export const serializeAws_json1_1CancelReplayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.CancelReplay",
+    "x-amz-target": "AWSEvents.CancelReplay",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelReplayRequest(input, context));
@@ -226,7 +226,7 @@ export const serializeAws_json1_1CreateArchiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.CreateArchive",
+    "x-amz-target": "AWSEvents.CreateArchive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateArchiveRequest(input, context));
@@ -239,7 +239,7 @@ export const serializeAws_json1_1CreateEventBusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.CreateEventBus",
+    "x-amz-target": "AWSEvents.CreateEventBus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEventBusRequest(input, context));
@@ -252,7 +252,7 @@ export const serializeAws_json1_1CreatePartnerEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.CreatePartnerEventSource",
+    "x-amz-target": "AWSEvents.CreatePartnerEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePartnerEventSourceRequest(input, context));
@@ -265,7 +265,7 @@ export const serializeAws_json1_1DeactivateEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DeactivateEventSource",
+    "x-amz-target": "AWSEvents.DeactivateEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeactivateEventSourceRequest(input, context));
@@ -278,7 +278,7 @@ export const serializeAws_json1_1DeleteArchiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DeleteArchive",
+    "x-amz-target": "AWSEvents.DeleteArchive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteArchiveRequest(input, context));
@@ -291,7 +291,7 @@ export const serializeAws_json1_1DeleteEventBusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DeleteEventBus",
+    "x-amz-target": "AWSEvents.DeleteEventBus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEventBusRequest(input, context));
@@ -304,7 +304,7 @@ export const serializeAws_json1_1DeletePartnerEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DeletePartnerEventSource",
+    "x-amz-target": "AWSEvents.DeletePartnerEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePartnerEventSourceRequest(input, context));
@@ -317,7 +317,7 @@ export const serializeAws_json1_1DeleteRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DeleteRule",
+    "x-amz-target": "AWSEvents.DeleteRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRuleRequest(input, context));
@@ -330,7 +330,7 @@ export const serializeAws_json1_1DescribeArchiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribeArchive",
+    "x-amz-target": "AWSEvents.DescribeArchive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeArchiveRequest(input, context));
@@ -343,7 +343,7 @@ export const serializeAws_json1_1DescribeEventBusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribeEventBus",
+    "x-amz-target": "AWSEvents.DescribeEventBus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventBusRequest(input, context));
@@ -356,7 +356,7 @@ export const serializeAws_json1_1DescribeEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribeEventSource",
+    "x-amz-target": "AWSEvents.DescribeEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventSourceRequest(input, context));
@@ -369,7 +369,7 @@ export const serializeAws_json1_1DescribePartnerEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribePartnerEventSource",
+    "x-amz-target": "AWSEvents.DescribePartnerEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePartnerEventSourceRequest(input, context));
@@ -382,7 +382,7 @@ export const serializeAws_json1_1DescribeReplayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribeReplay",
+    "x-amz-target": "AWSEvents.DescribeReplay",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReplayRequest(input, context));
@@ -395,7 +395,7 @@ export const serializeAws_json1_1DescribeRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribeRule",
+    "x-amz-target": "AWSEvents.DescribeRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRuleRequest(input, context));
@@ -408,7 +408,7 @@ export const serializeAws_json1_1DisableRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DisableRule",
+    "x-amz-target": "AWSEvents.DisableRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableRuleRequest(input, context));
@@ -421,7 +421,7 @@ export const serializeAws_json1_1EnableRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.EnableRule",
+    "x-amz-target": "AWSEvents.EnableRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableRuleRequest(input, context));
@@ -434,7 +434,7 @@ export const serializeAws_json1_1ListArchivesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListArchives",
+    "x-amz-target": "AWSEvents.ListArchives",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListArchivesRequest(input, context));
@@ -447,7 +447,7 @@ export const serializeAws_json1_1ListEventBusesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListEventBuses",
+    "x-amz-target": "AWSEvents.ListEventBuses",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEventBusesRequest(input, context));
@@ -460,7 +460,7 @@ export const serializeAws_json1_1ListEventSourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListEventSources",
+    "x-amz-target": "AWSEvents.ListEventSources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEventSourcesRequest(input, context));
@@ -473,7 +473,7 @@ export const serializeAws_json1_1ListPartnerEventSourceAccountsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListPartnerEventSourceAccounts",
+    "x-amz-target": "AWSEvents.ListPartnerEventSourceAccounts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPartnerEventSourceAccountsRequest(input, context));
@@ -486,7 +486,7 @@ export const serializeAws_json1_1ListPartnerEventSourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListPartnerEventSources",
+    "x-amz-target": "AWSEvents.ListPartnerEventSources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPartnerEventSourcesRequest(input, context));
@@ -499,7 +499,7 @@ export const serializeAws_json1_1ListReplaysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListReplays",
+    "x-amz-target": "AWSEvents.ListReplays",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListReplaysRequest(input, context));
@@ -512,7 +512,7 @@ export const serializeAws_json1_1ListRuleNamesByTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListRuleNamesByTarget",
+    "x-amz-target": "AWSEvents.ListRuleNamesByTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRuleNamesByTargetRequest(input, context));
@@ -525,7 +525,7 @@ export const serializeAws_json1_1ListRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListRules",
+    "x-amz-target": "AWSEvents.ListRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRulesRequest(input, context));
@@ -538,7 +538,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListTagsForResource",
+    "x-amz-target": "AWSEvents.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -551,7 +551,7 @@ export const serializeAws_json1_1ListTargetsByRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListTargetsByRule",
+    "x-amz-target": "AWSEvents.ListTargetsByRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTargetsByRuleRequest(input, context));
@@ -564,7 +564,7 @@ export const serializeAws_json1_1PutEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.PutEvents",
+    "x-amz-target": "AWSEvents.PutEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutEventsRequest(input, context));
@@ -577,7 +577,7 @@ export const serializeAws_json1_1PutPartnerEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.PutPartnerEvents",
+    "x-amz-target": "AWSEvents.PutPartnerEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutPartnerEventsRequest(input, context));
@@ -590,7 +590,7 @@ export const serializeAws_json1_1PutPermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.PutPermission",
+    "x-amz-target": "AWSEvents.PutPermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutPermissionRequest(input, context));
@@ -603,7 +603,7 @@ export const serializeAws_json1_1PutRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.PutRule",
+    "x-amz-target": "AWSEvents.PutRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRuleRequest(input, context));
@@ -616,7 +616,7 @@ export const serializeAws_json1_1PutTargetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.PutTargets",
+    "x-amz-target": "AWSEvents.PutTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutTargetsRequest(input, context));
@@ -629,7 +629,7 @@ export const serializeAws_json1_1RemovePermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.RemovePermission",
+    "x-amz-target": "AWSEvents.RemovePermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemovePermissionRequest(input, context));
@@ -642,7 +642,7 @@ export const serializeAws_json1_1RemoveTargetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.RemoveTargets",
+    "x-amz-target": "AWSEvents.RemoveTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTargetsRequest(input, context));
@@ -655,7 +655,7 @@ export const serializeAws_json1_1StartReplayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.StartReplay",
+    "x-amz-target": "AWSEvents.StartReplay",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartReplayRequest(input, context));
@@ -668,7 +668,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.TagResource",
+    "x-amz-target": "AWSEvents.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -681,7 +681,7 @@ export const serializeAws_json1_1TestEventPatternCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.TestEventPattern",
+    "x-amz-target": "AWSEvents.TestEventPattern",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TestEventPatternRequest(input, context));
@@ -694,7 +694,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.UntagResource",
+    "x-amz-target": "AWSEvents.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -707,7 +707,7 @@ export const serializeAws_json1_1UpdateArchiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.UpdateArchive",
+    "x-amz-target": "AWSEvents.UpdateArchive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateArchiveRequest(input, context));

--- a/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
+++ b/clients/client-cloudwatch-logs/protocols/Aws_json1_1.ts
@@ -194,7 +194,7 @@ export const serializeAws_json1_1AssociateKmsKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.AssociateKmsKey",
+    "x-amz-target": "Logs_20140328.AssociateKmsKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateKmsKeyRequest(input, context));
@@ -207,7 +207,7 @@ export const serializeAws_json1_1CancelExportTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.CancelExportTask",
+    "x-amz-target": "Logs_20140328.CancelExportTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelExportTaskRequest(input, context));
@@ -220,7 +220,7 @@ export const serializeAws_json1_1CreateExportTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.CreateExportTask",
+    "x-amz-target": "Logs_20140328.CreateExportTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateExportTaskRequest(input, context));
@@ -233,7 +233,7 @@ export const serializeAws_json1_1CreateLogGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.CreateLogGroup",
+    "x-amz-target": "Logs_20140328.CreateLogGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLogGroupRequest(input, context));
@@ -246,7 +246,7 @@ export const serializeAws_json1_1CreateLogStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.CreateLogStream",
+    "x-amz-target": "Logs_20140328.CreateLogStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLogStreamRequest(input, context));
@@ -259,7 +259,7 @@ export const serializeAws_json1_1DeleteDestinationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DeleteDestination",
+    "x-amz-target": "Logs_20140328.DeleteDestination",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDestinationRequest(input, context));
@@ -272,7 +272,7 @@ export const serializeAws_json1_1DeleteLogGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DeleteLogGroup",
+    "x-amz-target": "Logs_20140328.DeleteLogGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLogGroupRequest(input, context));
@@ -285,7 +285,7 @@ export const serializeAws_json1_1DeleteLogStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DeleteLogStream",
+    "x-amz-target": "Logs_20140328.DeleteLogStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLogStreamRequest(input, context));
@@ -298,7 +298,7 @@ export const serializeAws_json1_1DeleteMetricFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DeleteMetricFilter",
+    "x-amz-target": "Logs_20140328.DeleteMetricFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMetricFilterRequest(input, context));
@@ -311,7 +311,7 @@ export const serializeAws_json1_1DeleteQueryDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DeleteQueryDefinition",
+    "x-amz-target": "Logs_20140328.DeleteQueryDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteQueryDefinitionRequest(input, context));
@@ -324,7 +324,7 @@ export const serializeAws_json1_1DeleteResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DeleteResourcePolicy",
+    "x-amz-target": "Logs_20140328.DeleteResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResourcePolicyRequest(input, context));
@@ -337,7 +337,7 @@ export const serializeAws_json1_1DeleteRetentionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DeleteRetentionPolicy",
+    "x-amz-target": "Logs_20140328.DeleteRetentionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRetentionPolicyRequest(input, context));
@@ -350,7 +350,7 @@ export const serializeAws_json1_1DeleteSubscriptionFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DeleteSubscriptionFilter",
+    "x-amz-target": "Logs_20140328.DeleteSubscriptionFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSubscriptionFilterRequest(input, context));
@@ -363,7 +363,7 @@ export const serializeAws_json1_1DescribeDestinationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DescribeDestinations",
+    "x-amz-target": "Logs_20140328.DescribeDestinations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDestinationsRequest(input, context));
@@ -376,7 +376,7 @@ export const serializeAws_json1_1DescribeExportTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DescribeExportTasks",
+    "x-amz-target": "Logs_20140328.DescribeExportTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeExportTasksRequest(input, context));
@@ -389,7 +389,7 @@ export const serializeAws_json1_1DescribeLogGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DescribeLogGroups",
+    "x-amz-target": "Logs_20140328.DescribeLogGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLogGroupsRequest(input, context));
@@ -402,7 +402,7 @@ export const serializeAws_json1_1DescribeLogStreamsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DescribeLogStreams",
+    "x-amz-target": "Logs_20140328.DescribeLogStreams",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLogStreamsRequest(input, context));
@@ -415,7 +415,7 @@ export const serializeAws_json1_1DescribeMetricFiltersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DescribeMetricFilters",
+    "x-amz-target": "Logs_20140328.DescribeMetricFilters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMetricFiltersRequest(input, context));
@@ -428,7 +428,7 @@ export const serializeAws_json1_1DescribeQueriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DescribeQueries",
+    "x-amz-target": "Logs_20140328.DescribeQueries",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeQueriesRequest(input, context));
@@ -441,7 +441,7 @@ export const serializeAws_json1_1DescribeQueryDefinitionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DescribeQueryDefinitions",
+    "x-amz-target": "Logs_20140328.DescribeQueryDefinitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeQueryDefinitionsRequest(input, context));
@@ -454,7 +454,7 @@ export const serializeAws_json1_1DescribeResourcePoliciesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DescribeResourcePolicies",
+    "x-amz-target": "Logs_20140328.DescribeResourcePolicies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeResourcePoliciesRequest(input, context));
@@ -467,7 +467,7 @@ export const serializeAws_json1_1DescribeSubscriptionFiltersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DescribeSubscriptionFilters",
+    "x-amz-target": "Logs_20140328.DescribeSubscriptionFilters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSubscriptionFiltersRequest(input, context));
@@ -480,7 +480,7 @@ export const serializeAws_json1_1DisassociateKmsKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.DisassociateKmsKey",
+    "x-amz-target": "Logs_20140328.DisassociateKmsKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateKmsKeyRequest(input, context));
@@ -493,7 +493,7 @@ export const serializeAws_json1_1FilterLogEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.FilterLogEvents",
+    "x-amz-target": "Logs_20140328.FilterLogEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1FilterLogEventsRequest(input, context));
@@ -506,7 +506,7 @@ export const serializeAws_json1_1GetLogEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.GetLogEvents",
+    "x-amz-target": "Logs_20140328.GetLogEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLogEventsRequest(input, context));
@@ -519,7 +519,7 @@ export const serializeAws_json1_1GetLogGroupFieldsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.GetLogGroupFields",
+    "x-amz-target": "Logs_20140328.GetLogGroupFields",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLogGroupFieldsRequest(input, context));
@@ -532,7 +532,7 @@ export const serializeAws_json1_1GetLogRecordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.GetLogRecord",
+    "x-amz-target": "Logs_20140328.GetLogRecord",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLogRecordRequest(input, context));
@@ -545,7 +545,7 @@ export const serializeAws_json1_1GetQueryResultsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.GetQueryResults",
+    "x-amz-target": "Logs_20140328.GetQueryResults",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetQueryResultsRequest(input, context));
@@ -558,7 +558,7 @@ export const serializeAws_json1_1ListTagsLogGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.ListTagsLogGroup",
+    "x-amz-target": "Logs_20140328.ListTagsLogGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsLogGroupRequest(input, context));
@@ -571,7 +571,7 @@ export const serializeAws_json1_1PutDestinationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.PutDestination",
+    "x-amz-target": "Logs_20140328.PutDestination",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutDestinationRequest(input, context));
@@ -584,7 +584,7 @@ export const serializeAws_json1_1PutDestinationPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.PutDestinationPolicy",
+    "x-amz-target": "Logs_20140328.PutDestinationPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutDestinationPolicyRequest(input, context));
@@ -597,7 +597,7 @@ export const serializeAws_json1_1PutLogEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.PutLogEvents",
+    "x-amz-target": "Logs_20140328.PutLogEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutLogEventsRequest(input, context));
@@ -610,7 +610,7 @@ export const serializeAws_json1_1PutMetricFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.PutMetricFilter",
+    "x-amz-target": "Logs_20140328.PutMetricFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutMetricFilterRequest(input, context));
@@ -623,7 +623,7 @@ export const serializeAws_json1_1PutQueryDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.PutQueryDefinition",
+    "x-amz-target": "Logs_20140328.PutQueryDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutQueryDefinitionRequest(input, context));
@@ -636,7 +636,7 @@ export const serializeAws_json1_1PutResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.PutResourcePolicy",
+    "x-amz-target": "Logs_20140328.PutResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutResourcePolicyRequest(input, context));
@@ -649,7 +649,7 @@ export const serializeAws_json1_1PutRetentionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.PutRetentionPolicy",
+    "x-amz-target": "Logs_20140328.PutRetentionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRetentionPolicyRequest(input, context));
@@ -662,7 +662,7 @@ export const serializeAws_json1_1PutSubscriptionFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.PutSubscriptionFilter",
+    "x-amz-target": "Logs_20140328.PutSubscriptionFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutSubscriptionFilterRequest(input, context));
@@ -675,7 +675,7 @@ export const serializeAws_json1_1StartQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.StartQuery",
+    "x-amz-target": "Logs_20140328.StartQuery",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartQueryRequest(input, context));
@@ -688,7 +688,7 @@ export const serializeAws_json1_1StopQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.StopQuery",
+    "x-amz-target": "Logs_20140328.StopQuery",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopQueryRequest(input, context));
@@ -701,7 +701,7 @@ export const serializeAws_json1_1TagLogGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.TagLogGroup",
+    "x-amz-target": "Logs_20140328.TagLogGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagLogGroupRequest(input, context));
@@ -714,7 +714,7 @@ export const serializeAws_json1_1TestMetricFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.TestMetricFilter",
+    "x-amz-target": "Logs_20140328.TestMetricFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TestMetricFilterRequest(input, context));
@@ -727,7 +727,7 @@ export const serializeAws_json1_1UntagLogGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Logs_20140328.UntagLogGroup",
+    "x-amz-target": "Logs_20140328.UntagLogGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagLogGroupRequest(input, context));

--- a/clients/client-codebuild/protocols/Aws_json1_1.ts
+++ b/clients/client-codebuild/protocols/Aws_json1_1.ts
@@ -249,7 +249,7 @@ export const serializeAws_json1_1BatchDeleteBuildsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.BatchDeleteBuilds",
+    "x-amz-target": "CodeBuild_20161006.BatchDeleteBuilds",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDeleteBuildsInput(input, context));
@@ -262,7 +262,7 @@ export const serializeAws_json1_1BatchGetBuildBatchesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.BatchGetBuildBatches",
+    "x-amz-target": "CodeBuild_20161006.BatchGetBuildBatches",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetBuildBatchesInput(input, context));
@@ -275,7 +275,7 @@ export const serializeAws_json1_1BatchGetBuildsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.BatchGetBuilds",
+    "x-amz-target": "CodeBuild_20161006.BatchGetBuilds",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetBuildsInput(input, context));
@@ -288,7 +288,7 @@ export const serializeAws_json1_1BatchGetProjectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.BatchGetProjects",
+    "x-amz-target": "CodeBuild_20161006.BatchGetProjects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetProjectsInput(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_1BatchGetReportGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.BatchGetReportGroups",
+    "x-amz-target": "CodeBuild_20161006.BatchGetReportGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetReportGroupsInput(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_1BatchGetReportsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.BatchGetReports",
+    "x-amz-target": "CodeBuild_20161006.BatchGetReports",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetReportsInput(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1CreateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.CreateProject",
+    "x-amz-target": "CodeBuild_20161006.CreateProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProjectInput(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1CreateReportGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.CreateReportGroup",
+    "x-amz-target": "CodeBuild_20161006.CreateReportGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateReportGroupInput(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1CreateWebhookCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.CreateWebhook",
+    "x-amz-target": "CodeBuild_20161006.CreateWebhook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWebhookInput(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_1DeleteBuildBatchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.DeleteBuildBatch",
+    "x-amz-target": "CodeBuild_20161006.DeleteBuildBatch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBuildBatchInput(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_1DeleteProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.DeleteProject",
+    "x-amz-target": "CodeBuild_20161006.DeleteProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProjectInput(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_1DeleteReportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.DeleteReport",
+    "x-amz-target": "CodeBuild_20161006.DeleteReport",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteReportInput(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_1DeleteReportGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.DeleteReportGroup",
+    "x-amz-target": "CodeBuild_20161006.DeleteReportGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteReportGroupInput(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_1DeleteResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.DeleteResourcePolicy",
+    "x-amz-target": "CodeBuild_20161006.DeleteResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResourcePolicyInput(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_1DeleteSourceCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.DeleteSourceCredentials",
+    "x-amz-target": "CodeBuild_20161006.DeleteSourceCredentials",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSourceCredentialsInput(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_1DeleteWebhookCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.DeleteWebhook",
+    "x-amz-target": "CodeBuild_20161006.DeleteWebhook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWebhookInput(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_1DescribeCodeCoveragesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.DescribeCodeCoverages",
+    "x-amz-target": "CodeBuild_20161006.DescribeCodeCoverages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCodeCoveragesInput(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_1DescribeTestCasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.DescribeTestCases",
+    "x-amz-target": "CodeBuild_20161006.DescribeTestCases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTestCasesInput(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_1GetReportGroupTrendCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.GetReportGroupTrend",
+    "x-amz-target": "CodeBuild_20161006.GetReportGroupTrend",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetReportGroupTrendInput(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_1GetResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.GetResourcePolicy",
+    "x-amz-target": "CodeBuild_20161006.GetResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResourcePolicyInput(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_1ImportSourceCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ImportSourceCredentials",
+    "x-amz-target": "CodeBuild_20161006.ImportSourceCredentials",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportSourceCredentialsInput(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_1InvalidateProjectCacheCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.InvalidateProjectCache",
+    "x-amz-target": "CodeBuild_20161006.InvalidateProjectCache",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1InvalidateProjectCacheInput(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1ListBuildBatchesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListBuildBatches",
+    "x-amz-target": "CodeBuild_20161006.ListBuildBatches",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBuildBatchesInput(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1ListBuildBatchesForProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListBuildBatchesForProject",
+    "x-amz-target": "CodeBuild_20161006.ListBuildBatchesForProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBuildBatchesForProjectInput(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1ListBuildsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListBuilds",
+    "x-amz-target": "CodeBuild_20161006.ListBuilds",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBuildsInput(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_1ListBuildsForProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListBuildsForProject",
+    "x-amz-target": "CodeBuild_20161006.ListBuildsForProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBuildsForProjectInput(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_1ListCuratedEnvironmentImagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListCuratedEnvironmentImages",
+    "x-amz-target": "CodeBuild_20161006.ListCuratedEnvironmentImages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCuratedEnvironmentImagesInput(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_1ListProjectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListProjects",
+    "x-amz-target": "CodeBuild_20161006.ListProjects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProjectsInput(input, context));
@@ -613,7 +613,7 @@ export const serializeAws_json1_1ListReportGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListReportGroups",
+    "x-amz-target": "CodeBuild_20161006.ListReportGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListReportGroupsInput(input, context));
@@ -626,7 +626,7 @@ export const serializeAws_json1_1ListReportsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListReports",
+    "x-amz-target": "CodeBuild_20161006.ListReports",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListReportsInput(input, context));
@@ -639,7 +639,7 @@ export const serializeAws_json1_1ListReportsForReportGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListReportsForReportGroup",
+    "x-amz-target": "CodeBuild_20161006.ListReportsForReportGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListReportsForReportGroupInput(input, context));
@@ -652,7 +652,7 @@ export const serializeAws_json1_1ListSharedProjectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListSharedProjects",
+    "x-amz-target": "CodeBuild_20161006.ListSharedProjects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSharedProjectsInput(input, context));
@@ -665,7 +665,7 @@ export const serializeAws_json1_1ListSharedReportGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListSharedReportGroups",
+    "x-amz-target": "CodeBuild_20161006.ListSharedReportGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSharedReportGroupsInput(input, context));
@@ -678,7 +678,7 @@ export const serializeAws_json1_1ListSourceCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.ListSourceCredentials",
+    "x-amz-target": "CodeBuild_20161006.ListSourceCredentials",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSourceCredentialsInput(input, context));
@@ -691,7 +691,7 @@ export const serializeAws_json1_1PutResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.PutResourcePolicy",
+    "x-amz-target": "CodeBuild_20161006.PutResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutResourcePolicyInput(input, context));
@@ -704,7 +704,7 @@ export const serializeAws_json1_1RetryBuildCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.RetryBuild",
+    "x-amz-target": "CodeBuild_20161006.RetryBuild",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RetryBuildInput(input, context));
@@ -717,7 +717,7 @@ export const serializeAws_json1_1RetryBuildBatchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.RetryBuildBatch",
+    "x-amz-target": "CodeBuild_20161006.RetryBuildBatch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RetryBuildBatchInput(input, context));
@@ -730,7 +730,7 @@ export const serializeAws_json1_1StartBuildCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.StartBuild",
+    "x-amz-target": "CodeBuild_20161006.StartBuild",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartBuildInput(input, context));
@@ -743,7 +743,7 @@ export const serializeAws_json1_1StartBuildBatchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.StartBuildBatch",
+    "x-amz-target": "CodeBuild_20161006.StartBuildBatch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartBuildBatchInput(input, context));
@@ -756,7 +756,7 @@ export const serializeAws_json1_1StopBuildCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.StopBuild",
+    "x-amz-target": "CodeBuild_20161006.StopBuild",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopBuildInput(input, context));
@@ -769,7 +769,7 @@ export const serializeAws_json1_1StopBuildBatchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.StopBuildBatch",
+    "x-amz-target": "CodeBuild_20161006.StopBuildBatch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopBuildBatchInput(input, context));
@@ -782,7 +782,7 @@ export const serializeAws_json1_1UpdateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.UpdateProject",
+    "x-amz-target": "CodeBuild_20161006.UpdateProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateProjectInput(input, context));
@@ -795,7 +795,7 @@ export const serializeAws_json1_1UpdateReportGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.UpdateReportGroup",
+    "x-amz-target": "CodeBuild_20161006.UpdateReportGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateReportGroupInput(input, context));
@@ -808,7 +808,7 @@ export const serializeAws_json1_1UpdateWebhookCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeBuild_20161006.UpdateWebhook",
+    "x-amz-target": "CodeBuild_20161006.UpdateWebhook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateWebhookInput(input, context));

--- a/clients/client-codecommit/protocols/Aws_json1_1.ts
+++ b/clients/client-codecommit/protocols/Aws_json1_1.ts
@@ -626,7 +626,7 @@ export const serializeAws_json1_1AssociateApprovalRuleTemplateWithRepositoryComm
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.AssociateApprovalRuleTemplateWithRepository",
+    "x-amz-target": "CodeCommit_20150413.AssociateApprovalRuleTemplateWithRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateApprovalRuleTemplateWithRepositoryInput(input, context));
@@ -639,7 +639,7 @@ export const serializeAws_json1_1BatchAssociateApprovalRuleTemplateWithRepositor
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.BatchAssociateApprovalRuleTemplateWithRepositories",
+    "x-amz-target": "CodeCommit_20150413.BatchAssociateApprovalRuleTemplateWithRepositories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchAssociateApprovalRuleTemplateWithRepositoriesInput(input, context));
@@ -652,7 +652,7 @@ export const serializeAws_json1_1BatchDescribeMergeConflictsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.BatchDescribeMergeConflicts",
+    "x-amz-target": "CodeCommit_20150413.BatchDescribeMergeConflicts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDescribeMergeConflictsInput(input, context));
@@ -665,7 +665,7 @@ export const serializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromReposi
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.BatchDisassociateApprovalRuleTemplateFromRepositories",
+    "x-amz-target": "CodeCommit_20150413.BatchDisassociateApprovalRuleTemplateFromRepositories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDisassociateApprovalRuleTemplateFromRepositoriesInput(input, context));
@@ -678,7 +678,7 @@ export const serializeAws_json1_1BatchGetCommitsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.BatchGetCommits",
+    "x-amz-target": "CodeCommit_20150413.BatchGetCommits",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetCommitsInput(input, context));
@@ -691,7 +691,7 @@ export const serializeAws_json1_1BatchGetRepositoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.BatchGetRepositories",
+    "x-amz-target": "CodeCommit_20150413.BatchGetRepositories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetRepositoriesInput(input, context));
@@ -704,7 +704,7 @@ export const serializeAws_json1_1CreateApprovalRuleTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.CreateApprovalRuleTemplate",
+    "x-amz-target": "CodeCommit_20150413.CreateApprovalRuleTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateApprovalRuleTemplateInput(input, context));
@@ -717,7 +717,7 @@ export const serializeAws_json1_1CreateBranchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.CreateBranch",
+    "x-amz-target": "CodeCommit_20150413.CreateBranch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateBranchInput(input, context));
@@ -730,7 +730,7 @@ export const serializeAws_json1_1CreateCommitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.CreateCommit",
+    "x-amz-target": "CodeCommit_20150413.CreateCommit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCommitInput(input, context));
@@ -743,7 +743,7 @@ export const serializeAws_json1_1CreatePullRequestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.CreatePullRequest",
+    "x-amz-target": "CodeCommit_20150413.CreatePullRequest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePullRequestInput(input, context));
@@ -756,7 +756,7 @@ export const serializeAws_json1_1CreatePullRequestApprovalRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.CreatePullRequestApprovalRule",
+    "x-amz-target": "CodeCommit_20150413.CreatePullRequestApprovalRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePullRequestApprovalRuleInput(input, context));
@@ -769,7 +769,7 @@ export const serializeAws_json1_1CreateRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.CreateRepository",
+    "x-amz-target": "CodeCommit_20150413.CreateRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRepositoryInput(input, context));
@@ -782,7 +782,7 @@ export const serializeAws_json1_1CreateUnreferencedMergeCommitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.CreateUnreferencedMergeCommit",
+    "x-amz-target": "CodeCommit_20150413.CreateUnreferencedMergeCommit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUnreferencedMergeCommitInput(input, context));
@@ -795,7 +795,7 @@ export const serializeAws_json1_1DeleteApprovalRuleTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.DeleteApprovalRuleTemplate",
+    "x-amz-target": "CodeCommit_20150413.DeleteApprovalRuleTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApprovalRuleTemplateInput(input, context));
@@ -808,7 +808,7 @@ export const serializeAws_json1_1DeleteBranchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.DeleteBranch",
+    "x-amz-target": "CodeCommit_20150413.DeleteBranch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBranchInput(input, context));
@@ -821,7 +821,7 @@ export const serializeAws_json1_1DeleteCommentContentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.DeleteCommentContent",
+    "x-amz-target": "CodeCommit_20150413.DeleteCommentContent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCommentContentInput(input, context));
@@ -834,7 +834,7 @@ export const serializeAws_json1_1DeleteFileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.DeleteFile",
+    "x-amz-target": "CodeCommit_20150413.DeleteFile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFileInput(input, context));
@@ -847,7 +847,7 @@ export const serializeAws_json1_1DeletePullRequestApprovalRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.DeletePullRequestApprovalRule",
+    "x-amz-target": "CodeCommit_20150413.DeletePullRequestApprovalRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePullRequestApprovalRuleInput(input, context));
@@ -860,7 +860,7 @@ export const serializeAws_json1_1DeleteRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.DeleteRepository",
+    "x-amz-target": "CodeCommit_20150413.DeleteRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRepositoryInput(input, context));
@@ -873,7 +873,7 @@ export const serializeAws_json1_1DescribeMergeConflictsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.DescribeMergeConflicts",
+    "x-amz-target": "CodeCommit_20150413.DescribeMergeConflicts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMergeConflictsInput(input, context));
@@ -886,7 +886,7 @@ export const serializeAws_json1_1DescribePullRequestEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.DescribePullRequestEvents",
+    "x-amz-target": "CodeCommit_20150413.DescribePullRequestEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePullRequestEventsInput(input, context));
@@ -899,7 +899,7 @@ export const serializeAws_json1_1DisassociateApprovalRuleTemplateFromRepositoryC
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.DisassociateApprovalRuleTemplateFromRepository",
+    "x-amz-target": "CodeCommit_20150413.DisassociateApprovalRuleTemplateFromRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateApprovalRuleTemplateFromRepositoryInput(input, context));
@@ -912,7 +912,7 @@ export const serializeAws_json1_1EvaluatePullRequestApprovalRulesCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.EvaluatePullRequestApprovalRules",
+    "x-amz-target": "CodeCommit_20150413.EvaluatePullRequestApprovalRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EvaluatePullRequestApprovalRulesInput(input, context));
@@ -925,7 +925,7 @@ export const serializeAws_json1_1GetApprovalRuleTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetApprovalRuleTemplate",
+    "x-amz-target": "CodeCommit_20150413.GetApprovalRuleTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetApprovalRuleTemplateInput(input, context));
@@ -938,7 +938,7 @@ export const serializeAws_json1_1GetBlobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetBlob",
+    "x-amz-target": "CodeCommit_20150413.GetBlob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetBlobInput(input, context));
@@ -951,7 +951,7 @@ export const serializeAws_json1_1GetBranchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetBranch",
+    "x-amz-target": "CodeCommit_20150413.GetBranch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetBranchInput(input, context));
@@ -964,7 +964,7 @@ export const serializeAws_json1_1GetCommentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetComment",
+    "x-amz-target": "CodeCommit_20150413.GetComment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCommentInput(input, context));
@@ -977,7 +977,7 @@ export const serializeAws_json1_1GetCommentReactionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetCommentReactions",
+    "x-amz-target": "CodeCommit_20150413.GetCommentReactions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCommentReactionsInput(input, context));
@@ -990,7 +990,7 @@ export const serializeAws_json1_1GetCommentsForComparedCommitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetCommentsForComparedCommit",
+    "x-amz-target": "CodeCommit_20150413.GetCommentsForComparedCommit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCommentsForComparedCommitInput(input, context));
@@ -1003,7 +1003,7 @@ export const serializeAws_json1_1GetCommentsForPullRequestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetCommentsForPullRequest",
+    "x-amz-target": "CodeCommit_20150413.GetCommentsForPullRequest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCommentsForPullRequestInput(input, context));
@@ -1016,7 +1016,7 @@ export const serializeAws_json1_1GetCommitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetCommit",
+    "x-amz-target": "CodeCommit_20150413.GetCommit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCommitInput(input, context));
@@ -1029,7 +1029,7 @@ export const serializeAws_json1_1GetDifferencesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetDifferences",
+    "x-amz-target": "CodeCommit_20150413.GetDifferences",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDifferencesInput(input, context));
@@ -1042,7 +1042,7 @@ export const serializeAws_json1_1GetFileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetFile",
+    "x-amz-target": "CodeCommit_20150413.GetFile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetFileInput(input, context));
@@ -1055,7 +1055,7 @@ export const serializeAws_json1_1GetFolderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetFolder",
+    "x-amz-target": "CodeCommit_20150413.GetFolder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetFolderInput(input, context));
@@ -1068,7 +1068,7 @@ export const serializeAws_json1_1GetMergeCommitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetMergeCommit",
+    "x-amz-target": "CodeCommit_20150413.GetMergeCommit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMergeCommitInput(input, context));
@@ -1081,7 +1081,7 @@ export const serializeAws_json1_1GetMergeConflictsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetMergeConflicts",
+    "x-amz-target": "CodeCommit_20150413.GetMergeConflicts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMergeConflictsInput(input, context));
@@ -1094,7 +1094,7 @@ export const serializeAws_json1_1GetMergeOptionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetMergeOptions",
+    "x-amz-target": "CodeCommit_20150413.GetMergeOptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMergeOptionsInput(input, context));
@@ -1107,7 +1107,7 @@ export const serializeAws_json1_1GetPullRequestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetPullRequest",
+    "x-amz-target": "CodeCommit_20150413.GetPullRequest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPullRequestInput(input, context));
@@ -1120,7 +1120,7 @@ export const serializeAws_json1_1GetPullRequestApprovalStatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetPullRequestApprovalStates",
+    "x-amz-target": "CodeCommit_20150413.GetPullRequestApprovalStates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPullRequestApprovalStatesInput(input, context));
@@ -1133,7 +1133,7 @@ export const serializeAws_json1_1GetPullRequestOverrideStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetPullRequestOverrideState",
+    "x-amz-target": "CodeCommit_20150413.GetPullRequestOverrideState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPullRequestOverrideStateInput(input, context));
@@ -1146,7 +1146,7 @@ export const serializeAws_json1_1GetRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetRepository",
+    "x-amz-target": "CodeCommit_20150413.GetRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRepositoryInput(input, context));
@@ -1159,7 +1159,7 @@ export const serializeAws_json1_1GetRepositoryTriggersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.GetRepositoryTriggers",
+    "x-amz-target": "CodeCommit_20150413.GetRepositoryTriggers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRepositoryTriggersInput(input, context));
@@ -1172,7 +1172,7 @@ export const serializeAws_json1_1ListApprovalRuleTemplatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.ListApprovalRuleTemplates",
+    "x-amz-target": "CodeCommit_20150413.ListApprovalRuleTemplates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListApprovalRuleTemplatesInput(input, context));
@@ -1185,7 +1185,7 @@ export const serializeAws_json1_1ListAssociatedApprovalRuleTemplatesForRepositor
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.ListAssociatedApprovalRuleTemplatesForRepository",
+    "x-amz-target": "CodeCommit_20150413.ListAssociatedApprovalRuleTemplatesForRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssociatedApprovalRuleTemplatesForRepositoryInput(input, context));
@@ -1198,7 +1198,7 @@ export const serializeAws_json1_1ListBranchesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.ListBranches",
+    "x-amz-target": "CodeCommit_20150413.ListBranches",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBranchesInput(input, context));
@@ -1211,7 +1211,7 @@ export const serializeAws_json1_1ListPullRequestsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.ListPullRequests",
+    "x-amz-target": "CodeCommit_20150413.ListPullRequests",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPullRequestsInput(input, context));
@@ -1224,7 +1224,7 @@ export const serializeAws_json1_1ListRepositoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.ListRepositories",
+    "x-amz-target": "CodeCommit_20150413.ListRepositories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRepositoriesInput(input, context));
@@ -1237,7 +1237,7 @@ export const serializeAws_json1_1ListRepositoriesForApprovalRuleTemplateCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.ListRepositoriesForApprovalRuleTemplate",
+    "x-amz-target": "CodeCommit_20150413.ListRepositoriesForApprovalRuleTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRepositoriesForApprovalRuleTemplateInput(input, context));
@@ -1250,7 +1250,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.ListTagsForResource",
+    "x-amz-target": "CodeCommit_20150413.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceInput(input, context));
@@ -1263,7 +1263,7 @@ export const serializeAws_json1_1MergeBranchesByFastForwardCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.MergeBranchesByFastForward",
+    "x-amz-target": "CodeCommit_20150413.MergeBranchesByFastForward",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MergeBranchesByFastForwardInput(input, context));
@@ -1276,7 +1276,7 @@ export const serializeAws_json1_1MergeBranchesBySquashCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.MergeBranchesBySquash",
+    "x-amz-target": "CodeCommit_20150413.MergeBranchesBySquash",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MergeBranchesBySquashInput(input, context));
@@ -1289,7 +1289,7 @@ export const serializeAws_json1_1MergeBranchesByThreeWayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.MergeBranchesByThreeWay",
+    "x-amz-target": "CodeCommit_20150413.MergeBranchesByThreeWay",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MergeBranchesByThreeWayInput(input, context));
@@ -1302,7 +1302,7 @@ export const serializeAws_json1_1MergePullRequestByFastForwardCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.MergePullRequestByFastForward",
+    "x-amz-target": "CodeCommit_20150413.MergePullRequestByFastForward",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MergePullRequestByFastForwardInput(input, context));
@@ -1315,7 +1315,7 @@ export const serializeAws_json1_1MergePullRequestBySquashCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.MergePullRequestBySquash",
+    "x-amz-target": "CodeCommit_20150413.MergePullRequestBySquash",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MergePullRequestBySquashInput(input, context));
@@ -1328,7 +1328,7 @@ export const serializeAws_json1_1MergePullRequestByThreeWayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.MergePullRequestByThreeWay",
+    "x-amz-target": "CodeCommit_20150413.MergePullRequestByThreeWay",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MergePullRequestByThreeWayInput(input, context));
@@ -1341,7 +1341,7 @@ export const serializeAws_json1_1OverridePullRequestApprovalRulesCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.OverridePullRequestApprovalRules",
+    "x-amz-target": "CodeCommit_20150413.OverridePullRequestApprovalRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1OverridePullRequestApprovalRulesInput(input, context));
@@ -1354,7 +1354,7 @@ export const serializeAws_json1_1PostCommentForComparedCommitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.PostCommentForComparedCommit",
+    "x-amz-target": "CodeCommit_20150413.PostCommentForComparedCommit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PostCommentForComparedCommitInput(input, context));
@@ -1367,7 +1367,7 @@ export const serializeAws_json1_1PostCommentForPullRequestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.PostCommentForPullRequest",
+    "x-amz-target": "CodeCommit_20150413.PostCommentForPullRequest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PostCommentForPullRequestInput(input, context));
@@ -1380,7 +1380,7 @@ export const serializeAws_json1_1PostCommentReplyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.PostCommentReply",
+    "x-amz-target": "CodeCommit_20150413.PostCommentReply",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PostCommentReplyInput(input, context));
@@ -1393,7 +1393,7 @@ export const serializeAws_json1_1PutCommentReactionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.PutCommentReaction",
+    "x-amz-target": "CodeCommit_20150413.PutCommentReaction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutCommentReactionInput(input, context));
@@ -1406,7 +1406,7 @@ export const serializeAws_json1_1PutFileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.PutFile",
+    "x-amz-target": "CodeCommit_20150413.PutFile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutFileInput(input, context));
@@ -1419,7 +1419,7 @@ export const serializeAws_json1_1PutRepositoryTriggersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.PutRepositoryTriggers",
+    "x-amz-target": "CodeCommit_20150413.PutRepositoryTriggers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRepositoryTriggersInput(input, context));
@@ -1432,7 +1432,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.TagResource",
+    "x-amz-target": "CodeCommit_20150413.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceInput(input, context));
@@ -1445,7 +1445,7 @@ export const serializeAws_json1_1TestRepositoryTriggersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.TestRepositoryTriggers",
+    "x-amz-target": "CodeCommit_20150413.TestRepositoryTriggers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TestRepositoryTriggersInput(input, context));
@@ -1458,7 +1458,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UntagResource",
+    "x-amz-target": "CodeCommit_20150413.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceInput(input, context));
@@ -1471,7 +1471,7 @@ export const serializeAws_json1_1UpdateApprovalRuleTemplateContentCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdateApprovalRuleTemplateContent",
+    "x-amz-target": "CodeCommit_20150413.UpdateApprovalRuleTemplateContent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateApprovalRuleTemplateContentInput(input, context));
@@ -1484,7 +1484,7 @@ export const serializeAws_json1_1UpdateApprovalRuleTemplateDescriptionCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdateApprovalRuleTemplateDescription",
+    "x-amz-target": "CodeCommit_20150413.UpdateApprovalRuleTemplateDescription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateApprovalRuleTemplateDescriptionInput(input, context));
@@ -1497,7 +1497,7 @@ export const serializeAws_json1_1UpdateApprovalRuleTemplateNameCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdateApprovalRuleTemplateName",
+    "x-amz-target": "CodeCommit_20150413.UpdateApprovalRuleTemplateName",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateApprovalRuleTemplateNameInput(input, context));
@@ -1510,7 +1510,7 @@ export const serializeAws_json1_1UpdateCommentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdateComment",
+    "x-amz-target": "CodeCommit_20150413.UpdateComment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCommentInput(input, context));
@@ -1523,7 +1523,7 @@ export const serializeAws_json1_1UpdateDefaultBranchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdateDefaultBranch",
+    "x-amz-target": "CodeCommit_20150413.UpdateDefaultBranch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDefaultBranchInput(input, context));
@@ -1536,7 +1536,7 @@ export const serializeAws_json1_1UpdatePullRequestApprovalRuleContentCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdatePullRequestApprovalRuleContent",
+    "x-amz-target": "CodeCommit_20150413.UpdatePullRequestApprovalRuleContent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePullRequestApprovalRuleContentInput(input, context));
@@ -1549,7 +1549,7 @@ export const serializeAws_json1_1UpdatePullRequestApprovalStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdatePullRequestApprovalState",
+    "x-amz-target": "CodeCommit_20150413.UpdatePullRequestApprovalState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePullRequestApprovalStateInput(input, context));
@@ -1562,7 +1562,7 @@ export const serializeAws_json1_1UpdatePullRequestDescriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdatePullRequestDescription",
+    "x-amz-target": "CodeCommit_20150413.UpdatePullRequestDescription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePullRequestDescriptionInput(input, context));
@@ -1575,7 +1575,7 @@ export const serializeAws_json1_1UpdatePullRequestStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdatePullRequestStatus",
+    "x-amz-target": "CodeCommit_20150413.UpdatePullRequestStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePullRequestStatusInput(input, context));
@@ -1588,7 +1588,7 @@ export const serializeAws_json1_1UpdatePullRequestTitleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdatePullRequestTitle",
+    "x-amz-target": "CodeCommit_20150413.UpdatePullRequestTitle",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePullRequestTitleInput(input, context));
@@ -1601,7 +1601,7 @@ export const serializeAws_json1_1UpdateRepositoryDescriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdateRepositoryDescription",
+    "x-amz-target": "CodeCommit_20150413.UpdateRepositoryDescription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRepositoryDescriptionInput(input, context));
@@ -1614,7 +1614,7 @@ export const serializeAws_json1_1UpdateRepositoryNameCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeCommit_20150413.UpdateRepositoryName",
+    "x-amz-target": "CodeCommit_20150413.UpdateRepositoryName",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRepositoryNameInput(input, context));

--- a/clients/client-codedeploy/protocols/Aws_json1_1.ts
+++ b/clients/client-codedeploy/protocols/Aws_json1_1.ts
@@ -417,7 +417,7 @@ export const serializeAws_json1_1AddTagsToOnPremisesInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.AddTagsToOnPremisesInstances",
+    "x-amz-target": "CodeDeploy_20141006.AddTagsToOnPremisesInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsToOnPremisesInstancesInput(input, context));
@@ -430,7 +430,7 @@ export const serializeAws_json1_1BatchGetApplicationRevisionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.BatchGetApplicationRevisions",
+    "x-amz-target": "CodeDeploy_20141006.BatchGetApplicationRevisions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetApplicationRevisionsInput(input, context));
@@ -443,7 +443,7 @@ export const serializeAws_json1_1BatchGetApplicationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.BatchGetApplications",
+    "x-amz-target": "CodeDeploy_20141006.BatchGetApplications",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetApplicationsInput(input, context));
@@ -456,7 +456,7 @@ export const serializeAws_json1_1BatchGetDeploymentGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.BatchGetDeploymentGroups",
+    "x-amz-target": "CodeDeploy_20141006.BatchGetDeploymentGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetDeploymentGroupsInput(input, context));
@@ -469,7 +469,7 @@ export const serializeAws_json1_1BatchGetDeploymentInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.BatchGetDeploymentInstances",
+    "x-amz-target": "CodeDeploy_20141006.BatchGetDeploymentInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetDeploymentInstancesInput(input, context));
@@ -482,7 +482,7 @@ export const serializeAws_json1_1BatchGetDeploymentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.BatchGetDeployments",
+    "x-amz-target": "CodeDeploy_20141006.BatchGetDeployments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetDeploymentsInput(input, context));
@@ -495,7 +495,7 @@ export const serializeAws_json1_1BatchGetDeploymentTargetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.BatchGetDeploymentTargets",
+    "x-amz-target": "CodeDeploy_20141006.BatchGetDeploymentTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetDeploymentTargetsInput(input, context));
@@ -508,7 +508,7 @@ export const serializeAws_json1_1BatchGetOnPremisesInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.BatchGetOnPremisesInstances",
+    "x-amz-target": "CodeDeploy_20141006.BatchGetOnPremisesInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetOnPremisesInstancesInput(input, context));
@@ -521,7 +521,7 @@ export const serializeAws_json1_1ContinueDeploymentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ContinueDeployment",
+    "x-amz-target": "CodeDeploy_20141006.ContinueDeployment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ContinueDeploymentInput(input, context));
@@ -534,7 +534,7 @@ export const serializeAws_json1_1CreateApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.CreateApplication",
+    "x-amz-target": "CodeDeploy_20141006.CreateApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateApplicationInput(input, context));
@@ -547,7 +547,7 @@ export const serializeAws_json1_1CreateDeploymentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.CreateDeployment",
+    "x-amz-target": "CodeDeploy_20141006.CreateDeployment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDeploymentInput(input, context));
@@ -560,7 +560,7 @@ export const serializeAws_json1_1CreateDeploymentConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.CreateDeploymentConfig",
+    "x-amz-target": "CodeDeploy_20141006.CreateDeploymentConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDeploymentConfigInput(input, context));
@@ -573,7 +573,7 @@ export const serializeAws_json1_1CreateDeploymentGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.CreateDeploymentGroup",
+    "x-amz-target": "CodeDeploy_20141006.CreateDeploymentGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDeploymentGroupInput(input, context));
@@ -586,7 +586,7 @@ export const serializeAws_json1_1DeleteApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.DeleteApplication",
+    "x-amz-target": "CodeDeploy_20141006.DeleteApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationInput(input, context));
@@ -599,7 +599,7 @@ export const serializeAws_json1_1DeleteDeploymentConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.DeleteDeploymentConfig",
+    "x-amz-target": "CodeDeploy_20141006.DeleteDeploymentConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDeploymentConfigInput(input, context));
@@ -612,7 +612,7 @@ export const serializeAws_json1_1DeleteDeploymentGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.DeleteDeploymentGroup",
+    "x-amz-target": "CodeDeploy_20141006.DeleteDeploymentGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDeploymentGroupInput(input, context));
@@ -625,7 +625,7 @@ export const serializeAws_json1_1DeleteGitHubAccountTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.DeleteGitHubAccountToken",
+    "x-amz-target": "CodeDeploy_20141006.DeleteGitHubAccountToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteGitHubAccountTokenInput(input, context));
@@ -638,7 +638,7 @@ export const serializeAws_json1_1DeleteResourcesByExternalIdCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.DeleteResourcesByExternalId",
+    "x-amz-target": "CodeDeploy_20141006.DeleteResourcesByExternalId",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResourcesByExternalIdInput(input, context));
@@ -651,7 +651,7 @@ export const serializeAws_json1_1DeregisterOnPremisesInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.DeregisterOnPremisesInstance",
+    "x-amz-target": "CodeDeploy_20141006.DeregisterOnPremisesInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterOnPremisesInstanceInput(input, context));
@@ -664,7 +664,7 @@ export const serializeAws_json1_1GetApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.GetApplication",
+    "x-amz-target": "CodeDeploy_20141006.GetApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetApplicationInput(input, context));
@@ -677,7 +677,7 @@ export const serializeAws_json1_1GetApplicationRevisionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.GetApplicationRevision",
+    "x-amz-target": "CodeDeploy_20141006.GetApplicationRevision",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetApplicationRevisionInput(input, context));
@@ -690,7 +690,7 @@ export const serializeAws_json1_1GetDeploymentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.GetDeployment",
+    "x-amz-target": "CodeDeploy_20141006.GetDeployment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeploymentInput(input, context));
@@ -703,7 +703,7 @@ export const serializeAws_json1_1GetDeploymentConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.GetDeploymentConfig",
+    "x-amz-target": "CodeDeploy_20141006.GetDeploymentConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeploymentConfigInput(input, context));
@@ -716,7 +716,7 @@ export const serializeAws_json1_1GetDeploymentGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.GetDeploymentGroup",
+    "x-amz-target": "CodeDeploy_20141006.GetDeploymentGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeploymentGroupInput(input, context));
@@ -729,7 +729,7 @@ export const serializeAws_json1_1GetDeploymentInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.GetDeploymentInstance",
+    "x-amz-target": "CodeDeploy_20141006.GetDeploymentInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeploymentInstanceInput(input, context));
@@ -742,7 +742,7 @@ export const serializeAws_json1_1GetDeploymentTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.GetDeploymentTarget",
+    "x-amz-target": "CodeDeploy_20141006.GetDeploymentTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeploymentTargetInput(input, context));
@@ -755,7 +755,7 @@ export const serializeAws_json1_1GetOnPremisesInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.GetOnPremisesInstance",
+    "x-amz-target": "CodeDeploy_20141006.GetOnPremisesInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOnPremisesInstanceInput(input, context));
@@ -768,7 +768,7 @@ export const serializeAws_json1_1ListApplicationRevisionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ListApplicationRevisions",
+    "x-amz-target": "CodeDeploy_20141006.ListApplicationRevisions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListApplicationRevisionsInput(input, context));
@@ -781,7 +781,7 @@ export const serializeAws_json1_1ListApplicationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ListApplications",
+    "x-amz-target": "CodeDeploy_20141006.ListApplications",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListApplicationsInput(input, context));
@@ -794,7 +794,7 @@ export const serializeAws_json1_1ListDeploymentConfigsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ListDeploymentConfigs",
+    "x-amz-target": "CodeDeploy_20141006.ListDeploymentConfigs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDeploymentConfigsInput(input, context));
@@ -807,7 +807,7 @@ export const serializeAws_json1_1ListDeploymentGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ListDeploymentGroups",
+    "x-amz-target": "CodeDeploy_20141006.ListDeploymentGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDeploymentGroupsInput(input, context));
@@ -820,7 +820,7 @@ export const serializeAws_json1_1ListDeploymentInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ListDeploymentInstances",
+    "x-amz-target": "CodeDeploy_20141006.ListDeploymentInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDeploymentInstancesInput(input, context));
@@ -833,7 +833,7 @@ export const serializeAws_json1_1ListDeploymentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ListDeployments",
+    "x-amz-target": "CodeDeploy_20141006.ListDeployments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDeploymentsInput(input, context));
@@ -846,7 +846,7 @@ export const serializeAws_json1_1ListDeploymentTargetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ListDeploymentTargets",
+    "x-amz-target": "CodeDeploy_20141006.ListDeploymentTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDeploymentTargetsInput(input, context));
@@ -859,7 +859,7 @@ export const serializeAws_json1_1ListGitHubAccountTokenNamesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ListGitHubAccountTokenNames",
+    "x-amz-target": "CodeDeploy_20141006.ListGitHubAccountTokenNames",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGitHubAccountTokenNamesInput(input, context));
@@ -872,7 +872,7 @@ export const serializeAws_json1_1ListOnPremisesInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ListOnPremisesInstances",
+    "x-amz-target": "CodeDeploy_20141006.ListOnPremisesInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListOnPremisesInstancesInput(input, context));
@@ -885,7 +885,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.ListTagsForResource",
+    "x-amz-target": "CodeDeploy_20141006.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceInput(input, context));
@@ -898,7 +898,7 @@ export const serializeAws_json1_1PutLifecycleEventHookExecutionStatusCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.PutLifecycleEventHookExecutionStatus",
+    "x-amz-target": "CodeDeploy_20141006.PutLifecycleEventHookExecutionStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutLifecycleEventHookExecutionStatusInput(input, context));
@@ -911,7 +911,7 @@ export const serializeAws_json1_1RegisterApplicationRevisionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.RegisterApplicationRevision",
+    "x-amz-target": "CodeDeploy_20141006.RegisterApplicationRevision",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterApplicationRevisionInput(input, context));
@@ -924,7 +924,7 @@ export const serializeAws_json1_1RegisterOnPremisesInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.RegisterOnPremisesInstance",
+    "x-amz-target": "CodeDeploy_20141006.RegisterOnPremisesInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterOnPremisesInstanceInput(input, context));
@@ -937,7 +937,7 @@ export const serializeAws_json1_1RemoveTagsFromOnPremisesInstancesCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.RemoveTagsFromOnPremisesInstances",
+    "x-amz-target": "CodeDeploy_20141006.RemoveTagsFromOnPremisesInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsFromOnPremisesInstancesInput(input, context));
@@ -950,7 +950,7 @@ export const serializeAws_json1_1SkipWaitTimeForInstanceTerminationCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.SkipWaitTimeForInstanceTermination",
+    "x-amz-target": "CodeDeploy_20141006.SkipWaitTimeForInstanceTermination",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SkipWaitTimeForInstanceTerminationInput(input, context));
@@ -963,7 +963,7 @@ export const serializeAws_json1_1StopDeploymentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.StopDeployment",
+    "x-amz-target": "CodeDeploy_20141006.StopDeployment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopDeploymentInput(input, context));
@@ -976,7 +976,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.TagResource",
+    "x-amz-target": "CodeDeploy_20141006.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceInput(input, context));
@@ -989,7 +989,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.UntagResource",
+    "x-amz-target": "CodeDeploy_20141006.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceInput(input, context));
@@ -1002,7 +1002,7 @@ export const serializeAws_json1_1UpdateApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.UpdateApplication",
+    "x-amz-target": "CodeDeploy_20141006.UpdateApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateApplicationInput(input, context));
@@ -1015,7 +1015,7 @@ export const serializeAws_json1_1UpdateDeploymentGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeDeploy_20141006.UpdateDeploymentGroup",
+    "x-amz-target": "CodeDeploy_20141006.UpdateDeploymentGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDeploymentGroupInput(input, context));

--- a/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
+++ b/clients/client-codeguruprofiler/protocols/Aws_restJson1.ts
@@ -368,7 +368,7 @@ export const serializeAws_restJson1GetProfileCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.accept) && { Accept: input.accept! }),
+    ...(isSerializableHeaderValue(input.accept) && { accept: input.accept! }),
   };
   let resolvedPath = "/profilingGroups/{profilingGroupName}/profile";
   if (input.profilingGroupName !== undefined) {
@@ -443,7 +443,7 @@ export const serializeAws_restJson1PostAgentProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/octet-stream",
-    ...(isSerializableHeaderValue(input.contentType) && { "Content-Type": input.contentType! }),
+    ...(isSerializableHeaderValue(input.contentType) && { "content-type": input.contentType! }),
   };
   let resolvedPath = "/profilingGroups/{profilingGroupName}/agentProfile";
   if (input.profilingGroupName !== undefined) {

--- a/clients/client-codepipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-codepipeline/protocols/Aws_json1_1.ts
@@ -273,7 +273,7 @@ export const serializeAws_json1_1AcknowledgeJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.AcknowledgeJob",
+    "x-amz-target": "CodePipeline_20150709.AcknowledgeJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AcknowledgeJobInput(input, context));
@@ -286,7 +286,7 @@ export const serializeAws_json1_1AcknowledgeThirdPartyJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.AcknowledgeThirdPartyJob",
+    "x-amz-target": "CodePipeline_20150709.AcknowledgeThirdPartyJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AcknowledgeThirdPartyJobInput(input, context));
@@ -299,7 +299,7 @@ export const serializeAws_json1_1CreateCustomActionTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.CreateCustomActionType",
+    "x-amz-target": "CodePipeline_20150709.CreateCustomActionType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCustomActionTypeInput(input, context));
@@ -312,7 +312,7 @@ export const serializeAws_json1_1CreatePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.CreatePipeline",
+    "x-amz-target": "CodePipeline_20150709.CreatePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePipelineInput(input, context));
@@ -325,7 +325,7 @@ export const serializeAws_json1_1DeleteCustomActionTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.DeleteCustomActionType",
+    "x-amz-target": "CodePipeline_20150709.DeleteCustomActionType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCustomActionTypeInput(input, context));
@@ -338,7 +338,7 @@ export const serializeAws_json1_1DeletePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.DeletePipeline",
+    "x-amz-target": "CodePipeline_20150709.DeletePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePipelineInput(input, context));
@@ -351,7 +351,7 @@ export const serializeAws_json1_1DeleteWebhookCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.DeleteWebhook",
+    "x-amz-target": "CodePipeline_20150709.DeleteWebhook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWebhookInput(input, context));
@@ -364,7 +364,7 @@ export const serializeAws_json1_1DeregisterWebhookWithThirdPartyCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.DeregisterWebhookWithThirdParty",
+    "x-amz-target": "CodePipeline_20150709.DeregisterWebhookWithThirdParty",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterWebhookWithThirdPartyInput(input, context));
@@ -377,7 +377,7 @@ export const serializeAws_json1_1DisableStageTransitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.DisableStageTransition",
+    "x-amz-target": "CodePipeline_20150709.DisableStageTransition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableStageTransitionInput(input, context));
@@ -390,7 +390,7 @@ export const serializeAws_json1_1EnableStageTransitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.EnableStageTransition",
+    "x-amz-target": "CodePipeline_20150709.EnableStageTransition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableStageTransitionInput(input, context));
@@ -403,7 +403,7 @@ export const serializeAws_json1_1GetJobDetailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.GetJobDetails",
+    "x-amz-target": "CodePipeline_20150709.GetJobDetails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetJobDetailsInput(input, context));
@@ -416,7 +416,7 @@ export const serializeAws_json1_1GetPipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.GetPipeline",
+    "x-amz-target": "CodePipeline_20150709.GetPipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPipelineInput(input, context));
@@ -429,7 +429,7 @@ export const serializeAws_json1_1GetPipelineExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.GetPipelineExecution",
+    "x-amz-target": "CodePipeline_20150709.GetPipelineExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPipelineExecutionInput(input, context));
@@ -442,7 +442,7 @@ export const serializeAws_json1_1GetPipelineStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.GetPipelineState",
+    "x-amz-target": "CodePipeline_20150709.GetPipelineState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPipelineStateInput(input, context));
@@ -455,7 +455,7 @@ export const serializeAws_json1_1GetThirdPartyJobDetailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.GetThirdPartyJobDetails",
+    "x-amz-target": "CodePipeline_20150709.GetThirdPartyJobDetails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetThirdPartyJobDetailsInput(input, context));
@@ -468,7 +468,7 @@ export const serializeAws_json1_1ListActionExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.ListActionExecutions",
+    "x-amz-target": "CodePipeline_20150709.ListActionExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListActionExecutionsInput(input, context));
@@ -481,7 +481,7 @@ export const serializeAws_json1_1ListActionTypesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.ListActionTypes",
+    "x-amz-target": "CodePipeline_20150709.ListActionTypes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListActionTypesInput(input, context));
@@ -494,7 +494,7 @@ export const serializeAws_json1_1ListPipelineExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.ListPipelineExecutions",
+    "x-amz-target": "CodePipeline_20150709.ListPipelineExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPipelineExecutionsInput(input, context));
@@ -507,7 +507,7 @@ export const serializeAws_json1_1ListPipelinesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.ListPipelines",
+    "x-amz-target": "CodePipeline_20150709.ListPipelines",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPipelinesInput(input, context));
@@ -520,7 +520,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.ListTagsForResource",
+    "x-amz-target": "CodePipeline_20150709.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceInput(input, context));
@@ -533,7 +533,7 @@ export const serializeAws_json1_1ListWebhooksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.ListWebhooks",
+    "x-amz-target": "CodePipeline_20150709.ListWebhooks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListWebhooksInput(input, context));
@@ -546,7 +546,7 @@ export const serializeAws_json1_1PollForJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.PollForJobs",
+    "x-amz-target": "CodePipeline_20150709.PollForJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PollForJobsInput(input, context));
@@ -559,7 +559,7 @@ export const serializeAws_json1_1PollForThirdPartyJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.PollForThirdPartyJobs",
+    "x-amz-target": "CodePipeline_20150709.PollForThirdPartyJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PollForThirdPartyJobsInput(input, context));
@@ -572,7 +572,7 @@ export const serializeAws_json1_1PutActionRevisionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.PutActionRevision",
+    "x-amz-target": "CodePipeline_20150709.PutActionRevision",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutActionRevisionInput(input, context));
@@ -585,7 +585,7 @@ export const serializeAws_json1_1PutApprovalResultCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.PutApprovalResult",
+    "x-amz-target": "CodePipeline_20150709.PutApprovalResult",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutApprovalResultInput(input, context));
@@ -598,7 +598,7 @@ export const serializeAws_json1_1PutJobFailureResultCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.PutJobFailureResult",
+    "x-amz-target": "CodePipeline_20150709.PutJobFailureResult",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutJobFailureResultInput(input, context));
@@ -611,7 +611,7 @@ export const serializeAws_json1_1PutJobSuccessResultCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.PutJobSuccessResult",
+    "x-amz-target": "CodePipeline_20150709.PutJobSuccessResult",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutJobSuccessResultInput(input, context));
@@ -624,7 +624,7 @@ export const serializeAws_json1_1PutThirdPartyJobFailureResultCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.PutThirdPartyJobFailureResult",
+    "x-amz-target": "CodePipeline_20150709.PutThirdPartyJobFailureResult",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutThirdPartyJobFailureResultInput(input, context));
@@ -637,7 +637,7 @@ export const serializeAws_json1_1PutThirdPartyJobSuccessResultCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.PutThirdPartyJobSuccessResult",
+    "x-amz-target": "CodePipeline_20150709.PutThirdPartyJobSuccessResult",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutThirdPartyJobSuccessResultInput(input, context));
@@ -650,7 +650,7 @@ export const serializeAws_json1_1PutWebhookCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.PutWebhook",
+    "x-amz-target": "CodePipeline_20150709.PutWebhook",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutWebhookInput(input, context));
@@ -663,7 +663,7 @@ export const serializeAws_json1_1RegisterWebhookWithThirdPartyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.RegisterWebhookWithThirdParty",
+    "x-amz-target": "CodePipeline_20150709.RegisterWebhookWithThirdParty",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterWebhookWithThirdPartyInput(input, context));
@@ -676,7 +676,7 @@ export const serializeAws_json1_1RetryStageExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.RetryStageExecution",
+    "x-amz-target": "CodePipeline_20150709.RetryStageExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RetryStageExecutionInput(input, context));
@@ -689,7 +689,7 @@ export const serializeAws_json1_1StartPipelineExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.StartPipelineExecution",
+    "x-amz-target": "CodePipeline_20150709.StartPipelineExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartPipelineExecutionInput(input, context));
@@ -702,7 +702,7 @@ export const serializeAws_json1_1StopPipelineExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.StopPipelineExecution",
+    "x-amz-target": "CodePipeline_20150709.StopPipelineExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopPipelineExecutionInput(input, context));
@@ -715,7 +715,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.TagResource",
+    "x-amz-target": "CodePipeline_20150709.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceInput(input, context));
@@ -728,7 +728,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.UntagResource",
+    "x-amz-target": "CodePipeline_20150709.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceInput(input, context));
@@ -741,7 +741,7 @@ export const serializeAws_json1_1UpdatePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodePipeline_20150709.UpdatePipeline",
+    "x-amz-target": "CodePipeline_20150709.UpdatePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePipelineInput(input, context));

--- a/clients/client-codestar-connections/protocols/Aws_json1_0.ts
+++ b/clients/client-codestar-connections/protocols/Aws_json1_0.ts
@@ -64,7 +64,7 @@ export const serializeAws_json1_0CreateConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.CreateConnection",
+    "x-amz-target": "CodeStar_connections_20191201.CreateConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateConnectionInput(input, context));
@@ -77,7 +77,7 @@ export const serializeAws_json1_0CreateHostCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.CreateHost",
+    "x-amz-target": "CodeStar_connections_20191201.CreateHost",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateHostInput(input, context));
@@ -90,7 +90,7 @@ export const serializeAws_json1_0DeleteConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.DeleteConnection",
+    "x-amz-target": "CodeStar_connections_20191201.DeleteConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteConnectionInput(input, context));
@@ -103,7 +103,7 @@ export const serializeAws_json1_0DeleteHostCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.DeleteHost",
+    "x-amz-target": "CodeStar_connections_20191201.DeleteHost",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteHostInput(input, context));
@@ -116,7 +116,7 @@ export const serializeAws_json1_0GetConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.GetConnection",
+    "x-amz-target": "CodeStar_connections_20191201.GetConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetConnectionInput(input, context));
@@ -129,7 +129,7 @@ export const serializeAws_json1_0GetHostCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.GetHost",
+    "x-amz-target": "CodeStar_connections_20191201.GetHost",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetHostInput(input, context));
@@ -142,7 +142,7 @@ export const serializeAws_json1_0ListConnectionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.ListConnections",
+    "x-amz-target": "CodeStar_connections_20191201.ListConnections",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListConnectionsInput(input, context));
@@ -155,7 +155,7 @@ export const serializeAws_json1_0ListHostsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.ListHosts",
+    "x-amz-target": "CodeStar_connections_20191201.ListHosts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListHostsInput(input, context));
@@ -168,7 +168,7 @@ export const serializeAws_json1_0ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.ListTagsForResource",
+    "x-amz-target": "CodeStar_connections_20191201.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListTagsForResourceInput(input, context));
@@ -181,7 +181,7 @@ export const serializeAws_json1_0TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.TagResource",
+    "x-amz-target": "CodeStar_connections_20191201.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0TagResourceInput(input, context));
@@ -194,7 +194,7 @@ export const serializeAws_json1_0UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.UntagResource",
+    "x-amz-target": "CodeStar_connections_20191201.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UntagResourceInput(input, context));
@@ -207,7 +207,7 @@ export const serializeAws_json1_0UpdateHostCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "CodeStar_connections_20191201.UpdateHost",
+    "x-amz-target": "CodeStar_connections_20191201.UpdateHost",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateHostInput(input, context));

--- a/clients/client-codestar/protocols/Aws_json1_1.ts
+++ b/clients/client-codestar/protocols/Aws_json1_1.ts
@@ -105,7 +105,7 @@ export const serializeAws_json1_1AssociateTeamMemberCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.AssociateTeamMember",
+    "x-amz-target": "CodeStar_20170419.AssociateTeamMember",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateTeamMemberRequest(input, context));
@@ -118,7 +118,7 @@ export const serializeAws_json1_1CreateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.CreateProject",
+    "x-amz-target": "CodeStar_20170419.CreateProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProjectRequest(input, context));
@@ -131,7 +131,7 @@ export const serializeAws_json1_1CreateUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.CreateUserProfile",
+    "x-amz-target": "CodeStar_20170419.CreateUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserProfileRequest(input, context));
@@ -144,7 +144,7 @@ export const serializeAws_json1_1DeleteProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.DeleteProject",
+    "x-amz-target": "CodeStar_20170419.DeleteProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProjectRequest(input, context));
@@ -157,7 +157,7 @@ export const serializeAws_json1_1DeleteUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.DeleteUserProfile",
+    "x-amz-target": "CodeStar_20170419.DeleteUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserProfileRequest(input, context));
@@ -170,7 +170,7 @@ export const serializeAws_json1_1DescribeProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.DescribeProject",
+    "x-amz-target": "CodeStar_20170419.DescribeProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProjectRequest(input, context));
@@ -183,7 +183,7 @@ export const serializeAws_json1_1DescribeUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.DescribeUserProfile",
+    "x-amz-target": "CodeStar_20170419.DescribeUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserProfileRequest(input, context));
@@ -196,7 +196,7 @@ export const serializeAws_json1_1DisassociateTeamMemberCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.DisassociateTeamMember",
+    "x-amz-target": "CodeStar_20170419.DisassociateTeamMember",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateTeamMemberRequest(input, context));
@@ -209,7 +209,7 @@ export const serializeAws_json1_1ListProjectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.ListProjects",
+    "x-amz-target": "CodeStar_20170419.ListProjects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProjectsRequest(input, context));
@@ -222,7 +222,7 @@ export const serializeAws_json1_1ListResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.ListResources",
+    "x-amz-target": "CodeStar_20170419.ListResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourcesRequest(input, context));
@@ -235,7 +235,7 @@ export const serializeAws_json1_1ListTagsForProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.ListTagsForProject",
+    "x-amz-target": "CodeStar_20170419.ListTagsForProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForProjectRequest(input, context));
@@ -248,7 +248,7 @@ export const serializeAws_json1_1ListTeamMembersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.ListTeamMembers",
+    "x-amz-target": "CodeStar_20170419.ListTeamMembers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTeamMembersRequest(input, context));
@@ -261,7 +261,7 @@ export const serializeAws_json1_1ListUserProfilesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.ListUserProfiles",
+    "x-amz-target": "CodeStar_20170419.ListUserProfiles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUserProfilesRequest(input, context));
@@ -274,7 +274,7 @@ export const serializeAws_json1_1TagProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.TagProject",
+    "x-amz-target": "CodeStar_20170419.TagProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagProjectRequest(input, context));
@@ -287,7 +287,7 @@ export const serializeAws_json1_1UntagProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.UntagProject",
+    "x-amz-target": "CodeStar_20170419.UntagProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagProjectRequest(input, context));
@@ -300,7 +300,7 @@ export const serializeAws_json1_1UpdateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.UpdateProject",
+    "x-amz-target": "CodeStar_20170419.UpdateProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateProjectRequest(input, context));
@@ -313,7 +313,7 @@ export const serializeAws_json1_1UpdateTeamMemberCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.UpdateTeamMember",
+    "x-amz-target": "CodeStar_20170419.UpdateTeamMember",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTeamMemberRequest(input, context));
@@ -326,7 +326,7 @@ export const serializeAws_json1_1UpdateUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "CodeStar_20170419.UpdateUserProfile",
+    "x-amz-target": "CodeStar_20170419.UpdateUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateUserProfileRequest(input, context));

--- a/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity-provider/protocols/Aws_json1_1.ts
@@ -583,7 +583,7 @@ export const serializeAws_json1_1AddCustomAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AddCustomAttributes",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AddCustomAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddCustomAttributesRequest(input, context));
@@ -596,7 +596,7 @@ export const serializeAws_json1_1AdminAddUserToGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminAddUserToGroup",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminAddUserToGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminAddUserToGroupRequest(input, context));
@@ -609,7 +609,7 @@ export const serializeAws_json1_1AdminConfirmSignUpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminConfirmSignUp",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminConfirmSignUp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminConfirmSignUpRequest(input, context));
@@ -622,7 +622,7 @@ export const serializeAws_json1_1AdminCreateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminCreateUser",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminCreateUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminCreateUserRequest(input, context));
@@ -635,7 +635,7 @@ export const serializeAws_json1_1AdminDeleteUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminDeleteUser",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminDeleteUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminDeleteUserRequest(input, context));
@@ -648,7 +648,7 @@ export const serializeAws_json1_1AdminDeleteUserAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminDeleteUserAttributes",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminDeleteUserAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminDeleteUserAttributesRequest(input, context));
@@ -661,7 +661,7 @@ export const serializeAws_json1_1AdminDisableProviderForUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminDisableProviderForUser",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminDisableProviderForUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminDisableProviderForUserRequest(input, context));
@@ -674,7 +674,7 @@ export const serializeAws_json1_1AdminDisableUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminDisableUser",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminDisableUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminDisableUserRequest(input, context));
@@ -687,7 +687,7 @@ export const serializeAws_json1_1AdminEnableUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminEnableUser",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminEnableUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminEnableUserRequest(input, context));
@@ -700,7 +700,7 @@ export const serializeAws_json1_1AdminForgetDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminForgetDevice",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminForgetDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminForgetDeviceRequest(input, context));
@@ -713,7 +713,7 @@ export const serializeAws_json1_1AdminGetDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminGetDevice",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminGetDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminGetDeviceRequest(input, context));
@@ -726,7 +726,7 @@ export const serializeAws_json1_1AdminGetUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminGetUser",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminGetUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminGetUserRequest(input, context));
@@ -739,7 +739,7 @@ export const serializeAws_json1_1AdminInitiateAuthCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminInitiateAuth",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminInitiateAuth",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminInitiateAuthRequest(input, context));
@@ -752,7 +752,7 @@ export const serializeAws_json1_1AdminLinkProviderForUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminLinkProviderForUser",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminLinkProviderForUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminLinkProviderForUserRequest(input, context));
@@ -765,7 +765,7 @@ export const serializeAws_json1_1AdminListDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminListDevices",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminListDevices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminListDevicesRequest(input, context));
@@ -778,7 +778,7 @@ export const serializeAws_json1_1AdminListGroupsForUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminListGroupsForUser",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminListGroupsForUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminListGroupsForUserRequest(input, context));
@@ -791,7 +791,7 @@ export const serializeAws_json1_1AdminListUserAuthEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminListUserAuthEvents",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminListUserAuthEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminListUserAuthEventsRequest(input, context));
@@ -804,7 +804,7 @@ export const serializeAws_json1_1AdminRemoveUserFromGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminRemoveUserFromGroup",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminRemoveUserFromGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminRemoveUserFromGroupRequest(input, context));
@@ -817,7 +817,7 @@ export const serializeAws_json1_1AdminResetUserPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminResetUserPassword",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminResetUserPassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminResetUserPasswordRequest(input, context));
@@ -830,7 +830,7 @@ export const serializeAws_json1_1AdminRespondToAuthChallengeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminRespondToAuthChallenge",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminRespondToAuthChallenge",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminRespondToAuthChallengeRequest(input, context));
@@ -843,7 +843,7 @@ export const serializeAws_json1_1AdminSetUserMFAPreferenceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminSetUserMFAPreference",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminSetUserMFAPreference",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminSetUserMFAPreferenceRequest(input, context));
@@ -856,7 +856,7 @@ export const serializeAws_json1_1AdminSetUserPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminSetUserPassword",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminSetUserPassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminSetUserPasswordRequest(input, context));
@@ -869,7 +869,7 @@ export const serializeAws_json1_1AdminSetUserSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminSetUserSettings",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminSetUserSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminSetUserSettingsRequest(input, context));
@@ -882,7 +882,7 @@ export const serializeAws_json1_1AdminUpdateAuthEventFeedbackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminUpdateAuthEventFeedback",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminUpdateAuthEventFeedback",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminUpdateAuthEventFeedbackRequest(input, context));
@@ -895,7 +895,7 @@ export const serializeAws_json1_1AdminUpdateDeviceStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminUpdateDeviceStatus",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminUpdateDeviceStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminUpdateDeviceStatusRequest(input, context));
@@ -908,7 +908,7 @@ export const serializeAws_json1_1AdminUpdateUserAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminUpdateUserAttributes",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminUpdateUserAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminUpdateUserAttributesRequest(input, context));
@@ -921,7 +921,7 @@ export const serializeAws_json1_1AdminUserGlobalSignOutCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AdminUserGlobalSignOut",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AdminUserGlobalSignOut",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdminUserGlobalSignOutRequest(input, context));
@@ -934,7 +934,7 @@ export const serializeAws_json1_1AssociateSoftwareTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.AssociateSoftwareToken",
+    "x-amz-target": "AWSCognitoIdentityProviderService.AssociateSoftwareToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateSoftwareTokenRequest(input, context));
@@ -947,7 +947,7 @@ export const serializeAws_json1_1ChangePasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ChangePassword",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ChangePassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ChangePasswordRequest(input, context));
@@ -960,7 +960,7 @@ export const serializeAws_json1_1ConfirmDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmDevice",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ConfirmDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ConfirmDeviceRequest(input, context));
@@ -973,7 +973,7 @@ export const serializeAws_json1_1ConfirmForgotPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmForgotPassword",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ConfirmForgotPassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ConfirmForgotPasswordRequest(input, context));
@@ -986,7 +986,7 @@ export const serializeAws_json1_1ConfirmSignUpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ConfirmSignUp",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ConfirmSignUp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ConfirmSignUpRequest(input, context));
@@ -999,7 +999,7 @@ export const serializeAws_json1_1CreateGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.CreateGroup",
+    "x-amz-target": "AWSCognitoIdentityProviderService.CreateGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGroupRequest(input, context));
@@ -1012,7 +1012,7 @@ export const serializeAws_json1_1CreateIdentityProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.CreateIdentityProvider",
+    "x-amz-target": "AWSCognitoIdentityProviderService.CreateIdentityProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateIdentityProviderRequest(input, context));
@@ -1025,7 +1025,7 @@ export const serializeAws_json1_1CreateResourceServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.CreateResourceServer",
+    "x-amz-target": "AWSCognitoIdentityProviderService.CreateResourceServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateResourceServerRequest(input, context));
@@ -1038,7 +1038,7 @@ export const serializeAws_json1_1CreateUserImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.CreateUserImportJob",
+    "x-amz-target": "AWSCognitoIdentityProviderService.CreateUserImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserImportJobRequest(input, context));
@@ -1051,7 +1051,7 @@ export const serializeAws_json1_1CreateUserPoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.CreateUserPool",
+    "x-amz-target": "AWSCognitoIdentityProviderService.CreateUserPool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserPoolRequest(input, context));
@@ -1064,7 +1064,7 @@ export const serializeAws_json1_1CreateUserPoolClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.CreateUserPoolClient",
+    "x-amz-target": "AWSCognitoIdentityProviderService.CreateUserPoolClient",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserPoolClientRequest(input, context));
@@ -1077,7 +1077,7 @@ export const serializeAws_json1_1CreateUserPoolDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.CreateUserPoolDomain",
+    "x-amz-target": "AWSCognitoIdentityProviderService.CreateUserPoolDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserPoolDomainRequest(input, context));
@@ -1090,7 +1090,7 @@ export const serializeAws_json1_1DeleteGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DeleteGroup",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteGroupRequest(input, context));
@@ -1103,7 +1103,7 @@ export const serializeAws_json1_1DeleteIdentityProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DeleteIdentityProvider",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteIdentityProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteIdentityProviderRequest(input, context));
@@ -1116,7 +1116,7 @@ export const serializeAws_json1_1DeleteResourceServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DeleteResourceServer",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteResourceServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResourceServerRequest(input, context));
@@ -1129,7 +1129,7 @@ export const serializeAws_json1_1DeleteUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DeleteUser",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserRequest(input, context));
@@ -1142,7 +1142,7 @@ export const serializeAws_json1_1DeleteUserAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DeleteUserAttributes",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUserAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserAttributesRequest(input, context));
@@ -1155,7 +1155,7 @@ export const serializeAws_json1_1DeleteUserPoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DeleteUserPool",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUserPool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserPoolRequest(input, context));
@@ -1168,7 +1168,7 @@ export const serializeAws_json1_1DeleteUserPoolClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DeleteUserPoolClient",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUserPoolClient",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserPoolClientRequest(input, context));
@@ -1181,7 +1181,7 @@ export const serializeAws_json1_1DeleteUserPoolDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DeleteUserPoolDomain",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DeleteUserPoolDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserPoolDomainRequest(input, context));
@@ -1194,7 +1194,7 @@ export const serializeAws_json1_1DescribeIdentityProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DescribeIdentityProvider",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeIdentityProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeIdentityProviderRequest(input, context));
@@ -1207,7 +1207,7 @@ export const serializeAws_json1_1DescribeResourceServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DescribeResourceServer",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeResourceServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeResourceServerRequest(input, context));
@@ -1220,7 +1220,7 @@ export const serializeAws_json1_1DescribeRiskConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DescribeRiskConfiguration",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeRiskConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRiskConfigurationRequest(input, context));
@@ -1233,7 +1233,7 @@ export const serializeAws_json1_1DescribeUserImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DescribeUserImportJob",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeUserImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserImportJobRequest(input, context));
@@ -1246,7 +1246,7 @@ export const serializeAws_json1_1DescribeUserPoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DescribeUserPool",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeUserPool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserPoolRequest(input, context));
@@ -1259,7 +1259,7 @@ export const serializeAws_json1_1DescribeUserPoolClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DescribeUserPoolClient",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeUserPoolClient",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserPoolClientRequest(input, context));
@@ -1272,7 +1272,7 @@ export const serializeAws_json1_1DescribeUserPoolDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.DescribeUserPoolDomain",
+    "x-amz-target": "AWSCognitoIdentityProviderService.DescribeUserPoolDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserPoolDomainRequest(input, context));
@@ -1285,7 +1285,7 @@ export const serializeAws_json1_1ForgetDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ForgetDevice",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ForgetDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ForgetDeviceRequest(input, context));
@@ -1298,7 +1298,7 @@ export const serializeAws_json1_1ForgotPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ForgotPassword",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ForgotPassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ForgotPasswordRequest(input, context));
@@ -1311,7 +1311,7 @@ export const serializeAws_json1_1GetCSVHeaderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.GetCSVHeader",
+    "x-amz-target": "AWSCognitoIdentityProviderService.GetCSVHeader",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCSVHeaderRequest(input, context));
@@ -1324,7 +1324,7 @@ export const serializeAws_json1_1GetDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.GetDevice",
+    "x-amz-target": "AWSCognitoIdentityProviderService.GetDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeviceRequest(input, context));
@@ -1337,7 +1337,7 @@ export const serializeAws_json1_1GetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.GetGroup",
+    "x-amz-target": "AWSCognitoIdentityProviderService.GetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetGroupRequest(input, context));
@@ -1350,7 +1350,7 @@ export const serializeAws_json1_1GetIdentityProviderByIdentifierCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.GetIdentityProviderByIdentifier",
+    "x-amz-target": "AWSCognitoIdentityProviderService.GetIdentityProviderByIdentifier",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetIdentityProviderByIdentifierRequest(input, context));
@@ -1363,7 +1363,7 @@ export const serializeAws_json1_1GetSigningCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.GetSigningCertificate",
+    "x-amz-target": "AWSCognitoIdentityProviderService.GetSigningCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSigningCertificateRequest(input, context));
@@ -1376,7 +1376,7 @@ export const serializeAws_json1_1GetUICustomizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.GetUICustomization",
+    "x-amz-target": "AWSCognitoIdentityProviderService.GetUICustomization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetUICustomizationRequest(input, context));
@@ -1389,7 +1389,7 @@ export const serializeAws_json1_1GetUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.GetUser",
+    "x-amz-target": "AWSCognitoIdentityProviderService.GetUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetUserRequest(input, context));
@@ -1402,7 +1402,7 @@ export const serializeAws_json1_1GetUserAttributeVerificationCodeCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.GetUserAttributeVerificationCode",
+    "x-amz-target": "AWSCognitoIdentityProviderService.GetUserAttributeVerificationCode",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetUserAttributeVerificationCodeRequest(input, context));
@@ -1415,7 +1415,7 @@ export const serializeAws_json1_1GetUserPoolMfaConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.GetUserPoolMfaConfig",
+    "x-amz-target": "AWSCognitoIdentityProviderService.GetUserPoolMfaConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetUserPoolMfaConfigRequest(input, context));
@@ -1428,7 +1428,7 @@ export const serializeAws_json1_1GlobalSignOutCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.GlobalSignOut",
+    "x-amz-target": "AWSCognitoIdentityProviderService.GlobalSignOut",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GlobalSignOutRequest(input, context));
@@ -1441,7 +1441,7 @@ export const serializeAws_json1_1InitiateAuthCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.InitiateAuth",
+    "x-amz-target": "AWSCognitoIdentityProviderService.InitiateAuth",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1InitiateAuthRequest(input, context));
@@ -1454,7 +1454,7 @@ export const serializeAws_json1_1ListDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ListDevices",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ListDevices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDevicesRequest(input, context));
@@ -1467,7 +1467,7 @@ export const serializeAws_json1_1ListGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ListGroups",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ListGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGroupsRequest(input, context));
@@ -1480,7 +1480,7 @@ export const serializeAws_json1_1ListIdentityProvidersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ListIdentityProviders",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ListIdentityProviders",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListIdentityProvidersRequest(input, context));
@@ -1493,7 +1493,7 @@ export const serializeAws_json1_1ListResourceServersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ListResourceServers",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ListResourceServers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourceServersRequest(input, context));
@@ -1506,7 +1506,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ListTagsForResource",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -1519,7 +1519,7 @@ export const serializeAws_json1_1ListUserImportJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ListUserImportJobs",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ListUserImportJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUserImportJobsRequest(input, context));
@@ -1532,7 +1532,7 @@ export const serializeAws_json1_1ListUserPoolClientsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ListUserPoolClients",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ListUserPoolClients",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUserPoolClientsRequest(input, context));
@@ -1545,7 +1545,7 @@ export const serializeAws_json1_1ListUserPoolsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ListUserPools",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ListUserPools",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUserPoolsRequest(input, context));
@@ -1558,7 +1558,7 @@ export const serializeAws_json1_1ListUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ListUsers",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ListUsers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUsersRequest(input, context));
@@ -1571,7 +1571,7 @@ export const serializeAws_json1_1ListUsersInGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ListUsersInGroup",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ListUsersInGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUsersInGroupRequest(input, context));
@@ -1584,7 +1584,7 @@ export const serializeAws_json1_1ResendConfirmationCodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.ResendConfirmationCode",
+    "x-amz-target": "AWSCognitoIdentityProviderService.ResendConfirmationCode",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResendConfirmationCodeRequest(input, context));
@@ -1597,7 +1597,7 @@ export const serializeAws_json1_1RespondToAuthChallengeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge",
+    "x-amz-target": "AWSCognitoIdentityProviderService.RespondToAuthChallenge",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RespondToAuthChallengeRequest(input, context));
@@ -1610,7 +1610,7 @@ export const serializeAws_json1_1SetRiskConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.SetRiskConfiguration",
+    "x-amz-target": "AWSCognitoIdentityProviderService.SetRiskConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetRiskConfigurationRequest(input, context));
@@ -1623,7 +1623,7 @@ export const serializeAws_json1_1SetUICustomizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.SetUICustomization",
+    "x-amz-target": "AWSCognitoIdentityProviderService.SetUICustomization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetUICustomizationRequest(input, context));
@@ -1636,7 +1636,7 @@ export const serializeAws_json1_1SetUserMFAPreferenceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.SetUserMFAPreference",
+    "x-amz-target": "AWSCognitoIdentityProviderService.SetUserMFAPreference",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetUserMFAPreferenceRequest(input, context));
@@ -1649,7 +1649,7 @@ export const serializeAws_json1_1SetUserPoolMfaConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.SetUserPoolMfaConfig",
+    "x-amz-target": "AWSCognitoIdentityProviderService.SetUserPoolMfaConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetUserPoolMfaConfigRequest(input, context));
@@ -1662,7 +1662,7 @@ export const serializeAws_json1_1SetUserSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.SetUserSettings",
+    "x-amz-target": "AWSCognitoIdentityProviderService.SetUserSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetUserSettingsRequest(input, context));
@@ -1675,7 +1675,7 @@ export const serializeAws_json1_1SignUpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.SignUp",
+    "x-amz-target": "AWSCognitoIdentityProviderService.SignUp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SignUpRequest(input, context));
@@ -1688,7 +1688,7 @@ export const serializeAws_json1_1StartUserImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.StartUserImportJob",
+    "x-amz-target": "AWSCognitoIdentityProviderService.StartUserImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartUserImportJobRequest(input, context));
@@ -1701,7 +1701,7 @@ export const serializeAws_json1_1StopUserImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.StopUserImportJob",
+    "x-amz-target": "AWSCognitoIdentityProviderService.StopUserImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopUserImportJobRequest(input, context));
@@ -1714,7 +1714,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.TagResource",
+    "x-amz-target": "AWSCognitoIdentityProviderService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -1727,7 +1727,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.UntagResource",
+    "x-amz-target": "AWSCognitoIdentityProviderService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -1740,7 +1740,7 @@ export const serializeAws_json1_1UpdateAuthEventFeedbackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.UpdateAuthEventFeedback",
+    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateAuthEventFeedback",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAuthEventFeedbackRequest(input, context));
@@ -1753,7 +1753,7 @@ export const serializeAws_json1_1UpdateDeviceStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.UpdateDeviceStatus",
+    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateDeviceStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDeviceStatusRequest(input, context));
@@ -1766,7 +1766,7 @@ export const serializeAws_json1_1UpdateGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.UpdateGroup",
+    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGroupRequest(input, context));
@@ -1779,7 +1779,7 @@ export const serializeAws_json1_1UpdateIdentityProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.UpdateIdentityProvider",
+    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateIdentityProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateIdentityProviderRequest(input, context));
@@ -1792,7 +1792,7 @@ export const serializeAws_json1_1UpdateResourceServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.UpdateResourceServer",
+    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateResourceServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateResourceServerRequest(input, context));
@@ -1805,7 +1805,7 @@ export const serializeAws_json1_1UpdateUserAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.UpdateUserAttributes",
+    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateUserAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateUserAttributesRequest(input, context));
@@ -1818,7 +1818,7 @@ export const serializeAws_json1_1UpdateUserPoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.UpdateUserPool",
+    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateUserPool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateUserPoolRequest(input, context));
@@ -1831,7 +1831,7 @@ export const serializeAws_json1_1UpdateUserPoolClientCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.UpdateUserPoolClient",
+    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateUserPoolClient",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateUserPoolClientRequest(input, context));
@@ -1844,7 +1844,7 @@ export const serializeAws_json1_1UpdateUserPoolDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.UpdateUserPoolDomain",
+    "x-amz-target": "AWSCognitoIdentityProviderService.UpdateUserPoolDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateUserPoolDomainRequest(input, context));
@@ -1857,7 +1857,7 @@ export const serializeAws_json1_1VerifySoftwareTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.VerifySoftwareToken",
+    "x-amz-target": "AWSCognitoIdentityProviderService.VerifySoftwareToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1VerifySoftwareTokenRequest(input, context));
@@ -1870,7 +1870,7 @@ export const serializeAws_json1_1VerifyUserAttributeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityProviderService.VerifyUserAttribute",
+    "x-amz-target": "AWSCognitoIdentityProviderService.VerifyUserAttribute",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1VerifyUserAttributeRequest(input, context));

--- a/clients/client-cognito-identity/protocols/Aws_json1_1.ts
+++ b/clients/client-cognito-identity/protocols/Aws_json1_1.ts
@@ -117,7 +117,7 @@ export const serializeAws_json1_1CreateIdentityPoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.CreateIdentityPool",
+    "x-amz-target": "AWSCognitoIdentityService.CreateIdentityPool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateIdentityPoolInput(input, context));
@@ -130,7 +130,7 @@ export const serializeAws_json1_1DeleteIdentitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.DeleteIdentities",
+    "x-amz-target": "AWSCognitoIdentityService.DeleteIdentities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteIdentitiesInput(input, context));
@@ -143,7 +143,7 @@ export const serializeAws_json1_1DeleteIdentityPoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.DeleteIdentityPool",
+    "x-amz-target": "AWSCognitoIdentityService.DeleteIdentityPool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteIdentityPoolInput(input, context));
@@ -156,7 +156,7 @@ export const serializeAws_json1_1DescribeIdentityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.DescribeIdentity",
+    "x-amz-target": "AWSCognitoIdentityService.DescribeIdentity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeIdentityInput(input, context));
@@ -169,7 +169,7 @@ export const serializeAws_json1_1DescribeIdentityPoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.DescribeIdentityPool",
+    "x-amz-target": "AWSCognitoIdentityService.DescribeIdentityPool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeIdentityPoolInput(input, context));
@@ -182,7 +182,7 @@ export const serializeAws_json1_1GetCredentialsForIdentityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.GetCredentialsForIdentity",
+    "x-amz-target": "AWSCognitoIdentityService.GetCredentialsForIdentity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCredentialsForIdentityInput(input, context));
@@ -195,7 +195,7 @@ export const serializeAws_json1_1GetIdCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.GetId",
+    "x-amz-target": "AWSCognitoIdentityService.GetId",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetIdInput(input, context));
@@ -208,7 +208,7 @@ export const serializeAws_json1_1GetIdentityPoolRolesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.GetIdentityPoolRoles",
+    "x-amz-target": "AWSCognitoIdentityService.GetIdentityPoolRoles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetIdentityPoolRolesInput(input, context));
@@ -221,7 +221,7 @@ export const serializeAws_json1_1GetOpenIdTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.GetOpenIdToken",
+    "x-amz-target": "AWSCognitoIdentityService.GetOpenIdToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOpenIdTokenInput(input, context));
@@ -234,7 +234,7 @@ export const serializeAws_json1_1GetOpenIdTokenForDeveloperIdentityCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.GetOpenIdTokenForDeveloperIdentity",
+    "x-amz-target": "AWSCognitoIdentityService.GetOpenIdTokenForDeveloperIdentity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOpenIdTokenForDeveloperIdentityInput(input, context));
@@ -247,7 +247,7 @@ export const serializeAws_json1_1ListIdentitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.ListIdentities",
+    "x-amz-target": "AWSCognitoIdentityService.ListIdentities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListIdentitiesInput(input, context));
@@ -260,7 +260,7 @@ export const serializeAws_json1_1ListIdentityPoolsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.ListIdentityPools",
+    "x-amz-target": "AWSCognitoIdentityService.ListIdentityPools",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListIdentityPoolsInput(input, context));
@@ -273,7 +273,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.ListTagsForResource",
+    "x-amz-target": "AWSCognitoIdentityService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceInput(input, context));
@@ -286,7 +286,7 @@ export const serializeAws_json1_1LookupDeveloperIdentityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.LookupDeveloperIdentity",
+    "x-amz-target": "AWSCognitoIdentityService.LookupDeveloperIdentity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1LookupDeveloperIdentityInput(input, context));
@@ -299,7 +299,7 @@ export const serializeAws_json1_1MergeDeveloperIdentitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.MergeDeveloperIdentities",
+    "x-amz-target": "AWSCognitoIdentityService.MergeDeveloperIdentities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MergeDeveloperIdentitiesInput(input, context));
@@ -312,7 +312,7 @@ export const serializeAws_json1_1SetIdentityPoolRolesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.SetIdentityPoolRoles",
+    "x-amz-target": "AWSCognitoIdentityService.SetIdentityPoolRoles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetIdentityPoolRolesInput(input, context));
@@ -325,7 +325,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.TagResource",
+    "x-amz-target": "AWSCognitoIdentityService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceInput(input, context));
@@ -338,7 +338,7 @@ export const serializeAws_json1_1UnlinkDeveloperIdentityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.UnlinkDeveloperIdentity",
+    "x-amz-target": "AWSCognitoIdentityService.UnlinkDeveloperIdentity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UnlinkDeveloperIdentityInput(input, context));
@@ -351,7 +351,7 @@ export const serializeAws_json1_1UnlinkIdentityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.UnlinkIdentity",
+    "x-amz-target": "AWSCognitoIdentityService.UnlinkIdentity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UnlinkIdentityInput(input, context));
@@ -364,7 +364,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.UntagResource",
+    "x-amz-target": "AWSCognitoIdentityService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceInput(input, context));
@@ -377,7 +377,7 @@ export const serializeAws_json1_1UpdateIdentityPoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSCognitoIdentityService.UpdateIdentityPool",
+    "x-amz-target": "AWSCognitoIdentityService.UpdateIdentityPool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1IdentityPool(input, context));

--- a/clients/client-cognito-sync/protocols/Aws_restJson1.ts
+++ b/clients/client-cognito-sync/protocols/Aws_restJson1.ts
@@ -692,7 +692,7 @@ export const serializeAws_restJson1UpdateRecordsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ClientContext) && { "x-amz-Client-Context": input.ClientContext! }),
+    ...(isSerializableHeaderValue(input.ClientContext) && { "x-amz-client-context": input.ClientContext! }),
   };
   let resolvedPath = "/identitypools/{IdentityPoolId}/identities/{IdentityId}/datasets/{DatasetName}";
   if (input.IdentityPoolId !== undefined) {

--- a/clients/client-comprehend/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehend/protocols/Aws_json1_1.ts
@@ -409,7 +409,7 @@ export const serializeAws_json1_1BatchDetectDominantLanguageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.BatchDetectDominantLanguage",
+    "x-amz-target": "Comprehend_20171127.BatchDetectDominantLanguage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDetectDominantLanguageRequest(input, context));
@@ -422,7 +422,7 @@ export const serializeAws_json1_1BatchDetectEntitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.BatchDetectEntities",
+    "x-amz-target": "Comprehend_20171127.BatchDetectEntities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDetectEntitiesRequest(input, context));
@@ -435,7 +435,7 @@ export const serializeAws_json1_1BatchDetectKeyPhrasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.BatchDetectKeyPhrases",
+    "x-amz-target": "Comprehend_20171127.BatchDetectKeyPhrases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDetectKeyPhrasesRequest(input, context));
@@ -448,7 +448,7 @@ export const serializeAws_json1_1BatchDetectSentimentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.BatchDetectSentiment",
+    "x-amz-target": "Comprehend_20171127.BatchDetectSentiment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDetectSentimentRequest(input, context));
@@ -461,7 +461,7 @@ export const serializeAws_json1_1BatchDetectSyntaxCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.BatchDetectSyntax",
+    "x-amz-target": "Comprehend_20171127.BatchDetectSyntax",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDetectSyntaxRequest(input, context));
@@ -474,7 +474,7 @@ export const serializeAws_json1_1ClassifyDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ClassifyDocument",
+    "x-amz-target": "Comprehend_20171127.ClassifyDocument",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ClassifyDocumentRequest(input, context));
@@ -487,7 +487,7 @@ export const serializeAws_json1_1CreateDocumentClassifierCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.CreateDocumentClassifier",
+    "x-amz-target": "Comprehend_20171127.CreateDocumentClassifier",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDocumentClassifierRequest(input, context));
@@ -500,7 +500,7 @@ export const serializeAws_json1_1CreateEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.CreateEndpoint",
+    "x-amz-target": "Comprehend_20171127.CreateEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEndpointRequest(input, context));
@@ -513,7 +513,7 @@ export const serializeAws_json1_1CreateEntityRecognizerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.CreateEntityRecognizer",
+    "x-amz-target": "Comprehend_20171127.CreateEntityRecognizer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEntityRecognizerRequest(input, context));
@@ -526,7 +526,7 @@ export const serializeAws_json1_1DeleteDocumentClassifierCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DeleteDocumentClassifier",
+    "x-amz-target": "Comprehend_20171127.DeleteDocumentClassifier",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDocumentClassifierRequest(input, context));
@@ -539,7 +539,7 @@ export const serializeAws_json1_1DeleteEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DeleteEndpoint",
+    "x-amz-target": "Comprehend_20171127.DeleteEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEndpointRequest(input, context));
@@ -552,7 +552,7 @@ export const serializeAws_json1_1DeleteEntityRecognizerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DeleteEntityRecognizer",
+    "x-amz-target": "Comprehend_20171127.DeleteEntityRecognizer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEntityRecognizerRequest(input, context));
@@ -565,7 +565,7 @@ export const serializeAws_json1_1DescribeDocumentClassificationJobCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribeDocumentClassificationJob",
+    "x-amz-target": "Comprehend_20171127.DescribeDocumentClassificationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDocumentClassificationJobRequest(input, context));
@@ -578,7 +578,7 @@ export const serializeAws_json1_1DescribeDocumentClassifierCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribeDocumentClassifier",
+    "x-amz-target": "Comprehend_20171127.DescribeDocumentClassifier",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDocumentClassifierRequest(input, context));
@@ -591,7 +591,7 @@ export const serializeAws_json1_1DescribeDominantLanguageDetectionJobCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribeDominantLanguageDetectionJob",
+    "x-amz-target": "Comprehend_20171127.DescribeDominantLanguageDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDominantLanguageDetectionJobRequest(input, context));
@@ -604,7 +604,7 @@ export const serializeAws_json1_1DescribeEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribeEndpoint",
+    "x-amz-target": "Comprehend_20171127.DescribeEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEndpointRequest(input, context));
@@ -617,7 +617,7 @@ export const serializeAws_json1_1DescribeEntitiesDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribeEntitiesDetectionJob",
+    "x-amz-target": "Comprehend_20171127.DescribeEntitiesDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEntitiesDetectionJobRequest(input, context));
@@ -630,7 +630,7 @@ export const serializeAws_json1_1DescribeEntityRecognizerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribeEntityRecognizer",
+    "x-amz-target": "Comprehend_20171127.DescribeEntityRecognizer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEntityRecognizerRequest(input, context));
@@ -643,7 +643,7 @@ export const serializeAws_json1_1DescribeEventsDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribeEventsDetectionJob",
+    "x-amz-target": "Comprehend_20171127.DescribeEventsDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventsDetectionJobRequest(input, context));
@@ -656,7 +656,7 @@ export const serializeAws_json1_1DescribeKeyPhrasesDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribeKeyPhrasesDetectionJob",
+    "x-amz-target": "Comprehend_20171127.DescribeKeyPhrasesDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeKeyPhrasesDetectionJobRequest(input, context));
@@ -669,7 +669,7 @@ export const serializeAws_json1_1DescribePiiEntitiesDetectionJobCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribePiiEntitiesDetectionJob",
+    "x-amz-target": "Comprehend_20171127.DescribePiiEntitiesDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePiiEntitiesDetectionJobRequest(input, context));
@@ -682,7 +682,7 @@ export const serializeAws_json1_1DescribeSentimentDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribeSentimentDetectionJob",
+    "x-amz-target": "Comprehend_20171127.DescribeSentimentDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSentimentDetectionJobRequest(input, context));
@@ -695,7 +695,7 @@ export const serializeAws_json1_1DescribeTopicsDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DescribeTopicsDetectionJob",
+    "x-amz-target": "Comprehend_20171127.DescribeTopicsDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTopicsDetectionJobRequest(input, context));
@@ -708,7 +708,7 @@ export const serializeAws_json1_1DetectDominantLanguageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DetectDominantLanguage",
+    "x-amz-target": "Comprehend_20171127.DetectDominantLanguage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectDominantLanguageRequest(input, context));
@@ -721,7 +721,7 @@ export const serializeAws_json1_1DetectEntitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DetectEntities",
+    "x-amz-target": "Comprehend_20171127.DetectEntities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectEntitiesRequest(input, context));
@@ -734,7 +734,7 @@ export const serializeAws_json1_1DetectKeyPhrasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DetectKeyPhrases",
+    "x-amz-target": "Comprehend_20171127.DetectKeyPhrases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectKeyPhrasesRequest(input, context));
@@ -747,7 +747,7 @@ export const serializeAws_json1_1DetectPiiEntitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DetectPiiEntities",
+    "x-amz-target": "Comprehend_20171127.DetectPiiEntities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectPiiEntitiesRequest(input, context));
@@ -760,7 +760,7 @@ export const serializeAws_json1_1DetectSentimentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DetectSentiment",
+    "x-amz-target": "Comprehend_20171127.DetectSentiment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectSentimentRequest(input, context));
@@ -773,7 +773,7 @@ export const serializeAws_json1_1DetectSyntaxCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.DetectSyntax",
+    "x-amz-target": "Comprehend_20171127.DetectSyntax",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectSyntaxRequest(input, context));
@@ -786,7 +786,7 @@ export const serializeAws_json1_1ListDocumentClassificationJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListDocumentClassificationJobs",
+    "x-amz-target": "Comprehend_20171127.ListDocumentClassificationJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDocumentClassificationJobsRequest(input, context));
@@ -799,7 +799,7 @@ export const serializeAws_json1_1ListDocumentClassifiersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListDocumentClassifiers",
+    "x-amz-target": "Comprehend_20171127.ListDocumentClassifiers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDocumentClassifiersRequest(input, context));
@@ -812,7 +812,7 @@ export const serializeAws_json1_1ListDominantLanguageDetectionJobsCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListDominantLanguageDetectionJobs",
+    "x-amz-target": "Comprehend_20171127.ListDominantLanguageDetectionJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDominantLanguageDetectionJobsRequest(input, context));
@@ -825,7 +825,7 @@ export const serializeAws_json1_1ListEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListEndpoints",
+    "x-amz-target": "Comprehend_20171127.ListEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEndpointsRequest(input, context));
@@ -838,7 +838,7 @@ export const serializeAws_json1_1ListEntitiesDetectionJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListEntitiesDetectionJobs",
+    "x-amz-target": "Comprehend_20171127.ListEntitiesDetectionJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEntitiesDetectionJobsRequest(input, context));
@@ -851,7 +851,7 @@ export const serializeAws_json1_1ListEntityRecognizersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListEntityRecognizers",
+    "x-amz-target": "Comprehend_20171127.ListEntityRecognizers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEntityRecognizersRequest(input, context));
@@ -864,7 +864,7 @@ export const serializeAws_json1_1ListEventsDetectionJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListEventsDetectionJobs",
+    "x-amz-target": "Comprehend_20171127.ListEventsDetectionJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEventsDetectionJobsRequest(input, context));
@@ -877,7 +877,7 @@ export const serializeAws_json1_1ListKeyPhrasesDetectionJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListKeyPhrasesDetectionJobs",
+    "x-amz-target": "Comprehend_20171127.ListKeyPhrasesDetectionJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListKeyPhrasesDetectionJobsRequest(input, context));
@@ -890,7 +890,7 @@ export const serializeAws_json1_1ListPiiEntitiesDetectionJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListPiiEntitiesDetectionJobs",
+    "x-amz-target": "Comprehend_20171127.ListPiiEntitiesDetectionJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPiiEntitiesDetectionJobsRequest(input, context));
@@ -903,7 +903,7 @@ export const serializeAws_json1_1ListSentimentDetectionJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListSentimentDetectionJobs",
+    "x-amz-target": "Comprehend_20171127.ListSentimentDetectionJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSentimentDetectionJobsRequest(input, context));
@@ -916,7 +916,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListTagsForResource",
+    "x-amz-target": "Comprehend_20171127.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -929,7 +929,7 @@ export const serializeAws_json1_1ListTopicsDetectionJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.ListTopicsDetectionJobs",
+    "x-amz-target": "Comprehend_20171127.ListTopicsDetectionJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTopicsDetectionJobsRequest(input, context));
@@ -942,7 +942,7 @@ export const serializeAws_json1_1StartDocumentClassificationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StartDocumentClassificationJob",
+    "x-amz-target": "Comprehend_20171127.StartDocumentClassificationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartDocumentClassificationJobRequest(input, context));
@@ -955,7 +955,7 @@ export const serializeAws_json1_1StartDominantLanguageDetectionJobCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StartDominantLanguageDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StartDominantLanguageDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartDominantLanguageDetectionJobRequest(input, context));
@@ -968,7 +968,7 @@ export const serializeAws_json1_1StartEntitiesDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StartEntitiesDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StartEntitiesDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartEntitiesDetectionJobRequest(input, context));
@@ -981,7 +981,7 @@ export const serializeAws_json1_1StartEventsDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StartEventsDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StartEventsDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartEventsDetectionJobRequest(input, context));
@@ -994,7 +994,7 @@ export const serializeAws_json1_1StartKeyPhrasesDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StartKeyPhrasesDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StartKeyPhrasesDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartKeyPhrasesDetectionJobRequest(input, context));
@@ -1007,7 +1007,7 @@ export const serializeAws_json1_1StartPiiEntitiesDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StartPiiEntitiesDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StartPiiEntitiesDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartPiiEntitiesDetectionJobRequest(input, context));
@@ -1020,7 +1020,7 @@ export const serializeAws_json1_1StartSentimentDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StartSentimentDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StartSentimentDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartSentimentDetectionJobRequest(input, context));
@@ -1033,7 +1033,7 @@ export const serializeAws_json1_1StartTopicsDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StartTopicsDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StartTopicsDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartTopicsDetectionJobRequest(input, context));
@@ -1046,7 +1046,7 @@ export const serializeAws_json1_1StopDominantLanguageDetectionJobCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StopDominantLanguageDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StopDominantLanguageDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopDominantLanguageDetectionJobRequest(input, context));
@@ -1059,7 +1059,7 @@ export const serializeAws_json1_1StopEntitiesDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StopEntitiesDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StopEntitiesDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopEntitiesDetectionJobRequest(input, context));
@@ -1072,7 +1072,7 @@ export const serializeAws_json1_1StopEventsDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StopEventsDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StopEventsDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopEventsDetectionJobRequest(input, context));
@@ -1085,7 +1085,7 @@ export const serializeAws_json1_1StopKeyPhrasesDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StopKeyPhrasesDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StopKeyPhrasesDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopKeyPhrasesDetectionJobRequest(input, context));
@@ -1098,7 +1098,7 @@ export const serializeAws_json1_1StopPiiEntitiesDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StopPiiEntitiesDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StopPiiEntitiesDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopPiiEntitiesDetectionJobRequest(input, context));
@@ -1111,7 +1111,7 @@ export const serializeAws_json1_1StopSentimentDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StopSentimentDetectionJob",
+    "x-amz-target": "Comprehend_20171127.StopSentimentDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopSentimentDetectionJobRequest(input, context));
@@ -1124,7 +1124,7 @@ export const serializeAws_json1_1StopTrainingDocumentClassifierCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StopTrainingDocumentClassifier",
+    "x-amz-target": "Comprehend_20171127.StopTrainingDocumentClassifier",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopTrainingDocumentClassifierRequest(input, context));
@@ -1137,7 +1137,7 @@ export const serializeAws_json1_1StopTrainingEntityRecognizerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.StopTrainingEntityRecognizer",
+    "x-amz-target": "Comprehend_20171127.StopTrainingEntityRecognizer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopTrainingEntityRecognizerRequest(input, context));
@@ -1150,7 +1150,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.TagResource",
+    "x-amz-target": "Comprehend_20171127.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -1163,7 +1163,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.UntagResource",
+    "x-amz-target": "Comprehend_20171127.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -1176,7 +1176,7 @@ export const serializeAws_json1_1UpdateEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Comprehend_20171127.UpdateEndpoint",
+    "x-amz-target": "Comprehend_20171127.UpdateEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateEndpointRequest(input, context));

--- a/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
+++ b/clients/client-comprehendmedical/protocols/Aws_json1_1.ts
@@ -152,7 +152,7 @@ export const serializeAws_json1_1DescribeEntitiesDetectionV2JobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.DescribeEntitiesDetectionV2Job",
+    "x-amz-target": "ComprehendMedical_20181030.DescribeEntitiesDetectionV2Job",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEntitiesDetectionV2JobRequest(input, context));
@@ -165,7 +165,7 @@ export const serializeAws_json1_1DescribeICD10CMInferenceJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.DescribeICD10CMInferenceJob",
+    "x-amz-target": "ComprehendMedical_20181030.DescribeICD10CMInferenceJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeICD10CMInferenceJobRequest(input, context));
@@ -178,7 +178,7 @@ export const serializeAws_json1_1DescribePHIDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.DescribePHIDetectionJob",
+    "x-amz-target": "ComprehendMedical_20181030.DescribePHIDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePHIDetectionJobRequest(input, context));
@@ -191,7 +191,7 @@ export const serializeAws_json1_1DescribeRxNormInferenceJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.DescribeRxNormInferenceJob",
+    "x-amz-target": "ComprehendMedical_20181030.DescribeRxNormInferenceJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRxNormInferenceJobRequest(input, context));
@@ -204,7 +204,7 @@ export const serializeAws_json1_1DetectEntitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.DetectEntities",
+    "x-amz-target": "ComprehendMedical_20181030.DetectEntities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectEntitiesRequest(input, context));
@@ -217,7 +217,7 @@ export const serializeAws_json1_1DetectEntitiesV2Command = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.DetectEntitiesV2",
+    "x-amz-target": "ComprehendMedical_20181030.DetectEntitiesV2",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectEntitiesV2Request(input, context));
@@ -230,7 +230,7 @@ export const serializeAws_json1_1DetectPHICommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.DetectPHI",
+    "x-amz-target": "ComprehendMedical_20181030.DetectPHI",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectPHIRequest(input, context));
@@ -243,7 +243,7 @@ export const serializeAws_json1_1InferICD10CMCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.InferICD10CM",
+    "x-amz-target": "ComprehendMedical_20181030.InferICD10CM",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1InferICD10CMRequest(input, context));
@@ -256,7 +256,7 @@ export const serializeAws_json1_1InferRxNormCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.InferRxNorm",
+    "x-amz-target": "ComprehendMedical_20181030.InferRxNorm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1InferRxNormRequest(input, context));
@@ -269,7 +269,7 @@ export const serializeAws_json1_1ListEntitiesDetectionV2JobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.ListEntitiesDetectionV2Jobs",
+    "x-amz-target": "ComprehendMedical_20181030.ListEntitiesDetectionV2Jobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEntitiesDetectionV2JobsRequest(input, context));
@@ -282,7 +282,7 @@ export const serializeAws_json1_1ListICD10CMInferenceJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.ListICD10CMInferenceJobs",
+    "x-amz-target": "ComprehendMedical_20181030.ListICD10CMInferenceJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListICD10CMInferenceJobsRequest(input, context));
@@ -295,7 +295,7 @@ export const serializeAws_json1_1ListPHIDetectionJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.ListPHIDetectionJobs",
+    "x-amz-target": "ComprehendMedical_20181030.ListPHIDetectionJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPHIDetectionJobsRequest(input, context));
@@ -308,7 +308,7 @@ export const serializeAws_json1_1ListRxNormInferenceJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.ListRxNormInferenceJobs",
+    "x-amz-target": "ComprehendMedical_20181030.ListRxNormInferenceJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRxNormInferenceJobsRequest(input, context));
@@ -321,7 +321,7 @@ export const serializeAws_json1_1StartEntitiesDetectionV2JobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.StartEntitiesDetectionV2Job",
+    "x-amz-target": "ComprehendMedical_20181030.StartEntitiesDetectionV2Job",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartEntitiesDetectionV2JobRequest(input, context));
@@ -334,7 +334,7 @@ export const serializeAws_json1_1StartICD10CMInferenceJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.StartICD10CMInferenceJob",
+    "x-amz-target": "ComprehendMedical_20181030.StartICD10CMInferenceJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartICD10CMInferenceJobRequest(input, context));
@@ -347,7 +347,7 @@ export const serializeAws_json1_1StartPHIDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.StartPHIDetectionJob",
+    "x-amz-target": "ComprehendMedical_20181030.StartPHIDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartPHIDetectionJobRequest(input, context));
@@ -360,7 +360,7 @@ export const serializeAws_json1_1StartRxNormInferenceJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.StartRxNormInferenceJob",
+    "x-amz-target": "ComprehendMedical_20181030.StartRxNormInferenceJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartRxNormInferenceJobRequest(input, context));
@@ -373,7 +373,7 @@ export const serializeAws_json1_1StopEntitiesDetectionV2JobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.StopEntitiesDetectionV2Job",
+    "x-amz-target": "ComprehendMedical_20181030.StopEntitiesDetectionV2Job",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopEntitiesDetectionV2JobRequest(input, context));
@@ -386,7 +386,7 @@ export const serializeAws_json1_1StopICD10CMInferenceJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.StopICD10CMInferenceJob",
+    "x-amz-target": "ComprehendMedical_20181030.StopICD10CMInferenceJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopICD10CMInferenceJobRequest(input, context));
@@ -399,7 +399,7 @@ export const serializeAws_json1_1StopPHIDetectionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.StopPHIDetectionJob",
+    "x-amz-target": "ComprehendMedical_20181030.StopPHIDetectionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopPHIDetectionJobRequest(input, context));
@@ -412,7 +412,7 @@ export const serializeAws_json1_1StopRxNormInferenceJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ComprehendMedical_20181030.StopRxNormInferenceJob",
+    "x-amz-target": "ComprehendMedical_20181030.StopRxNormInferenceJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopRxNormInferenceJobRequest(input, context));

--- a/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
+++ b/clients/client-compute-optimizer/protocols/Aws_json1_0.ts
@@ -110,7 +110,7 @@ export const serializeAws_json1_0DescribeRecommendationExportJobsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "ComputeOptimizerService.DescribeRecommendationExportJobs",
+    "x-amz-target": "ComputeOptimizerService.DescribeRecommendationExportJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeRecommendationExportJobsRequest(input, context));
@@ -123,7 +123,7 @@ export const serializeAws_json1_0ExportAutoScalingGroupRecommendationsCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "ComputeOptimizerService.ExportAutoScalingGroupRecommendations",
+    "x-amz-target": "ComputeOptimizerService.ExportAutoScalingGroupRecommendations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ExportAutoScalingGroupRecommendationsRequest(input, context));
@@ -136,7 +136,7 @@ export const serializeAws_json1_0ExportEC2InstanceRecommendationsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "ComputeOptimizerService.ExportEC2InstanceRecommendations",
+    "x-amz-target": "ComputeOptimizerService.ExportEC2InstanceRecommendations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ExportEC2InstanceRecommendationsRequest(input, context));
@@ -149,7 +149,7 @@ export const serializeAws_json1_0GetAutoScalingGroupRecommendationsCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "ComputeOptimizerService.GetAutoScalingGroupRecommendations",
+    "x-amz-target": "ComputeOptimizerService.GetAutoScalingGroupRecommendations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetAutoScalingGroupRecommendationsRequest(input, context));
@@ -162,7 +162,7 @@ export const serializeAws_json1_0GetEBSVolumeRecommendationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "ComputeOptimizerService.GetEBSVolumeRecommendations",
+    "x-amz-target": "ComputeOptimizerService.GetEBSVolumeRecommendations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetEBSVolumeRecommendationsRequest(input, context));
@@ -175,7 +175,7 @@ export const serializeAws_json1_0GetEC2InstanceRecommendationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "ComputeOptimizerService.GetEC2InstanceRecommendations",
+    "x-amz-target": "ComputeOptimizerService.GetEC2InstanceRecommendations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetEC2InstanceRecommendationsRequest(input, context));
@@ -188,7 +188,7 @@ export const serializeAws_json1_0GetEC2RecommendationProjectedMetricsCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "ComputeOptimizerService.GetEC2RecommendationProjectedMetrics",
+    "x-amz-target": "ComputeOptimizerService.GetEC2RecommendationProjectedMetrics",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetEC2RecommendationProjectedMetricsRequest(input, context));
@@ -201,7 +201,7 @@ export const serializeAws_json1_0GetEnrollmentStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "ComputeOptimizerService.GetEnrollmentStatus",
+    "x-amz-target": "ComputeOptimizerService.GetEnrollmentStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetEnrollmentStatusRequest(input, context));
@@ -214,7 +214,7 @@ export const serializeAws_json1_0GetRecommendationSummariesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "ComputeOptimizerService.GetRecommendationSummaries",
+    "x-amz-target": "ComputeOptimizerService.GetRecommendationSummaries",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetRecommendationSummariesRequest(input, context));
@@ -227,7 +227,7 @@ export const serializeAws_json1_0UpdateEnrollmentStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "ComputeOptimizerService.UpdateEnrollmentStatus",
+    "x-amz-target": "ComputeOptimizerService.UpdateEnrollmentStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateEnrollmentStatusRequest(input, context));

--- a/clients/client-config-service/protocols/Aws_json1_1.ts
+++ b/clients/client-config-service/protocols/Aws_json1_1.ts
@@ -580,7 +580,7 @@ export const serializeAws_json1_1BatchGetAggregateResourceConfigCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.BatchGetAggregateResourceConfig",
+    "x-amz-target": "StarlingDoveService.BatchGetAggregateResourceConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetAggregateResourceConfigRequest(input, context));
@@ -593,7 +593,7 @@ export const serializeAws_json1_1BatchGetResourceConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.BatchGetResourceConfig",
+    "x-amz-target": "StarlingDoveService.BatchGetResourceConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetResourceConfigRequest(input, context));
@@ -606,7 +606,7 @@ export const serializeAws_json1_1DeleteAggregationAuthorizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteAggregationAuthorization",
+    "x-amz-target": "StarlingDoveService.DeleteAggregationAuthorization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAggregationAuthorizationRequest(input, context));
@@ -619,7 +619,7 @@ export const serializeAws_json1_1DeleteConfigRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteConfigRule",
+    "x-amz-target": "StarlingDoveService.DeleteConfigRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConfigRuleRequest(input, context));
@@ -632,7 +632,7 @@ export const serializeAws_json1_1DeleteConfigurationAggregatorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteConfigurationAggregator",
+    "x-amz-target": "StarlingDoveService.DeleteConfigurationAggregator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConfigurationAggregatorRequest(input, context));
@@ -645,7 +645,7 @@ export const serializeAws_json1_1DeleteConfigurationRecorderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteConfigurationRecorder",
+    "x-amz-target": "StarlingDoveService.DeleteConfigurationRecorder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConfigurationRecorderRequest(input, context));
@@ -658,7 +658,7 @@ export const serializeAws_json1_1DeleteConformancePackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteConformancePack",
+    "x-amz-target": "StarlingDoveService.DeleteConformancePack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConformancePackRequest(input, context));
@@ -671,7 +671,7 @@ export const serializeAws_json1_1DeleteDeliveryChannelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteDeliveryChannel",
+    "x-amz-target": "StarlingDoveService.DeleteDeliveryChannel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDeliveryChannelRequest(input, context));
@@ -684,7 +684,7 @@ export const serializeAws_json1_1DeleteEvaluationResultsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteEvaluationResults",
+    "x-amz-target": "StarlingDoveService.DeleteEvaluationResults",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEvaluationResultsRequest(input, context));
@@ -697,7 +697,7 @@ export const serializeAws_json1_1DeleteOrganizationConfigRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteOrganizationConfigRule",
+    "x-amz-target": "StarlingDoveService.DeleteOrganizationConfigRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteOrganizationConfigRuleRequest(input, context));
@@ -710,7 +710,7 @@ export const serializeAws_json1_1DeleteOrganizationConformancePackCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteOrganizationConformancePack",
+    "x-amz-target": "StarlingDoveService.DeleteOrganizationConformancePack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteOrganizationConformancePackRequest(input, context));
@@ -723,7 +723,7 @@ export const serializeAws_json1_1DeletePendingAggregationRequestCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeletePendingAggregationRequest",
+    "x-amz-target": "StarlingDoveService.DeletePendingAggregationRequest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePendingAggregationRequestRequest(input, context));
@@ -736,7 +736,7 @@ export const serializeAws_json1_1DeleteRemediationConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteRemediationConfiguration",
+    "x-amz-target": "StarlingDoveService.DeleteRemediationConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRemediationConfigurationRequest(input, context));
@@ -749,7 +749,7 @@ export const serializeAws_json1_1DeleteRemediationExceptionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteRemediationExceptions",
+    "x-amz-target": "StarlingDoveService.DeleteRemediationExceptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRemediationExceptionsRequest(input, context));
@@ -762,7 +762,7 @@ export const serializeAws_json1_1DeleteResourceConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteResourceConfig",
+    "x-amz-target": "StarlingDoveService.DeleteResourceConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResourceConfigRequest(input, context));
@@ -775,7 +775,7 @@ export const serializeAws_json1_1DeleteRetentionConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeleteRetentionConfiguration",
+    "x-amz-target": "StarlingDoveService.DeleteRetentionConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRetentionConfigurationRequest(input, context));
@@ -788,7 +788,7 @@ export const serializeAws_json1_1DeliverConfigSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DeliverConfigSnapshot",
+    "x-amz-target": "StarlingDoveService.DeliverConfigSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeliverConfigSnapshotRequest(input, context));
@@ -801,7 +801,7 @@ export const serializeAws_json1_1DescribeAggregateComplianceByConfigRulesCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeAggregateComplianceByConfigRules",
+    "x-amz-target": "StarlingDoveService.DescribeAggregateComplianceByConfigRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAggregateComplianceByConfigRulesRequest(input, context));
@@ -814,7 +814,7 @@ export const serializeAws_json1_1DescribeAggregationAuthorizationsCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeAggregationAuthorizations",
+    "x-amz-target": "StarlingDoveService.DescribeAggregationAuthorizations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAggregationAuthorizationsRequest(input, context));
@@ -827,7 +827,7 @@ export const serializeAws_json1_1DescribeComplianceByConfigRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeComplianceByConfigRule",
+    "x-amz-target": "StarlingDoveService.DescribeComplianceByConfigRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeComplianceByConfigRuleRequest(input, context));
@@ -840,7 +840,7 @@ export const serializeAws_json1_1DescribeComplianceByResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeComplianceByResource",
+    "x-amz-target": "StarlingDoveService.DescribeComplianceByResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeComplianceByResourceRequest(input, context));
@@ -853,7 +853,7 @@ export const serializeAws_json1_1DescribeConfigRuleEvaluationStatusCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeConfigRuleEvaluationStatus",
+    "x-amz-target": "StarlingDoveService.DescribeConfigRuleEvaluationStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConfigRuleEvaluationStatusRequest(input, context));
@@ -866,7 +866,7 @@ export const serializeAws_json1_1DescribeConfigRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeConfigRules",
+    "x-amz-target": "StarlingDoveService.DescribeConfigRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConfigRulesRequest(input, context));
@@ -879,7 +879,7 @@ export const serializeAws_json1_1DescribeConfigurationAggregatorsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeConfigurationAggregators",
+    "x-amz-target": "StarlingDoveService.DescribeConfigurationAggregators",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConfigurationAggregatorsRequest(input, context));
@@ -892,7 +892,7 @@ export const serializeAws_json1_1DescribeConfigurationAggregatorSourcesStatusCom
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeConfigurationAggregatorSourcesStatus",
+    "x-amz-target": "StarlingDoveService.DescribeConfigurationAggregatorSourcesStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConfigurationAggregatorSourcesStatusRequest(input, context));
@@ -905,7 +905,7 @@ export const serializeAws_json1_1DescribeConfigurationRecordersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeConfigurationRecorders",
+    "x-amz-target": "StarlingDoveService.DescribeConfigurationRecorders",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConfigurationRecordersRequest(input, context));
@@ -918,7 +918,7 @@ export const serializeAws_json1_1DescribeConfigurationRecorderStatusCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeConfigurationRecorderStatus",
+    "x-amz-target": "StarlingDoveService.DescribeConfigurationRecorderStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConfigurationRecorderStatusRequest(input, context));
@@ -931,7 +931,7 @@ export const serializeAws_json1_1DescribeConformancePackComplianceCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeConformancePackCompliance",
+    "x-amz-target": "StarlingDoveService.DescribeConformancePackCompliance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConformancePackComplianceRequest(input, context));
@@ -944,7 +944,7 @@ export const serializeAws_json1_1DescribeConformancePacksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeConformancePacks",
+    "x-amz-target": "StarlingDoveService.DescribeConformancePacks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConformancePacksRequest(input, context));
@@ -957,7 +957,7 @@ export const serializeAws_json1_1DescribeConformancePackStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeConformancePackStatus",
+    "x-amz-target": "StarlingDoveService.DescribeConformancePackStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConformancePackStatusRequest(input, context));
@@ -970,7 +970,7 @@ export const serializeAws_json1_1DescribeDeliveryChannelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeDeliveryChannels",
+    "x-amz-target": "StarlingDoveService.DescribeDeliveryChannels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDeliveryChannelsRequest(input, context));
@@ -983,7 +983,7 @@ export const serializeAws_json1_1DescribeDeliveryChannelStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeDeliveryChannelStatus",
+    "x-amz-target": "StarlingDoveService.DescribeDeliveryChannelStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDeliveryChannelStatusRequest(input, context));
@@ -996,7 +996,7 @@ export const serializeAws_json1_1DescribeOrganizationConfigRulesCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeOrganizationConfigRules",
+    "x-amz-target": "StarlingDoveService.DescribeOrganizationConfigRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeOrganizationConfigRulesRequest(input, context));
@@ -1009,7 +1009,7 @@ export const serializeAws_json1_1DescribeOrganizationConfigRuleStatusesCommand =
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeOrganizationConfigRuleStatuses",
+    "x-amz-target": "StarlingDoveService.DescribeOrganizationConfigRuleStatuses",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeOrganizationConfigRuleStatusesRequest(input, context));
@@ -1022,7 +1022,7 @@ export const serializeAws_json1_1DescribeOrganizationConformancePacksCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeOrganizationConformancePacks",
+    "x-amz-target": "StarlingDoveService.DescribeOrganizationConformancePacks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeOrganizationConformancePacksRequest(input, context));
@@ -1035,7 +1035,7 @@ export const serializeAws_json1_1DescribeOrganizationConformancePackStatusesComm
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeOrganizationConformancePackStatuses",
+    "x-amz-target": "StarlingDoveService.DescribeOrganizationConformancePackStatuses",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeOrganizationConformancePackStatusesRequest(input, context));
@@ -1048,7 +1048,7 @@ export const serializeAws_json1_1DescribePendingAggregationRequestsCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribePendingAggregationRequests",
+    "x-amz-target": "StarlingDoveService.DescribePendingAggregationRequests",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePendingAggregationRequestsRequest(input, context));
@@ -1061,7 +1061,7 @@ export const serializeAws_json1_1DescribeRemediationConfigurationsCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeRemediationConfigurations",
+    "x-amz-target": "StarlingDoveService.DescribeRemediationConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRemediationConfigurationsRequest(input, context));
@@ -1074,7 +1074,7 @@ export const serializeAws_json1_1DescribeRemediationExceptionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeRemediationExceptions",
+    "x-amz-target": "StarlingDoveService.DescribeRemediationExceptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRemediationExceptionsRequest(input, context));
@@ -1087,7 +1087,7 @@ export const serializeAws_json1_1DescribeRemediationExecutionStatusCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeRemediationExecutionStatus",
+    "x-amz-target": "StarlingDoveService.DescribeRemediationExecutionStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRemediationExecutionStatusRequest(input, context));
@@ -1100,7 +1100,7 @@ export const serializeAws_json1_1DescribeRetentionConfigurationsCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.DescribeRetentionConfigurations",
+    "x-amz-target": "StarlingDoveService.DescribeRetentionConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRetentionConfigurationsRequest(input, context));
@@ -1113,7 +1113,7 @@ export const serializeAws_json1_1GetAggregateComplianceDetailsByConfigRuleComman
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetAggregateComplianceDetailsByConfigRule",
+    "x-amz-target": "StarlingDoveService.GetAggregateComplianceDetailsByConfigRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAggregateComplianceDetailsByConfigRuleRequest(input, context));
@@ -1126,7 +1126,7 @@ export const serializeAws_json1_1GetAggregateConfigRuleComplianceSummaryCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetAggregateConfigRuleComplianceSummary",
+    "x-amz-target": "StarlingDoveService.GetAggregateConfigRuleComplianceSummary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAggregateConfigRuleComplianceSummaryRequest(input, context));
@@ -1139,7 +1139,7 @@ export const serializeAws_json1_1GetAggregateDiscoveredResourceCountsCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetAggregateDiscoveredResourceCounts",
+    "x-amz-target": "StarlingDoveService.GetAggregateDiscoveredResourceCounts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAggregateDiscoveredResourceCountsRequest(input, context));
@@ -1152,7 +1152,7 @@ export const serializeAws_json1_1GetAggregateResourceConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetAggregateResourceConfig",
+    "x-amz-target": "StarlingDoveService.GetAggregateResourceConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAggregateResourceConfigRequest(input, context));
@@ -1165,7 +1165,7 @@ export const serializeAws_json1_1GetComplianceDetailsByConfigRuleCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetComplianceDetailsByConfigRule",
+    "x-amz-target": "StarlingDoveService.GetComplianceDetailsByConfigRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetComplianceDetailsByConfigRuleRequest(input, context));
@@ -1178,7 +1178,7 @@ export const serializeAws_json1_1GetComplianceDetailsByResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetComplianceDetailsByResource",
+    "x-amz-target": "StarlingDoveService.GetComplianceDetailsByResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetComplianceDetailsByResourceRequest(input, context));
@@ -1191,7 +1191,7 @@ export const serializeAws_json1_1GetComplianceSummaryByConfigRuleCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetComplianceSummaryByConfigRule",
+    "x-amz-target": "StarlingDoveService.GetComplianceSummaryByConfigRule",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -1202,7 +1202,7 @@ export const serializeAws_json1_1GetComplianceSummaryByResourceTypeCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetComplianceSummaryByResourceType",
+    "x-amz-target": "StarlingDoveService.GetComplianceSummaryByResourceType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetComplianceSummaryByResourceTypeRequest(input, context));
@@ -1215,7 +1215,7 @@ export const serializeAws_json1_1GetConformancePackComplianceDetailsCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetConformancePackComplianceDetails",
+    "x-amz-target": "StarlingDoveService.GetConformancePackComplianceDetails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetConformancePackComplianceDetailsRequest(input, context));
@@ -1228,7 +1228,7 @@ export const serializeAws_json1_1GetConformancePackComplianceSummaryCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetConformancePackComplianceSummary",
+    "x-amz-target": "StarlingDoveService.GetConformancePackComplianceSummary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetConformancePackComplianceSummaryRequest(input, context));
@@ -1241,7 +1241,7 @@ export const serializeAws_json1_1GetDiscoveredResourceCountsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetDiscoveredResourceCounts",
+    "x-amz-target": "StarlingDoveService.GetDiscoveredResourceCounts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDiscoveredResourceCountsRequest(input, context));
@@ -1254,7 +1254,7 @@ export const serializeAws_json1_1GetOrganizationConfigRuleDetailedStatusCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetOrganizationConfigRuleDetailedStatus",
+    "x-amz-target": "StarlingDoveService.GetOrganizationConfigRuleDetailedStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOrganizationConfigRuleDetailedStatusRequest(input, context));
@@ -1267,7 +1267,7 @@ export const serializeAws_json1_1GetOrganizationConformancePackDetailedStatusCom
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetOrganizationConformancePackDetailedStatus",
+    "x-amz-target": "StarlingDoveService.GetOrganizationConformancePackDetailedStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOrganizationConformancePackDetailedStatusRequest(input, context));
@@ -1280,7 +1280,7 @@ export const serializeAws_json1_1GetResourceConfigHistoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.GetResourceConfigHistory",
+    "x-amz-target": "StarlingDoveService.GetResourceConfigHistory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResourceConfigHistoryRequest(input, context));
@@ -1293,7 +1293,7 @@ export const serializeAws_json1_1ListAggregateDiscoveredResourcesCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.ListAggregateDiscoveredResources",
+    "x-amz-target": "StarlingDoveService.ListAggregateDiscoveredResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAggregateDiscoveredResourcesRequest(input, context));
@@ -1306,7 +1306,7 @@ export const serializeAws_json1_1ListDiscoveredResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.ListDiscoveredResources",
+    "x-amz-target": "StarlingDoveService.ListDiscoveredResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDiscoveredResourcesRequest(input, context));
@@ -1319,7 +1319,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.ListTagsForResource",
+    "x-amz-target": "StarlingDoveService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -1332,7 +1332,7 @@ export const serializeAws_json1_1PutAggregationAuthorizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutAggregationAuthorization",
+    "x-amz-target": "StarlingDoveService.PutAggregationAuthorization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAggregationAuthorizationRequest(input, context));
@@ -1345,7 +1345,7 @@ export const serializeAws_json1_1PutConfigRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutConfigRule",
+    "x-amz-target": "StarlingDoveService.PutConfigRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutConfigRuleRequest(input, context));
@@ -1358,7 +1358,7 @@ export const serializeAws_json1_1PutConfigurationAggregatorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutConfigurationAggregator",
+    "x-amz-target": "StarlingDoveService.PutConfigurationAggregator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutConfigurationAggregatorRequest(input, context));
@@ -1371,7 +1371,7 @@ export const serializeAws_json1_1PutConfigurationRecorderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutConfigurationRecorder",
+    "x-amz-target": "StarlingDoveService.PutConfigurationRecorder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutConfigurationRecorderRequest(input, context));
@@ -1384,7 +1384,7 @@ export const serializeAws_json1_1PutConformancePackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutConformancePack",
+    "x-amz-target": "StarlingDoveService.PutConformancePack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutConformancePackRequest(input, context));
@@ -1397,7 +1397,7 @@ export const serializeAws_json1_1PutDeliveryChannelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutDeliveryChannel",
+    "x-amz-target": "StarlingDoveService.PutDeliveryChannel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutDeliveryChannelRequest(input, context));
@@ -1410,7 +1410,7 @@ export const serializeAws_json1_1PutEvaluationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutEvaluations",
+    "x-amz-target": "StarlingDoveService.PutEvaluations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutEvaluationsRequest(input, context));
@@ -1423,7 +1423,7 @@ export const serializeAws_json1_1PutOrganizationConfigRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutOrganizationConfigRule",
+    "x-amz-target": "StarlingDoveService.PutOrganizationConfigRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutOrganizationConfigRuleRequest(input, context));
@@ -1436,7 +1436,7 @@ export const serializeAws_json1_1PutOrganizationConformancePackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutOrganizationConformancePack",
+    "x-amz-target": "StarlingDoveService.PutOrganizationConformancePack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutOrganizationConformancePackRequest(input, context));
@@ -1449,7 +1449,7 @@ export const serializeAws_json1_1PutRemediationConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutRemediationConfigurations",
+    "x-amz-target": "StarlingDoveService.PutRemediationConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRemediationConfigurationsRequest(input, context));
@@ -1462,7 +1462,7 @@ export const serializeAws_json1_1PutRemediationExceptionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutRemediationExceptions",
+    "x-amz-target": "StarlingDoveService.PutRemediationExceptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRemediationExceptionsRequest(input, context));
@@ -1475,7 +1475,7 @@ export const serializeAws_json1_1PutResourceConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutResourceConfig",
+    "x-amz-target": "StarlingDoveService.PutResourceConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutResourceConfigRequest(input, context));
@@ -1488,7 +1488,7 @@ export const serializeAws_json1_1PutRetentionConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.PutRetentionConfiguration",
+    "x-amz-target": "StarlingDoveService.PutRetentionConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRetentionConfigurationRequest(input, context));
@@ -1501,7 +1501,7 @@ export const serializeAws_json1_1SelectAggregateResourceConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.SelectAggregateResourceConfig",
+    "x-amz-target": "StarlingDoveService.SelectAggregateResourceConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SelectAggregateResourceConfigRequest(input, context));
@@ -1514,7 +1514,7 @@ export const serializeAws_json1_1SelectResourceConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.SelectResourceConfig",
+    "x-amz-target": "StarlingDoveService.SelectResourceConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SelectResourceConfigRequest(input, context));
@@ -1527,7 +1527,7 @@ export const serializeAws_json1_1StartConfigRulesEvaluationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.StartConfigRulesEvaluation",
+    "x-amz-target": "StarlingDoveService.StartConfigRulesEvaluation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartConfigRulesEvaluationRequest(input, context));
@@ -1540,7 +1540,7 @@ export const serializeAws_json1_1StartConfigurationRecorderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.StartConfigurationRecorder",
+    "x-amz-target": "StarlingDoveService.StartConfigurationRecorder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartConfigurationRecorderRequest(input, context));
@@ -1553,7 +1553,7 @@ export const serializeAws_json1_1StartRemediationExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.StartRemediationExecution",
+    "x-amz-target": "StarlingDoveService.StartRemediationExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartRemediationExecutionRequest(input, context));
@@ -1566,7 +1566,7 @@ export const serializeAws_json1_1StopConfigurationRecorderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.StopConfigurationRecorder",
+    "x-amz-target": "StarlingDoveService.StopConfigurationRecorder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopConfigurationRecorderRequest(input, context));
@@ -1579,7 +1579,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.TagResource",
+    "x-amz-target": "StarlingDoveService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -1592,7 +1592,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StarlingDoveService.UntagResource",
+    "x-amz-target": "StarlingDoveService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));

--- a/clients/client-connectparticipant/protocols/Aws_restJson1.ts
+++ b/clients/client-connectparticipant/protocols/Aws_restJson1.ts
@@ -36,7 +36,7 @@ export const serializeAws_restJson1CreateParticipantConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ParticipantToken) && { "X-Amz-Bearer": input.ParticipantToken! }),
+    ...(isSerializableHeaderValue(input.ParticipantToken) && { "x-amz-bearer": input.ParticipantToken! }),
   };
   let resolvedPath = "/participant/connection";
   let body: any;
@@ -62,7 +62,7 @@ export const serializeAws_restJson1DisconnectParticipantCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ConnectionToken) && { "X-Amz-Bearer": input.ConnectionToken! }),
+    ...(isSerializableHeaderValue(input.ConnectionToken) && { "x-amz-bearer": input.ConnectionToken! }),
   };
   let resolvedPath = "/participant/disconnect";
   let body: any;
@@ -87,7 +87,7 @@ export const serializeAws_restJson1GetTranscriptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ConnectionToken) && { "X-Amz-Bearer": input.ConnectionToken! }),
+    ...(isSerializableHeaderValue(input.ConnectionToken) && { "x-amz-bearer": input.ConnectionToken! }),
   };
   let resolvedPath = "/participant/transcript";
   let body: any;
@@ -120,7 +120,7 @@ export const serializeAws_restJson1SendEventCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ConnectionToken) && { "X-Amz-Bearer": input.ConnectionToken! }),
+    ...(isSerializableHeaderValue(input.ConnectionToken) && { "x-amz-bearer": input.ConnectionToken! }),
   };
   let resolvedPath = "/participant/event";
   let body: any;
@@ -147,7 +147,7 @@ export const serializeAws_restJson1SendMessageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ConnectionToken) && { "X-Amz-Bearer": input.ConnectionToken! }),
+    ...(isSerializableHeaderValue(input.ConnectionToken) && { "x-amz-bearer": input.ConnectionToken! }),
   };
   let resolvedPath = "/participant/message";
   let body: any;

--- a/clients/client-cost-and-usage-report-service/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-and-usage-report-service/protocols/Aws_json1_1.ts
@@ -47,7 +47,7 @@ export const serializeAws_json1_1DeleteReportDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrigamiServiceGatewayService.DeleteReportDefinition",
+    "x-amz-target": "AWSOrigamiServiceGatewayService.DeleteReportDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteReportDefinitionRequest(input, context));
@@ -60,7 +60,7 @@ export const serializeAws_json1_1DescribeReportDefinitionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrigamiServiceGatewayService.DescribeReportDefinitions",
+    "x-amz-target": "AWSOrigamiServiceGatewayService.DescribeReportDefinitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReportDefinitionsRequest(input, context));
@@ -73,7 +73,7 @@ export const serializeAws_json1_1ModifyReportDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrigamiServiceGatewayService.ModifyReportDefinition",
+    "x-amz-target": "AWSOrigamiServiceGatewayService.ModifyReportDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyReportDefinitionRequest(input, context));
@@ -86,7 +86,7 @@ export const serializeAws_json1_1PutReportDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrigamiServiceGatewayService.PutReportDefinition",
+    "x-amz-target": "AWSOrigamiServiceGatewayService.PutReportDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutReportDefinitionRequest(input, context));

--- a/clients/client-cost-explorer/protocols/Aws_json1_1.ts
+++ b/clients/client-cost-explorer/protocols/Aws_json1_1.ts
@@ -251,7 +251,7 @@ export const serializeAws_json1_1CreateAnomalyMonitorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.CreateAnomalyMonitor",
+    "x-amz-target": "AWSInsightsIndexService.CreateAnomalyMonitor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAnomalyMonitorRequest(input, context));
@@ -264,7 +264,7 @@ export const serializeAws_json1_1CreateAnomalySubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.CreateAnomalySubscription",
+    "x-amz-target": "AWSInsightsIndexService.CreateAnomalySubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAnomalySubscriptionRequest(input, context));
@@ -277,7 +277,7 @@ export const serializeAws_json1_1CreateCostCategoryDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.CreateCostCategoryDefinition",
+    "x-amz-target": "AWSInsightsIndexService.CreateCostCategoryDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCostCategoryDefinitionRequest(input, context));
@@ -290,7 +290,7 @@ export const serializeAws_json1_1DeleteAnomalyMonitorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.DeleteAnomalyMonitor",
+    "x-amz-target": "AWSInsightsIndexService.DeleteAnomalyMonitor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAnomalyMonitorRequest(input, context));
@@ -303,7 +303,7 @@ export const serializeAws_json1_1DeleteAnomalySubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.DeleteAnomalySubscription",
+    "x-amz-target": "AWSInsightsIndexService.DeleteAnomalySubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAnomalySubscriptionRequest(input, context));
@@ -316,7 +316,7 @@ export const serializeAws_json1_1DeleteCostCategoryDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.DeleteCostCategoryDefinition",
+    "x-amz-target": "AWSInsightsIndexService.DeleteCostCategoryDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCostCategoryDefinitionRequest(input, context));
@@ -329,7 +329,7 @@ export const serializeAws_json1_1DescribeCostCategoryDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.DescribeCostCategoryDefinition",
+    "x-amz-target": "AWSInsightsIndexService.DescribeCostCategoryDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCostCategoryDefinitionRequest(input, context));
@@ -342,7 +342,7 @@ export const serializeAws_json1_1GetAnomaliesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetAnomalies",
+    "x-amz-target": "AWSInsightsIndexService.GetAnomalies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAnomaliesRequest(input, context));
@@ -355,7 +355,7 @@ export const serializeAws_json1_1GetAnomalyMonitorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetAnomalyMonitors",
+    "x-amz-target": "AWSInsightsIndexService.GetAnomalyMonitors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAnomalyMonitorsRequest(input, context));
@@ -368,7 +368,7 @@ export const serializeAws_json1_1GetAnomalySubscriptionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetAnomalySubscriptions",
+    "x-amz-target": "AWSInsightsIndexService.GetAnomalySubscriptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAnomalySubscriptionsRequest(input, context));
@@ -381,7 +381,7 @@ export const serializeAws_json1_1GetCostAndUsageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetCostAndUsage",
+    "x-amz-target": "AWSInsightsIndexService.GetCostAndUsage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCostAndUsageRequest(input, context));
@@ -394,7 +394,7 @@ export const serializeAws_json1_1GetCostAndUsageWithResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetCostAndUsageWithResources",
+    "x-amz-target": "AWSInsightsIndexService.GetCostAndUsageWithResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCostAndUsageWithResourcesRequest(input, context));
@@ -407,7 +407,7 @@ export const serializeAws_json1_1GetCostForecastCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetCostForecast",
+    "x-amz-target": "AWSInsightsIndexService.GetCostForecast",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCostForecastRequest(input, context));
@@ -420,7 +420,7 @@ export const serializeAws_json1_1GetDimensionValuesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetDimensionValues",
+    "x-amz-target": "AWSInsightsIndexService.GetDimensionValues",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDimensionValuesRequest(input, context));
@@ -433,7 +433,7 @@ export const serializeAws_json1_1GetReservationCoverageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetReservationCoverage",
+    "x-amz-target": "AWSInsightsIndexService.GetReservationCoverage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetReservationCoverageRequest(input, context));
@@ -446,7 +446,7 @@ export const serializeAws_json1_1GetReservationPurchaseRecommendationCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetReservationPurchaseRecommendation",
+    "x-amz-target": "AWSInsightsIndexService.GetReservationPurchaseRecommendation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetReservationPurchaseRecommendationRequest(input, context));
@@ -459,7 +459,7 @@ export const serializeAws_json1_1GetReservationUtilizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetReservationUtilization",
+    "x-amz-target": "AWSInsightsIndexService.GetReservationUtilization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetReservationUtilizationRequest(input, context));
@@ -472,7 +472,7 @@ export const serializeAws_json1_1GetRightsizingRecommendationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetRightsizingRecommendation",
+    "x-amz-target": "AWSInsightsIndexService.GetRightsizingRecommendation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRightsizingRecommendationRequest(input, context));
@@ -485,7 +485,7 @@ export const serializeAws_json1_1GetSavingsPlansCoverageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetSavingsPlansCoverage",
+    "x-amz-target": "AWSInsightsIndexService.GetSavingsPlansCoverage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSavingsPlansCoverageRequest(input, context));
@@ -498,7 +498,7 @@ export const serializeAws_json1_1GetSavingsPlansPurchaseRecommendationCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetSavingsPlansPurchaseRecommendation",
+    "x-amz-target": "AWSInsightsIndexService.GetSavingsPlansPurchaseRecommendation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSavingsPlansPurchaseRecommendationRequest(input, context));
@@ -511,7 +511,7 @@ export const serializeAws_json1_1GetSavingsPlansUtilizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetSavingsPlansUtilization",
+    "x-amz-target": "AWSInsightsIndexService.GetSavingsPlansUtilization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSavingsPlansUtilizationRequest(input, context));
@@ -524,7 +524,7 @@ export const serializeAws_json1_1GetSavingsPlansUtilizationDetailsCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetSavingsPlansUtilizationDetails",
+    "x-amz-target": "AWSInsightsIndexService.GetSavingsPlansUtilizationDetails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSavingsPlansUtilizationDetailsRequest(input, context));
@@ -537,7 +537,7 @@ export const serializeAws_json1_1GetTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetTags",
+    "x-amz-target": "AWSInsightsIndexService.GetTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTagsRequest(input, context));
@@ -550,7 +550,7 @@ export const serializeAws_json1_1GetUsageForecastCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.GetUsageForecast",
+    "x-amz-target": "AWSInsightsIndexService.GetUsageForecast",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetUsageForecastRequest(input, context));
@@ -563,7 +563,7 @@ export const serializeAws_json1_1ListCostCategoryDefinitionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.ListCostCategoryDefinitions",
+    "x-amz-target": "AWSInsightsIndexService.ListCostCategoryDefinitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCostCategoryDefinitionsRequest(input, context));
@@ -576,7 +576,7 @@ export const serializeAws_json1_1ProvideAnomalyFeedbackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.ProvideAnomalyFeedback",
+    "x-amz-target": "AWSInsightsIndexService.ProvideAnomalyFeedback",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ProvideAnomalyFeedbackRequest(input, context));
@@ -589,7 +589,7 @@ export const serializeAws_json1_1UpdateAnomalyMonitorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.UpdateAnomalyMonitor",
+    "x-amz-target": "AWSInsightsIndexService.UpdateAnomalyMonitor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAnomalyMonitorRequest(input, context));
@@ -602,7 +602,7 @@ export const serializeAws_json1_1UpdateAnomalySubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.UpdateAnomalySubscription",
+    "x-amz-target": "AWSInsightsIndexService.UpdateAnomalySubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAnomalySubscriptionRequest(input, context));
@@ -615,7 +615,7 @@ export const serializeAws_json1_1UpdateCostCategoryDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSInsightsIndexService.UpdateCostCategoryDefinition",
+    "x-amz-target": "AWSInsightsIndexService.UpdateCostCategoryDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCostCategoryDefinitionRequest(input, context));

--- a/clients/client-data-pipeline/protocols/Aws_json1_1.ts
+++ b/clients/client-data-pipeline/protocols/Aws_json1_1.ts
@@ -103,7 +103,7 @@ export const serializeAws_json1_1ActivatePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.ActivatePipeline",
+    "x-amz-target": "DataPipeline.ActivatePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ActivatePipelineInput(input, context));
@@ -116,7 +116,7 @@ export const serializeAws_json1_1AddTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.AddTags",
+    "x-amz-target": "DataPipeline.AddTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsInput(input, context));
@@ -129,7 +129,7 @@ export const serializeAws_json1_1CreatePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.CreatePipeline",
+    "x-amz-target": "DataPipeline.CreatePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePipelineInput(input, context));
@@ -142,7 +142,7 @@ export const serializeAws_json1_1DeactivatePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.DeactivatePipeline",
+    "x-amz-target": "DataPipeline.DeactivatePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeactivatePipelineInput(input, context));
@@ -155,7 +155,7 @@ export const serializeAws_json1_1DeletePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.DeletePipeline",
+    "x-amz-target": "DataPipeline.DeletePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePipelineInput(input, context));
@@ -168,7 +168,7 @@ export const serializeAws_json1_1DescribeObjectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.DescribeObjects",
+    "x-amz-target": "DataPipeline.DescribeObjects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeObjectsInput(input, context));
@@ -181,7 +181,7 @@ export const serializeAws_json1_1DescribePipelinesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.DescribePipelines",
+    "x-amz-target": "DataPipeline.DescribePipelines",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePipelinesInput(input, context));
@@ -194,7 +194,7 @@ export const serializeAws_json1_1EvaluateExpressionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.EvaluateExpression",
+    "x-amz-target": "DataPipeline.EvaluateExpression",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EvaluateExpressionInput(input, context));
@@ -207,7 +207,7 @@ export const serializeAws_json1_1GetPipelineDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.GetPipelineDefinition",
+    "x-amz-target": "DataPipeline.GetPipelineDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPipelineDefinitionInput(input, context));
@@ -220,7 +220,7 @@ export const serializeAws_json1_1ListPipelinesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.ListPipelines",
+    "x-amz-target": "DataPipeline.ListPipelines",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPipelinesInput(input, context));
@@ -233,7 +233,7 @@ export const serializeAws_json1_1PollForTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.PollForTask",
+    "x-amz-target": "DataPipeline.PollForTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PollForTaskInput(input, context));
@@ -246,7 +246,7 @@ export const serializeAws_json1_1PutPipelineDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.PutPipelineDefinition",
+    "x-amz-target": "DataPipeline.PutPipelineDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutPipelineDefinitionInput(input, context));
@@ -259,7 +259,7 @@ export const serializeAws_json1_1QueryObjectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.QueryObjects",
+    "x-amz-target": "DataPipeline.QueryObjects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1QueryObjectsInput(input, context));
@@ -272,7 +272,7 @@ export const serializeAws_json1_1RemoveTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.RemoveTags",
+    "x-amz-target": "DataPipeline.RemoveTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsInput(input, context));
@@ -285,7 +285,7 @@ export const serializeAws_json1_1ReportTaskProgressCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.ReportTaskProgress",
+    "x-amz-target": "DataPipeline.ReportTaskProgress",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ReportTaskProgressInput(input, context));
@@ -298,7 +298,7 @@ export const serializeAws_json1_1ReportTaskRunnerHeartbeatCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.ReportTaskRunnerHeartbeat",
+    "x-amz-target": "DataPipeline.ReportTaskRunnerHeartbeat",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ReportTaskRunnerHeartbeatInput(input, context));
@@ -311,7 +311,7 @@ export const serializeAws_json1_1SetStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.SetStatus",
+    "x-amz-target": "DataPipeline.SetStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetStatusInput(input, context));
@@ -324,7 +324,7 @@ export const serializeAws_json1_1SetTaskStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.SetTaskStatus",
+    "x-amz-target": "DataPipeline.SetTaskStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetTaskStatusInput(input, context));
@@ -337,7 +337,7 @@ export const serializeAws_json1_1ValidatePipelineDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DataPipeline.ValidatePipelineDefinition",
+    "x-amz-target": "DataPipeline.ValidatePipelineDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ValidatePipelineDefinitionInput(input, context));

--- a/clients/client-database-migration-service/protocols/Aws_json1_1.ts
+++ b/clients/client-database-migration-service/protocols/Aws_json1_1.ts
@@ -369,7 +369,7 @@ export const serializeAws_json1_1AddTagsToResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.AddTagsToResource",
+    "x-amz-target": "AmazonDMSv20160101.AddTagsToResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsToResourceMessage(input, context));
@@ -382,7 +382,7 @@ export const serializeAws_json1_1ApplyPendingMaintenanceActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.ApplyPendingMaintenanceAction",
+    "x-amz-target": "AmazonDMSv20160101.ApplyPendingMaintenanceAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ApplyPendingMaintenanceActionMessage(input, context));
@@ -395,7 +395,7 @@ export const serializeAws_json1_1CancelReplicationTaskAssessmentRunCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.CancelReplicationTaskAssessmentRun",
+    "x-amz-target": "AmazonDMSv20160101.CancelReplicationTaskAssessmentRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelReplicationTaskAssessmentRunMessage(input, context));
@@ -408,7 +408,7 @@ export const serializeAws_json1_1CreateEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.CreateEndpoint",
+    "x-amz-target": "AmazonDMSv20160101.CreateEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEndpointMessage(input, context));
@@ -421,7 +421,7 @@ export const serializeAws_json1_1CreateEventSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.CreateEventSubscription",
+    "x-amz-target": "AmazonDMSv20160101.CreateEventSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEventSubscriptionMessage(input, context));
@@ -434,7 +434,7 @@ export const serializeAws_json1_1CreateReplicationInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.CreateReplicationInstance",
+    "x-amz-target": "AmazonDMSv20160101.CreateReplicationInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateReplicationInstanceMessage(input, context));
@@ -447,7 +447,7 @@ export const serializeAws_json1_1CreateReplicationSubnetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.CreateReplicationSubnetGroup",
+    "x-amz-target": "AmazonDMSv20160101.CreateReplicationSubnetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateReplicationSubnetGroupMessage(input, context));
@@ -460,7 +460,7 @@ export const serializeAws_json1_1CreateReplicationTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.CreateReplicationTask",
+    "x-amz-target": "AmazonDMSv20160101.CreateReplicationTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateReplicationTaskMessage(input, context));
@@ -473,7 +473,7 @@ export const serializeAws_json1_1DeleteCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DeleteCertificate",
+    "x-amz-target": "AmazonDMSv20160101.DeleteCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCertificateMessage(input, context));
@@ -486,7 +486,7 @@ export const serializeAws_json1_1DeleteConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DeleteConnection",
+    "x-amz-target": "AmazonDMSv20160101.DeleteConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConnectionMessage(input, context));
@@ -499,7 +499,7 @@ export const serializeAws_json1_1DeleteEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DeleteEndpoint",
+    "x-amz-target": "AmazonDMSv20160101.DeleteEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEndpointMessage(input, context));
@@ -512,7 +512,7 @@ export const serializeAws_json1_1DeleteEventSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DeleteEventSubscription",
+    "x-amz-target": "AmazonDMSv20160101.DeleteEventSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEventSubscriptionMessage(input, context));
@@ -525,7 +525,7 @@ export const serializeAws_json1_1DeleteReplicationInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DeleteReplicationInstance",
+    "x-amz-target": "AmazonDMSv20160101.DeleteReplicationInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteReplicationInstanceMessage(input, context));
@@ -538,7 +538,7 @@ export const serializeAws_json1_1DeleteReplicationSubnetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DeleteReplicationSubnetGroup",
+    "x-amz-target": "AmazonDMSv20160101.DeleteReplicationSubnetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteReplicationSubnetGroupMessage(input, context));
@@ -551,7 +551,7 @@ export const serializeAws_json1_1DeleteReplicationTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DeleteReplicationTask",
+    "x-amz-target": "AmazonDMSv20160101.DeleteReplicationTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteReplicationTaskMessage(input, context));
@@ -564,7 +564,7 @@ export const serializeAws_json1_1DeleteReplicationTaskAssessmentRunCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DeleteReplicationTaskAssessmentRun",
+    "x-amz-target": "AmazonDMSv20160101.DeleteReplicationTaskAssessmentRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteReplicationTaskAssessmentRunMessage(input, context));
@@ -577,7 +577,7 @@ export const serializeAws_json1_1DescribeAccountAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeAccountAttributes",
+    "x-amz-target": "AmazonDMSv20160101.DescribeAccountAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAccountAttributesMessage(input, context));
@@ -590,7 +590,7 @@ export const serializeAws_json1_1DescribeApplicableIndividualAssessmentsCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeApplicableIndividualAssessments",
+    "x-amz-target": "AmazonDMSv20160101.DescribeApplicableIndividualAssessments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeApplicableIndividualAssessmentsMessage(input, context));
@@ -603,7 +603,7 @@ export const serializeAws_json1_1DescribeCertificatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeCertificates",
+    "x-amz-target": "AmazonDMSv20160101.DescribeCertificates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCertificatesMessage(input, context));
@@ -616,7 +616,7 @@ export const serializeAws_json1_1DescribeConnectionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeConnections",
+    "x-amz-target": "AmazonDMSv20160101.DescribeConnections",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConnectionsMessage(input, context));
@@ -629,7 +629,7 @@ export const serializeAws_json1_1DescribeEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeEndpoints",
+    "x-amz-target": "AmazonDMSv20160101.DescribeEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEndpointsMessage(input, context));
@@ -642,7 +642,7 @@ export const serializeAws_json1_1DescribeEndpointTypesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeEndpointTypes",
+    "x-amz-target": "AmazonDMSv20160101.DescribeEndpointTypes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEndpointTypesMessage(input, context));
@@ -655,7 +655,7 @@ export const serializeAws_json1_1DescribeEventCategoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeEventCategories",
+    "x-amz-target": "AmazonDMSv20160101.DescribeEventCategories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventCategoriesMessage(input, context));
@@ -668,7 +668,7 @@ export const serializeAws_json1_1DescribeEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeEvents",
+    "x-amz-target": "AmazonDMSv20160101.DescribeEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventsMessage(input, context));
@@ -681,7 +681,7 @@ export const serializeAws_json1_1DescribeEventSubscriptionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeEventSubscriptions",
+    "x-amz-target": "AmazonDMSv20160101.DescribeEventSubscriptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventSubscriptionsMessage(input, context));
@@ -694,7 +694,7 @@ export const serializeAws_json1_1DescribeOrderableReplicationInstancesCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeOrderableReplicationInstances",
+    "x-amz-target": "AmazonDMSv20160101.DescribeOrderableReplicationInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeOrderableReplicationInstancesMessage(input, context));
@@ -707,7 +707,7 @@ export const serializeAws_json1_1DescribePendingMaintenanceActionsCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribePendingMaintenanceActions",
+    "x-amz-target": "AmazonDMSv20160101.DescribePendingMaintenanceActions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePendingMaintenanceActionsMessage(input, context));
@@ -720,7 +720,7 @@ export const serializeAws_json1_1DescribeRefreshSchemasStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeRefreshSchemasStatus",
+    "x-amz-target": "AmazonDMSv20160101.DescribeRefreshSchemasStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRefreshSchemasStatusMessage(input, context));
@@ -733,7 +733,7 @@ export const serializeAws_json1_1DescribeReplicationInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeReplicationInstances",
+    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReplicationInstancesMessage(input, context));
@@ -746,7 +746,7 @@ export const serializeAws_json1_1DescribeReplicationInstanceTaskLogsCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeReplicationInstanceTaskLogs",
+    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationInstanceTaskLogs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReplicationInstanceTaskLogsMessage(input, context));
@@ -759,7 +759,7 @@ export const serializeAws_json1_1DescribeReplicationSubnetGroupsCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeReplicationSubnetGroups",
+    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationSubnetGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReplicationSubnetGroupsMessage(input, context));
@@ -772,7 +772,7 @@ export const serializeAws_json1_1DescribeReplicationTaskAssessmentResultsCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeReplicationTaskAssessmentResults",
+    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationTaskAssessmentResults",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReplicationTaskAssessmentResultsMessage(input, context));
@@ -785,7 +785,7 @@ export const serializeAws_json1_1DescribeReplicationTaskAssessmentRunsCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeReplicationTaskAssessmentRuns",
+    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationTaskAssessmentRuns",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReplicationTaskAssessmentRunsMessage(input, context));
@@ -798,7 +798,7 @@ export const serializeAws_json1_1DescribeReplicationTaskIndividualAssessmentsCom
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeReplicationTaskIndividualAssessments",
+    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationTaskIndividualAssessments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReplicationTaskIndividualAssessmentsMessage(input, context));
@@ -811,7 +811,7 @@ export const serializeAws_json1_1DescribeReplicationTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeReplicationTasks",
+    "x-amz-target": "AmazonDMSv20160101.DescribeReplicationTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReplicationTasksMessage(input, context));
@@ -824,7 +824,7 @@ export const serializeAws_json1_1DescribeSchemasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeSchemas",
+    "x-amz-target": "AmazonDMSv20160101.DescribeSchemas",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSchemasMessage(input, context));
@@ -837,7 +837,7 @@ export const serializeAws_json1_1DescribeTableStatisticsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.DescribeTableStatistics",
+    "x-amz-target": "AmazonDMSv20160101.DescribeTableStatistics",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTableStatisticsMessage(input, context));
@@ -850,7 +850,7 @@ export const serializeAws_json1_1ImportCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.ImportCertificate",
+    "x-amz-target": "AmazonDMSv20160101.ImportCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportCertificateMessage(input, context));
@@ -863,7 +863,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.ListTagsForResource",
+    "x-amz-target": "AmazonDMSv20160101.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceMessage(input, context));
@@ -876,7 +876,7 @@ export const serializeAws_json1_1ModifyEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.ModifyEndpoint",
+    "x-amz-target": "AmazonDMSv20160101.ModifyEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyEndpointMessage(input, context));
@@ -889,7 +889,7 @@ export const serializeAws_json1_1ModifyEventSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.ModifyEventSubscription",
+    "x-amz-target": "AmazonDMSv20160101.ModifyEventSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyEventSubscriptionMessage(input, context));
@@ -902,7 +902,7 @@ export const serializeAws_json1_1ModifyReplicationInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.ModifyReplicationInstance",
+    "x-amz-target": "AmazonDMSv20160101.ModifyReplicationInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyReplicationInstanceMessage(input, context));
@@ -915,7 +915,7 @@ export const serializeAws_json1_1ModifyReplicationSubnetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.ModifyReplicationSubnetGroup",
+    "x-amz-target": "AmazonDMSv20160101.ModifyReplicationSubnetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyReplicationSubnetGroupMessage(input, context));
@@ -928,7 +928,7 @@ export const serializeAws_json1_1ModifyReplicationTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.ModifyReplicationTask",
+    "x-amz-target": "AmazonDMSv20160101.ModifyReplicationTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyReplicationTaskMessage(input, context));
@@ -941,7 +941,7 @@ export const serializeAws_json1_1MoveReplicationTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.MoveReplicationTask",
+    "x-amz-target": "AmazonDMSv20160101.MoveReplicationTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MoveReplicationTaskMessage(input, context));
@@ -954,7 +954,7 @@ export const serializeAws_json1_1RebootReplicationInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.RebootReplicationInstance",
+    "x-amz-target": "AmazonDMSv20160101.RebootReplicationInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RebootReplicationInstanceMessage(input, context));
@@ -967,7 +967,7 @@ export const serializeAws_json1_1RefreshSchemasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.RefreshSchemas",
+    "x-amz-target": "AmazonDMSv20160101.RefreshSchemas",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RefreshSchemasMessage(input, context));
@@ -980,7 +980,7 @@ export const serializeAws_json1_1ReloadTablesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.ReloadTables",
+    "x-amz-target": "AmazonDMSv20160101.ReloadTables",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ReloadTablesMessage(input, context));
@@ -993,7 +993,7 @@ export const serializeAws_json1_1RemoveTagsFromResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.RemoveTagsFromResource",
+    "x-amz-target": "AmazonDMSv20160101.RemoveTagsFromResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsFromResourceMessage(input, context));
@@ -1006,7 +1006,7 @@ export const serializeAws_json1_1StartReplicationTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.StartReplicationTask",
+    "x-amz-target": "AmazonDMSv20160101.StartReplicationTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartReplicationTaskMessage(input, context));
@@ -1019,7 +1019,7 @@ export const serializeAws_json1_1StartReplicationTaskAssessmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.StartReplicationTaskAssessment",
+    "x-amz-target": "AmazonDMSv20160101.StartReplicationTaskAssessment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartReplicationTaskAssessmentMessage(input, context));
@@ -1032,7 +1032,7 @@ export const serializeAws_json1_1StartReplicationTaskAssessmentRunCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.StartReplicationTaskAssessmentRun",
+    "x-amz-target": "AmazonDMSv20160101.StartReplicationTaskAssessmentRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartReplicationTaskAssessmentRunMessage(input, context));
@@ -1045,7 +1045,7 @@ export const serializeAws_json1_1StopReplicationTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.StopReplicationTask",
+    "x-amz-target": "AmazonDMSv20160101.StopReplicationTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopReplicationTaskMessage(input, context));
@@ -1058,7 +1058,7 @@ export const serializeAws_json1_1TestConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDMSv20160101.TestConnection",
+    "x-amz-target": "AmazonDMSv20160101.TestConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TestConnectionMessage(input, context));

--- a/clients/client-datasync/protocols/Aws_json1_1.ts
+++ b/clients/client-datasync/protocols/Aws_json1_1.ts
@@ -164,7 +164,7 @@ export const serializeAws_json1_1CancelTaskExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.CancelTaskExecution",
+    "x-amz-target": "FmrsService.CancelTaskExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelTaskExecutionRequest(input, context));
@@ -177,7 +177,7 @@ export const serializeAws_json1_1CreateAgentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.CreateAgent",
+    "x-amz-target": "FmrsService.CreateAgent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAgentRequest(input, context));
@@ -190,7 +190,7 @@ export const serializeAws_json1_1CreateLocationEfsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.CreateLocationEfs",
+    "x-amz-target": "FmrsService.CreateLocationEfs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLocationEfsRequest(input, context));
@@ -203,7 +203,7 @@ export const serializeAws_json1_1CreateLocationFsxWindowsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.CreateLocationFsxWindows",
+    "x-amz-target": "FmrsService.CreateLocationFsxWindows",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLocationFsxWindowsRequest(input, context));
@@ -216,7 +216,7 @@ export const serializeAws_json1_1CreateLocationNfsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.CreateLocationNfs",
+    "x-amz-target": "FmrsService.CreateLocationNfs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLocationNfsRequest(input, context));
@@ -229,7 +229,7 @@ export const serializeAws_json1_1CreateLocationObjectStorageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.CreateLocationObjectStorage",
+    "x-amz-target": "FmrsService.CreateLocationObjectStorage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLocationObjectStorageRequest(input, context));
@@ -242,7 +242,7 @@ export const serializeAws_json1_1CreateLocationS3Command = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.CreateLocationS3",
+    "x-amz-target": "FmrsService.CreateLocationS3",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLocationS3Request(input, context));
@@ -255,7 +255,7 @@ export const serializeAws_json1_1CreateLocationSmbCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.CreateLocationSmb",
+    "x-amz-target": "FmrsService.CreateLocationSmb",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLocationSmbRequest(input, context));
@@ -268,7 +268,7 @@ export const serializeAws_json1_1CreateTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.CreateTask",
+    "x-amz-target": "FmrsService.CreateTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTaskRequest(input, context));
@@ -281,7 +281,7 @@ export const serializeAws_json1_1DeleteAgentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DeleteAgent",
+    "x-amz-target": "FmrsService.DeleteAgent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAgentRequest(input, context));
@@ -294,7 +294,7 @@ export const serializeAws_json1_1DeleteLocationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DeleteLocation",
+    "x-amz-target": "FmrsService.DeleteLocation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLocationRequest(input, context));
@@ -307,7 +307,7 @@ export const serializeAws_json1_1DeleteTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DeleteTask",
+    "x-amz-target": "FmrsService.DeleteTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTaskRequest(input, context));
@@ -320,7 +320,7 @@ export const serializeAws_json1_1DescribeAgentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DescribeAgent",
+    "x-amz-target": "FmrsService.DescribeAgent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAgentRequest(input, context));
@@ -333,7 +333,7 @@ export const serializeAws_json1_1DescribeLocationEfsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DescribeLocationEfs",
+    "x-amz-target": "FmrsService.DescribeLocationEfs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLocationEfsRequest(input, context));
@@ -346,7 +346,7 @@ export const serializeAws_json1_1DescribeLocationFsxWindowsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DescribeLocationFsxWindows",
+    "x-amz-target": "FmrsService.DescribeLocationFsxWindows",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLocationFsxWindowsRequest(input, context));
@@ -359,7 +359,7 @@ export const serializeAws_json1_1DescribeLocationNfsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DescribeLocationNfs",
+    "x-amz-target": "FmrsService.DescribeLocationNfs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLocationNfsRequest(input, context));
@@ -372,7 +372,7 @@ export const serializeAws_json1_1DescribeLocationObjectStorageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DescribeLocationObjectStorage",
+    "x-amz-target": "FmrsService.DescribeLocationObjectStorage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLocationObjectStorageRequest(input, context));
@@ -385,7 +385,7 @@ export const serializeAws_json1_1DescribeLocationS3Command = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DescribeLocationS3",
+    "x-amz-target": "FmrsService.DescribeLocationS3",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLocationS3Request(input, context));
@@ -398,7 +398,7 @@ export const serializeAws_json1_1DescribeLocationSmbCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DescribeLocationSmb",
+    "x-amz-target": "FmrsService.DescribeLocationSmb",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLocationSmbRequest(input, context));
@@ -411,7 +411,7 @@ export const serializeAws_json1_1DescribeTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DescribeTask",
+    "x-amz-target": "FmrsService.DescribeTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTaskRequest(input, context));
@@ -424,7 +424,7 @@ export const serializeAws_json1_1DescribeTaskExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.DescribeTaskExecution",
+    "x-amz-target": "FmrsService.DescribeTaskExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTaskExecutionRequest(input, context));
@@ -437,7 +437,7 @@ export const serializeAws_json1_1ListAgentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.ListAgents",
+    "x-amz-target": "FmrsService.ListAgents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAgentsRequest(input, context));
@@ -450,7 +450,7 @@ export const serializeAws_json1_1ListLocationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.ListLocations",
+    "x-amz-target": "FmrsService.ListLocations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLocationsRequest(input, context));
@@ -463,7 +463,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.ListTagsForResource",
+    "x-amz-target": "FmrsService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -476,7 +476,7 @@ export const serializeAws_json1_1ListTaskExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.ListTaskExecutions",
+    "x-amz-target": "FmrsService.ListTaskExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTaskExecutionsRequest(input, context));
@@ -489,7 +489,7 @@ export const serializeAws_json1_1ListTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.ListTasks",
+    "x-amz-target": "FmrsService.ListTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTasksRequest(input, context));
@@ -502,7 +502,7 @@ export const serializeAws_json1_1StartTaskExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.StartTaskExecution",
+    "x-amz-target": "FmrsService.StartTaskExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartTaskExecutionRequest(input, context));
@@ -515,7 +515,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.TagResource",
+    "x-amz-target": "FmrsService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -528,7 +528,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.UntagResource",
+    "x-amz-target": "FmrsService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -541,7 +541,7 @@ export const serializeAws_json1_1UpdateAgentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.UpdateAgent",
+    "x-amz-target": "FmrsService.UpdateAgent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAgentRequest(input, context));
@@ -554,7 +554,7 @@ export const serializeAws_json1_1UpdateTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.UpdateTask",
+    "x-amz-target": "FmrsService.UpdateTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTaskRequest(input, context));
@@ -567,7 +567,7 @@ export const serializeAws_json1_1UpdateTaskExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "FmrsService.UpdateTaskExecution",
+    "x-amz-target": "FmrsService.UpdateTaskExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTaskExecutionRequest(input, context));

--- a/clients/client-dax/protocols/Aws_json1_1.ts
+++ b/clients/client-dax/protocols/Aws_json1_1.ts
@@ -145,7 +145,7 @@ export const serializeAws_json1_1CreateClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.CreateCluster",
+    "x-amz-target": "AmazonDAXV3.CreateCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateClusterRequest(input, context));
@@ -158,7 +158,7 @@ export const serializeAws_json1_1CreateParameterGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.CreateParameterGroup",
+    "x-amz-target": "AmazonDAXV3.CreateParameterGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateParameterGroupRequest(input, context));
@@ -171,7 +171,7 @@ export const serializeAws_json1_1CreateSubnetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.CreateSubnetGroup",
+    "x-amz-target": "AmazonDAXV3.CreateSubnetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSubnetGroupRequest(input, context));
@@ -184,7 +184,7 @@ export const serializeAws_json1_1DecreaseReplicationFactorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.DecreaseReplicationFactor",
+    "x-amz-target": "AmazonDAXV3.DecreaseReplicationFactor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DecreaseReplicationFactorRequest(input, context));
@@ -197,7 +197,7 @@ export const serializeAws_json1_1DeleteClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.DeleteCluster",
+    "x-amz-target": "AmazonDAXV3.DeleteCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteClusterRequest(input, context));
@@ -210,7 +210,7 @@ export const serializeAws_json1_1DeleteParameterGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.DeleteParameterGroup",
+    "x-amz-target": "AmazonDAXV3.DeleteParameterGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteParameterGroupRequest(input, context));
@@ -223,7 +223,7 @@ export const serializeAws_json1_1DeleteSubnetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.DeleteSubnetGroup",
+    "x-amz-target": "AmazonDAXV3.DeleteSubnetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSubnetGroupRequest(input, context));
@@ -236,7 +236,7 @@ export const serializeAws_json1_1DescribeClustersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.DescribeClusters",
+    "x-amz-target": "AmazonDAXV3.DescribeClusters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeClustersRequest(input, context));
@@ -249,7 +249,7 @@ export const serializeAws_json1_1DescribeDefaultParametersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.DescribeDefaultParameters",
+    "x-amz-target": "AmazonDAXV3.DescribeDefaultParameters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDefaultParametersRequest(input, context));
@@ -262,7 +262,7 @@ export const serializeAws_json1_1DescribeEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.DescribeEvents",
+    "x-amz-target": "AmazonDAXV3.DescribeEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventsRequest(input, context));
@@ -275,7 +275,7 @@ export const serializeAws_json1_1DescribeParameterGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.DescribeParameterGroups",
+    "x-amz-target": "AmazonDAXV3.DescribeParameterGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeParameterGroupsRequest(input, context));
@@ -288,7 +288,7 @@ export const serializeAws_json1_1DescribeParametersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.DescribeParameters",
+    "x-amz-target": "AmazonDAXV3.DescribeParameters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeParametersRequest(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_1DescribeSubnetGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.DescribeSubnetGroups",
+    "x-amz-target": "AmazonDAXV3.DescribeSubnetGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSubnetGroupsRequest(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_1IncreaseReplicationFactorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.IncreaseReplicationFactor",
+    "x-amz-target": "AmazonDAXV3.IncreaseReplicationFactor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1IncreaseReplicationFactorRequest(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1ListTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.ListTags",
+    "x-amz-target": "AmazonDAXV3.ListTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsRequest(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1RebootNodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.RebootNode",
+    "x-amz-target": "AmazonDAXV3.RebootNode",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RebootNodeRequest(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.TagResource",
+    "x-amz-target": "AmazonDAXV3.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.UntagResource",
+    "x-amz-target": "AmazonDAXV3.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_1UpdateClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.UpdateCluster",
+    "x-amz-target": "AmazonDAXV3.UpdateCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateClusterRequest(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_1UpdateParameterGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.UpdateParameterGroup",
+    "x-amz-target": "AmazonDAXV3.UpdateParameterGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateParameterGroupRequest(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_1UpdateSubnetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonDAXV3.UpdateSubnetGroup",
+    "x-amz-target": "AmazonDAXV3.UpdateSubnetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSubnetGroupRequest(input, context));

--- a/clients/client-device-farm/protocols/Aws_json1_1.ts
+++ b/clients/client-device-farm/protocols/Aws_json1_1.ts
@@ -405,7 +405,7 @@ export const serializeAws_json1_1CreateDevicePoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.CreateDevicePool",
+    "x-amz-target": "DeviceFarm_20150623.CreateDevicePool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDevicePoolRequest(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_1CreateInstanceProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.CreateInstanceProfile",
+    "x-amz-target": "DeviceFarm_20150623.CreateInstanceProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateInstanceProfileRequest(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_1CreateNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.CreateNetworkProfile",
+    "x-amz-target": "DeviceFarm_20150623.CreateNetworkProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateNetworkProfileRequest(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_1CreateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.CreateProject",
+    "x-amz-target": "DeviceFarm_20150623.CreateProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProjectRequest(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_1CreateRemoteAccessSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.CreateRemoteAccessSession",
+    "x-amz-target": "DeviceFarm_20150623.CreateRemoteAccessSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRemoteAccessSessionRequest(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_1CreateTestGridProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.CreateTestGridProject",
+    "x-amz-target": "DeviceFarm_20150623.CreateTestGridProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTestGridProjectRequest(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_1CreateTestGridUrlCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.CreateTestGridUrl",
+    "x-amz-target": "DeviceFarm_20150623.CreateTestGridUrl",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTestGridUrlRequest(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_1CreateUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.CreateUpload",
+    "x-amz-target": "DeviceFarm_20150623.CreateUpload",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUploadRequest(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_1CreateVPCEConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.CreateVPCEConfiguration",
+    "x-amz-target": "DeviceFarm_20150623.CreateVPCEConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateVPCEConfigurationRequest(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_1DeleteDevicePoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.DeleteDevicePool",
+    "x-amz-target": "DeviceFarm_20150623.DeleteDevicePool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDevicePoolRequest(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1DeleteInstanceProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.DeleteInstanceProfile",
+    "x-amz-target": "DeviceFarm_20150623.DeleteInstanceProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteInstanceProfileRequest(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1DeleteNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.DeleteNetworkProfile",
+    "x-amz-target": "DeviceFarm_20150623.DeleteNetworkProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteNetworkProfileRequest(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1DeleteProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.DeleteProject",
+    "x-amz-target": "DeviceFarm_20150623.DeleteProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProjectRequest(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_1DeleteRemoteAccessSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.DeleteRemoteAccessSession",
+    "x-amz-target": "DeviceFarm_20150623.DeleteRemoteAccessSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRemoteAccessSessionRequest(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_1DeleteRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.DeleteRun",
+    "x-amz-target": "DeviceFarm_20150623.DeleteRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRunRequest(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_1DeleteTestGridProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.DeleteTestGridProject",
+    "x-amz-target": "DeviceFarm_20150623.DeleteTestGridProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTestGridProjectRequest(input, context));
@@ -613,7 +613,7 @@ export const serializeAws_json1_1DeleteUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.DeleteUpload",
+    "x-amz-target": "DeviceFarm_20150623.DeleteUpload",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUploadRequest(input, context));
@@ -626,7 +626,7 @@ export const serializeAws_json1_1DeleteVPCEConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.DeleteVPCEConfiguration",
+    "x-amz-target": "DeviceFarm_20150623.DeleteVPCEConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteVPCEConfigurationRequest(input, context));
@@ -639,7 +639,7 @@ export const serializeAws_json1_1GetAccountSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetAccountSettings",
+    "x-amz-target": "DeviceFarm_20150623.GetAccountSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAccountSettingsRequest(input, context));
@@ -652,7 +652,7 @@ export const serializeAws_json1_1GetDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetDevice",
+    "x-amz-target": "DeviceFarm_20150623.GetDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeviceRequest(input, context));
@@ -665,7 +665,7 @@ export const serializeAws_json1_1GetDeviceInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetDeviceInstance",
+    "x-amz-target": "DeviceFarm_20150623.GetDeviceInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeviceInstanceRequest(input, context));
@@ -678,7 +678,7 @@ export const serializeAws_json1_1GetDevicePoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetDevicePool",
+    "x-amz-target": "DeviceFarm_20150623.GetDevicePool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDevicePoolRequest(input, context));
@@ -691,7 +691,7 @@ export const serializeAws_json1_1GetDevicePoolCompatibilityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetDevicePoolCompatibility",
+    "x-amz-target": "DeviceFarm_20150623.GetDevicePoolCompatibility",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDevicePoolCompatibilityRequest(input, context));
@@ -704,7 +704,7 @@ export const serializeAws_json1_1GetInstanceProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetInstanceProfile",
+    "x-amz-target": "DeviceFarm_20150623.GetInstanceProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstanceProfileRequest(input, context));
@@ -717,7 +717,7 @@ export const serializeAws_json1_1GetJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetJob",
+    "x-amz-target": "DeviceFarm_20150623.GetJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetJobRequest(input, context));
@@ -730,7 +730,7 @@ export const serializeAws_json1_1GetNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetNetworkProfile",
+    "x-amz-target": "DeviceFarm_20150623.GetNetworkProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetNetworkProfileRequest(input, context));
@@ -743,7 +743,7 @@ export const serializeAws_json1_1GetOfferingStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetOfferingStatus",
+    "x-amz-target": "DeviceFarm_20150623.GetOfferingStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOfferingStatusRequest(input, context));
@@ -756,7 +756,7 @@ export const serializeAws_json1_1GetProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetProject",
+    "x-amz-target": "DeviceFarm_20150623.GetProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetProjectRequest(input, context));
@@ -769,7 +769,7 @@ export const serializeAws_json1_1GetRemoteAccessSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetRemoteAccessSession",
+    "x-amz-target": "DeviceFarm_20150623.GetRemoteAccessSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRemoteAccessSessionRequest(input, context));
@@ -782,7 +782,7 @@ export const serializeAws_json1_1GetRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetRun",
+    "x-amz-target": "DeviceFarm_20150623.GetRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRunRequest(input, context));
@@ -795,7 +795,7 @@ export const serializeAws_json1_1GetSuiteCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetSuite",
+    "x-amz-target": "DeviceFarm_20150623.GetSuite",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSuiteRequest(input, context));
@@ -808,7 +808,7 @@ export const serializeAws_json1_1GetTestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetTest",
+    "x-amz-target": "DeviceFarm_20150623.GetTest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTestRequest(input, context));
@@ -821,7 +821,7 @@ export const serializeAws_json1_1GetTestGridProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetTestGridProject",
+    "x-amz-target": "DeviceFarm_20150623.GetTestGridProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTestGridProjectRequest(input, context));
@@ -834,7 +834,7 @@ export const serializeAws_json1_1GetTestGridSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetTestGridSession",
+    "x-amz-target": "DeviceFarm_20150623.GetTestGridSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTestGridSessionRequest(input, context));
@@ -847,7 +847,7 @@ export const serializeAws_json1_1GetUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetUpload",
+    "x-amz-target": "DeviceFarm_20150623.GetUpload",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetUploadRequest(input, context));
@@ -860,7 +860,7 @@ export const serializeAws_json1_1GetVPCEConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.GetVPCEConfiguration",
+    "x-amz-target": "DeviceFarm_20150623.GetVPCEConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetVPCEConfigurationRequest(input, context));
@@ -873,7 +873,7 @@ export const serializeAws_json1_1InstallToRemoteAccessSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.InstallToRemoteAccessSession",
+    "x-amz-target": "DeviceFarm_20150623.InstallToRemoteAccessSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1InstallToRemoteAccessSessionRequest(input, context));
@@ -886,7 +886,7 @@ export const serializeAws_json1_1ListArtifactsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListArtifacts",
+    "x-amz-target": "DeviceFarm_20150623.ListArtifacts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListArtifactsRequest(input, context));
@@ -899,7 +899,7 @@ export const serializeAws_json1_1ListDeviceInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListDeviceInstances",
+    "x-amz-target": "DeviceFarm_20150623.ListDeviceInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDeviceInstancesRequest(input, context));
@@ -912,7 +912,7 @@ export const serializeAws_json1_1ListDevicePoolsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListDevicePools",
+    "x-amz-target": "DeviceFarm_20150623.ListDevicePools",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDevicePoolsRequest(input, context));
@@ -925,7 +925,7 @@ export const serializeAws_json1_1ListDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListDevices",
+    "x-amz-target": "DeviceFarm_20150623.ListDevices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDevicesRequest(input, context));
@@ -938,7 +938,7 @@ export const serializeAws_json1_1ListInstanceProfilesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListInstanceProfiles",
+    "x-amz-target": "DeviceFarm_20150623.ListInstanceProfiles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListInstanceProfilesRequest(input, context));
@@ -951,7 +951,7 @@ export const serializeAws_json1_1ListJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListJobs",
+    "x-amz-target": "DeviceFarm_20150623.ListJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListJobsRequest(input, context));
@@ -964,7 +964,7 @@ export const serializeAws_json1_1ListNetworkProfilesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListNetworkProfiles",
+    "x-amz-target": "DeviceFarm_20150623.ListNetworkProfiles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListNetworkProfilesRequest(input, context));
@@ -977,7 +977,7 @@ export const serializeAws_json1_1ListOfferingPromotionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListOfferingPromotions",
+    "x-amz-target": "DeviceFarm_20150623.ListOfferingPromotions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListOfferingPromotionsRequest(input, context));
@@ -990,7 +990,7 @@ export const serializeAws_json1_1ListOfferingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListOfferings",
+    "x-amz-target": "DeviceFarm_20150623.ListOfferings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListOfferingsRequest(input, context));
@@ -1003,7 +1003,7 @@ export const serializeAws_json1_1ListOfferingTransactionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListOfferingTransactions",
+    "x-amz-target": "DeviceFarm_20150623.ListOfferingTransactions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListOfferingTransactionsRequest(input, context));
@@ -1016,7 +1016,7 @@ export const serializeAws_json1_1ListProjectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListProjects",
+    "x-amz-target": "DeviceFarm_20150623.ListProjects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProjectsRequest(input, context));
@@ -1029,7 +1029,7 @@ export const serializeAws_json1_1ListRemoteAccessSessionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListRemoteAccessSessions",
+    "x-amz-target": "DeviceFarm_20150623.ListRemoteAccessSessions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRemoteAccessSessionsRequest(input, context));
@@ -1042,7 +1042,7 @@ export const serializeAws_json1_1ListRunsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListRuns",
+    "x-amz-target": "DeviceFarm_20150623.ListRuns",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRunsRequest(input, context));
@@ -1055,7 +1055,7 @@ export const serializeAws_json1_1ListSamplesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListSamples",
+    "x-amz-target": "DeviceFarm_20150623.ListSamples",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSamplesRequest(input, context));
@@ -1068,7 +1068,7 @@ export const serializeAws_json1_1ListSuitesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListSuites",
+    "x-amz-target": "DeviceFarm_20150623.ListSuites",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSuitesRequest(input, context));
@@ -1081,7 +1081,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListTagsForResource",
+    "x-amz-target": "DeviceFarm_20150623.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -1094,7 +1094,7 @@ export const serializeAws_json1_1ListTestGridProjectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListTestGridProjects",
+    "x-amz-target": "DeviceFarm_20150623.ListTestGridProjects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTestGridProjectsRequest(input, context));
@@ -1107,7 +1107,7 @@ export const serializeAws_json1_1ListTestGridSessionActionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListTestGridSessionActions",
+    "x-amz-target": "DeviceFarm_20150623.ListTestGridSessionActions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTestGridSessionActionsRequest(input, context));
@@ -1120,7 +1120,7 @@ export const serializeAws_json1_1ListTestGridSessionArtifactsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListTestGridSessionArtifacts",
+    "x-amz-target": "DeviceFarm_20150623.ListTestGridSessionArtifacts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTestGridSessionArtifactsRequest(input, context));
@@ -1133,7 +1133,7 @@ export const serializeAws_json1_1ListTestGridSessionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListTestGridSessions",
+    "x-amz-target": "DeviceFarm_20150623.ListTestGridSessions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTestGridSessionsRequest(input, context));
@@ -1146,7 +1146,7 @@ export const serializeAws_json1_1ListTestsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListTests",
+    "x-amz-target": "DeviceFarm_20150623.ListTests",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTestsRequest(input, context));
@@ -1159,7 +1159,7 @@ export const serializeAws_json1_1ListUniqueProblemsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListUniqueProblems",
+    "x-amz-target": "DeviceFarm_20150623.ListUniqueProblems",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUniqueProblemsRequest(input, context));
@@ -1172,7 +1172,7 @@ export const serializeAws_json1_1ListUploadsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListUploads",
+    "x-amz-target": "DeviceFarm_20150623.ListUploads",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUploadsRequest(input, context));
@@ -1185,7 +1185,7 @@ export const serializeAws_json1_1ListVPCEConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ListVPCEConfigurations",
+    "x-amz-target": "DeviceFarm_20150623.ListVPCEConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListVPCEConfigurationsRequest(input, context));
@@ -1198,7 +1198,7 @@ export const serializeAws_json1_1PurchaseOfferingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.PurchaseOffering",
+    "x-amz-target": "DeviceFarm_20150623.PurchaseOffering",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PurchaseOfferingRequest(input, context));
@@ -1211,7 +1211,7 @@ export const serializeAws_json1_1RenewOfferingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.RenewOffering",
+    "x-amz-target": "DeviceFarm_20150623.RenewOffering",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RenewOfferingRequest(input, context));
@@ -1224,7 +1224,7 @@ export const serializeAws_json1_1ScheduleRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.ScheduleRun",
+    "x-amz-target": "DeviceFarm_20150623.ScheduleRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ScheduleRunRequest(input, context));
@@ -1237,7 +1237,7 @@ export const serializeAws_json1_1StopJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.StopJob",
+    "x-amz-target": "DeviceFarm_20150623.StopJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopJobRequest(input, context));
@@ -1250,7 +1250,7 @@ export const serializeAws_json1_1StopRemoteAccessSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.StopRemoteAccessSession",
+    "x-amz-target": "DeviceFarm_20150623.StopRemoteAccessSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopRemoteAccessSessionRequest(input, context));
@@ -1263,7 +1263,7 @@ export const serializeAws_json1_1StopRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.StopRun",
+    "x-amz-target": "DeviceFarm_20150623.StopRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopRunRequest(input, context));
@@ -1276,7 +1276,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.TagResource",
+    "x-amz-target": "DeviceFarm_20150623.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -1289,7 +1289,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.UntagResource",
+    "x-amz-target": "DeviceFarm_20150623.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -1302,7 +1302,7 @@ export const serializeAws_json1_1UpdateDeviceInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.UpdateDeviceInstance",
+    "x-amz-target": "DeviceFarm_20150623.UpdateDeviceInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDeviceInstanceRequest(input, context));
@@ -1315,7 +1315,7 @@ export const serializeAws_json1_1UpdateDevicePoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.UpdateDevicePool",
+    "x-amz-target": "DeviceFarm_20150623.UpdateDevicePool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDevicePoolRequest(input, context));
@@ -1328,7 +1328,7 @@ export const serializeAws_json1_1UpdateInstanceProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.UpdateInstanceProfile",
+    "x-amz-target": "DeviceFarm_20150623.UpdateInstanceProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateInstanceProfileRequest(input, context));
@@ -1341,7 +1341,7 @@ export const serializeAws_json1_1UpdateNetworkProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.UpdateNetworkProfile",
+    "x-amz-target": "DeviceFarm_20150623.UpdateNetworkProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateNetworkProfileRequest(input, context));
@@ -1354,7 +1354,7 @@ export const serializeAws_json1_1UpdateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.UpdateProject",
+    "x-amz-target": "DeviceFarm_20150623.UpdateProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateProjectRequest(input, context));
@@ -1367,7 +1367,7 @@ export const serializeAws_json1_1UpdateTestGridProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.UpdateTestGridProject",
+    "x-amz-target": "DeviceFarm_20150623.UpdateTestGridProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTestGridProjectRequest(input, context));
@@ -1380,7 +1380,7 @@ export const serializeAws_json1_1UpdateUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.UpdateUpload",
+    "x-amz-target": "DeviceFarm_20150623.UpdateUpload",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateUploadRequest(input, context));
@@ -1393,7 +1393,7 @@ export const serializeAws_json1_1UpdateVPCEConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DeviceFarm_20150623.UpdateVPCEConfiguration",
+    "x-amz-target": "DeviceFarm_20150623.UpdateVPCEConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateVPCEConfigurationRequest(input, context));

--- a/clients/client-direct-connect/protocols/Aws_json1_1.ts
+++ b/clients/client-direct-connect/protocols/Aws_json1_1.ts
@@ -310,7 +310,7 @@ export const serializeAws_json1_1AcceptDirectConnectGatewayAssociationProposalCo
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.AcceptDirectConnectGatewayAssociationProposal",
+    "x-amz-target": "OvertureService.AcceptDirectConnectGatewayAssociationProposal",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AcceptDirectConnectGatewayAssociationProposalRequest(input, context));
@@ -323,7 +323,7 @@ export const serializeAws_json1_1AllocateConnectionOnInterconnectCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.AllocateConnectionOnInterconnect",
+    "x-amz-target": "OvertureService.AllocateConnectionOnInterconnect",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AllocateConnectionOnInterconnectRequest(input, context));
@@ -336,7 +336,7 @@ export const serializeAws_json1_1AllocateHostedConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.AllocateHostedConnection",
+    "x-amz-target": "OvertureService.AllocateHostedConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AllocateHostedConnectionRequest(input, context));
@@ -349,7 +349,7 @@ export const serializeAws_json1_1AllocatePrivateVirtualInterfaceCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.AllocatePrivateVirtualInterface",
+    "x-amz-target": "OvertureService.AllocatePrivateVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AllocatePrivateVirtualInterfaceRequest(input, context));
@@ -362,7 +362,7 @@ export const serializeAws_json1_1AllocatePublicVirtualInterfaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.AllocatePublicVirtualInterface",
+    "x-amz-target": "OvertureService.AllocatePublicVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AllocatePublicVirtualInterfaceRequest(input, context));
@@ -375,7 +375,7 @@ export const serializeAws_json1_1AllocateTransitVirtualInterfaceCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.AllocateTransitVirtualInterface",
+    "x-amz-target": "OvertureService.AllocateTransitVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AllocateTransitVirtualInterfaceRequest(input, context));
@@ -388,7 +388,7 @@ export const serializeAws_json1_1AssociateConnectionWithLagCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.AssociateConnectionWithLag",
+    "x-amz-target": "OvertureService.AssociateConnectionWithLag",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateConnectionWithLagRequest(input, context));
@@ -401,7 +401,7 @@ export const serializeAws_json1_1AssociateHostedConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.AssociateHostedConnection",
+    "x-amz-target": "OvertureService.AssociateHostedConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateHostedConnectionRequest(input, context));
@@ -414,7 +414,7 @@ export const serializeAws_json1_1AssociateVirtualInterfaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.AssociateVirtualInterface",
+    "x-amz-target": "OvertureService.AssociateVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateVirtualInterfaceRequest(input, context));
@@ -427,7 +427,7 @@ export const serializeAws_json1_1ConfirmConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.ConfirmConnection",
+    "x-amz-target": "OvertureService.ConfirmConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ConfirmConnectionRequest(input, context));
@@ -440,7 +440,7 @@ export const serializeAws_json1_1ConfirmPrivateVirtualInterfaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.ConfirmPrivateVirtualInterface",
+    "x-amz-target": "OvertureService.ConfirmPrivateVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ConfirmPrivateVirtualInterfaceRequest(input, context));
@@ -453,7 +453,7 @@ export const serializeAws_json1_1ConfirmPublicVirtualInterfaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.ConfirmPublicVirtualInterface",
+    "x-amz-target": "OvertureService.ConfirmPublicVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ConfirmPublicVirtualInterfaceRequest(input, context));
@@ -466,7 +466,7 @@ export const serializeAws_json1_1ConfirmTransitVirtualInterfaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.ConfirmTransitVirtualInterface",
+    "x-amz-target": "OvertureService.ConfirmTransitVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ConfirmTransitVirtualInterfaceRequest(input, context));
@@ -479,7 +479,7 @@ export const serializeAws_json1_1CreateBGPPeerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.CreateBGPPeer",
+    "x-amz-target": "OvertureService.CreateBGPPeer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateBGPPeerRequest(input, context));
@@ -492,7 +492,7 @@ export const serializeAws_json1_1CreateConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.CreateConnection",
+    "x-amz-target": "OvertureService.CreateConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateConnectionRequest(input, context));
@@ -505,7 +505,7 @@ export const serializeAws_json1_1CreateDirectConnectGatewayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.CreateDirectConnectGateway",
+    "x-amz-target": "OvertureService.CreateDirectConnectGateway",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDirectConnectGatewayRequest(input, context));
@@ -518,7 +518,7 @@ export const serializeAws_json1_1CreateDirectConnectGatewayAssociationCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.CreateDirectConnectGatewayAssociation",
+    "x-amz-target": "OvertureService.CreateDirectConnectGatewayAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDirectConnectGatewayAssociationRequest(input, context));
@@ -531,7 +531,7 @@ export const serializeAws_json1_1CreateDirectConnectGatewayAssociationProposalCo
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.CreateDirectConnectGatewayAssociationProposal",
+    "x-amz-target": "OvertureService.CreateDirectConnectGatewayAssociationProposal",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDirectConnectGatewayAssociationProposalRequest(input, context));
@@ -544,7 +544,7 @@ export const serializeAws_json1_1CreateInterconnectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.CreateInterconnect",
+    "x-amz-target": "OvertureService.CreateInterconnect",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateInterconnectRequest(input, context));
@@ -557,7 +557,7 @@ export const serializeAws_json1_1CreateLagCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.CreateLag",
+    "x-amz-target": "OvertureService.CreateLag",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLagRequest(input, context));
@@ -570,7 +570,7 @@ export const serializeAws_json1_1CreatePrivateVirtualInterfaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.CreatePrivateVirtualInterface",
+    "x-amz-target": "OvertureService.CreatePrivateVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePrivateVirtualInterfaceRequest(input, context));
@@ -583,7 +583,7 @@ export const serializeAws_json1_1CreatePublicVirtualInterfaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.CreatePublicVirtualInterface",
+    "x-amz-target": "OvertureService.CreatePublicVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePublicVirtualInterfaceRequest(input, context));
@@ -596,7 +596,7 @@ export const serializeAws_json1_1CreateTransitVirtualInterfaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.CreateTransitVirtualInterface",
+    "x-amz-target": "OvertureService.CreateTransitVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTransitVirtualInterfaceRequest(input, context));
@@ -609,7 +609,7 @@ export const serializeAws_json1_1DeleteBGPPeerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DeleteBGPPeer",
+    "x-amz-target": "OvertureService.DeleteBGPPeer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBGPPeerRequest(input, context));
@@ -622,7 +622,7 @@ export const serializeAws_json1_1DeleteConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DeleteConnection",
+    "x-amz-target": "OvertureService.DeleteConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConnectionRequest(input, context));
@@ -635,7 +635,7 @@ export const serializeAws_json1_1DeleteDirectConnectGatewayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DeleteDirectConnectGateway",
+    "x-amz-target": "OvertureService.DeleteDirectConnectGateway",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDirectConnectGatewayRequest(input, context));
@@ -648,7 +648,7 @@ export const serializeAws_json1_1DeleteDirectConnectGatewayAssociationCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DeleteDirectConnectGatewayAssociation",
+    "x-amz-target": "OvertureService.DeleteDirectConnectGatewayAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDirectConnectGatewayAssociationRequest(input, context));
@@ -661,7 +661,7 @@ export const serializeAws_json1_1DeleteDirectConnectGatewayAssociationProposalCo
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DeleteDirectConnectGatewayAssociationProposal",
+    "x-amz-target": "OvertureService.DeleteDirectConnectGatewayAssociationProposal",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDirectConnectGatewayAssociationProposalRequest(input, context));
@@ -674,7 +674,7 @@ export const serializeAws_json1_1DeleteInterconnectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DeleteInterconnect",
+    "x-amz-target": "OvertureService.DeleteInterconnect",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteInterconnectRequest(input, context));
@@ -687,7 +687,7 @@ export const serializeAws_json1_1DeleteLagCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DeleteLag",
+    "x-amz-target": "OvertureService.DeleteLag",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLagRequest(input, context));
@@ -700,7 +700,7 @@ export const serializeAws_json1_1DeleteVirtualInterfaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DeleteVirtualInterface",
+    "x-amz-target": "OvertureService.DeleteVirtualInterface",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteVirtualInterfaceRequest(input, context));
@@ -713,7 +713,7 @@ export const serializeAws_json1_1DescribeConnectionLoaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeConnectionLoa",
+    "x-amz-target": "OvertureService.DescribeConnectionLoa",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConnectionLoaRequest(input, context));
@@ -726,7 +726,7 @@ export const serializeAws_json1_1DescribeConnectionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeConnections",
+    "x-amz-target": "OvertureService.DescribeConnections",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConnectionsRequest(input, context));
@@ -739,7 +739,7 @@ export const serializeAws_json1_1DescribeConnectionsOnInterconnectCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeConnectionsOnInterconnect",
+    "x-amz-target": "OvertureService.DescribeConnectionsOnInterconnect",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConnectionsOnInterconnectRequest(input, context));
@@ -752,7 +752,7 @@ export const serializeAws_json1_1DescribeDirectConnectGatewayAssociationProposal
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeDirectConnectGatewayAssociationProposals",
+    "x-amz-target": "OvertureService.DescribeDirectConnectGatewayAssociationProposals",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDirectConnectGatewayAssociationProposalsRequest(input, context));
@@ -765,7 +765,7 @@ export const serializeAws_json1_1DescribeDirectConnectGatewayAssociationsCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeDirectConnectGatewayAssociations",
+    "x-amz-target": "OvertureService.DescribeDirectConnectGatewayAssociations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDirectConnectGatewayAssociationsRequest(input, context));
@@ -778,7 +778,7 @@ export const serializeAws_json1_1DescribeDirectConnectGatewayAttachmentsCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeDirectConnectGatewayAttachments",
+    "x-amz-target": "OvertureService.DescribeDirectConnectGatewayAttachments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDirectConnectGatewayAttachmentsRequest(input, context));
@@ -791,7 +791,7 @@ export const serializeAws_json1_1DescribeDirectConnectGatewaysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeDirectConnectGateways",
+    "x-amz-target": "OvertureService.DescribeDirectConnectGateways",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDirectConnectGatewaysRequest(input, context));
@@ -804,7 +804,7 @@ export const serializeAws_json1_1DescribeHostedConnectionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeHostedConnections",
+    "x-amz-target": "OvertureService.DescribeHostedConnections",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeHostedConnectionsRequest(input, context));
@@ -817,7 +817,7 @@ export const serializeAws_json1_1DescribeInterconnectLoaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeInterconnectLoa",
+    "x-amz-target": "OvertureService.DescribeInterconnectLoa",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInterconnectLoaRequest(input, context));
@@ -830,7 +830,7 @@ export const serializeAws_json1_1DescribeInterconnectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeInterconnects",
+    "x-amz-target": "OvertureService.DescribeInterconnects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInterconnectsRequest(input, context));
@@ -843,7 +843,7 @@ export const serializeAws_json1_1DescribeLagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeLags",
+    "x-amz-target": "OvertureService.DescribeLags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLagsRequest(input, context));
@@ -856,7 +856,7 @@ export const serializeAws_json1_1DescribeLoaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeLoa",
+    "x-amz-target": "OvertureService.DescribeLoa",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLoaRequest(input, context));
@@ -869,7 +869,7 @@ export const serializeAws_json1_1DescribeLocationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeLocations",
+    "x-amz-target": "OvertureService.DescribeLocations",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -880,7 +880,7 @@ export const serializeAws_json1_1DescribeTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeTags",
+    "x-amz-target": "OvertureService.DescribeTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTagsRequest(input, context));
@@ -893,7 +893,7 @@ export const serializeAws_json1_1DescribeVirtualGatewaysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeVirtualGateways",
+    "x-amz-target": "OvertureService.DescribeVirtualGateways",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -904,7 +904,7 @@ export const serializeAws_json1_1DescribeVirtualInterfacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DescribeVirtualInterfaces",
+    "x-amz-target": "OvertureService.DescribeVirtualInterfaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeVirtualInterfacesRequest(input, context));
@@ -917,7 +917,7 @@ export const serializeAws_json1_1DisassociateConnectionFromLagCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.DisassociateConnectionFromLag",
+    "x-amz-target": "OvertureService.DisassociateConnectionFromLag",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateConnectionFromLagRequest(input, context));
@@ -930,7 +930,7 @@ export const serializeAws_json1_1ListVirtualInterfaceTestHistoryCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.ListVirtualInterfaceTestHistory",
+    "x-amz-target": "OvertureService.ListVirtualInterfaceTestHistory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListVirtualInterfaceTestHistoryRequest(input, context));
@@ -943,7 +943,7 @@ export const serializeAws_json1_1StartBgpFailoverTestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.StartBgpFailoverTest",
+    "x-amz-target": "OvertureService.StartBgpFailoverTest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartBgpFailoverTestRequest(input, context));
@@ -956,7 +956,7 @@ export const serializeAws_json1_1StopBgpFailoverTestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.StopBgpFailoverTest",
+    "x-amz-target": "OvertureService.StopBgpFailoverTest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopBgpFailoverTestRequest(input, context));
@@ -969,7 +969,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.TagResource",
+    "x-amz-target": "OvertureService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -982,7 +982,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.UntagResource",
+    "x-amz-target": "OvertureService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -995,7 +995,7 @@ export const serializeAws_json1_1UpdateDirectConnectGatewayAssociationCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.UpdateDirectConnectGatewayAssociation",
+    "x-amz-target": "OvertureService.UpdateDirectConnectGatewayAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDirectConnectGatewayAssociationRequest(input, context));
@@ -1008,7 +1008,7 @@ export const serializeAws_json1_1UpdateLagCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.UpdateLag",
+    "x-amz-target": "OvertureService.UpdateLag",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateLagRequest(input, context));
@@ -1021,7 +1021,7 @@ export const serializeAws_json1_1UpdateVirtualInterfaceAttributesCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OvertureService.UpdateVirtualInterfaceAttributes",
+    "x-amz-target": "OvertureService.UpdateVirtualInterfaceAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateVirtualInterfaceAttributesRequest(input, context));

--- a/clients/client-directory-service/protocols/Aws_json1_1.ts
+++ b/clients/client-directory-service/protocols/Aws_json1_1.ts
@@ -347,7 +347,7 @@ export const serializeAws_json1_1AcceptSharedDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.AcceptSharedDirectory",
+    "x-amz-target": "DirectoryService_20150416.AcceptSharedDirectory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AcceptSharedDirectoryRequest(input, context));
@@ -360,7 +360,7 @@ export const serializeAws_json1_1AddIpRoutesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.AddIpRoutes",
+    "x-amz-target": "DirectoryService_20150416.AddIpRoutes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddIpRoutesRequest(input, context));
@@ -373,7 +373,7 @@ export const serializeAws_json1_1AddRegionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.AddRegion",
+    "x-amz-target": "DirectoryService_20150416.AddRegion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddRegionRequest(input, context));
@@ -386,7 +386,7 @@ export const serializeAws_json1_1AddTagsToResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.AddTagsToResource",
+    "x-amz-target": "DirectoryService_20150416.AddTagsToResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsToResourceRequest(input, context));
@@ -399,7 +399,7 @@ export const serializeAws_json1_1CancelSchemaExtensionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.CancelSchemaExtension",
+    "x-amz-target": "DirectoryService_20150416.CancelSchemaExtension",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelSchemaExtensionRequest(input, context));
@@ -412,7 +412,7 @@ export const serializeAws_json1_1ConnectDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.ConnectDirectory",
+    "x-amz-target": "DirectoryService_20150416.ConnectDirectory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ConnectDirectoryRequest(input, context));
@@ -425,7 +425,7 @@ export const serializeAws_json1_1CreateAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.CreateAlias",
+    "x-amz-target": "DirectoryService_20150416.CreateAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAliasRequest(input, context));
@@ -438,7 +438,7 @@ export const serializeAws_json1_1CreateComputerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.CreateComputer",
+    "x-amz-target": "DirectoryService_20150416.CreateComputer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateComputerRequest(input, context));
@@ -451,7 +451,7 @@ export const serializeAws_json1_1CreateConditionalForwarderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.CreateConditionalForwarder",
+    "x-amz-target": "DirectoryService_20150416.CreateConditionalForwarder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateConditionalForwarderRequest(input, context));
@@ -464,7 +464,7 @@ export const serializeAws_json1_1CreateDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.CreateDirectory",
+    "x-amz-target": "DirectoryService_20150416.CreateDirectory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDirectoryRequest(input, context));
@@ -477,7 +477,7 @@ export const serializeAws_json1_1CreateLogSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.CreateLogSubscription",
+    "x-amz-target": "DirectoryService_20150416.CreateLogSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLogSubscriptionRequest(input, context));
@@ -490,7 +490,7 @@ export const serializeAws_json1_1CreateMicrosoftADCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.CreateMicrosoftAD",
+    "x-amz-target": "DirectoryService_20150416.CreateMicrosoftAD",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateMicrosoftADRequest(input, context));
@@ -503,7 +503,7 @@ export const serializeAws_json1_1CreateSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.CreateSnapshot",
+    "x-amz-target": "DirectoryService_20150416.CreateSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSnapshotRequest(input, context));
@@ -516,7 +516,7 @@ export const serializeAws_json1_1CreateTrustCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.CreateTrust",
+    "x-amz-target": "DirectoryService_20150416.CreateTrust",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTrustRequest(input, context));
@@ -529,7 +529,7 @@ export const serializeAws_json1_1DeleteConditionalForwarderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DeleteConditionalForwarder",
+    "x-amz-target": "DirectoryService_20150416.DeleteConditionalForwarder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConditionalForwarderRequest(input, context));
@@ -542,7 +542,7 @@ export const serializeAws_json1_1DeleteDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DeleteDirectory",
+    "x-amz-target": "DirectoryService_20150416.DeleteDirectory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDirectoryRequest(input, context));
@@ -555,7 +555,7 @@ export const serializeAws_json1_1DeleteLogSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DeleteLogSubscription",
+    "x-amz-target": "DirectoryService_20150416.DeleteLogSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLogSubscriptionRequest(input, context));
@@ -568,7 +568,7 @@ export const serializeAws_json1_1DeleteSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DeleteSnapshot",
+    "x-amz-target": "DirectoryService_20150416.DeleteSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSnapshotRequest(input, context));
@@ -581,7 +581,7 @@ export const serializeAws_json1_1DeleteTrustCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DeleteTrust",
+    "x-amz-target": "DirectoryService_20150416.DeleteTrust",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTrustRequest(input, context));
@@ -594,7 +594,7 @@ export const serializeAws_json1_1DeregisterCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DeregisterCertificate",
+    "x-amz-target": "DirectoryService_20150416.DeregisterCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterCertificateRequest(input, context));
@@ -607,7 +607,7 @@ export const serializeAws_json1_1DeregisterEventTopicCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DeregisterEventTopic",
+    "x-amz-target": "DirectoryService_20150416.DeregisterEventTopic",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterEventTopicRequest(input, context));
@@ -620,7 +620,7 @@ export const serializeAws_json1_1DescribeCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DescribeCertificate",
+    "x-amz-target": "DirectoryService_20150416.DescribeCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCertificateRequest(input, context));
@@ -633,7 +633,7 @@ export const serializeAws_json1_1DescribeConditionalForwardersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DescribeConditionalForwarders",
+    "x-amz-target": "DirectoryService_20150416.DescribeConditionalForwarders",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConditionalForwardersRequest(input, context));
@@ -646,7 +646,7 @@ export const serializeAws_json1_1DescribeDirectoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DescribeDirectories",
+    "x-amz-target": "DirectoryService_20150416.DescribeDirectories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDirectoriesRequest(input, context));
@@ -659,7 +659,7 @@ export const serializeAws_json1_1DescribeDomainControllersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DescribeDomainControllers",
+    "x-amz-target": "DirectoryService_20150416.DescribeDomainControllers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDomainControllersRequest(input, context));
@@ -672,7 +672,7 @@ export const serializeAws_json1_1DescribeEventTopicsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DescribeEventTopics",
+    "x-amz-target": "DirectoryService_20150416.DescribeEventTopics",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventTopicsRequest(input, context));
@@ -685,7 +685,7 @@ export const serializeAws_json1_1DescribeLDAPSSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DescribeLDAPSSettings",
+    "x-amz-target": "DirectoryService_20150416.DescribeLDAPSSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLDAPSSettingsRequest(input, context));
@@ -698,7 +698,7 @@ export const serializeAws_json1_1DescribeRegionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DescribeRegions",
+    "x-amz-target": "DirectoryService_20150416.DescribeRegions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRegionsRequest(input, context));
@@ -711,7 +711,7 @@ export const serializeAws_json1_1DescribeSharedDirectoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DescribeSharedDirectories",
+    "x-amz-target": "DirectoryService_20150416.DescribeSharedDirectories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSharedDirectoriesRequest(input, context));
@@ -724,7 +724,7 @@ export const serializeAws_json1_1DescribeSnapshotsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DescribeSnapshots",
+    "x-amz-target": "DirectoryService_20150416.DescribeSnapshots",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSnapshotsRequest(input, context));
@@ -737,7 +737,7 @@ export const serializeAws_json1_1DescribeTrustsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DescribeTrusts",
+    "x-amz-target": "DirectoryService_20150416.DescribeTrusts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTrustsRequest(input, context));
@@ -750,7 +750,7 @@ export const serializeAws_json1_1DisableClientAuthenticationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DisableClientAuthentication",
+    "x-amz-target": "DirectoryService_20150416.DisableClientAuthentication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableClientAuthenticationRequest(input, context));
@@ -763,7 +763,7 @@ export const serializeAws_json1_1DisableLDAPSCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DisableLDAPS",
+    "x-amz-target": "DirectoryService_20150416.DisableLDAPS",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableLDAPSRequest(input, context));
@@ -776,7 +776,7 @@ export const serializeAws_json1_1DisableRadiusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DisableRadius",
+    "x-amz-target": "DirectoryService_20150416.DisableRadius",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableRadiusRequest(input, context));
@@ -789,7 +789,7 @@ export const serializeAws_json1_1DisableSsoCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.DisableSso",
+    "x-amz-target": "DirectoryService_20150416.DisableSso",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableSsoRequest(input, context));
@@ -802,7 +802,7 @@ export const serializeAws_json1_1EnableClientAuthenticationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.EnableClientAuthentication",
+    "x-amz-target": "DirectoryService_20150416.EnableClientAuthentication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableClientAuthenticationRequest(input, context));
@@ -815,7 +815,7 @@ export const serializeAws_json1_1EnableLDAPSCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.EnableLDAPS",
+    "x-amz-target": "DirectoryService_20150416.EnableLDAPS",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableLDAPSRequest(input, context));
@@ -828,7 +828,7 @@ export const serializeAws_json1_1EnableRadiusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.EnableRadius",
+    "x-amz-target": "DirectoryService_20150416.EnableRadius",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableRadiusRequest(input, context));
@@ -841,7 +841,7 @@ export const serializeAws_json1_1EnableSsoCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.EnableSso",
+    "x-amz-target": "DirectoryService_20150416.EnableSso",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableSsoRequest(input, context));
@@ -854,7 +854,7 @@ export const serializeAws_json1_1GetDirectoryLimitsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.GetDirectoryLimits",
+    "x-amz-target": "DirectoryService_20150416.GetDirectoryLimits",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDirectoryLimitsRequest(input, context));
@@ -867,7 +867,7 @@ export const serializeAws_json1_1GetSnapshotLimitsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.GetSnapshotLimits",
+    "x-amz-target": "DirectoryService_20150416.GetSnapshotLimits",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSnapshotLimitsRequest(input, context));
@@ -880,7 +880,7 @@ export const serializeAws_json1_1ListCertificatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.ListCertificates",
+    "x-amz-target": "DirectoryService_20150416.ListCertificates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCertificatesRequest(input, context));
@@ -893,7 +893,7 @@ export const serializeAws_json1_1ListIpRoutesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.ListIpRoutes",
+    "x-amz-target": "DirectoryService_20150416.ListIpRoutes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListIpRoutesRequest(input, context));
@@ -906,7 +906,7 @@ export const serializeAws_json1_1ListLogSubscriptionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.ListLogSubscriptions",
+    "x-amz-target": "DirectoryService_20150416.ListLogSubscriptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLogSubscriptionsRequest(input, context));
@@ -919,7 +919,7 @@ export const serializeAws_json1_1ListSchemaExtensionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.ListSchemaExtensions",
+    "x-amz-target": "DirectoryService_20150416.ListSchemaExtensions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSchemaExtensionsRequest(input, context));
@@ -932,7 +932,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.ListTagsForResource",
+    "x-amz-target": "DirectoryService_20150416.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -945,7 +945,7 @@ export const serializeAws_json1_1RegisterCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.RegisterCertificate",
+    "x-amz-target": "DirectoryService_20150416.RegisterCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterCertificateRequest(input, context));
@@ -958,7 +958,7 @@ export const serializeAws_json1_1RegisterEventTopicCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.RegisterEventTopic",
+    "x-amz-target": "DirectoryService_20150416.RegisterEventTopic",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterEventTopicRequest(input, context));
@@ -971,7 +971,7 @@ export const serializeAws_json1_1RejectSharedDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.RejectSharedDirectory",
+    "x-amz-target": "DirectoryService_20150416.RejectSharedDirectory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RejectSharedDirectoryRequest(input, context));
@@ -984,7 +984,7 @@ export const serializeAws_json1_1RemoveIpRoutesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.RemoveIpRoutes",
+    "x-amz-target": "DirectoryService_20150416.RemoveIpRoutes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveIpRoutesRequest(input, context));
@@ -997,7 +997,7 @@ export const serializeAws_json1_1RemoveRegionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.RemoveRegion",
+    "x-amz-target": "DirectoryService_20150416.RemoveRegion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveRegionRequest(input, context));
@@ -1010,7 +1010,7 @@ export const serializeAws_json1_1RemoveTagsFromResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.RemoveTagsFromResource",
+    "x-amz-target": "DirectoryService_20150416.RemoveTagsFromResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsFromResourceRequest(input, context));
@@ -1023,7 +1023,7 @@ export const serializeAws_json1_1ResetUserPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.ResetUserPassword",
+    "x-amz-target": "DirectoryService_20150416.ResetUserPassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResetUserPasswordRequest(input, context));
@@ -1036,7 +1036,7 @@ export const serializeAws_json1_1RestoreFromSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.RestoreFromSnapshot",
+    "x-amz-target": "DirectoryService_20150416.RestoreFromSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RestoreFromSnapshotRequest(input, context));
@@ -1049,7 +1049,7 @@ export const serializeAws_json1_1ShareDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.ShareDirectory",
+    "x-amz-target": "DirectoryService_20150416.ShareDirectory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ShareDirectoryRequest(input, context));
@@ -1062,7 +1062,7 @@ export const serializeAws_json1_1StartSchemaExtensionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.StartSchemaExtension",
+    "x-amz-target": "DirectoryService_20150416.StartSchemaExtension",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartSchemaExtensionRequest(input, context));
@@ -1075,7 +1075,7 @@ export const serializeAws_json1_1UnshareDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.UnshareDirectory",
+    "x-amz-target": "DirectoryService_20150416.UnshareDirectory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UnshareDirectoryRequest(input, context));
@@ -1088,7 +1088,7 @@ export const serializeAws_json1_1UpdateConditionalForwarderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.UpdateConditionalForwarder",
+    "x-amz-target": "DirectoryService_20150416.UpdateConditionalForwarder",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateConditionalForwarderRequest(input, context));
@@ -1101,7 +1101,7 @@ export const serializeAws_json1_1UpdateNumberOfDomainControllersCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.UpdateNumberOfDomainControllers",
+    "x-amz-target": "DirectoryService_20150416.UpdateNumberOfDomainControllers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateNumberOfDomainControllersRequest(input, context));
@@ -1114,7 +1114,7 @@ export const serializeAws_json1_1UpdateRadiusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.UpdateRadius",
+    "x-amz-target": "DirectoryService_20150416.UpdateRadius",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRadiusRequest(input, context));
@@ -1127,7 +1127,7 @@ export const serializeAws_json1_1UpdateTrustCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.UpdateTrust",
+    "x-amz-target": "DirectoryService_20150416.UpdateTrust",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTrustRequest(input, context));
@@ -1140,7 +1140,7 @@ export const serializeAws_json1_1VerifyTrustCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "DirectoryService_20150416.VerifyTrust",
+    "x-amz-target": "DirectoryService_20150416.VerifyTrust",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1VerifyTrustRequest(input, context));

--- a/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb-streams/protocols/Aws_json1_0.ts
@@ -42,7 +42,7 @@ export const serializeAws_json1_0DescribeStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDBStreams_20120810.DescribeStream",
+    "x-amz-target": "DynamoDBStreams_20120810.DescribeStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeStreamInput(input, context));
@@ -55,7 +55,7 @@ export const serializeAws_json1_0GetRecordsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDBStreams_20120810.GetRecords",
+    "x-amz-target": "DynamoDBStreams_20120810.GetRecords",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetRecordsInput(input, context));
@@ -68,7 +68,7 @@ export const serializeAws_json1_0GetShardIteratorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDBStreams_20120810.GetShardIterator",
+    "x-amz-target": "DynamoDBStreams_20120810.GetShardIterator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetShardIteratorInput(input, context));
@@ -81,7 +81,7 @@ export const serializeAws_json1_0ListStreamsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDBStreams_20120810.ListStreams",
+    "x-amz-target": "DynamoDBStreams_20120810.ListStreams",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListStreamsInput(input, context));

--- a/clients/client-dynamodb/protocols/Aws_json1_0.ts
+++ b/clients/client-dynamodb/protocols/Aws_json1_0.ts
@@ -338,7 +338,7 @@ export const serializeAws_json1_0BatchExecuteStatementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.BatchExecuteStatement",
+    "x-amz-target": "DynamoDB_20120810.BatchExecuteStatement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0BatchExecuteStatementInput(input, context));
@@ -351,7 +351,7 @@ export const serializeAws_json1_0BatchGetItemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.BatchGetItem",
+    "x-amz-target": "DynamoDB_20120810.BatchGetItem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0BatchGetItemInput(input, context));
@@ -364,7 +364,7 @@ export const serializeAws_json1_0BatchWriteItemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.BatchWriteItem",
+    "x-amz-target": "DynamoDB_20120810.BatchWriteItem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0BatchWriteItemInput(input, context));
@@ -377,7 +377,7 @@ export const serializeAws_json1_0CreateBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.CreateBackup",
+    "x-amz-target": "DynamoDB_20120810.CreateBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateBackupInput(input, context));
@@ -390,7 +390,7 @@ export const serializeAws_json1_0CreateGlobalTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.CreateGlobalTable",
+    "x-amz-target": "DynamoDB_20120810.CreateGlobalTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateGlobalTableInput(input, context));
@@ -403,7 +403,7 @@ export const serializeAws_json1_0CreateTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.CreateTable",
+    "x-amz-target": "DynamoDB_20120810.CreateTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateTableInput(input, context));
@@ -416,7 +416,7 @@ export const serializeAws_json1_0DeleteBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DeleteBackup",
+    "x-amz-target": "DynamoDB_20120810.DeleteBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteBackupInput(input, context));
@@ -429,7 +429,7 @@ export const serializeAws_json1_0DeleteItemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DeleteItem",
+    "x-amz-target": "DynamoDB_20120810.DeleteItem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteItemInput(input, context));
@@ -442,7 +442,7 @@ export const serializeAws_json1_0DeleteTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DeleteTable",
+    "x-amz-target": "DynamoDB_20120810.DeleteTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteTableInput(input, context));
@@ -455,7 +455,7 @@ export const serializeAws_json1_0DescribeBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeBackup",
+    "x-amz-target": "DynamoDB_20120810.DescribeBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeBackupInput(input, context));
@@ -468,7 +468,7 @@ export const serializeAws_json1_0DescribeContinuousBackupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeContinuousBackups",
+    "x-amz-target": "DynamoDB_20120810.DescribeContinuousBackups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeContinuousBackupsInput(input, context));
@@ -481,7 +481,7 @@ export const serializeAws_json1_0DescribeContributorInsightsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeContributorInsights",
+    "x-amz-target": "DynamoDB_20120810.DescribeContributorInsights",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeContributorInsightsInput(input, context));
@@ -494,7 +494,7 @@ export const serializeAws_json1_0DescribeEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeEndpoints",
+    "x-amz-target": "DynamoDB_20120810.DescribeEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeEndpointsRequest(input, context));
@@ -507,7 +507,7 @@ export const serializeAws_json1_0DescribeExportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeExport",
+    "x-amz-target": "DynamoDB_20120810.DescribeExport",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeExportInput(input, context));
@@ -520,7 +520,7 @@ export const serializeAws_json1_0DescribeGlobalTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeGlobalTable",
+    "x-amz-target": "DynamoDB_20120810.DescribeGlobalTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeGlobalTableInput(input, context));
@@ -533,7 +533,7 @@ export const serializeAws_json1_0DescribeGlobalTableSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeGlobalTableSettings",
+    "x-amz-target": "DynamoDB_20120810.DescribeGlobalTableSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeGlobalTableSettingsInput(input, context));
@@ -546,7 +546,7 @@ export const serializeAws_json1_0DescribeKinesisStreamingDestinationCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeKinesisStreamingDestination",
+    "x-amz-target": "DynamoDB_20120810.DescribeKinesisStreamingDestination",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeKinesisStreamingDestinationInput(input, context));
@@ -559,7 +559,7 @@ export const serializeAws_json1_0DescribeLimitsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeLimits",
+    "x-amz-target": "DynamoDB_20120810.DescribeLimits",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeLimitsInput(input, context));
@@ -572,7 +572,7 @@ export const serializeAws_json1_0DescribeTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeTable",
+    "x-amz-target": "DynamoDB_20120810.DescribeTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeTableInput(input, context));
@@ -585,7 +585,7 @@ export const serializeAws_json1_0DescribeTableReplicaAutoScalingCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeTableReplicaAutoScaling",
+    "x-amz-target": "DynamoDB_20120810.DescribeTableReplicaAutoScaling",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeTableReplicaAutoScalingInput(input, context));
@@ -598,7 +598,7 @@ export const serializeAws_json1_0DescribeTimeToLiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DescribeTimeToLive",
+    "x-amz-target": "DynamoDB_20120810.DescribeTimeToLive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeTimeToLiveInput(input, context));
@@ -611,7 +611,7 @@ export const serializeAws_json1_0DisableKinesisStreamingDestinationCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.DisableKinesisStreamingDestination",
+    "x-amz-target": "DynamoDB_20120810.DisableKinesisStreamingDestination",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0KinesisStreamingDestinationInput(input, context));
@@ -624,7 +624,7 @@ export const serializeAws_json1_0EnableKinesisStreamingDestinationCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.EnableKinesisStreamingDestination",
+    "x-amz-target": "DynamoDB_20120810.EnableKinesisStreamingDestination",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0KinesisStreamingDestinationInput(input, context));
@@ -637,7 +637,7 @@ export const serializeAws_json1_0ExecuteStatementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.ExecuteStatement",
+    "x-amz-target": "DynamoDB_20120810.ExecuteStatement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ExecuteStatementInput(input, context));
@@ -650,7 +650,7 @@ export const serializeAws_json1_0ExecuteTransactionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.ExecuteTransaction",
+    "x-amz-target": "DynamoDB_20120810.ExecuteTransaction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ExecuteTransactionInput(input, context));
@@ -663,7 +663,7 @@ export const serializeAws_json1_0ExportTableToPointInTimeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.ExportTableToPointInTime",
+    "x-amz-target": "DynamoDB_20120810.ExportTableToPointInTime",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ExportTableToPointInTimeInput(input, context));
@@ -676,7 +676,7 @@ export const serializeAws_json1_0GetItemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.GetItem",
+    "x-amz-target": "DynamoDB_20120810.GetItem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetItemInput(input, context));
@@ -689,7 +689,7 @@ export const serializeAws_json1_0ListBackupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.ListBackups",
+    "x-amz-target": "DynamoDB_20120810.ListBackups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListBackupsInput(input, context));
@@ -702,7 +702,7 @@ export const serializeAws_json1_0ListContributorInsightsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.ListContributorInsights",
+    "x-amz-target": "DynamoDB_20120810.ListContributorInsights",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListContributorInsightsInput(input, context));
@@ -715,7 +715,7 @@ export const serializeAws_json1_0ListExportsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.ListExports",
+    "x-amz-target": "DynamoDB_20120810.ListExports",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListExportsInput(input, context));
@@ -728,7 +728,7 @@ export const serializeAws_json1_0ListGlobalTablesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.ListGlobalTables",
+    "x-amz-target": "DynamoDB_20120810.ListGlobalTables",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListGlobalTablesInput(input, context));
@@ -741,7 +741,7 @@ export const serializeAws_json1_0ListTablesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.ListTables",
+    "x-amz-target": "DynamoDB_20120810.ListTables",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListTablesInput(input, context));
@@ -754,7 +754,7 @@ export const serializeAws_json1_0ListTagsOfResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.ListTagsOfResource",
+    "x-amz-target": "DynamoDB_20120810.ListTagsOfResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListTagsOfResourceInput(input, context));
@@ -767,7 +767,7 @@ export const serializeAws_json1_0PutItemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.PutItem",
+    "x-amz-target": "DynamoDB_20120810.PutItem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0PutItemInput(input, context));
@@ -780,7 +780,7 @@ export const serializeAws_json1_0QueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.Query",
+    "x-amz-target": "DynamoDB_20120810.Query",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0QueryInput(input, context));
@@ -793,7 +793,7 @@ export const serializeAws_json1_0RestoreTableFromBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.RestoreTableFromBackup",
+    "x-amz-target": "DynamoDB_20120810.RestoreTableFromBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RestoreTableFromBackupInput(input, context));
@@ -806,7 +806,7 @@ export const serializeAws_json1_0RestoreTableToPointInTimeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.RestoreTableToPointInTime",
+    "x-amz-target": "DynamoDB_20120810.RestoreTableToPointInTime",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RestoreTableToPointInTimeInput(input, context));
@@ -819,7 +819,7 @@ export const serializeAws_json1_0ScanCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.Scan",
+    "x-amz-target": "DynamoDB_20120810.Scan",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ScanInput(input, context));
@@ -832,7 +832,7 @@ export const serializeAws_json1_0TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.TagResource",
+    "x-amz-target": "DynamoDB_20120810.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0TagResourceInput(input, context));
@@ -845,7 +845,7 @@ export const serializeAws_json1_0TransactGetItemsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.TransactGetItems",
+    "x-amz-target": "DynamoDB_20120810.TransactGetItems",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0TransactGetItemsInput(input, context));
@@ -858,7 +858,7 @@ export const serializeAws_json1_0TransactWriteItemsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.TransactWriteItems",
+    "x-amz-target": "DynamoDB_20120810.TransactWriteItems",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0TransactWriteItemsInput(input, context));
@@ -871,7 +871,7 @@ export const serializeAws_json1_0UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.UntagResource",
+    "x-amz-target": "DynamoDB_20120810.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UntagResourceInput(input, context));
@@ -884,7 +884,7 @@ export const serializeAws_json1_0UpdateContinuousBackupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.UpdateContinuousBackups",
+    "x-amz-target": "DynamoDB_20120810.UpdateContinuousBackups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateContinuousBackupsInput(input, context));
@@ -897,7 +897,7 @@ export const serializeAws_json1_0UpdateContributorInsightsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.UpdateContributorInsights",
+    "x-amz-target": "DynamoDB_20120810.UpdateContributorInsights",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateContributorInsightsInput(input, context));
@@ -910,7 +910,7 @@ export const serializeAws_json1_0UpdateGlobalTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.UpdateGlobalTable",
+    "x-amz-target": "DynamoDB_20120810.UpdateGlobalTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateGlobalTableInput(input, context));
@@ -923,7 +923,7 @@ export const serializeAws_json1_0UpdateGlobalTableSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.UpdateGlobalTableSettings",
+    "x-amz-target": "DynamoDB_20120810.UpdateGlobalTableSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateGlobalTableSettingsInput(input, context));
@@ -936,7 +936,7 @@ export const serializeAws_json1_0UpdateItemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.UpdateItem",
+    "x-amz-target": "DynamoDB_20120810.UpdateItem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateItemInput(input, context));
@@ -949,7 +949,7 @@ export const serializeAws_json1_0UpdateTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.UpdateTable",
+    "x-amz-target": "DynamoDB_20120810.UpdateTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateTableInput(input, context));
@@ -962,7 +962,7 @@ export const serializeAws_json1_0UpdateTableReplicaAutoScalingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.UpdateTableReplicaAutoScaling",
+    "x-amz-target": "DynamoDB_20120810.UpdateTableReplicaAutoScaling",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateTableReplicaAutoScalingInput(input, context));
@@ -975,7 +975,7 @@ export const serializeAws_json1_0UpdateTimeToLiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "DynamoDB_20120810.UpdateTimeToLive",
+    "x-amz-target": "DynamoDB_20120810.UpdateTimeToLive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateTimeToLiveInput(input, context));

--- a/clients/client-ebs/protocols/Aws_restJson1.ts
+++ b/clients/client-ebs/protocols/Aws_restJson1.ts
@@ -36,12 +36,12 @@ export const serializeAws_restJson1CompleteSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     ...(isSerializableHeaderValue(input.ChangedBlocksCount) && {
-      "x-amz-ChangedBlocksCount": input.ChangedBlocksCount!.toString(),
+      "x-amz-changedblockscount": input.ChangedBlocksCount!.toString(),
     }),
-    ...(isSerializableHeaderValue(input.Checksum) && { "x-amz-Checksum": input.Checksum! }),
-    ...(isSerializableHeaderValue(input.ChecksumAlgorithm) && { "x-amz-Checksum-Algorithm": input.ChecksumAlgorithm! }),
+    ...(isSerializableHeaderValue(input.Checksum) && { "x-amz-checksum": input.Checksum! }),
+    ...(isSerializableHeaderValue(input.ChecksumAlgorithm) && { "x-amz-checksum-algorithm": input.ChecksumAlgorithm! }),
     ...(isSerializableHeaderValue(input.ChecksumAggregationMethod) && {
-      "x-amz-Checksum-Aggregation-Method": input.ChecksumAggregationMethod!,
+      "x-amz-checksum-aggregation-method": input.ChecksumAggregationMethod!,
     }),
   };
   let resolvedPath = "/snapshots/completion/{SnapshotId}";
@@ -184,10 +184,10 @@ export const serializeAws_restJson1PutSnapshotBlockCommand = async (
   const headers: any = {
     "content-type": "application/octet-stream",
     "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
-    ...(isSerializableHeaderValue(input.DataLength) && { "x-amz-Data-Length": input.DataLength!.toString() }),
-    ...(isSerializableHeaderValue(input.Progress) && { "x-amz-Progress": input.Progress!.toString() }),
-    ...(isSerializableHeaderValue(input.Checksum) && { "x-amz-Checksum": input.Checksum! }),
-    ...(isSerializableHeaderValue(input.ChecksumAlgorithm) && { "x-amz-Checksum-Algorithm": input.ChecksumAlgorithm! }),
+    ...(isSerializableHeaderValue(input.DataLength) && { "x-amz-data-length": input.DataLength!.toString() }),
+    ...(isSerializableHeaderValue(input.Progress) && { "x-amz-progress": input.Progress!.toString() }),
+    ...(isSerializableHeaderValue(input.Checksum) && { "x-amz-checksum": input.Checksum! }),
+    ...(isSerializableHeaderValue(input.ChecksumAlgorithm) && { "x-amz-checksum-algorithm": input.ChecksumAlgorithm! }),
   };
   let resolvedPath = "/snapshots/{SnapshotId}/blocks/{BlockIndex}";
   if (input.SnapshotId !== undefined) {

--- a/clients/client-ec2-instance-connect/protocols/Aws_json1_1.ts
+++ b/clients/client-ec2-instance-connect/protocols/Aws_json1_1.ts
@@ -24,7 +24,7 @@ export const serializeAws_json1_1SendSSHPublicKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEC2InstanceConnectService.SendSSHPublicKey",
+    "x-amz-target": "AWSEC2InstanceConnectService.SendSSHPublicKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SendSSHPublicKeyRequest(input, context));

--- a/clients/client-ecr-public/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr-public/protocols/Aws_json1_1.ts
@@ -148,7 +148,7 @@ export const serializeAws_json1_1BatchCheckLayerAvailabilityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.BatchCheckLayerAvailability",
+    "x-amz-target": "SpencerFrontendService.BatchCheckLayerAvailability",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchCheckLayerAvailabilityRequest(input, context));
@@ -161,7 +161,7 @@ export const serializeAws_json1_1BatchDeleteImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.BatchDeleteImage",
+    "x-amz-target": "SpencerFrontendService.BatchDeleteImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDeleteImageRequest(input, context));
@@ -174,7 +174,7 @@ export const serializeAws_json1_1CompleteLayerUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.CompleteLayerUpload",
+    "x-amz-target": "SpencerFrontendService.CompleteLayerUpload",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CompleteLayerUploadRequest(input, context));
@@ -187,7 +187,7 @@ export const serializeAws_json1_1CreateRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.CreateRepository",
+    "x-amz-target": "SpencerFrontendService.CreateRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRepositoryRequest(input, context));
@@ -200,7 +200,7 @@ export const serializeAws_json1_1DeleteRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.DeleteRepository",
+    "x-amz-target": "SpencerFrontendService.DeleteRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRepositoryRequest(input, context));
@@ -213,7 +213,7 @@ export const serializeAws_json1_1DeleteRepositoryPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.DeleteRepositoryPolicy",
+    "x-amz-target": "SpencerFrontendService.DeleteRepositoryPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRepositoryPolicyRequest(input, context));
@@ -226,7 +226,7 @@ export const serializeAws_json1_1DescribeImagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.DescribeImages",
+    "x-amz-target": "SpencerFrontendService.DescribeImages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeImagesRequest(input, context));
@@ -239,7 +239,7 @@ export const serializeAws_json1_1DescribeImageTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.DescribeImageTags",
+    "x-amz-target": "SpencerFrontendService.DescribeImageTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeImageTagsRequest(input, context));
@@ -252,7 +252,7 @@ export const serializeAws_json1_1DescribeRegistriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.DescribeRegistries",
+    "x-amz-target": "SpencerFrontendService.DescribeRegistries",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRegistriesRequest(input, context));
@@ -265,7 +265,7 @@ export const serializeAws_json1_1DescribeRepositoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.DescribeRepositories",
+    "x-amz-target": "SpencerFrontendService.DescribeRepositories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRepositoriesRequest(input, context));
@@ -278,7 +278,7 @@ export const serializeAws_json1_1GetAuthorizationTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.GetAuthorizationToken",
+    "x-amz-target": "SpencerFrontendService.GetAuthorizationToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAuthorizationTokenRequest(input, context));
@@ -291,7 +291,7 @@ export const serializeAws_json1_1GetRegistryCatalogDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.GetRegistryCatalogData",
+    "x-amz-target": "SpencerFrontendService.GetRegistryCatalogData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRegistryCatalogDataRequest(input, context));
@@ -304,7 +304,7 @@ export const serializeAws_json1_1GetRepositoryCatalogDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.GetRepositoryCatalogData",
+    "x-amz-target": "SpencerFrontendService.GetRepositoryCatalogData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRepositoryCatalogDataRequest(input, context));
@@ -317,7 +317,7 @@ export const serializeAws_json1_1GetRepositoryPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.GetRepositoryPolicy",
+    "x-amz-target": "SpencerFrontendService.GetRepositoryPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRepositoryPolicyRequest(input, context));
@@ -330,7 +330,7 @@ export const serializeAws_json1_1InitiateLayerUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.InitiateLayerUpload",
+    "x-amz-target": "SpencerFrontendService.InitiateLayerUpload",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1InitiateLayerUploadRequest(input, context));
@@ -343,7 +343,7 @@ export const serializeAws_json1_1PutImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.PutImage",
+    "x-amz-target": "SpencerFrontendService.PutImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutImageRequest(input, context));
@@ -356,7 +356,7 @@ export const serializeAws_json1_1PutRegistryCatalogDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.PutRegistryCatalogData",
+    "x-amz-target": "SpencerFrontendService.PutRegistryCatalogData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRegistryCatalogDataRequest(input, context));
@@ -369,7 +369,7 @@ export const serializeAws_json1_1PutRepositoryCatalogDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.PutRepositoryCatalogData",
+    "x-amz-target": "SpencerFrontendService.PutRepositoryCatalogData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRepositoryCatalogDataRequest(input, context));
@@ -382,7 +382,7 @@ export const serializeAws_json1_1SetRepositoryPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.SetRepositoryPolicy",
+    "x-amz-target": "SpencerFrontendService.SetRepositoryPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetRepositoryPolicyRequest(input, context));
@@ -395,7 +395,7 @@ export const serializeAws_json1_1UploadLayerPartCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SpencerFrontendService.UploadLayerPart",
+    "x-amz-target": "SpencerFrontendService.UploadLayerPart",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UploadLayerPartRequest(input, context));

--- a/clients/client-ecr/protocols/Aws_json1_1.ts
+++ b/clients/client-ecr/protocols/Aws_json1_1.ts
@@ -228,7 +228,7 @@ export const serializeAws_json1_1BatchCheckLayerAvailabilityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.BatchCheckLayerAvailability",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.BatchCheckLayerAvailability",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchCheckLayerAvailabilityRequest(input, context));
@@ -241,7 +241,7 @@ export const serializeAws_json1_1BatchDeleteImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.BatchDeleteImage",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.BatchDeleteImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDeleteImageRequest(input, context));
@@ -254,7 +254,7 @@ export const serializeAws_json1_1BatchGetImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.BatchGetImage",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.BatchGetImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetImageRequest(input, context));
@@ -267,7 +267,7 @@ export const serializeAws_json1_1CompleteLayerUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.CompleteLayerUpload",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.CompleteLayerUpload",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CompleteLayerUploadRequest(input, context));
@@ -280,7 +280,7 @@ export const serializeAws_json1_1CreateRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.CreateRepository",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.CreateRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRepositoryRequest(input, context));
@@ -293,7 +293,7 @@ export const serializeAws_json1_1DeleteLifecyclePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.DeleteLifecyclePolicy",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DeleteLifecyclePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLifecyclePolicyRequest(input, context));
@@ -306,7 +306,7 @@ export const serializeAws_json1_1DeleteRegistryPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.DeleteRegistryPolicy",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DeleteRegistryPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRegistryPolicyRequest(input, context));
@@ -319,7 +319,7 @@ export const serializeAws_json1_1DeleteRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.DeleteRepository",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DeleteRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRepositoryRequest(input, context));
@@ -332,7 +332,7 @@ export const serializeAws_json1_1DeleteRepositoryPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.DeleteRepositoryPolicy",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DeleteRepositoryPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRepositoryPolicyRequest(input, context));
@@ -345,7 +345,7 @@ export const serializeAws_json1_1DescribeImagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.DescribeImages",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DescribeImages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeImagesRequest(input, context));
@@ -358,7 +358,7 @@ export const serializeAws_json1_1DescribeImageScanFindingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.DescribeImageScanFindings",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DescribeImageScanFindings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeImageScanFindingsRequest(input, context));
@@ -371,7 +371,7 @@ export const serializeAws_json1_1DescribeRegistryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.DescribeRegistry",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DescribeRegistry",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRegistryRequest(input, context));
@@ -384,7 +384,7 @@ export const serializeAws_json1_1DescribeRepositoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.DescribeRepositories",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.DescribeRepositories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRepositoriesRequest(input, context));
@@ -397,7 +397,7 @@ export const serializeAws_json1_1GetAuthorizationTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetAuthorizationToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAuthorizationTokenRequest(input, context));
@@ -410,7 +410,7 @@ export const serializeAws_json1_1GetDownloadUrlForLayerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.GetDownloadUrlForLayer",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetDownloadUrlForLayer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDownloadUrlForLayerRequest(input, context));
@@ -423,7 +423,7 @@ export const serializeAws_json1_1GetLifecyclePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.GetLifecyclePolicy",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetLifecyclePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLifecyclePolicyRequest(input, context));
@@ -436,7 +436,7 @@ export const serializeAws_json1_1GetLifecyclePolicyPreviewCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.GetLifecyclePolicyPreview",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetLifecyclePolicyPreview",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLifecyclePolicyPreviewRequest(input, context));
@@ -449,7 +449,7 @@ export const serializeAws_json1_1GetRegistryPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.GetRegistryPolicy",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetRegistryPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRegistryPolicyRequest(input, context));
@@ -462,7 +462,7 @@ export const serializeAws_json1_1GetRepositoryPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.GetRepositoryPolicy",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.GetRepositoryPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRepositoryPolicyRequest(input, context));
@@ -475,7 +475,7 @@ export const serializeAws_json1_1InitiateLayerUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.InitiateLayerUpload",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.InitiateLayerUpload",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1InitiateLayerUploadRequest(input, context));
@@ -488,7 +488,7 @@ export const serializeAws_json1_1ListImagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.ListImages",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.ListImages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListImagesRequest(input, context));
@@ -501,7 +501,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.ListTagsForResource",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -514,7 +514,7 @@ export const serializeAws_json1_1PutImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.PutImage",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutImageRequest(input, context));
@@ -527,7 +527,7 @@ export const serializeAws_json1_1PutImageScanningConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.PutImageScanningConfiguration",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutImageScanningConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutImageScanningConfigurationRequest(input, context));
@@ -540,7 +540,7 @@ export const serializeAws_json1_1PutImageTagMutabilityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.PutImageTagMutability",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutImageTagMutability",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutImageTagMutabilityRequest(input, context));
@@ -553,7 +553,7 @@ export const serializeAws_json1_1PutLifecyclePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.PutLifecyclePolicy",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutLifecyclePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutLifecyclePolicyRequest(input, context));
@@ -566,7 +566,7 @@ export const serializeAws_json1_1PutRegistryPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.PutRegistryPolicy",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutRegistryPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRegistryPolicyRequest(input, context));
@@ -579,7 +579,7 @@ export const serializeAws_json1_1PutReplicationConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.PutReplicationConfiguration",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.PutReplicationConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutReplicationConfigurationRequest(input, context));
@@ -592,7 +592,7 @@ export const serializeAws_json1_1SetRepositoryPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.SetRepositoryPolicy",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.SetRepositoryPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetRepositoryPolicyRequest(input, context));
@@ -605,7 +605,7 @@ export const serializeAws_json1_1StartImageScanCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.StartImageScan",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.StartImageScan",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartImageScanRequest(input, context));
@@ -618,7 +618,7 @@ export const serializeAws_json1_1StartLifecyclePolicyPreviewCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.StartLifecyclePolicyPreview",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.StartLifecyclePolicyPreview",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartLifecyclePolicyPreviewRequest(input, context));
@@ -631,7 +631,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.TagResource",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -644,7 +644,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.UntagResource",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -657,7 +657,7 @@ export const serializeAws_json1_1UploadLayerPartCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerRegistry_V20150921.UploadLayerPart",
+    "x-amz-target": "AmazonEC2ContainerRegistry_V20150921.UploadLayerPart",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UploadLayerPartRequest(input, context));

--- a/clients/client-ecs/protocols/Aws_json1_1.ts
+++ b/clients/client-ecs/protocols/Aws_json1_1.ts
@@ -346,7 +346,7 @@ export const serializeAws_json1_1CreateCapacityProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.CreateCapacityProvider",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.CreateCapacityProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCapacityProviderRequest(input, context));
@@ -359,7 +359,7 @@ export const serializeAws_json1_1CreateClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.CreateCluster",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.CreateCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateClusterRequest(input, context));
@@ -372,7 +372,7 @@ export const serializeAws_json1_1CreateServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.CreateService",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.CreateService",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateServiceRequest(input, context));
@@ -385,7 +385,7 @@ export const serializeAws_json1_1CreateTaskSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.CreateTaskSet",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.CreateTaskSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTaskSetRequest(input, context));
@@ -398,7 +398,7 @@ export const serializeAws_json1_1DeleteAccountSettingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DeleteAccountSetting",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteAccountSetting",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAccountSettingRequest(input, context));
@@ -411,7 +411,7 @@ export const serializeAws_json1_1DeleteAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DeleteAttributes",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAttributesRequest(input, context));
@@ -424,7 +424,7 @@ export const serializeAws_json1_1DeleteCapacityProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DeleteCapacityProvider",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteCapacityProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCapacityProviderRequest(input, context));
@@ -437,7 +437,7 @@ export const serializeAws_json1_1DeleteClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DeleteCluster",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteClusterRequest(input, context));
@@ -450,7 +450,7 @@ export const serializeAws_json1_1DeleteServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DeleteService",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteService",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteServiceRequest(input, context));
@@ -463,7 +463,7 @@ export const serializeAws_json1_1DeleteTaskSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DeleteTaskSet",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeleteTaskSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTaskSetRequest(input, context));
@@ -476,7 +476,7 @@ export const serializeAws_json1_1DeregisterContainerInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DeregisterContainerInstance",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeregisterContainerInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterContainerInstanceRequest(input, context));
@@ -489,7 +489,7 @@ export const serializeAws_json1_1DeregisterTaskDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DeregisterTaskDefinition",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DeregisterTaskDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterTaskDefinitionRequest(input, context));
@@ -502,7 +502,7 @@ export const serializeAws_json1_1DescribeCapacityProvidersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DescribeCapacityProviders",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeCapacityProviders",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCapacityProvidersRequest(input, context));
@@ -515,7 +515,7 @@ export const serializeAws_json1_1DescribeClustersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DescribeClusters",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeClusters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeClustersRequest(input, context));
@@ -528,7 +528,7 @@ export const serializeAws_json1_1DescribeContainerInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DescribeContainerInstances",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeContainerInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeContainerInstancesRequest(input, context));
@@ -541,7 +541,7 @@ export const serializeAws_json1_1DescribeServicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DescribeServices",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeServices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeServicesRequest(input, context));
@@ -554,7 +554,7 @@ export const serializeAws_json1_1DescribeTaskDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeTaskDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTaskDefinitionRequest(input, context));
@@ -567,7 +567,7 @@ export const serializeAws_json1_1DescribeTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DescribeTasks",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTasksRequest(input, context));
@@ -580,7 +580,7 @@ export const serializeAws_json1_1DescribeTaskSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DescribeTaskSets",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DescribeTaskSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTaskSetsRequest(input, context));
@@ -593,7 +593,7 @@ export const serializeAws_json1_1DiscoverPollEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.DiscoverPollEndpoint",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.DiscoverPollEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DiscoverPollEndpointRequest(input, context));
@@ -606,7 +606,7 @@ export const serializeAws_json1_1ListAccountSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.ListAccountSettings",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListAccountSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAccountSettingsRequest(input, context));
@@ -619,7 +619,7 @@ export const serializeAws_json1_1ListAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.ListAttributes",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAttributesRequest(input, context));
@@ -632,7 +632,7 @@ export const serializeAws_json1_1ListClustersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.ListClusters",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListClusters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListClustersRequest(input, context));
@@ -645,7 +645,7 @@ export const serializeAws_json1_1ListContainerInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.ListContainerInstances",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListContainerInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListContainerInstancesRequest(input, context));
@@ -658,7 +658,7 @@ export const serializeAws_json1_1ListServicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.ListServices",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListServices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListServicesRequest(input, context));
@@ -671,7 +671,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.ListTagsForResource",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -684,7 +684,7 @@ export const serializeAws_json1_1ListTaskDefinitionFamiliesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.ListTaskDefinitionFamilies",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListTaskDefinitionFamilies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTaskDefinitionFamiliesRequest(input, context));
@@ -697,7 +697,7 @@ export const serializeAws_json1_1ListTaskDefinitionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.ListTaskDefinitions",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListTaskDefinitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTaskDefinitionsRequest(input, context));
@@ -710,7 +710,7 @@ export const serializeAws_json1_1ListTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.ListTasks",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.ListTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTasksRequest(input, context));
@@ -723,7 +723,7 @@ export const serializeAws_json1_1PutAccountSettingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.PutAccountSetting",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.PutAccountSetting",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAccountSettingRequest(input, context));
@@ -736,7 +736,7 @@ export const serializeAws_json1_1PutAccountSettingDefaultCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.PutAccountSettingDefault",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.PutAccountSettingDefault",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAccountSettingDefaultRequest(input, context));
@@ -749,7 +749,7 @@ export const serializeAws_json1_1PutAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.PutAttributes",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.PutAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAttributesRequest(input, context));
@@ -762,7 +762,7 @@ export const serializeAws_json1_1PutClusterCapacityProvidersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.PutClusterCapacityProviders",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.PutClusterCapacityProviders",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutClusterCapacityProvidersRequest(input, context));
@@ -775,7 +775,7 @@ export const serializeAws_json1_1RegisterContainerInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.RegisterContainerInstance",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.RegisterContainerInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterContainerInstanceRequest(input, context));
@@ -788,7 +788,7 @@ export const serializeAws_json1_1RegisterTaskDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.RegisterTaskDefinition",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.RegisterTaskDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterTaskDefinitionRequest(input, context));
@@ -801,7 +801,7 @@ export const serializeAws_json1_1RunTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.RunTask",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.RunTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RunTaskRequest(input, context));
@@ -814,7 +814,7 @@ export const serializeAws_json1_1StartTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.StartTask",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.StartTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartTaskRequest(input, context));
@@ -827,7 +827,7 @@ export const serializeAws_json1_1StopTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.StopTask",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.StopTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopTaskRequest(input, context));
@@ -840,7 +840,7 @@ export const serializeAws_json1_1SubmitAttachmentStateChangesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.SubmitAttachmentStateChanges",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.SubmitAttachmentStateChanges",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SubmitAttachmentStateChangesRequest(input, context));
@@ -853,7 +853,7 @@ export const serializeAws_json1_1SubmitContainerStateChangeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.SubmitContainerStateChange",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.SubmitContainerStateChange",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SubmitContainerStateChangeRequest(input, context));
@@ -866,7 +866,7 @@ export const serializeAws_json1_1SubmitTaskStateChangeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.SubmitTaskStateChange",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.SubmitTaskStateChange",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SubmitTaskStateChangeRequest(input, context));
@@ -879,7 +879,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.TagResource",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -892,7 +892,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.UntagResource",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -905,7 +905,7 @@ export const serializeAws_json1_1UpdateCapacityProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.UpdateCapacityProvider",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateCapacityProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCapacityProviderRequest(input, context));
@@ -918,7 +918,7 @@ export const serializeAws_json1_1UpdateClusterSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.UpdateClusterSettings",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateClusterSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateClusterSettingsRequest(input, context));
@@ -931,7 +931,7 @@ export const serializeAws_json1_1UpdateContainerAgentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.UpdateContainerAgent",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateContainerAgent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateContainerAgentRequest(input, context));
@@ -944,7 +944,7 @@ export const serializeAws_json1_1UpdateContainerInstancesStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.UpdateContainerInstancesState",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateContainerInstancesState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateContainerInstancesStateRequest(input, context));
@@ -957,7 +957,7 @@ export const serializeAws_json1_1UpdateServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.UpdateService",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateService",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateServiceRequest(input, context));
@@ -970,7 +970,7 @@ export const serializeAws_json1_1UpdateServicePrimaryTaskSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.UpdateServicePrimaryTaskSet",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateServicePrimaryTaskSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateServicePrimaryTaskSetRequest(input, context));
@@ -983,7 +983,7 @@ export const serializeAws_json1_1UpdateTaskSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonEC2ContainerServiceV20141113.UpdateTaskSet",
+    "x-amz-target": "AmazonEC2ContainerServiceV20141113.UpdateTaskSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTaskSetRequest(input, context));

--- a/clients/client-emr/protocols/Aws_json1_1.ts
+++ b/clients/client-emr/protocols/Aws_json1_1.ts
@@ -314,7 +314,7 @@ export const serializeAws_json1_1AddInstanceFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.AddInstanceFleet",
+    "x-amz-target": "ElasticMapReduce.AddInstanceFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddInstanceFleetInput(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1AddInstanceGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.AddInstanceGroups",
+    "x-amz-target": "ElasticMapReduce.AddInstanceGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddInstanceGroupsInput(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1AddJobFlowStepsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.AddJobFlowSteps",
+    "x-amz-target": "ElasticMapReduce.AddJobFlowSteps",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddJobFlowStepsInput(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1AddTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.AddTags",
+    "x-amz-target": "ElasticMapReduce.AddTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsInput(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_1CancelStepsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.CancelSteps",
+    "x-amz-target": "ElasticMapReduce.CancelSteps",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelStepsInput(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_1CreateSecurityConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.CreateSecurityConfiguration",
+    "x-amz-target": "ElasticMapReduce.CreateSecurityConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSecurityConfigurationInput(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_1CreateStudioCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.CreateStudio",
+    "x-amz-target": "ElasticMapReduce.CreateStudio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateStudioInput(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_1CreateStudioSessionMappingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.CreateStudioSessionMapping",
+    "x-amz-target": "ElasticMapReduce.CreateStudioSessionMapping",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateStudioSessionMappingInput(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_1DeleteSecurityConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.DeleteSecurityConfiguration",
+    "x-amz-target": "ElasticMapReduce.DeleteSecurityConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSecurityConfigurationInput(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_1DeleteStudioCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.DeleteStudio",
+    "x-amz-target": "ElasticMapReduce.DeleteStudio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteStudioInput(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_1DeleteStudioSessionMappingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.DeleteStudioSessionMapping",
+    "x-amz-target": "ElasticMapReduce.DeleteStudioSessionMapping",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteStudioSessionMappingInput(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_1DescribeClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.DescribeCluster",
+    "x-amz-target": "ElasticMapReduce.DescribeCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeClusterInput(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_1DescribeJobFlowsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.DescribeJobFlows",
+    "x-amz-target": "ElasticMapReduce.DescribeJobFlows",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeJobFlowsInput(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_1DescribeNotebookExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.DescribeNotebookExecution",
+    "x-amz-target": "ElasticMapReduce.DescribeNotebookExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeNotebookExecutionInput(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_1DescribeSecurityConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.DescribeSecurityConfiguration",
+    "x-amz-target": "ElasticMapReduce.DescribeSecurityConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSecurityConfigurationInput(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_1DescribeStepCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.DescribeStep",
+    "x-amz-target": "ElasticMapReduce.DescribeStep",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStepInput(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_1DescribeStudioCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.DescribeStudio",
+    "x-amz-target": "ElasticMapReduce.DescribeStudio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStudioInput(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1GetBlockPublicAccessConfigurationCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.GetBlockPublicAccessConfiguration",
+    "x-amz-target": "ElasticMapReduce.GetBlockPublicAccessConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetBlockPublicAccessConfigurationInput(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1GetManagedScalingPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.GetManagedScalingPolicy",
+    "x-amz-target": "ElasticMapReduce.GetManagedScalingPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetManagedScalingPolicyInput(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1GetStudioSessionMappingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.GetStudioSessionMapping",
+    "x-amz-target": "ElasticMapReduce.GetStudioSessionMapping",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetStudioSessionMappingInput(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_1ListBootstrapActionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ListBootstrapActions",
+    "x-amz-target": "ElasticMapReduce.ListBootstrapActions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBootstrapActionsInput(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_1ListClustersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ListClusters",
+    "x-amz-target": "ElasticMapReduce.ListClusters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListClustersInput(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_1ListInstanceFleetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ListInstanceFleets",
+    "x-amz-target": "ElasticMapReduce.ListInstanceFleets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListInstanceFleetsInput(input, context));
@@ -613,7 +613,7 @@ export const serializeAws_json1_1ListInstanceGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ListInstanceGroups",
+    "x-amz-target": "ElasticMapReduce.ListInstanceGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListInstanceGroupsInput(input, context));
@@ -626,7 +626,7 @@ export const serializeAws_json1_1ListInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ListInstances",
+    "x-amz-target": "ElasticMapReduce.ListInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListInstancesInput(input, context));
@@ -639,7 +639,7 @@ export const serializeAws_json1_1ListNotebookExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ListNotebookExecutions",
+    "x-amz-target": "ElasticMapReduce.ListNotebookExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListNotebookExecutionsInput(input, context));
@@ -652,7 +652,7 @@ export const serializeAws_json1_1ListSecurityConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ListSecurityConfigurations",
+    "x-amz-target": "ElasticMapReduce.ListSecurityConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSecurityConfigurationsInput(input, context));
@@ -665,7 +665,7 @@ export const serializeAws_json1_1ListStepsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ListSteps",
+    "x-amz-target": "ElasticMapReduce.ListSteps",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListStepsInput(input, context));
@@ -678,7 +678,7 @@ export const serializeAws_json1_1ListStudiosCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ListStudios",
+    "x-amz-target": "ElasticMapReduce.ListStudios",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListStudiosInput(input, context));
@@ -691,7 +691,7 @@ export const serializeAws_json1_1ListStudioSessionMappingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ListStudioSessionMappings",
+    "x-amz-target": "ElasticMapReduce.ListStudioSessionMappings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListStudioSessionMappingsInput(input, context));
@@ -704,7 +704,7 @@ export const serializeAws_json1_1ModifyClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ModifyCluster",
+    "x-amz-target": "ElasticMapReduce.ModifyCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyClusterInput(input, context));
@@ -717,7 +717,7 @@ export const serializeAws_json1_1ModifyInstanceFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ModifyInstanceFleet",
+    "x-amz-target": "ElasticMapReduce.ModifyInstanceFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyInstanceFleetInput(input, context));
@@ -730,7 +730,7 @@ export const serializeAws_json1_1ModifyInstanceGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.ModifyInstanceGroups",
+    "x-amz-target": "ElasticMapReduce.ModifyInstanceGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyInstanceGroupsInput(input, context));
@@ -743,7 +743,7 @@ export const serializeAws_json1_1PutAutoScalingPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.PutAutoScalingPolicy",
+    "x-amz-target": "ElasticMapReduce.PutAutoScalingPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAutoScalingPolicyInput(input, context));
@@ -756,7 +756,7 @@ export const serializeAws_json1_1PutBlockPublicAccessConfigurationCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.PutBlockPublicAccessConfiguration",
+    "x-amz-target": "ElasticMapReduce.PutBlockPublicAccessConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutBlockPublicAccessConfigurationInput(input, context));
@@ -769,7 +769,7 @@ export const serializeAws_json1_1PutManagedScalingPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.PutManagedScalingPolicy",
+    "x-amz-target": "ElasticMapReduce.PutManagedScalingPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutManagedScalingPolicyInput(input, context));
@@ -782,7 +782,7 @@ export const serializeAws_json1_1RemoveAutoScalingPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.RemoveAutoScalingPolicy",
+    "x-amz-target": "ElasticMapReduce.RemoveAutoScalingPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveAutoScalingPolicyInput(input, context));
@@ -795,7 +795,7 @@ export const serializeAws_json1_1RemoveManagedScalingPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.RemoveManagedScalingPolicy",
+    "x-amz-target": "ElasticMapReduce.RemoveManagedScalingPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveManagedScalingPolicyInput(input, context));
@@ -808,7 +808,7 @@ export const serializeAws_json1_1RemoveTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.RemoveTags",
+    "x-amz-target": "ElasticMapReduce.RemoveTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsInput(input, context));
@@ -821,7 +821,7 @@ export const serializeAws_json1_1RunJobFlowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.RunJobFlow",
+    "x-amz-target": "ElasticMapReduce.RunJobFlow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RunJobFlowInput(input, context));
@@ -834,7 +834,7 @@ export const serializeAws_json1_1SetTerminationProtectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.SetTerminationProtection",
+    "x-amz-target": "ElasticMapReduce.SetTerminationProtection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetTerminationProtectionInput(input, context));
@@ -847,7 +847,7 @@ export const serializeAws_json1_1SetVisibleToAllUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.SetVisibleToAllUsers",
+    "x-amz-target": "ElasticMapReduce.SetVisibleToAllUsers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetVisibleToAllUsersInput(input, context));
@@ -860,7 +860,7 @@ export const serializeAws_json1_1StartNotebookExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.StartNotebookExecution",
+    "x-amz-target": "ElasticMapReduce.StartNotebookExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartNotebookExecutionInput(input, context));
@@ -873,7 +873,7 @@ export const serializeAws_json1_1StopNotebookExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.StopNotebookExecution",
+    "x-amz-target": "ElasticMapReduce.StopNotebookExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopNotebookExecutionInput(input, context));
@@ -886,7 +886,7 @@ export const serializeAws_json1_1TerminateJobFlowsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.TerminateJobFlows",
+    "x-amz-target": "ElasticMapReduce.TerminateJobFlows",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TerminateJobFlowsInput(input, context));
@@ -899,7 +899,7 @@ export const serializeAws_json1_1UpdateStudioSessionMappingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ElasticMapReduce.UpdateStudioSessionMapping",
+    "x-amz-target": "ElasticMapReduce.UpdateStudioSessionMapping",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateStudioSessionMappingInput(input, context));

--- a/clients/client-eventbridge/protocols/Aws_json1_1.ts
+++ b/clients/client-eventbridge/protocols/Aws_json1_1.ts
@@ -200,7 +200,7 @@ export const serializeAws_json1_1ActivateEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ActivateEventSource",
+    "x-amz-target": "AWSEvents.ActivateEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ActivateEventSourceRequest(input, context));
@@ -213,7 +213,7 @@ export const serializeAws_json1_1CancelReplayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.CancelReplay",
+    "x-amz-target": "AWSEvents.CancelReplay",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelReplayRequest(input, context));
@@ -226,7 +226,7 @@ export const serializeAws_json1_1CreateArchiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.CreateArchive",
+    "x-amz-target": "AWSEvents.CreateArchive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateArchiveRequest(input, context));
@@ -239,7 +239,7 @@ export const serializeAws_json1_1CreateEventBusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.CreateEventBus",
+    "x-amz-target": "AWSEvents.CreateEventBus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEventBusRequest(input, context));
@@ -252,7 +252,7 @@ export const serializeAws_json1_1CreatePartnerEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.CreatePartnerEventSource",
+    "x-amz-target": "AWSEvents.CreatePartnerEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePartnerEventSourceRequest(input, context));
@@ -265,7 +265,7 @@ export const serializeAws_json1_1DeactivateEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DeactivateEventSource",
+    "x-amz-target": "AWSEvents.DeactivateEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeactivateEventSourceRequest(input, context));
@@ -278,7 +278,7 @@ export const serializeAws_json1_1DeleteArchiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DeleteArchive",
+    "x-amz-target": "AWSEvents.DeleteArchive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteArchiveRequest(input, context));
@@ -291,7 +291,7 @@ export const serializeAws_json1_1DeleteEventBusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DeleteEventBus",
+    "x-amz-target": "AWSEvents.DeleteEventBus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEventBusRequest(input, context));
@@ -304,7 +304,7 @@ export const serializeAws_json1_1DeletePartnerEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DeletePartnerEventSource",
+    "x-amz-target": "AWSEvents.DeletePartnerEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePartnerEventSourceRequest(input, context));
@@ -317,7 +317,7 @@ export const serializeAws_json1_1DeleteRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DeleteRule",
+    "x-amz-target": "AWSEvents.DeleteRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRuleRequest(input, context));
@@ -330,7 +330,7 @@ export const serializeAws_json1_1DescribeArchiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribeArchive",
+    "x-amz-target": "AWSEvents.DescribeArchive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeArchiveRequest(input, context));
@@ -343,7 +343,7 @@ export const serializeAws_json1_1DescribeEventBusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribeEventBus",
+    "x-amz-target": "AWSEvents.DescribeEventBus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventBusRequest(input, context));
@@ -356,7 +356,7 @@ export const serializeAws_json1_1DescribeEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribeEventSource",
+    "x-amz-target": "AWSEvents.DescribeEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventSourceRequest(input, context));
@@ -369,7 +369,7 @@ export const serializeAws_json1_1DescribePartnerEventSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribePartnerEventSource",
+    "x-amz-target": "AWSEvents.DescribePartnerEventSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePartnerEventSourceRequest(input, context));
@@ -382,7 +382,7 @@ export const serializeAws_json1_1DescribeReplayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribeReplay",
+    "x-amz-target": "AWSEvents.DescribeReplay",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReplayRequest(input, context));
@@ -395,7 +395,7 @@ export const serializeAws_json1_1DescribeRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DescribeRule",
+    "x-amz-target": "AWSEvents.DescribeRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRuleRequest(input, context));
@@ -408,7 +408,7 @@ export const serializeAws_json1_1DisableRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.DisableRule",
+    "x-amz-target": "AWSEvents.DisableRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableRuleRequest(input, context));
@@ -421,7 +421,7 @@ export const serializeAws_json1_1EnableRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.EnableRule",
+    "x-amz-target": "AWSEvents.EnableRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableRuleRequest(input, context));
@@ -434,7 +434,7 @@ export const serializeAws_json1_1ListArchivesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListArchives",
+    "x-amz-target": "AWSEvents.ListArchives",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListArchivesRequest(input, context));
@@ -447,7 +447,7 @@ export const serializeAws_json1_1ListEventBusesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListEventBuses",
+    "x-amz-target": "AWSEvents.ListEventBuses",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEventBusesRequest(input, context));
@@ -460,7 +460,7 @@ export const serializeAws_json1_1ListEventSourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListEventSources",
+    "x-amz-target": "AWSEvents.ListEventSources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEventSourcesRequest(input, context));
@@ -473,7 +473,7 @@ export const serializeAws_json1_1ListPartnerEventSourceAccountsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListPartnerEventSourceAccounts",
+    "x-amz-target": "AWSEvents.ListPartnerEventSourceAccounts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPartnerEventSourceAccountsRequest(input, context));
@@ -486,7 +486,7 @@ export const serializeAws_json1_1ListPartnerEventSourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListPartnerEventSources",
+    "x-amz-target": "AWSEvents.ListPartnerEventSources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPartnerEventSourcesRequest(input, context));
@@ -499,7 +499,7 @@ export const serializeAws_json1_1ListReplaysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListReplays",
+    "x-amz-target": "AWSEvents.ListReplays",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListReplaysRequest(input, context));
@@ -512,7 +512,7 @@ export const serializeAws_json1_1ListRuleNamesByTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListRuleNamesByTarget",
+    "x-amz-target": "AWSEvents.ListRuleNamesByTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRuleNamesByTargetRequest(input, context));
@@ -525,7 +525,7 @@ export const serializeAws_json1_1ListRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListRules",
+    "x-amz-target": "AWSEvents.ListRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRulesRequest(input, context));
@@ -538,7 +538,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListTagsForResource",
+    "x-amz-target": "AWSEvents.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -551,7 +551,7 @@ export const serializeAws_json1_1ListTargetsByRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.ListTargetsByRule",
+    "x-amz-target": "AWSEvents.ListTargetsByRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTargetsByRuleRequest(input, context));
@@ -564,7 +564,7 @@ export const serializeAws_json1_1PutEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.PutEvents",
+    "x-amz-target": "AWSEvents.PutEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutEventsRequest(input, context));
@@ -577,7 +577,7 @@ export const serializeAws_json1_1PutPartnerEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.PutPartnerEvents",
+    "x-amz-target": "AWSEvents.PutPartnerEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutPartnerEventsRequest(input, context));
@@ -590,7 +590,7 @@ export const serializeAws_json1_1PutPermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.PutPermission",
+    "x-amz-target": "AWSEvents.PutPermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutPermissionRequest(input, context));
@@ -603,7 +603,7 @@ export const serializeAws_json1_1PutRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.PutRule",
+    "x-amz-target": "AWSEvents.PutRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRuleRequest(input, context));
@@ -616,7 +616,7 @@ export const serializeAws_json1_1PutTargetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.PutTargets",
+    "x-amz-target": "AWSEvents.PutTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutTargetsRequest(input, context));
@@ -629,7 +629,7 @@ export const serializeAws_json1_1RemovePermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.RemovePermission",
+    "x-amz-target": "AWSEvents.RemovePermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemovePermissionRequest(input, context));
@@ -642,7 +642,7 @@ export const serializeAws_json1_1RemoveTargetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.RemoveTargets",
+    "x-amz-target": "AWSEvents.RemoveTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTargetsRequest(input, context));
@@ -655,7 +655,7 @@ export const serializeAws_json1_1StartReplayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.StartReplay",
+    "x-amz-target": "AWSEvents.StartReplay",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartReplayRequest(input, context));
@@ -668,7 +668,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.TagResource",
+    "x-amz-target": "AWSEvents.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -681,7 +681,7 @@ export const serializeAws_json1_1TestEventPatternCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.TestEventPattern",
+    "x-amz-target": "AWSEvents.TestEventPattern",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TestEventPatternRequest(input, context));
@@ -694,7 +694,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.UntagResource",
+    "x-amz-target": "AWSEvents.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -707,7 +707,7 @@ export const serializeAws_json1_1UpdateArchiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSEvents.UpdateArchive",
+    "x-amz-target": "AWSEvents.UpdateArchive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateArchiveRequest(input, context));

--- a/clients/client-firehose/protocols/Aws_json1_1.ts
+++ b/clients/client-firehose/protocols/Aws_json1_1.ts
@@ -142,7 +142,7 @@ export const serializeAws_json1_1CreateDeliveryStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.CreateDeliveryStream",
+    "x-amz-target": "Firehose_20150804.CreateDeliveryStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDeliveryStreamInput(input, context));
@@ -155,7 +155,7 @@ export const serializeAws_json1_1DeleteDeliveryStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.DeleteDeliveryStream",
+    "x-amz-target": "Firehose_20150804.DeleteDeliveryStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDeliveryStreamInput(input, context));
@@ -168,7 +168,7 @@ export const serializeAws_json1_1DescribeDeliveryStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.DescribeDeliveryStream",
+    "x-amz-target": "Firehose_20150804.DescribeDeliveryStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDeliveryStreamInput(input, context));
@@ -181,7 +181,7 @@ export const serializeAws_json1_1ListDeliveryStreamsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.ListDeliveryStreams",
+    "x-amz-target": "Firehose_20150804.ListDeliveryStreams",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDeliveryStreamsInput(input, context));
@@ -194,7 +194,7 @@ export const serializeAws_json1_1ListTagsForDeliveryStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.ListTagsForDeliveryStream",
+    "x-amz-target": "Firehose_20150804.ListTagsForDeliveryStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForDeliveryStreamInput(input, context));
@@ -207,7 +207,7 @@ export const serializeAws_json1_1PutRecordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.PutRecord",
+    "x-amz-target": "Firehose_20150804.PutRecord",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRecordInput(input, context));
@@ -220,7 +220,7 @@ export const serializeAws_json1_1PutRecordBatchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.PutRecordBatch",
+    "x-amz-target": "Firehose_20150804.PutRecordBatch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRecordBatchInput(input, context));
@@ -233,7 +233,7 @@ export const serializeAws_json1_1StartDeliveryStreamEncryptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.StartDeliveryStreamEncryption",
+    "x-amz-target": "Firehose_20150804.StartDeliveryStreamEncryption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartDeliveryStreamEncryptionInput(input, context));
@@ -246,7 +246,7 @@ export const serializeAws_json1_1StopDeliveryStreamEncryptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.StopDeliveryStreamEncryption",
+    "x-amz-target": "Firehose_20150804.StopDeliveryStreamEncryption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopDeliveryStreamEncryptionInput(input, context));
@@ -259,7 +259,7 @@ export const serializeAws_json1_1TagDeliveryStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.TagDeliveryStream",
+    "x-amz-target": "Firehose_20150804.TagDeliveryStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagDeliveryStreamInput(input, context));
@@ -272,7 +272,7 @@ export const serializeAws_json1_1UntagDeliveryStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.UntagDeliveryStream",
+    "x-amz-target": "Firehose_20150804.UntagDeliveryStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagDeliveryStreamInput(input, context));
@@ -285,7 +285,7 @@ export const serializeAws_json1_1UpdateDestinationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Firehose_20150804.UpdateDestination",
+    "x-amz-target": "Firehose_20150804.UpdateDestination",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDestinationInput(input, context));

--- a/clients/client-fms/protocols/Aws_json1_1.ts
+++ b/clients/client-fms/protocols/Aws_json1_1.ts
@@ -157,7 +157,7 @@ export const serializeAws_json1_1AssociateAdminAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.AssociateAdminAccount",
+    "x-amz-target": "AWSFMS_20180101.AssociateAdminAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateAdminAccountRequest(input, context));
@@ -170,7 +170,7 @@ export const serializeAws_json1_1DeleteAppsListCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.DeleteAppsList",
+    "x-amz-target": "AWSFMS_20180101.DeleteAppsList",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAppsListRequest(input, context));
@@ -183,7 +183,7 @@ export const serializeAws_json1_1DeleteNotificationChannelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.DeleteNotificationChannel",
+    "x-amz-target": "AWSFMS_20180101.DeleteNotificationChannel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteNotificationChannelRequest(input, context));
@@ -196,7 +196,7 @@ export const serializeAws_json1_1DeletePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.DeletePolicy",
+    "x-amz-target": "AWSFMS_20180101.DeletePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePolicyRequest(input, context));
@@ -209,7 +209,7 @@ export const serializeAws_json1_1DeleteProtocolsListCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.DeleteProtocolsList",
+    "x-amz-target": "AWSFMS_20180101.DeleteProtocolsList",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProtocolsListRequest(input, context));
@@ -222,7 +222,7 @@ export const serializeAws_json1_1DisassociateAdminAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.DisassociateAdminAccount",
+    "x-amz-target": "AWSFMS_20180101.DisassociateAdminAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateAdminAccountRequest(input, context));
@@ -235,7 +235,7 @@ export const serializeAws_json1_1GetAdminAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.GetAdminAccount",
+    "x-amz-target": "AWSFMS_20180101.GetAdminAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAdminAccountRequest(input, context));
@@ -248,7 +248,7 @@ export const serializeAws_json1_1GetAppsListCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.GetAppsList",
+    "x-amz-target": "AWSFMS_20180101.GetAppsList",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAppsListRequest(input, context));
@@ -261,7 +261,7 @@ export const serializeAws_json1_1GetComplianceDetailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.GetComplianceDetail",
+    "x-amz-target": "AWSFMS_20180101.GetComplianceDetail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetComplianceDetailRequest(input, context));
@@ -274,7 +274,7 @@ export const serializeAws_json1_1GetNotificationChannelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.GetNotificationChannel",
+    "x-amz-target": "AWSFMS_20180101.GetNotificationChannel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetNotificationChannelRequest(input, context));
@@ -287,7 +287,7 @@ export const serializeAws_json1_1GetPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.GetPolicy",
+    "x-amz-target": "AWSFMS_20180101.GetPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPolicyRequest(input, context));
@@ -300,7 +300,7 @@ export const serializeAws_json1_1GetProtectionStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.GetProtectionStatus",
+    "x-amz-target": "AWSFMS_20180101.GetProtectionStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetProtectionStatusRequest(input, context));
@@ -313,7 +313,7 @@ export const serializeAws_json1_1GetProtocolsListCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.GetProtocolsList",
+    "x-amz-target": "AWSFMS_20180101.GetProtocolsList",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetProtocolsListRequest(input, context));
@@ -326,7 +326,7 @@ export const serializeAws_json1_1GetViolationDetailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.GetViolationDetails",
+    "x-amz-target": "AWSFMS_20180101.GetViolationDetails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetViolationDetailsRequest(input, context));
@@ -339,7 +339,7 @@ export const serializeAws_json1_1ListAppsListsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.ListAppsLists",
+    "x-amz-target": "AWSFMS_20180101.ListAppsLists",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAppsListsRequest(input, context));
@@ -352,7 +352,7 @@ export const serializeAws_json1_1ListComplianceStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.ListComplianceStatus",
+    "x-amz-target": "AWSFMS_20180101.ListComplianceStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListComplianceStatusRequest(input, context));
@@ -365,7 +365,7 @@ export const serializeAws_json1_1ListMemberAccountsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.ListMemberAccounts",
+    "x-amz-target": "AWSFMS_20180101.ListMemberAccounts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListMemberAccountsRequest(input, context));
@@ -378,7 +378,7 @@ export const serializeAws_json1_1ListPoliciesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.ListPolicies",
+    "x-amz-target": "AWSFMS_20180101.ListPolicies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPoliciesRequest(input, context));
@@ -391,7 +391,7 @@ export const serializeAws_json1_1ListProtocolsListsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.ListProtocolsLists",
+    "x-amz-target": "AWSFMS_20180101.ListProtocolsLists",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProtocolsListsRequest(input, context));
@@ -404,7 +404,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.ListTagsForResource",
+    "x-amz-target": "AWSFMS_20180101.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -417,7 +417,7 @@ export const serializeAws_json1_1PutAppsListCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.PutAppsList",
+    "x-amz-target": "AWSFMS_20180101.PutAppsList",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAppsListRequest(input, context));
@@ -430,7 +430,7 @@ export const serializeAws_json1_1PutNotificationChannelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.PutNotificationChannel",
+    "x-amz-target": "AWSFMS_20180101.PutNotificationChannel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutNotificationChannelRequest(input, context));
@@ -443,7 +443,7 @@ export const serializeAws_json1_1PutPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.PutPolicy",
+    "x-amz-target": "AWSFMS_20180101.PutPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutPolicyRequest(input, context));
@@ -456,7 +456,7 @@ export const serializeAws_json1_1PutProtocolsListCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.PutProtocolsList",
+    "x-amz-target": "AWSFMS_20180101.PutProtocolsList",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutProtocolsListRequest(input, context));
@@ -469,7 +469,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.TagResource",
+    "x-amz-target": "AWSFMS_20180101.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -482,7 +482,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSFMS_20180101.UntagResource",
+    "x-amz-target": "AWSFMS_20180101.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));

--- a/clients/client-forecast/protocols/Aws_json1_1.ts
+++ b/clients/client-forecast/protocols/Aws_json1_1.ts
@@ -191,7 +191,7 @@ export const serializeAws_json1_1CreateDatasetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.CreateDataset",
+    "x-amz-target": "AmazonForecast.CreateDataset",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDatasetRequest(input, context));
@@ -204,7 +204,7 @@ export const serializeAws_json1_1CreateDatasetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.CreateDatasetGroup",
+    "x-amz-target": "AmazonForecast.CreateDatasetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDatasetGroupRequest(input, context));
@@ -217,7 +217,7 @@ export const serializeAws_json1_1CreateDatasetImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.CreateDatasetImportJob",
+    "x-amz-target": "AmazonForecast.CreateDatasetImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDatasetImportJobRequest(input, context));
@@ -230,7 +230,7 @@ export const serializeAws_json1_1CreateForecastCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.CreateForecast",
+    "x-amz-target": "AmazonForecast.CreateForecast",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateForecastRequest(input, context));
@@ -243,7 +243,7 @@ export const serializeAws_json1_1CreateForecastExportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.CreateForecastExportJob",
+    "x-amz-target": "AmazonForecast.CreateForecastExportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateForecastExportJobRequest(input, context));
@@ -256,7 +256,7 @@ export const serializeAws_json1_1CreatePredictorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.CreatePredictor",
+    "x-amz-target": "AmazonForecast.CreatePredictor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePredictorRequest(input, context));
@@ -269,7 +269,7 @@ export const serializeAws_json1_1CreatePredictorBacktestExportJobCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.CreatePredictorBacktestExportJob",
+    "x-amz-target": "AmazonForecast.CreatePredictorBacktestExportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePredictorBacktestExportJobRequest(input, context));
@@ -282,7 +282,7 @@ export const serializeAws_json1_1DeleteDatasetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DeleteDataset",
+    "x-amz-target": "AmazonForecast.DeleteDataset",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDatasetRequest(input, context));
@@ -295,7 +295,7 @@ export const serializeAws_json1_1DeleteDatasetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DeleteDatasetGroup",
+    "x-amz-target": "AmazonForecast.DeleteDatasetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDatasetGroupRequest(input, context));
@@ -308,7 +308,7 @@ export const serializeAws_json1_1DeleteDatasetImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DeleteDatasetImportJob",
+    "x-amz-target": "AmazonForecast.DeleteDatasetImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDatasetImportJobRequest(input, context));
@@ -321,7 +321,7 @@ export const serializeAws_json1_1DeleteForecastCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DeleteForecast",
+    "x-amz-target": "AmazonForecast.DeleteForecast",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteForecastRequest(input, context));
@@ -334,7 +334,7 @@ export const serializeAws_json1_1DeleteForecastExportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DeleteForecastExportJob",
+    "x-amz-target": "AmazonForecast.DeleteForecastExportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteForecastExportJobRequest(input, context));
@@ -347,7 +347,7 @@ export const serializeAws_json1_1DeletePredictorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DeletePredictor",
+    "x-amz-target": "AmazonForecast.DeletePredictor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePredictorRequest(input, context));
@@ -360,7 +360,7 @@ export const serializeAws_json1_1DeletePredictorBacktestExportJobCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DeletePredictorBacktestExportJob",
+    "x-amz-target": "AmazonForecast.DeletePredictorBacktestExportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePredictorBacktestExportJobRequest(input, context));
@@ -373,7 +373,7 @@ export const serializeAws_json1_1DescribeDatasetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DescribeDataset",
+    "x-amz-target": "AmazonForecast.DescribeDataset",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDatasetRequest(input, context));
@@ -386,7 +386,7 @@ export const serializeAws_json1_1DescribeDatasetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DescribeDatasetGroup",
+    "x-amz-target": "AmazonForecast.DescribeDatasetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDatasetGroupRequest(input, context));
@@ -399,7 +399,7 @@ export const serializeAws_json1_1DescribeDatasetImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DescribeDatasetImportJob",
+    "x-amz-target": "AmazonForecast.DescribeDatasetImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDatasetImportJobRequest(input, context));
@@ -412,7 +412,7 @@ export const serializeAws_json1_1DescribeForecastCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DescribeForecast",
+    "x-amz-target": "AmazonForecast.DescribeForecast",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeForecastRequest(input, context));
@@ -425,7 +425,7 @@ export const serializeAws_json1_1DescribeForecastExportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DescribeForecastExportJob",
+    "x-amz-target": "AmazonForecast.DescribeForecastExportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeForecastExportJobRequest(input, context));
@@ -438,7 +438,7 @@ export const serializeAws_json1_1DescribePredictorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DescribePredictor",
+    "x-amz-target": "AmazonForecast.DescribePredictor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePredictorRequest(input, context));
@@ -451,7 +451,7 @@ export const serializeAws_json1_1DescribePredictorBacktestExportJobCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.DescribePredictorBacktestExportJob",
+    "x-amz-target": "AmazonForecast.DescribePredictorBacktestExportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePredictorBacktestExportJobRequest(input, context));
@@ -464,7 +464,7 @@ export const serializeAws_json1_1GetAccuracyMetricsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.GetAccuracyMetrics",
+    "x-amz-target": "AmazonForecast.GetAccuracyMetrics",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAccuracyMetricsRequest(input, context));
@@ -477,7 +477,7 @@ export const serializeAws_json1_1ListDatasetGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.ListDatasetGroups",
+    "x-amz-target": "AmazonForecast.ListDatasetGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDatasetGroupsRequest(input, context));
@@ -490,7 +490,7 @@ export const serializeAws_json1_1ListDatasetImportJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.ListDatasetImportJobs",
+    "x-amz-target": "AmazonForecast.ListDatasetImportJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDatasetImportJobsRequest(input, context));
@@ -503,7 +503,7 @@ export const serializeAws_json1_1ListDatasetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.ListDatasets",
+    "x-amz-target": "AmazonForecast.ListDatasets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDatasetsRequest(input, context));
@@ -516,7 +516,7 @@ export const serializeAws_json1_1ListForecastExportJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.ListForecastExportJobs",
+    "x-amz-target": "AmazonForecast.ListForecastExportJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListForecastExportJobsRequest(input, context));
@@ -529,7 +529,7 @@ export const serializeAws_json1_1ListForecastsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.ListForecasts",
+    "x-amz-target": "AmazonForecast.ListForecasts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListForecastsRequest(input, context));
@@ -542,7 +542,7 @@ export const serializeAws_json1_1ListPredictorBacktestExportJobsCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.ListPredictorBacktestExportJobs",
+    "x-amz-target": "AmazonForecast.ListPredictorBacktestExportJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPredictorBacktestExportJobsRequest(input, context));
@@ -555,7 +555,7 @@ export const serializeAws_json1_1ListPredictorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.ListPredictors",
+    "x-amz-target": "AmazonForecast.ListPredictors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPredictorsRequest(input, context));
@@ -568,7 +568,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.ListTagsForResource",
+    "x-amz-target": "AmazonForecast.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -581,7 +581,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.TagResource",
+    "x-amz-target": "AmazonForecast.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -594,7 +594,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.UntagResource",
+    "x-amz-target": "AmazonForecast.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -607,7 +607,7 @@ export const serializeAws_json1_1UpdateDatasetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecast.UpdateDatasetGroup",
+    "x-amz-target": "AmazonForecast.UpdateDatasetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDatasetGroupRequest(input, context));

--- a/clients/client-forecastquery/protocols/Aws_json1_1.ts
+++ b/clients/client-forecastquery/protocols/Aws_json1_1.ts
@@ -26,7 +26,7 @@ export const serializeAws_json1_1QueryForecastCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonForecastRuntime.QueryForecast",
+    "x-amz-target": "AmazonForecastRuntime.QueryForecast",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1QueryForecastRequest(input, context));

--- a/clients/client-frauddetector/protocols/Aws_json1_1.ts
+++ b/clients/client-frauddetector/protocols/Aws_json1_1.ts
@@ -249,7 +249,7 @@ export const serializeAws_json1_1BatchCreateVariableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.BatchCreateVariable",
+    "x-amz-target": "AWSHawksNestServiceFacade.BatchCreateVariable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchCreateVariableRequest(input, context));
@@ -262,7 +262,7 @@ export const serializeAws_json1_1BatchGetVariableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.BatchGetVariable",
+    "x-amz-target": "AWSHawksNestServiceFacade.BatchGetVariable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetVariableRequest(input, context));
@@ -275,7 +275,7 @@ export const serializeAws_json1_1CreateDetectorVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.CreateDetectorVersion",
+    "x-amz-target": "AWSHawksNestServiceFacade.CreateDetectorVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDetectorVersionRequest(input, context));
@@ -288,7 +288,7 @@ export const serializeAws_json1_1CreateModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.CreateModel",
+    "x-amz-target": "AWSHawksNestServiceFacade.CreateModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateModelRequest(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_1CreateModelVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.CreateModelVersion",
+    "x-amz-target": "AWSHawksNestServiceFacade.CreateModelVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateModelVersionRequest(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_1CreateRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.CreateRule",
+    "x-amz-target": "AWSHawksNestServiceFacade.CreateRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRuleRequest(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1CreateVariableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.CreateVariable",
+    "x-amz-target": "AWSHawksNestServiceFacade.CreateVariable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateVariableRequest(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1DeleteDetectorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteDetector",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteDetector",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDetectorRequest(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1DeleteDetectorVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteDetectorVersion",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteDetectorVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDetectorVersionRequest(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_1DeleteEntityTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteEntityType",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteEntityType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEntityTypeRequest(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_1DeleteEventCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteEvent",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteEvent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEventRequest(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_1DeleteEventTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteEventType",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteEventType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEventTypeRequest(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_1DeleteExternalModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteExternalModel",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteExternalModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteExternalModelRequest(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_1DeleteLabelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteLabel",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteLabel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLabelRequest(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_1DeleteModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteModel",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteModelRequest(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_1DeleteModelVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteModelVersion",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteModelVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteModelVersionRequest(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_1DeleteOutcomeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteOutcome",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteOutcome",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteOutcomeRequest(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_1DeleteRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteRule",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRuleRequest(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_1DeleteVariableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DeleteVariable",
+    "x-amz-target": "AWSHawksNestServiceFacade.DeleteVariable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteVariableRequest(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_1DescribeDetectorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DescribeDetector",
+    "x-amz-target": "AWSHawksNestServiceFacade.DescribeDetector",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDetectorRequest(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_1DescribeModelVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.DescribeModelVersions",
+    "x-amz-target": "AWSHawksNestServiceFacade.DescribeModelVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeModelVersionsRequest(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_1GetDetectorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetDetectors",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetDetectors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDetectorsRequest(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1GetDetectorVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetDetectorVersion",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetDetectorVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDetectorVersionRequest(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1GetEntityTypesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetEntityTypes",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetEntityTypes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetEntityTypesRequest(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1GetEventPredictionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetEventPrediction",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetEventPrediction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetEventPredictionRequest(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_1GetEventTypesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetEventTypes",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetEventTypes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetEventTypesRequest(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_1GetExternalModelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetExternalModels",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetExternalModels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetExternalModelsRequest(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_1GetKMSEncryptionKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetKMSEncryptionKey",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetKMSEncryptionKey",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -611,7 +611,7 @@ export const serializeAws_json1_1GetLabelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetLabels",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetLabels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLabelsRequest(input, context));
@@ -624,7 +624,7 @@ export const serializeAws_json1_1GetModelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetModels",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetModels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetModelsRequest(input, context));
@@ -637,7 +637,7 @@ export const serializeAws_json1_1GetModelVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetModelVersion",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetModelVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetModelVersionRequest(input, context));
@@ -650,7 +650,7 @@ export const serializeAws_json1_1GetOutcomesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetOutcomes",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetOutcomes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOutcomesRequest(input, context));
@@ -663,7 +663,7 @@ export const serializeAws_json1_1GetRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetRules",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRulesRequest(input, context));
@@ -676,7 +676,7 @@ export const serializeAws_json1_1GetVariablesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.GetVariables",
+    "x-amz-target": "AWSHawksNestServiceFacade.GetVariables",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetVariablesRequest(input, context));
@@ -689,7 +689,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.ListTagsForResource",
+    "x-amz-target": "AWSHawksNestServiceFacade.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -702,7 +702,7 @@ export const serializeAws_json1_1PutDetectorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.PutDetector",
+    "x-amz-target": "AWSHawksNestServiceFacade.PutDetector",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutDetectorRequest(input, context));
@@ -715,7 +715,7 @@ export const serializeAws_json1_1PutEntityTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.PutEntityType",
+    "x-amz-target": "AWSHawksNestServiceFacade.PutEntityType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutEntityTypeRequest(input, context));
@@ -728,7 +728,7 @@ export const serializeAws_json1_1PutEventTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.PutEventType",
+    "x-amz-target": "AWSHawksNestServiceFacade.PutEventType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutEventTypeRequest(input, context));
@@ -741,7 +741,7 @@ export const serializeAws_json1_1PutExternalModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.PutExternalModel",
+    "x-amz-target": "AWSHawksNestServiceFacade.PutExternalModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutExternalModelRequest(input, context));
@@ -754,7 +754,7 @@ export const serializeAws_json1_1PutKMSEncryptionKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.PutKMSEncryptionKey",
+    "x-amz-target": "AWSHawksNestServiceFacade.PutKMSEncryptionKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutKMSEncryptionKeyRequest(input, context));
@@ -767,7 +767,7 @@ export const serializeAws_json1_1PutLabelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.PutLabel",
+    "x-amz-target": "AWSHawksNestServiceFacade.PutLabel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutLabelRequest(input, context));
@@ -780,7 +780,7 @@ export const serializeAws_json1_1PutOutcomeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.PutOutcome",
+    "x-amz-target": "AWSHawksNestServiceFacade.PutOutcome",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutOutcomeRequest(input, context));
@@ -793,7 +793,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.TagResource",
+    "x-amz-target": "AWSHawksNestServiceFacade.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -806,7 +806,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.UntagResource",
+    "x-amz-target": "AWSHawksNestServiceFacade.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -819,7 +819,7 @@ export const serializeAws_json1_1UpdateDetectorVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.UpdateDetectorVersion",
+    "x-amz-target": "AWSHawksNestServiceFacade.UpdateDetectorVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDetectorVersionRequest(input, context));
@@ -832,7 +832,7 @@ export const serializeAws_json1_1UpdateDetectorVersionMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.UpdateDetectorVersionMetadata",
+    "x-amz-target": "AWSHawksNestServiceFacade.UpdateDetectorVersionMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDetectorVersionMetadataRequest(input, context));
@@ -845,7 +845,7 @@ export const serializeAws_json1_1UpdateDetectorVersionStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.UpdateDetectorVersionStatus",
+    "x-amz-target": "AWSHawksNestServiceFacade.UpdateDetectorVersionStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDetectorVersionStatusRequest(input, context));
@@ -858,7 +858,7 @@ export const serializeAws_json1_1UpdateModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.UpdateModel",
+    "x-amz-target": "AWSHawksNestServiceFacade.UpdateModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateModelRequest(input, context));
@@ -871,7 +871,7 @@ export const serializeAws_json1_1UpdateModelVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.UpdateModelVersion",
+    "x-amz-target": "AWSHawksNestServiceFacade.UpdateModelVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateModelVersionRequest(input, context));
@@ -884,7 +884,7 @@ export const serializeAws_json1_1UpdateModelVersionStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.UpdateModelVersionStatus",
+    "x-amz-target": "AWSHawksNestServiceFacade.UpdateModelVersionStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateModelVersionStatusRequest(input, context));
@@ -897,7 +897,7 @@ export const serializeAws_json1_1UpdateRuleMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.UpdateRuleMetadata",
+    "x-amz-target": "AWSHawksNestServiceFacade.UpdateRuleMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRuleMetadataRequest(input, context));
@@ -910,7 +910,7 @@ export const serializeAws_json1_1UpdateRuleVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.UpdateRuleVersion",
+    "x-amz-target": "AWSHawksNestServiceFacade.UpdateRuleVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRuleVersionRequest(input, context));
@@ -923,7 +923,7 @@ export const serializeAws_json1_1UpdateVariableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHawksNestServiceFacade.UpdateVariable",
+    "x-amz-target": "AWSHawksNestServiceFacade.UpdateVariable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateVariableRequest(input, context));

--- a/clients/client-fsx/protocols/Aws_json1_1.ts
+++ b/clients/client-fsx/protocols/Aws_json1_1.ts
@@ -147,7 +147,7 @@ export const serializeAws_json1_1AssociateFileSystemAliasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.AssociateFileSystemAliases",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.AssociateFileSystemAliases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateFileSystemAliasesRequest(input, context));
@@ -160,7 +160,7 @@ export const serializeAws_json1_1CancelDataRepositoryTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.CancelDataRepositoryTask",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.CancelDataRepositoryTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelDataRepositoryTaskRequest(input, context));
@@ -173,7 +173,7 @@ export const serializeAws_json1_1CreateBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.CreateBackup",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateBackupRequest(input, context));
@@ -186,7 +186,7 @@ export const serializeAws_json1_1CreateDataRepositoryTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.CreateDataRepositoryTask",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateDataRepositoryTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDataRepositoryTaskRequest(input, context));
@@ -199,7 +199,7 @@ export const serializeAws_json1_1CreateFileSystemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.CreateFileSystem",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateFileSystem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateFileSystemRequest(input, context));
@@ -212,7 +212,7 @@ export const serializeAws_json1_1CreateFileSystemFromBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.CreateFileSystemFromBackup",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.CreateFileSystemFromBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateFileSystemFromBackupRequest(input, context));
@@ -225,7 +225,7 @@ export const serializeAws_json1_1DeleteBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.DeleteBackup",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.DeleteBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBackupRequest(input, context));
@@ -238,7 +238,7 @@ export const serializeAws_json1_1DeleteFileSystemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.DeleteFileSystem",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.DeleteFileSystem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFileSystemRequest(input, context));
@@ -251,7 +251,7 @@ export const serializeAws_json1_1DescribeBackupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.DescribeBackups",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeBackups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBackupsRequest(input, context));
@@ -264,7 +264,7 @@ export const serializeAws_json1_1DescribeDataRepositoryTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.DescribeDataRepositoryTasks",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeDataRepositoryTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDataRepositoryTasksRequest(input, context));
@@ -277,7 +277,7 @@ export const serializeAws_json1_1DescribeFileSystemAliasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.DescribeFileSystemAliases",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeFileSystemAliases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFileSystemAliasesRequest(input, context));
@@ -290,7 +290,7 @@ export const serializeAws_json1_1DescribeFileSystemsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.DescribeFileSystems",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.DescribeFileSystems",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFileSystemsRequest(input, context));
@@ -303,7 +303,7 @@ export const serializeAws_json1_1DisassociateFileSystemAliasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.DisassociateFileSystemAliases",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.DisassociateFileSystemAliases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateFileSystemAliasesRequest(input, context));
@@ -316,7 +316,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.ListTagsForResource",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -329,7 +329,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.TagResource",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -342,7 +342,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.UntagResource",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -355,7 +355,7 @@ export const serializeAws_json1_1UpdateFileSystemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSimbaAPIService_v20180301.UpdateFileSystem",
+    "x-amz-target": "AWSSimbaAPIService_v20180301.UpdateFileSystem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateFileSystemRequest(input, context));

--- a/clients/client-gamelift/protocols/Aws_json1_1.ts
+++ b/clients/client-gamelift/protocols/Aws_json1_1.ts
@@ -504,7 +504,7 @@ export const serializeAws_json1_1AcceptMatchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.AcceptMatch",
+    "x-amz-target": "GameLift.AcceptMatch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AcceptMatchInput(input, context));
@@ -517,7 +517,7 @@ export const serializeAws_json1_1ClaimGameServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ClaimGameServer",
+    "x-amz-target": "GameLift.ClaimGameServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ClaimGameServerInput(input, context));
@@ -530,7 +530,7 @@ export const serializeAws_json1_1CreateAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateAlias",
+    "x-amz-target": "GameLift.CreateAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAliasInput(input, context));
@@ -543,7 +543,7 @@ export const serializeAws_json1_1CreateBuildCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateBuild",
+    "x-amz-target": "GameLift.CreateBuild",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateBuildInput(input, context));
@@ -556,7 +556,7 @@ export const serializeAws_json1_1CreateFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateFleet",
+    "x-amz-target": "GameLift.CreateFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateFleetInput(input, context));
@@ -569,7 +569,7 @@ export const serializeAws_json1_1CreateGameServerGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateGameServerGroup",
+    "x-amz-target": "GameLift.CreateGameServerGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGameServerGroupInput(input, context));
@@ -582,7 +582,7 @@ export const serializeAws_json1_1CreateGameSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateGameSession",
+    "x-amz-target": "GameLift.CreateGameSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGameSessionInput(input, context));
@@ -595,7 +595,7 @@ export const serializeAws_json1_1CreateGameSessionQueueCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateGameSessionQueue",
+    "x-amz-target": "GameLift.CreateGameSessionQueue",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGameSessionQueueInput(input, context));
@@ -608,7 +608,7 @@ export const serializeAws_json1_1CreateMatchmakingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateMatchmakingConfiguration",
+    "x-amz-target": "GameLift.CreateMatchmakingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateMatchmakingConfigurationInput(input, context));
@@ -621,7 +621,7 @@ export const serializeAws_json1_1CreateMatchmakingRuleSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateMatchmakingRuleSet",
+    "x-amz-target": "GameLift.CreateMatchmakingRuleSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateMatchmakingRuleSetInput(input, context));
@@ -634,7 +634,7 @@ export const serializeAws_json1_1CreatePlayerSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreatePlayerSession",
+    "x-amz-target": "GameLift.CreatePlayerSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePlayerSessionInput(input, context));
@@ -647,7 +647,7 @@ export const serializeAws_json1_1CreatePlayerSessionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreatePlayerSessions",
+    "x-amz-target": "GameLift.CreatePlayerSessions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePlayerSessionsInput(input, context));
@@ -660,7 +660,7 @@ export const serializeAws_json1_1CreateScriptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateScript",
+    "x-amz-target": "GameLift.CreateScript",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateScriptInput(input, context));
@@ -673,7 +673,7 @@ export const serializeAws_json1_1CreateVpcPeeringAuthorizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateVpcPeeringAuthorization",
+    "x-amz-target": "GameLift.CreateVpcPeeringAuthorization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateVpcPeeringAuthorizationInput(input, context));
@@ -686,7 +686,7 @@ export const serializeAws_json1_1CreateVpcPeeringConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.CreateVpcPeeringConnection",
+    "x-amz-target": "GameLift.CreateVpcPeeringConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateVpcPeeringConnectionInput(input, context));
@@ -699,7 +699,7 @@ export const serializeAws_json1_1DeleteAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteAlias",
+    "x-amz-target": "GameLift.DeleteAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAliasInput(input, context));
@@ -712,7 +712,7 @@ export const serializeAws_json1_1DeleteBuildCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteBuild",
+    "x-amz-target": "GameLift.DeleteBuild",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBuildInput(input, context));
@@ -725,7 +725,7 @@ export const serializeAws_json1_1DeleteFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteFleet",
+    "x-amz-target": "GameLift.DeleteFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFleetInput(input, context));
@@ -738,7 +738,7 @@ export const serializeAws_json1_1DeleteGameServerGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteGameServerGroup",
+    "x-amz-target": "GameLift.DeleteGameServerGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteGameServerGroupInput(input, context));
@@ -751,7 +751,7 @@ export const serializeAws_json1_1DeleteGameSessionQueueCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteGameSessionQueue",
+    "x-amz-target": "GameLift.DeleteGameSessionQueue",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteGameSessionQueueInput(input, context));
@@ -764,7 +764,7 @@ export const serializeAws_json1_1DeleteMatchmakingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteMatchmakingConfiguration",
+    "x-amz-target": "GameLift.DeleteMatchmakingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMatchmakingConfigurationInput(input, context));
@@ -777,7 +777,7 @@ export const serializeAws_json1_1DeleteMatchmakingRuleSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteMatchmakingRuleSet",
+    "x-amz-target": "GameLift.DeleteMatchmakingRuleSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMatchmakingRuleSetInput(input, context));
@@ -790,7 +790,7 @@ export const serializeAws_json1_1DeleteScalingPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteScalingPolicy",
+    "x-amz-target": "GameLift.DeleteScalingPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteScalingPolicyInput(input, context));
@@ -803,7 +803,7 @@ export const serializeAws_json1_1DeleteScriptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteScript",
+    "x-amz-target": "GameLift.DeleteScript",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteScriptInput(input, context));
@@ -816,7 +816,7 @@ export const serializeAws_json1_1DeleteVpcPeeringAuthorizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteVpcPeeringAuthorization",
+    "x-amz-target": "GameLift.DeleteVpcPeeringAuthorization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteVpcPeeringAuthorizationInput(input, context));
@@ -829,7 +829,7 @@ export const serializeAws_json1_1DeleteVpcPeeringConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeleteVpcPeeringConnection",
+    "x-amz-target": "GameLift.DeleteVpcPeeringConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteVpcPeeringConnectionInput(input, context));
@@ -842,7 +842,7 @@ export const serializeAws_json1_1DeregisterGameServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DeregisterGameServer",
+    "x-amz-target": "GameLift.DeregisterGameServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterGameServerInput(input, context));
@@ -855,7 +855,7 @@ export const serializeAws_json1_1DescribeAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeAlias",
+    "x-amz-target": "GameLift.DescribeAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAliasInput(input, context));
@@ -868,7 +868,7 @@ export const serializeAws_json1_1DescribeBuildCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeBuild",
+    "x-amz-target": "GameLift.DescribeBuild",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBuildInput(input, context));
@@ -881,7 +881,7 @@ export const serializeAws_json1_1DescribeEC2InstanceLimitsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeEC2InstanceLimits",
+    "x-amz-target": "GameLift.DescribeEC2InstanceLimits",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEC2InstanceLimitsInput(input, context));
@@ -894,7 +894,7 @@ export const serializeAws_json1_1DescribeFleetAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeFleetAttributes",
+    "x-amz-target": "GameLift.DescribeFleetAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFleetAttributesInput(input, context));
@@ -907,7 +907,7 @@ export const serializeAws_json1_1DescribeFleetCapacityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeFleetCapacity",
+    "x-amz-target": "GameLift.DescribeFleetCapacity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFleetCapacityInput(input, context));
@@ -920,7 +920,7 @@ export const serializeAws_json1_1DescribeFleetEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeFleetEvents",
+    "x-amz-target": "GameLift.DescribeFleetEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFleetEventsInput(input, context));
@@ -933,7 +933,7 @@ export const serializeAws_json1_1DescribeFleetPortSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeFleetPortSettings",
+    "x-amz-target": "GameLift.DescribeFleetPortSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFleetPortSettingsInput(input, context));
@@ -946,7 +946,7 @@ export const serializeAws_json1_1DescribeFleetUtilizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeFleetUtilization",
+    "x-amz-target": "GameLift.DescribeFleetUtilization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFleetUtilizationInput(input, context));
@@ -959,7 +959,7 @@ export const serializeAws_json1_1DescribeGameServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeGameServer",
+    "x-amz-target": "GameLift.DescribeGameServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeGameServerInput(input, context));
@@ -972,7 +972,7 @@ export const serializeAws_json1_1DescribeGameServerGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeGameServerGroup",
+    "x-amz-target": "GameLift.DescribeGameServerGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeGameServerGroupInput(input, context));
@@ -985,7 +985,7 @@ export const serializeAws_json1_1DescribeGameServerInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeGameServerInstances",
+    "x-amz-target": "GameLift.DescribeGameServerInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeGameServerInstancesInput(input, context));
@@ -998,7 +998,7 @@ export const serializeAws_json1_1DescribeGameSessionDetailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeGameSessionDetails",
+    "x-amz-target": "GameLift.DescribeGameSessionDetails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeGameSessionDetailsInput(input, context));
@@ -1011,7 +1011,7 @@ export const serializeAws_json1_1DescribeGameSessionPlacementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeGameSessionPlacement",
+    "x-amz-target": "GameLift.DescribeGameSessionPlacement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeGameSessionPlacementInput(input, context));
@@ -1024,7 +1024,7 @@ export const serializeAws_json1_1DescribeGameSessionQueuesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeGameSessionQueues",
+    "x-amz-target": "GameLift.DescribeGameSessionQueues",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeGameSessionQueuesInput(input, context));
@@ -1037,7 +1037,7 @@ export const serializeAws_json1_1DescribeGameSessionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeGameSessions",
+    "x-amz-target": "GameLift.DescribeGameSessions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeGameSessionsInput(input, context));
@@ -1050,7 +1050,7 @@ export const serializeAws_json1_1DescribeInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeInstances",
+    "x-amz-target": "GameLift.DescribeInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInstancesInput(input, context));
@@ -1063,7 +1063,7 @@ export const serializeAws_json1_1DescribeMatchmakingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeMatchmaking",
+    "x-amz-target": "GameLift.DescribeMatchmaking",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMatchmakingInput(input, context));
@@ -1076,7 +1076,7 @@ export const serializeAws_json1_1DescribeMatchmakingConfigurationsCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeMatchmakingConfigurations",
+    "x-amz-target": "GameLift.DescribeMatchmakingConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMatchmakingConfigurationsInput(input, context));
@@ -1089,7 +1089,7 @@ export const serializeAws_json1_1DescribeMatchmakingRuleSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeMatchmakingRuleSets",
+    "x-amz-target": "GameLift.DescribeMatchmakingRuleSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMatchmakingRuleSetsInput(input, context));
@@ -1102,7 +1102,7 @@ export const serializeAws_json1_1DescribePlayerSessionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribePlayerSessions",
+    "x-amz-target": "GameLift.DescribePlayerSessions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePlayerSessionsInput(input, context));
@@ -1115,7 +1115,7 @@ export const serializeAws_json1_1DescribeRuntimeConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeRuntimeConfiguration",
+    "x-amz-target": "GameLift.DescribeRuntimeConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRuntimeConfigurationInput(input, context));
@@ -1128,7 +1128,7 @@ export const serializeAws_json1_1DescribeScalingPoliciesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeScalingPolicies",
+    "x-amz-target": "GameLift.DescribeScalingPolicies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeScalingPoliciesInput(input, context));
@@ -1141,7 +1141,7 @@ export const serializeAws_json1_1DescribeScriptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeScript",
+    "x-amz-target": "GameLift.DescribeScript",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeScriptInput(input, context));
@@ -1154,7 +1154,7 @@ export const serializeAws_json1_1DescribeVpcPeeringAuthorizationsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeVpcPeeringAuthorizations",
+    "x-amz-target": "GameLift.DescribeVpcPeeringAuthorizations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeVpcPeeringAuthorizationsInput(input, context));
@@ -1167,7 +1167,7 @@ export const serializeAws_json1_1DescribeVpcPeeringConnectionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.DescribeVpcPeeringConnections",
+    "x-amz-target": "GameLift.DescribeVpcPeeringConnections",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeVpcPeeringConnectionsInput(input, context));
@@ -1180,7 +1180,7 @@ export const serializeAws_json1_1GetGameSessionLogUrlCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.GetGameSessionLogUrl",
+    "x-amz-target": "GameLift.GetGameSessionLogUrl",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetGameSessionLogUrlInput(input, context));
@@ -1193,7 +1193,7 @@ export const serializeAws_json1_1GetInstanceAccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.GetInstanceAccess",
+    "x-amz-target": "GameLift.GetInstanceAccess",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstanceAccessInput(input, context));
@@ -1206,7 +1206,7 @@ export const serializeAws_json1_1ListAliasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ListAliases",
+    "x-amz-target": "GameLift.ListAliases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAliasesInput(input, context));
@@ -1219,7 +1219,7 @@ export const serializeAws_json1_1ListBuildsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ListBuilds",
+    "x-amz-target": "GameLift.ListBuilds",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBuildsInput(input, context));
@@ -1232,7 +1232,7 @@ export const serializeAws_json1_1ListFleetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ListFleets",
+    "x-amz-target": "GameLift.ListFleets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListFleetsInput(input, context));
@@ -1245,7 +1245,7 @@ export const serializeAws_json1_1ListGameServerGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ListGameServerGroups",
+    "x-amz-target": "GameLift.ListGameServerGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGameServerGroupsInput(input, context));
@@ -1258,7 +1258,7 @@ export const serializeAws_json1_1ListGameServersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ListGameServers",
+    "x-amz-target": "GameLift.ListGameServers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGameServersInput(input, context));
@@ -1271,7 +1271,7 @@ export const serializeAws_json1_1ListScriptsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ListScripts",
+    "x-amz-target": "GameLift.ListScripts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListScriptsInput(input, context));
@@ -1284,7 +1284,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ListTagsForResource",
+    "x-amz-target": "GameLift.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -1297,7 +1297,7 @@ export const serializeAws_json1_1PutScalingPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.PutScalingPolicy",
+    "x-amz-target": "GameLift.PutScalingPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutScalingPolicyInput(input, context));
@@ -1310,7 +1310,7 @@ export const serializeAws_json1_1RegisterGameServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.RegisterGameServer",
+    "x-amz-target": "GameLift.RegisterGameServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterGameServerInput(input, context));
@@ -1323,7 +1323,7 @@ export const serializeAws_json1_1RequestUploadCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.RequestUploadCredentials",
+    "x-amz-target": "GameLift.RequestUploadCredentials",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RequestUploadCredentialsInput(input, context));
@@ -1336,7 +1336,7 @@ export const serializeAws_json1_1ResolveAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ResolveAlias",
+    "x-amz-target": "GameLift.ResolveAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResolveAliasInput(input, context));
@@ -1349,7 +1349,7 @@ export const serializeAws_json1_1ResumeGameServerGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ResumeGameServerGroup",
+    "x-amz-target": "GameLift.ResumeGameServerGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResumeGameServerGroupInput(input, context));
@@ -1362,7 +1362,7 @@ export const serializeAws_json1_1SearchGameSessionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.SearchGameSessions",
+    "x-amz-target": "GameLift.SearchGameSessions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchGameSessionsInput(input, context));
@@ -1375,7 +1375,7 @@ export const serializeAws_json1_1StartFleetActionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.StartFleetActions",
+    "x-amz-target": "GameLift.StartFleetActions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartFleetActionsInput(input, context));
@@ -1388,7 +1388,7 @@ export const serializeAws_json1_1StartGameSessionPlacementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.StartGameSessionPlacement",
+    "x-amz-target": "GameLift.StartGameSessionPlacement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartGameSessionPlacementInput(input, context));
@@ -1401,7 +1401,7 @@ export const serializeAws_json1_1StartMatchBackfillCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.StartMatchBackfill",
+    "x-amz-target": "GameLift.StartMatchBackfill",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartMatchBackfillInput(input, context));
@@ -1414,7 +1414,7 @@ export const serializeAws_json1_1StartMatchmakingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.StartMatchmaking",
+    "x-amz-target": "GameLift.StartMatchmaking",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartMatchmakingInput(input, context));
@@ -1427,7 +1427,7 @@ export const serializeAws_json1_1StopFleetActionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.StopFleetActions",
+    "x-amz-target": "GameLift.StopFleetActions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopFleetActionsInput(input, context));
@@ -1440,7 +1440,7 @@ export const serializeAws_json1_1StopGameSessionPlacementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.StopGameSessionPlacement",
+    "x-amz-target": "GameLift.StopGameSessionPlacement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopGameSessionPlacementInput(input, context));
@@ -1453,7 +1453,7 @@ export const serializeAws_json1_1StopMatchmakingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.StopMatchmaking",
+    "x-amz-target": "GameLift.StopMatchmaking",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopMatchmakingInput(input, context));
@@ -1466,7 +1466,7 @@ export const serializeAws_json1_1SuspendGameServerGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.SuspendGameServerGroup",
+    "x-amz-target": "GameLift.SuspendGameServerGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SuspendGameServerGroupInput(input, context));
@@ -1479,7 +1479,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.TagResource",
+    "x-amz-target": "GameLift.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -1492,7 +1492,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UntagResource",
+    "x-amz-target": "GameLift.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -1505,7 +1505,7 @@ export const serializeAws_json1_1UpdateAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateAlias",
+    "x-amz-target": "GameLift.UpdateAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAliasInput(input, context));
@@ -1518,7 +1518,7 @@ export const serializeAws_json1_1UpdateBuildCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateBuild",
+    "x-amz-target": "GameLift.UpdateBuild",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateBuildInput(input, context));
@@ -1531,7 +1531,7 @@ export const serializeAws_json1_1UpdateFleetAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateFleetAttributes",
+    "x-amz-target": "GameLift.UpdateFleetAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateFleetAttributesInput(input, context));
@@ -1544,7 +1544,7 @@ export const serializeAws_json1_1UpdateFleetCapacityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateFleetCapacity",
+    "x-amz-target": "GameLift.UpdateFleetCapacity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateFleetCapacityInput(input, context));
@@ -1557,7 +1557,7 @@ export const serializeAws_json1_1UpdateFleetPortSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateFleetPortSettings",
+    "x-amz-target": "GameLift.UpdateFleetPortSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateFleetPortSettingsInput(input, context));
@@ -1570,7 +1570,7 @@ export const serializeAws_json1_1UpdateGameServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateGameServer",
+    "x-amz-target": "GameLift.UpdateGameServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGameServerInput(input, context));
@@ -1583,7 +1583,7 @@ export const serializeAws_json1_1UpdateGameServerGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateGameServerGroup",
+    "x-amz-target": "GameLift.UpdateGameServerGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGameServerGroupInput(input, context));
@@ -1596,7 +1596,7 @@ export const serializeAws_json1_1UpdateGameSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateGameSession",
+    "x-amz-target": "GameLift.UpdateGameSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGameSessionInput(input, context));
@@ -1609,7 +1609,7 @@ export const serializeAws_json1_1UpdateGameSessionQueueCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateGameSessionQueue",
+    "x-amz-target": "GameLift.UpdateGameSessionQueue",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGameSessionQueueInput(input, context));
@@ -1622,7 +1622,7 @@ export const serializeAws_json1_1UpdateMatchmakingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateMatchmakingConfiguration",
+    "x-amz-target": "GameLift.UpdateMatchmakingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMatchmakingConfigurationInput(input, context));
@@ -1635,7 +1635,7 @@ export const serializeAws_json1_1UpdateRuntimeConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateRuntimeConfiguration",
+    "x-amz-target": "GameLift.UpdateRuntimeConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRuntimeConfigurationInput(input, context));
@@ -1648,7 +1648,7 @@ export const serializeAws_json1_1UpdateScriptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.UpdateScript",
+    "x-amz-target": "GameLift.UpdateScript",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateScriptInput(input, context));
@@ -1661,7 +1661,7 @@ export const serializeAws_json1_1ValidateMatchmakingRuleSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GameLift.ValidateMatchmakingRuleSet",
+    "x-amz-target": "GameLift.ValidateMatchmakingRuleSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ValidateMatchmakingRuleSetInput(input, context));

--- a/clients/client-glacier/protocols/Aws_restJson1.ts
+++ b/clients/client-glacier/protocols/Aws_restJson1.ts
@@ -658,7 +658,7 @@ export const serializeAws_restJson1GetJobOutputCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.range) && { Range: input.range! }),
+    ...(isSerializableHeaderValue(input.range) && { range: input.range! }),
   };
   let resolvedPath = "/{accountId}/vaults/{vaultName}/jobs/{jobId}/output";
   if (input.accountId !== undefined) {
@@ -1435,7 +1435,7 @@ export const serializeAws_restJson1UploadMultipartPartCommand = async (
   const headers: any = {
     "content-type": "application/octet-stream",
     ...(isSerializableHeaderValue(input.checksum) && { "x-amz-sha256-tree-hash": input.checksum! }),
-    ...(isSerializableHeaderValue(input.range) && { "Content-Range": input.range! }),
+    ...(isSerializableHeaderValue(input.range) && { "content-range": input.range! }),
   };
   let resolvedPath = "/{accountId}/vaults/{vaultName}/multipart-uploads/{uploadId}";
   if (input.accountId !== undefined) {

--- a/clients/client-global-accelerator/protocols/Aws_json1_1.ts
+++ b/clients/client-global-accelerator/protocols/Aws_json1_1.ts
@@ -286,7 +286,7 @@ export const serializeAws_json1_1AddCustomRoutingEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.AddCustomRoutingEndpoints",
+    "x-amz-target": "GlobalAccelerator_V20180706.AddCustomRoutingEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddCustomRoutingEndpointsRequest(input, context));
@@ -299,7 +299,7 @@ export const serializeAws_json1_1AdvertiseByoipCidrCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.AdvertiseByoipCidr",
+    "x-amz-target": "GlobalAccelerator_V20180706.AdvertiseByoipCidr",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AdvertiseByoipCidrRequest(input, context));
@@ -312,7 +312,7 @@ export const serializeAws_json1_1AllowCustomRoutingTrafficCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.AllowCustomRoutingTraffic",
+    "x-amz-target": "GlobalAccelerator_V20180706.AllowCustomRoutingTraffic",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AllowCustomRoutingTrafficRequest(input, context));
@@ -325,7 +325,7 @@ export const serializeAws_json1_1CreateAcceleratorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.CreateAccelerator",
+    "x-amz-target": "GlobalAccelerator_V20180706.CreateAccelerator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAcceleratorRequest(input, context));
@@ -338,7 +338,7 @@ export const serializeAws_json1_1CreateCustomRoutingAcceleratorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.CreateCustomRoutingAccelerator",
+    "x-amz-target": "GlobalAccelerator_V20180706.CreateCustomRoutingAccelerator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCustomRoutingAcceleratorRequest(input, context));
@@ -351,7 +351,7 @@ export const serializeAws_json1_1CreateCustomRoutingEndpointGroupCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.CreateCustomRoutingEndpointGroup",
+    "x-amz-target": "GlobalAccelerator_V20180706.CreateCustomRoutingEndpointGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCustomRoutingEndpointGroupRequest(input, context));
@@ -364,7 +364,7 @@ export const serializeAws_json1_1CreateCustomRoutingListenerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.CreateCustomRoutingListener",
+    "x-amz-target": "GlobalAccelerator_V20180706.CreateCustomRoutingListener",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCustomRoutingListenerRequest(input, context));
@@ -377,7 +377,7 @@ export const serializeAws_json1_1CreateEndpointGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.CreateEndpointGroup",
+    "x-amz-target": "GlobalAccelerator_V20180706.CreateEndpointGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEndpointGroupRequest(input, context));
@@ -390,7 +390,7 @@ export const serializeAws_json1_1CreateListenerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.CreateListener",
+    "x-amz-target": "GlobalAccelerator_V20180706.CreateListener",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateListenerRequest(input, context));
@@ -403,7 +403,7 @@ export const serializeAws_json1_1DeleteAcceleratorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DeleteAccelerator",
+    "x-amz-target": "GlobalAccelerator_V20180706.DeleteAccelerator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAcceleratorRequest(input, context));
@@ -416,7 +416,7 @@ export const serializeAws_json1_1DeleteCustomRoutingAcceleratorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DeleteCustomRoutingAccelerator",
+    "x-amz-target": "GlobalAccelerator_V20180706.DeleteCustomRoutingAccelerator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCustomRoutingAcceleratorRequest(input, context));
@@ -429,7 +429,7 @@ export const serializeAws_json1_1DeleteCustomRoutingEndpointGroupCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DeleteCustomRoutingEndpointGroup",
+    "x-amz-target": "GlobalAccelerator_V20180706.DeleteCustomRoutingEndpointGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCustomRoutingEndpointGroupRequest(input, context));
@@ -442,7 +442,7 @@ export const serializeAws_json1_1DeleteCustomRoutingListenerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DeleteCustomRoutingListener",
+    "x-amz-target": "GlobalAccelerator_V20180706.DeleteCustomRoutingListener",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCustomRoutingListenerRequest(input, context));
@@ -455,7 +455,7 @@ export const serializeAws_json1_1DeleteEndpointGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DeleteEndpointGroup",
+    "x-amz-target": "GlobalAccelerator_V20180706.DeleteEndpointGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEndpointGroupRequest(input, context));
@@ -468,7 +468,7 @@ export const serializeAws_json1_1DeleteListenerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DeleteListener",
+    "x-amz-target": "GlobalAccelerator_V20180706.DeleteListener",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteListenerRequest(input, context));
@@ -481,7 +481,7 @@ export const serializeAws_json1_1DenyCustomRoutingTrafficCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DenyCustomRoutingTraffic",
+    "x-amz-target": "GlobalAccelerator_V20180706.DenyCustomRoutingTraffic",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DenyCustomRoutingTrafficRequest(input, context));
@@ -494,7 +494,7 @@ export const serializeAws_json1_1DeprovisionByoipCidrCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DeprovisionByoipCidr",
+    "x-amz-target": "GlobalAccelerator_V20180706.DeprovisionByoipCidr",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeprovisionByoipCidrRequest(input, context));
@@ -507,7 +507,7 @@ export const serializeAws_json1_1DescribeAcceleratorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DescribeAccelerator",
+    "x-amz-target": "GlobalAccelerator_V20180706.DescribeAccelerator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAcceleratorRequest(input, context));
@@ -520,7 +520,7 @@ export const serializeAws_json1_1DescribeAcceleratorAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DescribeAcceleratorAttributes",
+    "x-amz-target": "GlobalAccelerator_V20180706.DescribeAcceleratorAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAcceleratorAttributesRequest(input, context));
@@ -533,7 +533,7 @@ export const serializeAws_json1_1DescribeCustomRoutingAcceleratorCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DescribeCustomRoutingAccelerator",
+    "x-amz-target": "GlobalAccelerator_V20180706.DescribeCustomRoutingAccelerator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCustomRoutingAcceleratorRequest(input, context));
@@ -546,7 +546,7 @@ export const serializeAws_json1_1DescribeCustomRoutingAcceleratorAttributesComma
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DescribeCustomRoutingAcceleratorAttributes",
+    "x-amz-target": "GlobalAccelerator_V20180706.DescribeCustomRoutingAcceleratorAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCustomRoutingAcceleratorAttributesRequest(input, context));
@@ -559,7 +559,7 @@ export const serializeAws_json1_1DescribeCustomRoutingEndpointGroupCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DescribeCustomRoutingEndpointGroup",
+    "x-amz-target": "GlobalAccelerator_V20180706.DescribeCustomRoutingEndpointGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCustomRoutingEndpointGroupRequest(input, context));
@@ -572,7 +572,7 @@ export const serializeAws_json1_1DescribeCustomRoutingListenerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DescribeCustomRoutingListener",
+    "x-amz-target": "GlobalAccelerator_V20180706.DescribeCustomRoutingListener",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCustomRoutingListenerRequest(input, context));
@@ -585,7 +585,7 @@ export const serializeAws_json1_1DescribeEndpointGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DescribeEndpointGroup",
+    "x-amz-target": "GlobalAccelerator_V20180706.DescribeEndpointGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEndpointGroupRequest(input, context));
@@ -598,7 +598,7 @@ export const serializeAws_json1_1DescribeListenerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.DescribeListener",
+    "x-amz-target": "GlobalAccelerator_V20180706.DescribeListener",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeListenerRequest(input, context));
@@ -611,7 +611,7 @@ export const serializeAws_json1_1ListAcceleratorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ListAccelerators",
+    "x-amz-target": "GlobalAccelerator_V20180706.ListAccelerators",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAcceleratorsRequest(input, context));
@@ -624,7 +624,7 @@ export const serializeAws_json1_1ListByoipCidrsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ListByoipCidrs",
+    "x-amz-target": "GlobalAccelerator_V20180706.ListByoipCidrs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListByoipCidrsRequest(input, context));
@@ -637,7 +637,7 @@ export const serializeAws_json1_1ListCustomRoutingAcceleratorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ListCustomRoutingAccelerators",
+    "x-amz-target": "GlobalAccelerator_V20180706.ListCustomRoutingAccelerators",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCustomRoutingAcceleratorsRequest(input, context));
@@ -650,7 +650,7 @@ export const serializeAws_json1_1ListCustomRoutingEndpointGroupsCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ListCustomRoutingEndpointGroups",
+    "x-amz-target": "GlobalAccelerator_V20180706.ListCustomRoutingEndpointGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCustomRoutingEndpointGroupsRequest(input, context));
@@ -663,7 +663,7 @@ export const serializeAws_json1_1ListCustomRoutingListenersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ListCustomRoutingListeners",
+    "x-amz-target": "GlobalAccelerator_V20180706.ListCustomRoutingListeners",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCustomRoutingListenersRequest(input, context));
@@ -676,7 +676,7 @@ export const serializeAws_json1_1ListCustomRoutingPortMappingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ListCustomRoutingPortMappings",
+    "x-amz-target": "GlobalAccelerator_V20180706.ListCustomRoutingPortMappings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCustomRoutingPortMappingsRequest(input, context));
@@ -689,7 +689,7 @@ export const serializeAws_json1_1ListCustomRoutingPortMappingsByDestinationComma
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ListCustomRoutingPortMappingsByDestination",
+    "x-amz-target": "GlobalAccelerator_V20180706.ListCustomRoutingPortMappingsByDestination",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCustomRoutingPortMappingsByDestinationRequest(input, context));
@@ -702,7 +702,7 @@ export const serializeAws_json1_1ListEndpointGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ListEndpointGroups",
+    "x-amz-target": "GlobalAccelerator_V20180706.ListEndpointGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEndpointGroupsRequest(input, context));
@@ -715,7 +715,7 @@ export const serializeAws_json1_1ListListenersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ListListeners",
+    "x-amz-target": "GlobalAccelerator_V20180706.ListListeners",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListListenersRequest(input, context));
@@ -728,7 +728,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ListTagsForResource",
+    "x-amz-target": "GlobalAccelerator_V20180706.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -741,7 +741,7 @@ export const serializeAws_json1_1ProvisionByoipCidrCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.ProvisionByoipCidr",
+    "x-amz-target": "GlobalAccelerator_V20180706.ProvisionByoipCidr",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ProvisionByoipCidrRequest(input, context));
@@ -754,7 +754,7 @@ export const serializeAws_json1_1RemoveCustomRoutingEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.RemoveCustomRoutingEndpoints",
+    "x-amz-target": "GlobalAccelerator_V20180706.RemoveCustomRoutingEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveCustomRoutingEndpointsRequest(input, context));
@@ -767,7 +767,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.TagResource",
+    "x-amz-target": "GlobalAccelerator_V20180706.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -780,7 +780,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.UntagResource",
+    "x-amz-target": "GlobalAccelerator_V20180706.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -793,7 +793,7 @@ export const serializeAws_json1_1UpdateAcceleratorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.UpdateAccelerator",
+    "x-amz-target": "GlobalAccelerator_V20180706.UpdateAccelerator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAcceleratorRequest(input, context));
@@ -806,7 +806,7 @@ export const serializeAws_json1_1UpdateAcceleratorAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.UpdateAcceleratorAttributes",
+    "x-amz-target": "GlobalAccelerator_V20180706.UpdateAcceleratorAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAcceleratorAttributesRequest(input, context));
@@ -819,7 +819,7 @@ export const serializeAws_json1_1UpdateCustomRoutingAcceleratorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.UpdateCustomRoutingAccelerator",
+    "x-amz-target": "GlobalAccelerator_V20180706.UpdateCustomRoutingAccelerator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCustomRoutingAcceleratorRequest(input, context));
@@ -832,7 +832,7 @@ export const serializeAws_json1_1UpdateCustomRoutingAcceleratorAttributesCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.UpdateCustomRoutingAcceleratorAttributes",
+    "x-amz-target": "GlobalAccelerator_V20180706.UpdateCustomRoutingAcceleratorAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCustomRoutingAcceleratorAttributesRequest(input, context));
@@ -845,7 +845,7 @@ export const serializeAws_json1_1UpdateCustomRoutingListenerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.UpdateCustomRoutingListener",
+    "x-amz-target": "GlobalAccelerator_V20180706.UpdateCustomRoutingListener",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCustomRoutingListenerRequest(input, context));
@@ -858,7 +858,7 @@ export const serializeAws_json1_1UpdateEndpointGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.UpdateEndpointGroup",
+    "x-amz-target": "GlobalAccelerator_V20180706.UpdateEndpointGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateEndpointGroupRequest(input, context));
@@ -871,7 +871,7 @@ export const serializeAws_json1_1UpdateListenerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.UpdateListener",
+    "x-amz-target": "GlobalAccelerator_V20180706.UpdateListener",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateListenerRequest(input, context));
@@ -884,7 +884,7 @@ export const serializeAws_json1_1WithdrawByoipCidrCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "GlobalAccelerator_V20180706.WithdrawByoipCidr",
+    "x-amz-target": "GlobalAccelerator_V20180706.WithdrawByoipCidr",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1WithdrawByoipCidrRequest(input, context));

--- a/clients/client-glue/protocols/Aws_json1_1.ts
+++ b/clients/client-glue/protocols/Aws_json1_1.ts
@@ -806,7 +806,7 @@ export const serializeAws_json1_1BatchCreatePartitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchCreatePartition",
+    "x-amz-target": "AWSGlue.BatchCreatePartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchCreatePartitionRequest(input, context));
@@ -819,7 +819,7 @@ export const serializeAws_json1_1BatchDeleteConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchDeleteConnection",
+    "x-amz-target": "AWSGlue.BatchDeleteConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDeleteConnectionRequest(input, context));
@@ -832,7 +832,7 @@ export const serializeAws_json1_1BatchDeletePartitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchDeletePartition",
+    "x-amz-target": "AWSGlue.BatchDeletePartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDeletePartitionRequest(input, context));
@@ -845,7 +845,7 @@ export const serializeAws_json1_1BatchDeleteTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchDeleteTable",
+    "x-amz-target": "AWSGlue.BatchDeleteTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDeleteTableRequest(input, context));
@@ -858,7 +858,7 @@ export const serializeAws_json1_1BatchDeleteTableVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchDeleteTableVersion",
+    "x-amz-target": "AWSGlue.BatchDeleteTableVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDeleteTableVersionRequest(input, context));
@@ -871,7 +871,7 @@ export const serializeAws_json1_1BatchGetCrawlersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchGetCrawlers",
+    "x-amz-target": "AWSGlue.BatchGetCrawlers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetCrawlersRequest(input, context));
@@ -884,7 +884,7 @@ export const serializeAws_json1_1BatchGetDevEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchGetDevEndpoints",
+    "x-amz-target": "AWSGlue.BatchGetDevEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetDevEndpointsRequest(input, context));
@@ -897,7 +897,7 @@ export const serializeAws_json1_1BatchGetJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchGetJobs",
+    "x-amz-target": "AWSGlue.BatchGetJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetJobsRequest(input, context));
@@ -910,7 +910,7 @@ export const serializeAws_json1_1BatchGetPartitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchGetPartition",
+    "x-amz-target": "AWSGlue.BatchGetPartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetPartitionRequest(input, context));
@@ -923,7 +923,7 @@ export const serializeAws_json1_1BatchGetTriggersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchGetTriggers",
+    "x-amz-target": "AWSGlue.BatchGetTriggers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetTriggersRequest(input, context));
@@ -936,7 +936,7 @@ export const serializeAws_json1_1BatchGetWorkflowsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchGetWorkflows",
+    "x-amz-target": "AWSGlue.BatchGetWorkflows",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGetWorkflowsRequest(input, context));
@@ -949,7 +949,7 @@ export const serializeAws_json1_1BatchStopJobRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchStopJobRun",
+    "x-amz-target": "AWSGlue.BatchStopJobRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchStopJobRunRequest(input, context));
@@ -962,7 +962,7 @@ export const serializeAws_json1_1BatchUpdatePartitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.BatchUpdatePartition",
+    "x-amz-target": "AWSGlue.BatchUpdatePartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchUpdatePartitionRequest(input, context));
@@ -975,7 +975,7 @@ export const serializeAws_json1_1CancelMLTaskRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CancelMLTaskRun",
+    "x-amz-target": "AWSGlue.CancelMLTaskRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelMLTaskRunRequest(input, context));
@@ -988,7 +988,7 @@ export const serializeAws_json1_1CheckSchemaVersionValidityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CheckSchemaVersionValidity",
+    "x-amz-target": "AWSGlue.CheckSchemaVersionValidity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CheckSchemaVersionValidityInput(input, context));
@@ -1001,7 +1001,7 @@ export const serializeAws_json1_1CreateClassifierCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateClassifier",
+    "x-amz-target": "AWSGlue.CreateClassifier",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateClassifierRequest(input, context));
@@ -1014,7 +1014,7 @@ export const serializeAws_json1_1CreateConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateConnection",
+    "x-amz-target": "AWSGlue.CreateConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateConnectionRequest(input, context));
@@ -1027,7 +1027,7 @@ export const serializeAws_json1_1CreateCrawlerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateCrawler",
+    "x-amz-target": "AWSGlue.CreateCrawler",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCrawlerRequest(input, context));
@@ -1040,7 +1040,7 @@ export const serializeAws_json1_1CreateDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateDatabase",
+    "x-amz-target": "AWSGlue.CreateDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDatabaseRequest(input, context));
@@ -1053,7 +1053,7 @@ export const serializeAws_json1_1CreateDevEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateDevEndpoint",
+    "x-amz-target": "AWSGlue.CreateDevEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDevEndpointRequest(input, context));
@@ -1066,7 +1066,7 @@ export const serializeAws_json1_1CreateJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateJob",
+    "x-amz-target": "AWSGlue.CreateJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateJobRequest(input, context));
@@ -1079,7 +1079,7 @@ export const serializeAws_json1_1CreateMLTransformCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateMLTransform",
+    "x-amz-target": "AWSGlue.CreateMLTransform",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateMLTransformRequest(input, context));
@@ -1092,7 +1092,7 @@ export const serializeAws_json1_1CreatePartitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreatePartition",
+    "x-amz-target": "AWSGlue.CreatePartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePartitionRequest(input, context));
@@ -1105,7 +1105,7 @@ export const serializeAws_json1_1CreatePartitionIndexCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreatePartitionIndex",
+    "x-amz-target": "AWSGlue.CreatePartitionIndex",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePartitionIndexRequest(input, context));
@@ -1118,7 +1118,7 @@ export const serializeAws_json1_1CreateRegistryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateRegistry",
+    "x-amz-target": "AWSGlue.CreateRegistry",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRegistryInput(input, context));
@@ -1131,7 +1131,7 @@ export const serializeAws_json1_1CreateSchemaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateSchema",
+    "x-amz-target": "AWSGlue.CreateSchema",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSchemaInput(input, context));
@@ -1144,7 +1144,7 @@ export const serializeAws_json1_1CreateScriptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateScript",
+    "x-amz-target": "AWSGlue.CreateScript",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateScriptRequest(input, context));
@@ -1157,7 +1157,7 @@ export const serializeAws_json1_1CreateSecurityConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateSecurityConfiguration",
+    "x-amz-target": "AWSGlue.CreateSecurityConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSecurityConfigurationRequest(input, context));
@@ -1170,7 +1170,7 @@ export const serializeAws_json1_1CreateTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateTable",
+    "x-amz-target": "AWSGlue.CreateTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTableRequest(input, context));
@@ -1183,7 +1183,7 @@ export const serializeAws_json1_1CreateTriggerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateTrigger",
+    "x-amz-target": "AWSGlue.CreateTrigger",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTriggerRequest(input, context));
@@ -1196,7 +1196,7 @@ export const serializeAws_json1_1CreateUserDefinedFunctionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateUserDefinedFunction",
+    "x-amz-target": "AWSGlue.CreateUserDefinedFunction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserDefinedFunctionRequest(input, context));
@@ -1209,7 +1209,7 @@ export const serializeAws_json1_1CreateWorkflowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.CreateWorkflow",
+    "x-amz-target": "AWSGlue.CreateWorkflow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWorkflowRequest(input, context));
@@ -1222,7 +1222,7 @@ export const serializeAws_json1_1DeleteClassifierCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteClassifier",
+    "x-amz-target": "AWSGlue.DeleteClassifier",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteClassifierRequest(input, context));
@@ -1235,7 +1235,7 @@ export const serializeAws_json1_1DeleteColumnStatisticsForPartitionCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteColumnStatisticsForPartition",
+    "x-amz-target": "AWSGlue.DeleteColumnStatisticsForPartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteColumnStatisticsForPartitionRequest(input, context));
@@ -1248,7 +1248,7 @@ export const serializeAws_json1_1DeleteColumnStatisticsForTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteColumnStatisticsForTable",
+    "x-amz-target": "AWSGlue.DeleteColumnStatisticsForTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteColumnStatisticsForTableRequest(input, context));
@@ -1261,7 +1261,7 @@ export const serializeAws_json1_1DeleteConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteConnection",
+    "x-amz-target": "AWSGlue.DeleteConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConnectionRequest(input, context));
@@ -1274,7 +1274,7 @@ export const serializeAws_json1_1DeleteCrawlerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteCrawler",
+    "x-amz-target": "AWSGlue.DeleteCrawler",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCrawlerRequest(input, context));
@@ -1287,7 +1287,7 @@ export const serializeAws_json1_1DeleteDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteDatabase",
+    "x-amz-target": "AWSGlue.DeleteDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDatabaseRequest(input, context));
@@ -1300,7 +1300,7 @@ export const serializeAws_json1_1DeleteDevEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteDevEndpoint",
+    "x-amz-target": "AWSGlue.DeleteDevEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDevEndpointRequest(input, context));
@@ -1313,7 +1313,7 @@ export const serializeAws_json1_1DeleteJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteJob",
+    "x-amz-target": "AWSGlue.DeleteJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteJobRequest(input, context));
@@ -1326,7 +1326,7 @@ export const serializeAws_json1_1DeleteMLTransformCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteMLTransform",
+    "x-amz-target": "AWSGlue.DeleteMLTransform",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMLTransformRequest(input, context));
@@ -1339,7 +1339,7 @@ export const serializeAws_json1_1DeletePartitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeletePartition",
+    "x-amz-target": "AWSGlue.DeletePartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePartitionRequest(input, context));
@@ -1352,7 +1352,7 @@ export const serializeAws_json1_1DeletePartitionIndexCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeletePartitionIndex",
+    "x-amz-target": "AWSGlue.DeletePartitionIndex",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePartitionIndexRequest(input, context));
@@ -1365,7 +1365,7 @@ export const serializeAws_json1_1DeleteRegistryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteRegistry",
+    "x-amz-target": "AWSGlue.DeleteRegistry",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRegistryInput(input, context));
@@ -1378,7 +1378,7 @@ export const serializeAws_json1_1DeleteResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteResourcePolicy",
+    "x-amz-target": "AWSGlue.DeleteResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResourcePolicyRequest(input, context));
@@ -1391,7 +1391,7 @@ export const serializeAws_json1_1DeleteSchemaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteSchema",
+    "x-amz-target": "AWSGlue.DeleteSchema",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSchemaInput(input, context));
@@ -1404,7 +1404,7 @@ export const serializeAws_json1_1DeleteSchemaVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteSchemaVersions",
+    "x-amz-target": "AWSGlue.DeleteSchemaVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSchemaVersionsInput(input, context));
@@ -1417,7 +1417,7 @@ export const serializeAws_json1_1DeleteSecurityConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteSecurityConfiguration",
+    "x-amz-target": "AWSGlue.DeleteSecurityConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSecurityConfigurationRequest(input, context));
@@ -1430,7 +1430,7 @@ export const serializeAws_json1_1DeleteTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteTable",
+    "x-amz-target": "AWSGlue.DeleteTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTableRequest(input, context));
@@ -1443,7 +1443,7 @@ export const serializeAws_json1_1DeleteTableVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteTableVersion",
+    "x-amz-target": "AWSGlue.DeleteTableVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTableVersionRequest(input, context));
@@ -1456,7 +1456,7 @@ export const serializeAws_json1_1DeleteTriggerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteTrigger",
+    "x-amz-target": "AWSGlue.DeleteTrigger",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTriggerRequest(input, context));
@@ -1469,7 +1469,7 @@ export const serializeAws_json1_1DeleteUserDefinedFunctionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteUserDefinedFunction",
+    "x-amz-target": "AWSGlue.DeleteUserDefinedFunction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserDefinedFunctionRequest(input, context));
@@ -1482,7 +1482,7 @@ export const serializeAws_json1_1DeleteWorkflowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.DeleteWorkflow",
+    "x-amz-target": "AWSGlue.DeleteWorkflow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWorkflowRequest(input, context));
@@ -1495,7 +1495,7 @@ export const serializeAws_json1_1GetCatalogImportStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetCatalogImportStatus",
+    "x-amz-target": "AWSGlue.GetCatalogImportStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCatalogImportStatusRequest(input, context));
@@ -1508,7 +1508,7 @@ export const serializeAws_json1_1GetClassifierCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetClassifier",
+    "x-amz-target": "AWSGlue.GetClassifier",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetClassifierRequest(input, context));
@@ -1521,7 +1521,7 @@ export const serializeAws_json1_1GetClassifiersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetClassifiers",
+    "x-amz-target": "AWSGlue.GetClassifiers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetClassifiersRequest(input, context));
@@ -1534,7 +1534,7 @@ export const serializeAws_json1_1GetColumnStatisticsForPartitionCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetColumnStatisticsForPartition",
+    "x-amz-target": "AWSGlue.GetColumnStatisticsForPartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetColumnStatisticsForPartitionRequest(input, context));
@@ -1547,7 +1547,7 @@ export const serializeAws_json1_1GetColumnStatisticsForTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetColumnStatisticsForTable",
+    "x-amz-target": "AWSGlue.GetColumnStatisticsForTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetColumnStatisticsForTableRequest(input, context));
@@ -1560,7 +1560,7 @@ export const serializeAws_json1_1GetConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetConnection",
+    "x-amz-target": "AWSGlue.GetConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetConnectionRequest(input, context));
@@ -1573,7 +1573,7 @@ export const serializeAws_json1_1GetConnectionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetConnections",
+    "x-amz-target": "AWSGlue.GetConnections",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetConnectionsRequest(input, context));
@@ -1586,7 +1586,7 @@ export const serializeAws_json1_1GetCrawlerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetCrawler",
+    "x-amz-target": "AWSGlue.GetCrawler",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCrawlerRequest(input, context));
@@ -1599,7 +1599,7 @@ export const serializeAws_json1_1GetCrawlerMetricsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetCrawlerMetrics",
+    "x-amz-target": "AWSGlue.GetCrawlerMetrics",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCrawlerMetricsRequest(input, context));
@@ -1612,7 +1612,7 @@ export const serializeAws_json1_1GetCrawlersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetCrawlers",
+    "x-amz-target": "AWSGlue.GetCrawlers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCrawlersRequest(input, context));
@@ -1625,7 +1625,7 @@ export const serializeAws_json1_1GetDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetDatabase",
+    "x-amz-target": "AWSGlue.GetDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDatabaseRequest(input, context));
@@ -1638,7 +1638,7 @@ export const serializeAws_json1_1GetDatabasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetDatabases",
+    "x-amz-target": "AWSGlue.GetDatabases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDatabasesRequest(input, context));
@@ -1651,7 +1651,7 @@ export const serializeAws_json1_1GetDataCatalogEncryptionSettingsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetDataCatalogEncryptionSettings",
+    "x-amz-target": "AWSGlue.GetDataCatalogEncryptionSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDataCatalogEncryptionSettingsRequest(input, context));
@@ -1664,7 +1664,7 @@ export const serializeAws_json1_1GetDataflowGraphCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetDataflowGraph",
+    "x-amz-target": "AWSGlue.GetDataflowGraph",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDataflowGraphRequest(input, context));
@@ -1677,7 +1677,7 @@ export const serializeAws_json1_1GetDevEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetDevEndpoint",
+    "x-amz-target": "AWSGlue.GetDevEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDevEndpointRequest(input, context));
@@ -1690,7 +1690,7 @@ export const serializeAws_json1_1GetDevEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetDevEndpoints",
+    "x-amz-target": "AWSGlue.GetDevEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDevEndpointsRequest(input, context));
@@ -1703,7 +1703,7 @@ export const serializeAws_json1_1GetJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetJob",
+    "x-amz-target": "AWSGlue.GetJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetJobRequest(input, context));
@@ -1716,7 +1716,7 @@ export const serializeAws_json1_1GetJobBookmarkCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetJobBookmark",
+    "x-amz-target": "AWSGlue.GetJobBookmark",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetJobBookmarkRequest(input, context));
@@ -1729,7 +1729,7 @@ export const serializeAws_json1_1GetJobRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetJobRun",
+    "x-amz-target": "AWSGlue.GetJobRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetJobRunRequest(input, context));
@@ -1742,7 +1742,7 @@ export const serializeAws_json1_1GetJobRunsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetJobRuns",
+    "x-amz-target": "AWSGlue.GetJobRuns",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetJobRunsRequest(input, context));
@@ -1755,7 +1755,7 @@ export const serializeAws_json1_1GetJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetJobs",
+    "x-amz-target": "AWSGlue.GetJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetJobsRequest(input, context));
@@ -1768,7 +1768,7 @@ export const serializeAws_json1_1GetMappingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetMapping",
+    "x-amz-target": "AWSGlue.GetMapping",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMappingRequest(input, context));
@@ -1781,7 +1781,7 @@ export const serializeAws_json1_1GetMLTaskRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetMLTaskRun",
+    "x-amz-target": "AWSGlue.GetMLTaskRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMLTaskRunRequest(input, context));
@@ -1794,7 +1794,7 @@ export const serializeAws_json1_1GetMLTaskRunsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetMLTaskRuns",
+    "x-amz-target": "AWSGlue.GetMLTaskRuns",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMLTaskRunsRequest(input, context));
@@ -1807,7 +1807,7 @@ export const serializeAws_json1_1GetMLTransformCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetMLTransform",
+    "x-amz-target": "AWSGlue.GetMLTransform",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMLTransformRequest(input, context));
@@ -1820,7 +1820,7 @@ export const serializeAws_json1_1GetMLTransformsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetMLTransforms",
+    "x-amz-target": "AWSGlue.GetMLTransforms",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMLTransformsRequest(input, context));
@@ -1833,7 +1833,7 @@ export const serializeAws_json1_1GetPartitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetPartition",
+    "x-amz-target": "AWSGlue.GetPartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPartitionRequest(input, context));
@@ -1846,7 +1846,7 @@ export const serializeAws_json1_1GetPartitionIndexesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetPartitionIndexes",
+    "x-amz-target": "AWSGlue.GetPartitionIndexes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPartitionIndexesRequest(input, context));
@@ -1859,7 +1859,7 @@ export const serializeAws_json1_1GetPartitionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetPartitions",
+    "x-amz-target": "AWSGlue.GetPartitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPartitionsRequest(input, context));
@@ -1872,7 +1872,7 @@ export const serializeAws_json1_1GetPlanCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetPlan",
+    "x-amz-target": "AWSGlue.GetPlan",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPlanRequest(input, context));
@@ -1885,7 +1885,7 @@ export const serializeAws_json1_1GetRegistryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetRegistry",
+    "x-amz-target": "AWSGlue.GetRegistry",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRegistryInput(input, context));
@@ -1898,7 +1898,7 @@ export const serializeAws_json1_1GetResourcePoliciesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetResourcePolicies",
+    "x-amz-target": "AWSGlue.GetResourcePolicies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResourcePoliciesRequest(input, context));
@@ -1911,7 +1911,7 @@ export const serializeAws_json1_1GetResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetResourcePolicy",
+    "x-amz-target": "AWSGlue.GetResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResourcePolicyRequest(input, context));
@@ -1924,7 +1924,7 @@ export const serializeAws_json1_1GetSchemaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetSchema",
+    "x-amz-target": "AWSGlue.GetSchema",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSchemaInput(input, context));
@@ -1937,7 +1937,7 @@ export const serializeAws_json1_1GetSchemaByDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetSchemaByDefinition",
+    "x-amz-target": "AWSGlue.GetSchemaByDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSchemaByDefinitionInput(input, context));
@@ -1950,7 +1950,7 @@ export const serializeAws_json1_1GetSchemaVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetSchemaVersion",
+    "x-amz-target": "AWSGlue.GetSchemaVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSchemaVersionInput(input, context));
@@ -1963,7 +1963,7 @@ export const serializeAws_json1_1GetSchemaVersionsDiffCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetSchemaVersionsDiff",
+    "x-amz-target": "AWSGlue.GetSchemaVersionsDiff",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSchemaVersionsDiffInput(input, context));
@@ -1976,7 +1976,7 @@ export const serializeAws_json1_1GetSecurityConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetSecurityConfiguration",
+    "x-amz-target": "AWSGlue.GetSecurityConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSecurityConfigurationRequest(input, context));
@@ -1989,7 +1989,7 @@ export const serializeAws_json1_1GetSecurityConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetSecurityConfigurations",
+    "x-amz-target": "AWSGlue.GetSecurityConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSecurityConfigurationsRequest(input, context));
@@ -2002,7 +2002,7 @@ export const serializeAws_json1_1GetTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetTable",
+    "x-amz-target": "AWSGlue.GetTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTableRequest(input, context));
@@ -2015,7 +2015,7 @@ export const serializeAws_json1_1GetTablesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetTables",
+    "x-amz-target": "AWSGlue.GetTables",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTablesRequest(input, context));
@@ -2028,7 +2028,7 @@ export const serializeAws_json1_1GetTableVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetTableVersion",
+    "x-amz-target": "AWSGlue.GetTableVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTableVersionRequest(input, context));
@@ -2041,7 +2041,7 @@ export const serializeAws_json1_1GetTableVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetTableVersions",
+    "x-amz-target": "AWSGlue.GetTableVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTableVersionsRequest(input, context));
@@ -2054,7 +2054,7 @@ export const serializeAws_json1_1GetTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetTags",
+    "x-amz-target": "AWSGlue.GetTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTagsRequest(input, context));
@@ -2067,7 +2067,7 @@ export const serializeAws_json1_1GetTriggerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetTrigger",
+    "x-amz-target": "AWSGlue.GetTrigger",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTriggerRequest(input, context));
@@ -2080,7 +2080,7 @@ export const serializeAws_json1_1GetTriggersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetTriggers",
+    "x-amz-target": "AWSGlue.GetTriggers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTriggersRequest(input, context));
@@ -2093,7 +2093,7 @@ export const serializeAws_json1_1GetUserDefinedFunctionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetUserDefinedFunction",
+    "x-amz-target": "AWSGlue.GetUserDefinedFunction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetUserDefinedFunctionRequest(input, context));
@@ -2106,7 +2106,7 @@ export const serializeAws_json1_1GetUserDefinedFunctionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetUserDefinedFunctions",
+    "x-amz-target": "AWSGlue.GetUserDefinedFunctions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetUserDefinedFunctionsRequest(input, context));
@@ -2119,7 +2119,7 @@ export const serializeAws_json1_1GetWorkflowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetWorkflow",
+    "x-amz-target": "AWSGlue.GetWorkflow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetWorkflowRequest(input, context));
@@ -2132,7 +2132,7 @@ export const serializeAws_json1_1GetWorkflowRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetWorkflowRun",
+    "x-amz-target": "AWSGlue.GetWorkflowRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetWorkflowRunRequest(input, context));
@@ -2145,7 +2145,7 @@ export const serializeAws_json1_1GetWorkflowRunPropertiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetWorkflowRunProperties",
+    "x-amz-target": "AWSGlue.GetWorkflowRunProperties",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetWorkflowRunPropertiesRequest(input, context));
@@ -2158,7 +2158,7 @@ export const serializeAws_json1_1GetWorkflowRunsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.GetWorkflowRuns",
+    "x-amz-target": "AWSGlue.GetWorkflowRuns",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetWorkflowRunsRequest(input, context));
@@ -2171,7 +2171,7 @@ export const serializeAws_json1_1ImportCatalogToGlueCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ImportCatalogToGlue",
+    "x-amz-target": "AWSGlue.ImportCatalogToGlue",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportCatalogToGlueRequest(input, context));
@@ -2184,7 +2184,7 @@ export const serializeAws_json1_1ListCrawlersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ListCrawlers",
+    "x-amz-target": "AWSGlue.ListCrawlers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCrawlersRequest(input, context));
@@ -2197,7 +2197,7 @@ export const serializeAws_json1_1ListDevEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ListDevEndpoints",
+    "x-amz-target": "AWSGlue.ListDevEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDevEndpointsRequest(input, context));
@@ -2210,7 +2210,7 @@ export const serializeAws_json1_1ListJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ListJobs",
+    "x-amz-target": "AWSGlue.ListJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListJobsRequest(input, context));
@@ -2223,7 +2223,7 @@ export const serializeAws_json1_1ListMLTransformsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ListMLTransforms",
+    "x-amz-target": "AWSGlue.ListMLTransforms",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListMLTransformsRequest(input, context));
@@ -2236,7 +2236,7 @@ export const serializeAws_json1_1ListRegistriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ListRegistries",
+    "x-amz-target": "AWSGlue.ListRegistries",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRegistriesInput(input, context));
@@ -2249,7 +2249,7 @@ export const serializeAws_json1_1ListSchemasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ListSchemas",
+    "x-amz-target": "AWSGlue.ListSchemas",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSchemasInput(input, context));
@@ -2262,7 +2262,7 @@ export const serializeAws_json1_1ListSchemaVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ListSchemaVersions",
+    "x-amz-target": "AWSGlue.ListSchemaVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSchemaVersionsInput(input, context));
@@ -2275,7 +2275,7 @@ export const serializeAws_json1_1ListTriggersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ListTriggers",
+    "x-amz-target": "AWSGlue.ListTriggers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTriggersRequest(input, context));
@@ -2288,7 +2288,7 @@ export const serializeAws_json1_1ListWorkflowsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ListWorkflows",
+    "x-amz-target": "AWSGlue.ListWorkflows",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListWorkflowsRequest(input, context));
@@ -2301,7 +2301,7 @@ export const serializeAws_json1_1PutDataCatalogEncryptionSettingsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.PutDataCatalogEncryptionSettings",
+    "x-amz-target": "AWSGlue.PutDataCatalogEncryptionSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutDataCatalogEncryptionSettingsRequest(input, context));
@@ -2314,7 +2314,7 @@ export const serializeAws_json1_1PutResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.PutResourcePolicy",
+    "x-amz-target": "AWSGlue.PutResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutResourcePolicyRequest(input, context));
@@ -2327,7 +2327,7 @@ export const serializeAws_json1_1PutSchemaVersionMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.PutSchemaVersionMetadata",
+    "x-amz-target": "AWSGlue.PutSchemaVersionMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutSchemaVersionMetadataInput(input, context));
@@ -2340,7 +2340,7 @@ export const serializeAws_json1_1PutWorkflowRunPropertiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.PutWorkflowRunProperties",
+    "x-amz-target": "AWSGlue.PutWorkflowRunProperties",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutWorkflowRunPropertiesRequest(input, context));
@@ -2353,7 +2353,7 @@ export const serializeAws_json1_1QuerySchemaVersionMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.QuerySchemaVersionMetadata",
+    "x-amz-target": "AWSGlue.QuerySchemaVersionMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1QuerySchemaVersionMetadataInput(input, context));
@@ -2366,7 +2366,7 @@ export const serializeAws_json1_1RegisterSchemaVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.RegisterSchemaVersion",
+    "x-amz-target": "AWSGlue.RegisterSchemaVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterSchemaVersionInput(input, context));
@@ -2379,7 +2379,7 @@ export const serializeAws_json1_1RemoveSchemaVersionMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.RemoveSchemaVersionMetadata",
+    "x-amz-target": "AWSGlue.RemoveSchemaVersionMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveSchemaVersionMetadataInput(input, context));
@@ -2392,7 +2392,7 @@ export const serializeAws_json1_1ResetJobBookmarkCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ResetJobBookmark",
+    "x-amz-target": "AWSGlue.ResetJobBookmark",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResetJobBookmarkRequest(input, context));
@@ -2405,7 +2405,7 @@ export const serializeAws_json1_1ResumeWorkflowRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.ResumeWorkflowRun",
+    "x-amz-target": "AWSGlue.ResumeWorkflowRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResumeWorkflowRunRequest(input, context));
@@ -2418,7 +2418,7 @@ export const serializeAws_json1_1SearchTablesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.SearchTables",
+    "x-amz-target": "AWSGlue.SearchTables",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchTablesRequest(input, context));
@@ -2431,7 +2431,7 @@ export const serializeAws_json1_1StartCrawlerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StartCrawler",
+    "x-amz-target": "AWSGlue.StartCrawler",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartCrawlerRequest(input, context));
@@ -2444,7 +2444,7 @@ export const serializeAws_json1_1StartCrawlerScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StartCrawlerSchedule",
+    "x-amz-target": "AWSGlue.StartCrawlerSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartCrawlerScheduleRequest(input, context));
@@ -2457,7 +2457,7 @@ export const serializeAws_json1_1StartExportLabelsTaskRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StartExportLabelsTaskRun",
+    "x-amz-target": "AWSGlue.StartExportLabelsTaskRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartExportLabelsTaskRunRequest(input, context));
@@ -2470,7 +2470,7 @@ export const serializeAws_json1_1StartImportLabelsTaskRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StartImportLabelsTaskRun",
+    "x-amz-target": "AWSGlue.StartImportLabelsTaskRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartImportLabelsTaskRunRequest(input, context));
@@ -2483,7 +2483,7 @@ export const serializeAws_json1_1StartJobRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StartJobRun",
+    "x-amz-target": "AWSGlue.StartJobRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartJobRunRequest(input, context));
@@ -2496,7 +2496,7 @@ export const serializeAws_json1_1StartMLEvaluationTaskRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StartMLEvaluationTaskRun",
+    "x-amz-target": "AWSGlue.StartMLEvaluationTaskRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartMLEvaluationTaskRunRequest(input, context));
@@ -2509,7 +2509,7 @@ export const serializeAws_json1_1StartMLLabelingSetGenerationTaskRunCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StartMLLabelingSetGenerationTaskRun",
+    "x-amz-target": "AWSGlue.StartMLLabelingSetGenerationTaskRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartMLLabelingSetGenerationTaskRunRequest(input, context));
@@ -2522,7 +2522,7 @@ export const serializeAws_json1_1StartTriggerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StartTrigger",
+    "x-amz-target": "AWSGlue.StartTrigger",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartTriggerRequest(input, context));
@@ -2535,7 +2535,7 @@ export const serializeAws_json1_1StartWorkflowRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StartWorkflowRun",
+    "x-amz-target": "AWSGlue.StartWorkflowRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartWorkflowRunRequest(input, context));
@@ -2548,7 +2548,7 @@ export const serializeAws_json1_1StopCrawlerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StopCrawler",
+    "x-amz-target": "AWSGlue.StopCrawler",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopCrawlerRequest(input, context));
@@ -2561,7 +2561,7 @@ export const serializeAws_json1_1StopCrawlerScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StopCrawlerSchedule",
+    "x-amz-target": "AWSGlue.StopCrawlerSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopCrawlerScheduleRequest(input, context));
@@ -2574,7 +2574,7 @@ export const serializeAws_json1_1StopTriggerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StopTrigger",
+    "x-amz-target": "AWSGlue.StopTrigger",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopTriggerRequest(input, context));
@@ -2587,7 +2587,7 @@ export const serializeAws_json1_1StopWorkflowRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.StopWorkflowRun",
+    "x-amz-target": "AWSGlue.StopWorkflowRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopWorkflowRunRequest(input, context));
@@ -2600,7 +2600,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.TagResource",
+    "x-amz-target": "AWSGlue.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -2613,7 +2613,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UntagResource",
+    "x-amz-target": "AWSGlue.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -2626,7 +2626,7 @@ export const serializeAws_json1_1UpdateClassifierCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateClassifier",
+    "x-amz-target": "AWSGlue.UpdateClassifier",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateClassifierRequest(input, context));
@@ -2639,7 +2639,7 @@ export const serializeAws_json1_1UpdateColumnStatisticsForPartitionCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateColumnStatisticsForPartition",
+    "x-amz-target": "AWSGlue.UpdateColumnStatisticsForPartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateColumnStatisticsForPartitionRequest(input, context));
@@ -2652,7 +2652,7 @@ export const serializeAws_json1_1UpdateColumnStatisticsForTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateColumnStatisticsForTable",
+    "x-amz-target": "AWSGlue.UpdateColumnStatisticsForTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateColumnStatisticsForTableRequest(input, context));
@@ -2665,7 +2665,7 @@ export const serializeAws_json1_1UpdateConnectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateConnection",
+    "x-amz-target": "AWSGlue.UpdateConnection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateConnectionRequest(input, context));
@@ -2678,7 +2678,7 @@ export const serializeAws_json1_1UpdateCrawlerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateCrawler",
+    "x-amz-target": "AWSGlue.UpdateCrawler",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCrawlerRequest(input, context));
@@ -2691,7 +2691,7 @@ export const serializeAws_json1_1UpdateCrawlerScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateCrawlerSchedule",
+    "x-amz-target": "AWSGlue.UpdateCrawlerSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCrawlerScheduleRequest(input, context));
@@ -2704,7 +2704,7 @@ export const serializeAws_json1_1UpdateDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateDatabase",
+    "x-amz-target": "AWSGlue.UpdateDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDatabaseRequest(input, context));
@@ -2717,7 +2717,7 @@ export const serializeAws_json1_1UpdateDevEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateDevEndpoint",
+    "x-amz-target": "AWSGlue.UpdateDevEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDevEndpointRequest(input, context));
@@ -2730,7 +2730,7 @@ export const serializeAws_json1_1UpdateJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateJob",
+    "x-amz-target": "AWSGlue.UpdateJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateJobRequest(input, context));
@@ -2743,7 +2743,7 @@ export const serializeAws_json1_1UpdateMLTransformCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateMLTransform",
+    "x-amz-target": "AWSGlue.UpdateMLTransform",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMLTransformRequest(input, context));
@@ -2756,7 +2756,7 @@ export const serializeAws_json1_1UpdatePartitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdatePartition",
+    "x-amz-target": "AWSGlue.UpdatePartition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePartitionRequest(input, context));
@@ -2769,7 +2769,7 @@ export const serializeAws_json1_1UpdateRegistryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateRegistry",
+    "x-amz-target": "AWSGlue.UpdateRegistry",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRegistryInput(input, context));
@@ -2782,7 +2782,7 @@ export const serializeAws_json1_1UpdateSchemaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateSchema",
+    "x-amz-target": "AWSGlue.UpdateSchema",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSchemaInput(input, context));
@@ -2795,7 +2795,7 @@ export const serializeAws_json1_1UpdateTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateTable",
+    "x-amz-target": "AWSGlue.UpdateTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTableRequest(input, context));
@@ -2808,7 +2808,7 @@ export const serializeAws_json1_1UpdateTriggerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateTrigger",
+    "x-amz-target": "AWSGlue.UpdateTrigger",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTriggerRequest(input, context));
@@ -2821,7 +2821,7 @@ export const serializeAws_json1_1UpdateUserDefinedFunctionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateUserDefinedFunction",
+    "x-amz-target": "AWSGlue.UpdateUserDefinedFunction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateUserDefinedFunctionRequest(input, context));
@@ -2834,7 +2834,7 @@ export const serializeAws_json1_1UpdateWorkflowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSGlue.UpdateWorkflow",
+    "x-amz-target": "AWSGlue.UpdateWorkflow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateWorkflowRequest(input, context));

--- a/clients/client-greengrass/protocols/Aws_restJson1.ts
+++ b/clients/client-greengrass/protocols/Aws_restJson1.ts
@@ -440,7 +440,7 @@ export const serializeAws_restJson1CreateConnectorDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/connectors";
   let body: any;
@@ -470,7 +470,7 @@ export const serializeAws_restJson1CreateConnectorDefinitionVersionCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/connectors/{ConnectorDefinitionId}/versions";
   if (input.ConnectorDefinitionId !== undefined) {
@@ -505,7 +505,7 @@ export const serializeAws_restJson1CreateCoreDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/cores";
   let body: any;
@@ -535,7 +535,7 @@ export const serializeAws_restJson1CreateCoreDefinitionVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/cores/{CoreDefinitionId}/versions";
   if (input.CoreDefinitionId !== undefined) {
@@ -570,7 +570,7 @@ export const serializeAws_restJson1CreateDeploymentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/groups/{GroupId}/deployments";
   if (input.GroupId !== undefined) {
@@ -608,7 +608,7 @@ export const serializeAws_restJson1CreateDeviceDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/devices";
   let body: any;
@@ -638,7 +638,7 @@ export const serializeAws_restJson1CreateDeviceDefinitionVersionCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/devices/{DeviceDefinitionId}/versions";
   if (input.DeviceDefinitionId !== undefined) {
@@ -673,7 +673,7 @@ export const serializeAws_restJson1CreateFunctionDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/functions";
   let body: any;
@@ -703,7 +703,7 @@ export const serializeAws_restJson1CreateFunctionDefinitionVersionCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/functions/{FunctionDefinitionId}/versions";
   if (input.FunctionDefinitionId !== undefined) {
@@ -742,7 +742,7 @@ export const serializeAws_restJson1CreateGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/groups";
   let body: any;
@@ -771,7 +771,7 @@ export const serializeAws_restJson1CreateGroupCertificateAuthorityCommand = asyn
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/groups/{GroupId}/certificateauthorities";
   if (input.GroupId !== undefined) {
@@ -802,7 +802,7 @@ export const serializeAws_restJson1CreateGroupVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/groups/{GroupId}/versions";
   if (input.GroupId !== undefined) {
@@ -857,7 +857,7 @@ export const serializeAws_restJson1CreateLoggerDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/loggers";
   let body: any;
@@ -887,7 +887,7 @@ export const serializeAws_restJson1CreateLoggerDefinitionVersionCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/loggers/{LoggerDefinitionId}/versions";
   if (input.LoggerDefinitionId !== undefined) {
@@ -922,7 +922,7 @@ export const serializeAws_restJson1CreateResourceDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/resources";
   let body: any;
@@ -952,7 +952,7 @@ export const serializeAws_restJson1CreateResourceDefinitionVersionCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/resources/{ResourceDefinitionId}/versions";
   if (input.ResourceDefinitionId !== undefined) {
@@ -987,7 +987,7 @@ export const serializeAws_restJson1CreateSoftwareUpdateJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/updates";
   let body: any;
@@ -1027,7 +1027,7 @@ export const serializeAws_restJson1CreateSubscriptionDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/subscriptions";
   let body: any;
@@ -1057,7 +1057,7 @@ export const serializeAws_restJson1CreateSubscriptionDefinitionVersionCommand = 
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/definition/subscriptions/{SubscriptionDefinitionId}/versions";
   if (input.SubscriptionDefinitionId !== undefined) {
@@ -2744,7 +2744,7 @@ export const serializeAws_restJson1ResetDeploymentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/groups/{GroupId}/deployments/$reset";
   if (input.GroupId !== undefined) {
@@ -2778,7 +2778,7 @@ export const serializeAws_restJson1StartBulkDeploymentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AmznClientToken) && { "X-Amzn-Client-Token": input.AmznClientToken! }),
+    ...(isSerializableHeaderValue(input.AmznClientToken) && { "x-amzn-client-token": input.AmznClientToken! }),
   };
   let resolvedPath = "/greengrass/bulk/deployments";
   let body: any;

--- a/clients/client-health/protocols/Aws_json1_1.ts
+++ b/clients/client-health/protocols/Aws_json1_1.ts
@@ -107,7 +107,7 @@ export const serializeAws_json1_1DescribeAffectedAccountsForOrganizationCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeAffectedAccountsForOrganization",
+    "x-amz-target": "AWSHealth_20160804.DescribeAffectedAccountsForOrganization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAffectedAccountsForOrganizationRequest(input, context));
@@ -120,7 +120,7 @@ export const serializeAws_json1_1DescribeAffectedEntitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeAffectedEntities",
+    "x-amz-target": "AWSHealth_20160804.DescribeAffectedEntities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAffectedEntitiesRequest(input, context));
@@ -133,7 +133,7 @@ export const serializeAws_json1_1DescribeAffectedEntitiesForOrganizationCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeAffectedEntitiesForOrganization",
+    "x-amz-target": "AWSHealth_20160804.DescribeAffectedEntitiesForOrganization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAffectedEntitiesForOrganizationRequest(input, context));
@@ -146,7 +146,7 @@ export const serializeAws_json1_1DescribeEntityAggregatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeEntityAggregates",
+    "x-amz-target": "AWSHealth_20160804.DescribeEntityAggregates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEntityAggregatesRequest(input, context));
@@ -159,7 +159,7 @@ export const serializeAws_json1_1DescribeEventAggregatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeEventAggregates",
+    "x-amz-target": "AWSHealth_20160804.DescribeEventAggregates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventAggregatesRequest(input, context));
@@ -172,7 +172,7 @@ export const serializeAws_json1_1DescribeEventDetailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeEventDetails",
+    "x-amz-target": "AWSHealth_20160804.DescribeEventDetails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventDetailsRequest(input, context));
@@ -185,7 +185,7 @@ export const serializeAws_json1_1DescribeEventDetailsForOrganizationCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeEventDetailsForOrganization",
+    "x-amz-target": "AWSHealth_20160804.DescribeEventDetailsForOrganization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventDetailsForOrganizationRequest(input, context));
@@ -198,7 +198,7 @@ export const serializeAws_json1_1DescribeEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeEvents",
+    "x-amz-target": "AWSHealth_20160804.DescribeEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventsRequest(input, context));
@@ -211,7 +211,7 @@ export const serializeAws_json1_1DescribeEventsForOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeEventsForOrganization",
+    "x-amz-target": "AWSHealth_20160804.DescribeEventsForOrganization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventsForOrganizationRequest(input, context));
@@ -224,7 +224,7 @@ export const serializeAws_json1_1DescribeEventTypesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeEventTypes",
+    "x-amz-target": "AWSHealth_20160804.DescribeEventTypes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventTypesRequest(input, context));
@@ -237,7 +237,7 @@ export const serializeAws_json1_1DescribeHealthServiceStatusForOrganizationComma
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DescribeHealthServiceStatusForOrganization",
+    "x-amz-target": "AWSHealth_20160804.DescribeHealthServiceStatusForOrganization",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -248,7 +248,7 @@ export const serializeAws_json1_1DisableHealthServiceAccessForOrganizationComman
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.DisableHealthServiceAccessForOrganization",
+    "x-amz-target": "AWSHealth_20160804.DisableHealthServiceAccessForOrganization",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -259,7 +259,7 @@ export const serializeAws_json1_1EnableHealthServiceAccessForOrganizationCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSHealth_20160804.EnableHealthServiceAccessForOrganization",
+    "x-amz-target": "AWSHealth_20160804.EnableHealthServiceAccessForOrganization",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };

--- a/clients/client-healthlake/protocols/Aws_json1_0.ts
+++ b/clients/client-healthlake/protocols/Aws_json1_0.ts
@@ -58,7 +58,7 @@ export const serializeAws_json1_0CreateFHIRDatastoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "HealthLake.CreateFHIRDatastore",
+    "x-amz-target": "HealthLake.CreateFHIRDatastore",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateFHIRDatastoreRequest(input, context));
@@ -71,7 +71,7 @@ export const serializeAws_json1_0DeleteFHIRDatastoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "HealthLake.DeleteFHIRDatastore",
+    "x-amz-target": "HealthLake.DeleteFHIRDatastore",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteFHIRDatastoreRequest(input, context));
@@ -84,7 +84,7 @@ export const serializeAws_json1_0DescribeFHIRDatastoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "HealthLake.DescribeFHIRDatastore",
+    "x-amz-target": "HealthLake.DescribeFHIRDatastore",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeFHIRDatastoreRequest(input, context));
@@ -97,7 +97,7 @@ export const serializeAws_json1_0DescribeFHIRImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "HealthLake.DescribeFHIRImportJob",
+    "x-amz-target": "HealthLake.DescribeFHIRImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeFHIRImportJobRequest(input, context));
@@ -110,7 +110,7 @@ export const serializeAws_json1_0ListFHIRDatastoresCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "HealthLake.ListFHIRDatastores",
+    "x-amz-target": "HealthLake.ListFHIRDatastores",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListFHIRDatastoresRequest(input, context));
@@ -123,7 +123,7 @@ export const serializeAws_json1_0StartFHIRImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "HealthLake.StartFHIRImportJob",
+    "x-amz-target": "HealthLake.StartFHIRImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0StartFHIRImportJobRequest(input, context));

--- a/clients/client-identitystore/protocols/Aws_json1_1.ts
+++ b/clients/client-identitystore/protocols/Aws_json1_1.ts
@@ -36,7 +36,7 @@ export const serializeAws_json1_1DescribeGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIdentityStore.DescribeGroup",
+    "x-amz-target": "AWSIdentityStore.DescribeGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeGroupRequest(input, context));
@@ -49,7 +49,7 @@ export const serializeAws_json1_1DescribeUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIdentityStore.DescribeUser",
+    "x-amz-target": "AWSIdentityStore.DescribeUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserRequest(input, context));
@@ -62,7 +62,7 @@ export const serializeAws_json1_1ListGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIdentityStore.ListGroups",
+    "x-amz-target": "AWSIdentityStore.ListGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGroupsRequest(input, context));
@@ -75,7 +75,7 @@ export const serializeAws_json1_1ListUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIdentityStore.ListUsers",
+    "x-amz-target": "AWSIdentityStore.ListUsers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUsersRequest(input, context));

--- a/clients/client-inspector/protocols/Aws_json1_1.ts
+++ b/clients/client-inspector/protocols/Aws_json1_1.ts
@@ -243,7 +243,7 @@ export const serializeAws_json1_1AddAttributesToFindingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.AddAttributesToFindings",
+    "x-amz-target": "InspectorService.AddAttributesToFindings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddAttributesToFindingsRequest(input, context));
@@ -256,7 +256,7 @@ export const serializeAws_json1_1CreateAssessmentTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.CreateAssessmentTarget",
+    "x-amz-target": "InspectorService.CreateAssessmentTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAssessmentTargetRequest(input, context));
@@ -269,7 +269,7 @@ export const serializeAws_json1_1CreateAssessmentTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.CreateAssessmentTemplate",
+    "x-amz-target": "InspectorService.CreateAssessmentTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAssessmentTemplateRequest(input, context));
@@ -282,7 +282,7 @@ export const serializeAws_json1_1CreateExclusionsPreviewCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.CreateExclusionsPreview",
+    "x-amz-target": "InspectorService.CreateExclusionsPreview",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateExclusionsPreviewRequest(input, context));
@@ -295,7 +295,7 @@ export const serializeAws_json1_1CreateResourceGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.CreateResourceGroup",
+    "x-amz-target": "InspectorService.CreateResourceGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateResourceGroupRequest(input, context));
@@ -308,7 +308,7 @@ export const serializeAws_json1_1DeleteAssessmentRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DeleteAssessmentRun",
+    "x-amz-target": "InspectorService.DeleteAssessmentRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAssessmentRunRequest(input, context));
@@ -321,7 +321,7 @@ export const serializeAws_json1_1DeleteAssessmentTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DeleteAssessmentTarget",
+    "x-amz-target": "InspectorService.DeleteAssessmentTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAssessmentTargetRequest(input, context));
@@ -334,7 +334,7 @@ export const serializeAws_json1_1DeleteAssessmentTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DeleteAssessmentTemplate",
+    "x-amz-target": "InspectorService.DeleteAssessmentTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAssessmentTemplateRequest(input, context));
@@ -347,7 +347,7 @@ export const serializeAws_json1_1DescribeAssessmentRunsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DescribeAssessmentRuns",
+    "x-amz-target": "InspectorService.DescribeAssessmentRuns",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAssessmentRunsRequest(input, context));
@@ -360,7 +360,7 @@ export const serializeAws_json1_1DescribeAssessmentTargetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DescribeAssessmentTargets",
+    "x-amz-target": "InspectorService.DescribeAssessmentTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAssessmentTargetsRequest(input, context));
@@ -373,7 +373,7 @@ export const serializeAws_json1_1DescribeAssessmentTemplatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DescribeAssessmentTemplates",
+    "x-amz-target": "InspectorService.DescribeAssessmentTemplates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAssessmentTemplatesRequest(input, context));
@@ -386,7 +386,7 @@ export const serializeAws_json1_1DescribeCrossAccountAccessRoleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DescribeCrossAccountAccessRole",
+    "x-amz-target": "InspectorService.DescribeCrossAccountAccessRole",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -397,7 +397,7 @@ export const serializeAws_json1_1DescribeExclusionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DescribeExclusions",
+    "x-amz-target": "InspectorService.DescribeExclusions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeExclusionsRequest(input, context));
@@ -410,7 +410,7 @@ export const serializeAws_json1_1DescribeFindingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DescribeFindings",
+    "x-amz-target": "InspectorService.DescribeFindings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFindingsRequest(input, context));
@@ -423,7 +423,7 @@ export const serializeAws_json1_1DescribeResourceGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DescribeResourceGroups",
+    "x-amz-target": "InspectorService.DescribeResourceGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeResourceGroupsRequest(input, context));
@@ -436,7 +436,7 @@ export const serializeAws_json1_1DescribeRulesPackagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.DescribeRulesPackages",
+    "x-amz-target": "InspectorService.DescribeRulesPackages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRulesPackagesRequest(input, context));
@@ -449,7 +449,7 @@ export const serializeAws_json1_1GetAssessmentReportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.GetAssessmentReport",
+    "x-amz-target": "InspectorService.GetAssessmentReport",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAssessmentReportRequest(input, context));
@@ -462,7 +462,7 @@ export const serializeAws_json1_1GetExclusionsPreviewCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.GetExclusionsPreview",
+    "x-amz-target": "InspectorService.GetExclusionsPreview",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetExclusionsPreviewRequest(input, context));
@@ -475,7 +475,7 @@ export const serializeAws_json1_1GetTelemetryMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.GetTelemetryMetadata",
+    "x-amz-target": "InspectorService.GetTelemetryMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTelemetryMetadataRequest(input, context));
@@ -488,7 +488,7 @@ export const serializeAws_json1_1ListAssessmentRunAgentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.ListAssessmentRunAgents",
+    "x-amz-target": "InspectorService.ListAssessmentRunAgents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssessmentRunAgentsRequest(input, context));
@@ -501,7 +501,7 @@ export const serializeAws_json1_1ListAssessmentRunsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.ListAssessmentRuns",
+    "x-amz-target": "InspectorService.ListAssessmentRuns",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssessmentRunsRequest(input, context));
@@ -514,7 +514,7 @@ export const serializeAws_json1_1ListAssessmentTargetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.ListAssessmentTargets",
+    "x-amz-target": "InspectorService.ListAssessmentTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssessmentTargetsRequest(input, context));
@@ -527,7 +527,7 @@ export const serializeAws_json1_1ListAssessmentTemplatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.ListAssessmentTemplates",
+    "x-amz-target": "InspectorService.ListAssessmentTemplates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssessmentTemplatesRequest(input, context));
@@ -540,7 +540,7 @@ export const serializeAws_json1_1ListEventSubscriptionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.ListEventSubscriptions",
+    "x-amz-target": "InspectorService.ListEventSubscriptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEventSubscriptionsRequest(input, context));
@@ -553,7 +553,7 @@ export const serializeAws_json1_1ListExclusionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.ListExclusions",
+    "x-amz-target": "InspectorService.ListExclusions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListExclusionsRequest(input, context));
@@ -566,7 +566,7 @@ export const serializeAws_json1_1ListFindingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.ListFindings",
+    "x-amz-target": "InspectorService.ListFindings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListFindingsRequest(input, context));
@@ -579,7 +579,7 @@ export const serializeAws_json1_1ListRulesPackagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.ListRulesPackages",
+    "x-amz-target": "InspectorService.ListRulesPackages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRulesPackagesRequest(input, context));
@@ -592,7 +592,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.ListTagsForResource",
+    "x-amz-target": "InspectorService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -605,7 +605,7 @@ export const serializeAws_json1_1PreviewAgentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.PreviewAgents",
+    "x-amz-target": "InspectorService.PreviewAgents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PreviewAgentsRequest(input, context));
@@ -618,7 +618,7 @@ export const serializeAws_json1_1RegisterCrossAccountAccessRoleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.RegisterCrossAccountAccessRole",
+    "x-amz-target": "InspectorService.RegisterCrossAccountAccessRole",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterCrossAccountAccessRoleRequest(input, context));
@@ -631,7 +631,7 @@ export const serializeAws_json1_1RemoveAttributesFromFindingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.RemoveAttributesFromFindings",
+    "x-amz-target": "InspectorService.RemoveAttributesFromFindings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveAttributesFromFindingsRequest(input, context));
@@ -644,7 +644,7 @@ export const serializeAws_json1_1SetTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.SetTagsForResource",
+    "x-amz-target": "InspectorService.SetTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetTagsForResourceRequest(input, context));
@@ -657,7 +657,7 @@ export const serializeAws_json1_1StartAssessmentRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.StartAssessmentRun",
+    "x-amz-target": "InspectorService.StartAssessmentRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartAssessmentRunRequest(input, context));
@@ -670,7 +670,7 @@ export const serializeAws_json1_1StopAssessmentRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.StopAssessmentRun",
+    "x-amz-target": "InspectorService.StopAssessmentRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopAssessmentRunRequest(input, context));
@@ -683,7 +683,7 @@ export const serializeAws_json1_1SubscribeToEventCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.SubscribeToEvent",
+    "x-amz-target": "InspectorService.SubscribeToEvent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SubscribeToEventRequest(input, context));
@@ -696,7 +696,7 @@ export const serializeAws_json1_1UnsubscribeFromEventCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.UnsubscribeFromEvent",
+    "x-amz-target": "InspectorService.UnsubscribeFromEvent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UnsubscribeFromEventRequest(input, context));
@@ -709,7 +709,7 @@ export const serializeAws_json1_1UpdateAssessmentTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "InspectorService.UpdateAssessmentTarget",
+    "x-amz-target": "InspectorService.UpdateAssessmentTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAssessmentTargetRequest(input, context));

--- a/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
+++ b/clients/client-iotsecuretunneling/protocols/Aws_json1_1.ts
@@ -48,7 +48,7 @@ export const serializeAws_json1_1CloseTunnelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IoTSecuredTunneling.CloseTunnel",
+    "x-amz-target": "IoTSecuredTunneling.CloseTunnel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CloseTunnelRequest(input, context));
@@ -61,7 +61,7 @@ export const serializeAws_json1_1DescribeTunnelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IoTSecuredTunneling.DescribeTunnel",
+    "x-amz-target": "IoTSecuredTunneling.DescribeTunnel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTunnelRequest(input, context));
@@ -74,7 +74,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IoTSecuredTunneling.ListTagsForResource",
+    "x-amz-target": "IoTSecuredTunneling.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -87,7 +87,7 @@ export const serializeAws_json1_1ListTunnelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IoTSecuredTunneling.ListTunnels",
+    "x-amz-target": "IoTSecuredTunneling.ListTunnels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTunnelsRequest(input, context));
@@ -100,7 +100,7 @@ export const serializeAws_json1_1OpenTunnelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IoTSecuredTunneling.OpenTunnel",
+    "x-amz-target": "IoTSecuredTunneling.OpenTunnel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1OpenTunnelRequest(input, context));
@@ -113,7 +113,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IoTSecuredTunneling.TagResource",
+    "x-amz-target": "IoTSecuredTunneling.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -126,7 +126,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IoTSecuredTunneling.UntagResource",
+    "x-amz-target": "IoTSecuredTunneling.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));

--- a/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
+++ b/clients/client-iotthingsgraph/protocols/Aws_json1_1.ts
@@ -210,7 +210,7 @@ export const serializeAws_json1_1AssociateEntityToThingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.AssociateEntityToThing",
+    "x-amz-target": "IotThingsGraphFrontEndService.AssociateEntityToThing",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateEntityToThingRequest(input, context));
@@ -223,7 +223,7 @@ export const serializeAws_json1_1CreateFlowTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.CreateFlowTemplate",
+    "x-amz-target": "IotThingsGraphFrontEndService.CreateFlowTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateFlowTemplateRequest(input, context));
@@ -236,7 +236,7 @@ export const serializeAws_json1_1CreateSystemInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.CreateSystemInstance",
+    "x-amz-target": "IotThingsGraphFrontEndService.CreateSystemInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSystemInstanceRequest(input, context));
@@ -249,7 +249,7 @@ export const serializeAws_json1_1CreateSystemTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.CreateSystemTemplate",
+    "x-amz-target": "IotThingsGraphFrontEndService.CreateSystemTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSystemTemplateRequest(input, context));
@@ -262,7 +262,7 @@ export const serializeAws_json1_1DeleteFlowTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.DeleteFlowTemplate",
+    "x-amz-target": "IotThingsGraphFrontEndService.DeleteFlowTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFlowTemplateRequest(input, context));
@@ -275,7 +275,7 @@ export const serializeAws_json1_1DeleteNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.DeleteNamespace",
+    "x-amz-target": "IotThingsGraphFrontEndService.DeleteNamespace",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteNamespaceRequest(input, context));
@@ -288,7 +288,7 @@ export const serializeAws_json1_1DeleteSystemInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.DeleteSystemInstance",
+    "x-amz-target": "IotThingsGraphFrontEndService.DeleteSystemInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSystemInstanceRequest(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_1DeleteSystemTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.DeleteSystemTemplate",
+    "x-amz-target": "IotThingsGraphFrontEndService.DeleteSystemTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSystemTemplateRequest(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_1DeploySystemInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.DeploySystemInstance",
+    "x-amz-target": "IotThingsGraphFrontEndService.DeploySystemInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeploySystemInstanceRequest(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1DeprecateFlowTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.DeprecateFlowTemplate",
+    "x-amz-target": "IotThingsGraphFrontEndService.DeprecateFlowTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeprecateFlowTemplateRequest(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1DeprecateSystemTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.DeprecateSystemTemplate",
+    "x-amz-target": "IotThingsGraphFrontEndService.DeprecateSystemTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeprecateSystemTemplateRequest(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1DescribeNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.DescribeNamespace",
+    "x-amz-target": "IotThingsGraphFrontEndService.DescribeNamespace",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeNamespaceRequest(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_1DissociateEntityFromThingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.DissociateEntityFromThing",
+    "x-amz-target": "IotThingsGraphFrontEndService.DissociateEntityFromThing",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DissociateEntityFromThingRequest(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_1GetEntitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.GetEntities",
+    "x-amz-target": "IotThingsGraphFrontEndService.GetEntities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetEntitiesRequest(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_1GetFlowTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.GetFlowTemplate",
+    "x-amz-target": "IotThingsGraphFrontEndService.GetFlowTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetFlowTemplateRequest(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_1GetFlowTemplateRevisionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.GetFlowTemplateRevisions",
+    "x-amz-target": "IotThingsGraphFrontEndService.GetFlowTemplateRevisions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetFlowTemplateRevisionsRequest(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_1GetNamespaceDeletionStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.GetNamespaceDeletionStatus",
+    "x-amz-target": "IotThingsGraphFrontEndService.GetNamespaceDeletionStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetNamespaceDeletionStatusRequest(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_1GetSystemInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.GetSystemInstance",
+    "x-amz-target": "IotThingsGraphFrontEndService.GetSystemInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSystemInstanceRequest(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_1GetSystemTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.GetSystemTemplate",
+    "x-amz-target": "IotThingsGraphFrontEndService.GetSystemTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSystemTemplateRequest(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_1GetSystemTemplateRevisionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.GetSystemTemplateRevisions",
+    "x-amz-target": "IotThingsGraphFrontEndService.GetSystemTemplateRevisions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSystemTemplateRevisionsRequest(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_1GetUploadStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.GetUploadStatus",
+    "x-amz-target": "IotThingsGraphFrontEndService.GetUploadStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetUploadStatusRequest(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_1ListFlowExecutionMessagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.ListFlowExecutionMessages",
+    "x-amz-target": "IotThingsGraphFrontEndService.ListFlowExecutionMessages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListFlowExecutionMessagesRequest(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.ListTagsForResource",
+    "x-amz-target": "IotThingsGraphFrontEndService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_1SearchEntitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.SearchEntities",
+    "x-amz-target": "IotThingsGraphFrontEndService.SearchEntities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchEntitiesRequest(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_1SearchFlowExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.SearchFlowExecutions",
+    "x-amz-target": "IotThingsGraphFrontEndService.SearchFlowExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchFlowExecutionsRequest(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1SearchFlowTemplatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.SearchFlowTemplates",
+    "x-amz-target": "IotThingsGraphFrontEndService.SearchFlowTemplates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchFlowTemplatesRequest(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1SearchSystemInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.SearchSystemInstances",
+    "x-amz-target": "IotThingsGraphFrontEndService.SearchSystemInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchSystemInstancesRequest(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1SearchSystemTemplatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.SearchSystemTemplates",
+    "x-amz-target": "IotThingsGraphFrontEndService.SearchSystemTemplates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchSystemTemplatesRequest(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_1SearchThingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.SearchThings",
+    "x-amz-target": "IotThingsGraphFrontEndService.SearchThings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchThingsRequest(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.TagResource",
+    "x-amz-target": "IotThingsGraphFrontEndService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_1UndeploySystemInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.UndeploySystemInstance",
+    "x-amz-target": "IotThingsGraphFrontEndService.UndeploySystemInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UndeploySystemInstanceRequest(input, context));
@@ -613,7 +613,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.UntagResource",
+    "x-amz-target": "IotThingsGraphFrontEndService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -626,7 +626,7 @@ export const serializeAws_json1_1UpdateFlowTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.UpdateFlowTemplate",
+    "x-amz-target": "IotThingsGraphFrontEndService.UpdateFlowTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateFlowTemplateRequest(input, context));
@@ -639,7 +639,7 @@ export const serializeAws_json1_1UpdateSystemTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.UpdateSystemTemplate",
+    "x-amz-target": "IotThingsGraphFrontEndService.UpdateSystemTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSystemTemplateRequest(input, context));
@@ -652,7 +652,7 @@ export const serializeAws_json1_1UploadEntityDefinitionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "IotThingsGraphFrontEndService.UploadEntityDefinitions",
+    "x-amz-target": "IotThingsGraphFrontEndService.UploadEntityDefinitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UploadEntityDefinitionsRequest(input, context));

--- a/clients/client-kendra/protocols/Aws_json1_1.ts
+++ b/clients/client-kendra/protocols/Aws_json1_1.ts
@@ -197,7 +197,7 @@ export const serializeAws_json1_1BatchDeleteDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.BatchDeleteDocument",
+    "x-amz-target": "AWSKendraFrontendService.BatchDeleteDocument",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchDeleteDocumentRequest(input, context));
@@ -210,7 +210,7 @@ export const serializeAws_json1_1BatchPutDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.BatchPutDocument",
+    "x-amz-target": "AWSKendraFrontendService.BatchPutDocument",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchPutDocumentRequest(input, context));
@@ -223,7 +223,7 @@ export const serializeAws_json1_1CreateDataSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.CreateDataSource",
+    "x-amz-target": "AWSKendraFrontendService.CreateDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDataSourceRequest(input, context));
@@ -236,7 +236,7 @@ export const serializeAws_json1_1CreateFaqCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.CreateFaq",
+    "x-amz-target": "AWSKendraFrontendService.CreateFaq",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateFaqRequest(input, context));
@@ -249,7 +249,7 @@ export const serializeAws_json1_1CreateIndexCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.CreateIndex",
+    "x-amz-target": "AWSKendraFrontendService.CreateIndex",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateIndexRequest(input, context));
@@ -262,7 +262,7 @@ export const serializeAws_json1_1CreateThesaurusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.CreateThesaurus",
+    "x-amz-target": "AWSKendraFrontendService.CreateThesaurus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateThesaurusRequest(input, context));
@@ -275,7 +275,7 @@ export const serializeAws_json1_1DeleteDataSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.DeleteDataSource",
+    "x-amz-target": "AWSKendraFrontendService.DeleteDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDataSourceRequest(input, context));
@@ -288,7 +288,7 @@ export const serializeAws_json1_1DeleteFaqCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.DeleteFaq",
+    "x-amz-target": "AWSKendraFrontendService.DeleteFaq",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFaqRequest(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_1DeleteIndexCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.DeleteIndex",
+    "x-amz-target": "AWSKendraFrontendService.DeleteIndex",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteIndexRequest(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_1DeleteThesaurusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.DeleteThesaurus",
+    "x-amz-target": "AWSKendraFrontendService.DeleteThesaurus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteThesaurusRequest(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1DescribeDataSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.DescribeDataSource",
+    "x-amz-target": "AWSKendraFrontendService.DescribeDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDataSourceRequest(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1DescribeFaqCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.DescribeFaq",
+    "x-amz-target": "AWSKendraFrontendService.DescribeFaq",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFaqRequest(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1DescribeIndexCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.DescribeIndex",
+    "x-amz-target": "AWSKendraFrontendService.DescribeIndex",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeIndexRequest(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_1DescribeThesaurusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.DescribeThesaurus",
+    "x-amz-target": "AWSKendraFrontendService.DescribeThesaurus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeThesaurusRequest(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_1ListDataSourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.ListDataSources",
+    "x-amz-target": "AWSKendraFrontendService.ListDataSources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDataSourcesRequest(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_1ListDataSourceSyncJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.ListDataSourceSyncJobs",
+    "x-amz-target": "AWSKendraFrontendService.ListDataSourceSyncJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDataSourceSyncJobsRequest(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_1ListFaqsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.ListFaqs",
+    "x-amz-target": "AWSKendraFrontendService.ListFaqs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListFaqsRequest(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_1ListIndicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.ListIndices",
+    "x-amz-target": "AWSKendraFrontendService.ListIndices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListIndicesRequest(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.ListTagsForResource",
+    "x-amz-target": "AWSKendraFrontendService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_1ListThesauriCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.ListThesauri",
+    "x-amz-target": "AWSKendraFrontendService.ListThesauri",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListThesauriRequest(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_1QueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.Query",
+    "x-amz-target": "AWSKendraFrontendService.Query",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1QueryRequest(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_1StartDataSourceSyncJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.StartDataSourceSyncJob",
+    "x-amz-target": "AWSKendraFrontendService.StartDataSourceSyncJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartDataSourceSyncJobRequest(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_1StopDataSourceSyncJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.StopDataSourceSyncJob",
+    "x-amz-target": "AWSKendraFrontendService.StopDataSourceSyncJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopDataSourceSyncJobRequest(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_1SubmitFeedbackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.SubmitFeedback",
+    "x-amz-target": "AWSKendraFrontendService.SubmitFeedback",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SubmitFeedbackRequest(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.TagResource",
+    "x-amz-target": "AWSKendraFrontendService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.UntagResource",
+    "x-amz-target": "AWSKendraFrontendService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1UpdateDataSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.UpdateDataSource",
+    "x-amz-target": "AWSKendraFrontendService.UpdateDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDataSourceRequest(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1UpdateIndexCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.UpdateIndex",
+    "x-amz-target": "AWSKendraFrontendService.UpdateIndex",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateIndexRequest(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1UpdateThesaurusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSKendraFrontendService.UpdateThesaurus",
+    "x-amz-target": "AWSKendraFrontendService.UpdateThesaurus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateThesaurusRequest(input, context));

--- a/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics-v2/protocols/Aws_json1_1.ts
@@ -262,7 +262,7 @@ export const serializeAws_json1_1AddApplicationCloudWatchLoggingOptionCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.AddApplicationCloudWatchLoggingOption",
+    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationCloudWatchLoggingOption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationCloudWatchLoggingOptionRequest(input, context));
@@ -275,7 +275,7 @@ export const serializeAws_json1_1AddApplicationInputCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.AddApplicationInput",
+    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationInput",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationInputRequest(input, context));
@@ -288,7 +288,7 @@ export const serializeAws_json1_1AddApplicationInputProcessingConfigurationComma
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.AddApplicationInputProcessingConfiguration",
+    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationInputProcessingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationInputProcessingConfigurationRequest(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_1AddApplicationOutputCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.AddApplicationOutput",
+    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationOutput",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationOutputRequest(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_1AddApplicationReferenceDataSourceCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.AddApplicationReferenceDataSource",
+    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationReferenceDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationReferenceDataSourceRequest(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1AddApplicationVpcConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.AddApplicationVpcConfiguration",
+    "x-amz-target": "KinesisAnalytics_20180523.AddApplicationVpcConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationVpcConfigurationRequest(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1CreateApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.CreateApplication",
+    "x-amz-target": "KinesisAnalytics_20180523.CreateApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateApplicationRequest(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1CreateApplicationPresignedUrlCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.CreateApplicationPresignedUrl",
+    "x-amz-target": "KinesisAnalytics_20180523.CreateApplicationPresignedUrl",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateApplicationPresignedUrlRequest(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_1CreateApplicationSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.CreateApplicationSnapshot",
+    "x-amz-target": "KinesisAnalytics_20180523.CreateApplicationSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateApplicationSnapshotRequest(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_1DeleteApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.DeleteApplication",
+    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationRequest(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_1DeleteApplicationCloudWatchLoggingOptionCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.DeleteApplicationCloudWatchLoggingOption",
+    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationCloudWatchLoggingOption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationCloudWatchLoggingOptionRequest(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_1DeleteApplicationInputProcessingConfigurationCo
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.DeleteApplicationInputProcessingConfiguration",
+    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationInputProcessingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationInputProcessingConfigurationRequest(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_1DeleteApplicationOutputCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.DeleteApplicationOutput",
+    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationOutput",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationOutputRequest(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_1DeleteApplicationReferenceDataSourceCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.DeleteApplicationReferenceDataSource",
+    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationReferenceDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationReferenceDataSourceRequest(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_1DeleteApplicationSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.DeleteApplicationSnapshot",
+    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationSnapshotRequest(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_1DeleteApplicationVpcConfigurationCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.DeleteApplicationVpcConfiguration",
+    "x-amz-target": "KinesisAnalytics_20180523.DeleteApplicationVpcConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationVpcConfigurationRequest(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_1DescribeApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.DescribeApplication",
+    "x-amz-target": "KinesisAnalytics_20180523.DescribeApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeApplicationRequest(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_1DescribeApplicationSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.DescribeApplicationSnapshot",
+    "x-amz-target": "KinesisAnalytics_20180523.DescribeApplicationSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeApplicationSnapshotRequest(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_1DiscoverInputSchemaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.DiscoverInputSchema",
+    "x-amz-target": "KinesisAnalytics_20180523.DiscoverInputSchema",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DiscoverInputSchemaRequest(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_1ListApplicationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.ListApplications",
+    "x-amz-target": "KinesisAnalytics_20180523.ListApplications",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListApplicationsRequest(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_1ListApplicationSnapshotsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.ListApplicationSnapshots",
+    "x-amz-target": "KinesisAnalytics_20180523.ListApplicationSnapshots",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListApplicationSnapshotsRequest(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.ListTagsForResource",
+    "x-amz-target": "KinesisAnalytics_20180523.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1StartApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.StartApplication",
+    "x-amz-target": "KinesisAnalytics_20180523.StartApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartApplicationRequest(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1StopApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.StopApplication",
+    "x-amz-target": "KinesisAnalytics_20180523.StopApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopApplicationRequest(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.TagResource",
+    "x-amz-target": "KinesisAnalytics_20180523.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.UntagResource",
+    "x-amz-target": "KinesisAnalytics_20180523.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_1UpdateApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20180523.UpdateApplication",
+    "x-amz-target": "KinesisAnalytics_20180523.UpdateApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateApplicationRequest(input, context));

--- a/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis-analytics/protocols/Aws_json1_1.ts
@@ -177,7 +177,7 @@ export const serializeAws_json1_1AddApplicationCloudWatchLoggingOptionCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.AddApplicationCloudWatchLoggingOption",
+    "x-amz-target": "KinesisAnalytics_20150814.AddApplicationCloudWatchLoggingOption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationCloudWatchLoggingOptionRequest(input, context));
@@ -190,7 +190,7 @@ export const serializeAws_json1_1AddApplicationInputCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.AddApplicationInput",
+    "x-amz-target": "KinesisAnalytics_20150814.AddApplicationInput",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationInputRequest(input, context));
@@ -203,7 +203,7 @@ export const serializeAws_json1_1AddApplicationInputProcessingConfigurationComma
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.AddApplicationInputProcessingConfiguration",
+    "x-amz-target": "KinesisAnalytics_20150814.AddApplicationInputProcessingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationInputProcessingConfigurationRequest(input, context));
@@ -216,7 +216,7 @@ export const serializeAws_json1_1AddApplicationOutputCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.AddApplicationOutput",
+    "x-amz-target": "KinesisAnalytics_20150814.AddApplicationOutput",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationOutputRequest(input, context));
@@ -229,7 +229,7 @@ export const serializeAws_json1_1AddApplicationReferenceDataSourceCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.AddApplicationReferenceDataSource",
+    "x-amz-target": "KinesisAnalytics_20150814.AddApplicationReferenceDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddApplicationReferenceDataSourceRequest(input, context));
@@ -242,7 +242,7 @@ export const serializeAws_json1_1CreateApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.CreateApplication",
+    "x-amz-target": "KinesisAnalytics_20150814.CreateApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateApplicationRequest(input, context));
@@ -255,7 +255,7 @@ export const serializeAws_json1_1DeleteApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.DeleteApplication",
+    "x-amz-target": "KinesisAnalytics_20150814.DeleteApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationRequest(input, context));
@@ -268,7 +268,7 @@ export const serializeAws_json1_1DeleteApplicationCloudWatchLoggingOptionCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.DeleteApplicationCloudWatchLoggingOption",
+    "x-amz-target": "KinesisAnalytics_20150814.DeleteApplicationCloudWatchLoggingOption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationCloudWatchLoggingOptionRequest(input, context));
@@ -281,7 +281,7 @@ export const serializeAws_json1_1DeleteApplicationInputProcessingConfigurationCo
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.DeleteApplicationInputProcessingConfiguration",
+    "x-amz-target": "KinesisAnalytics_20150814.DeleteApplicationInputProcessingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationInputProcessingConfigurationRequest(input, context));
@@ -294,7 +294,7 @@ export const serializeAws_json1_1DeleteApplicationOutputCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.DeleteApplicationOutput",
+    "x-amz-target": "KinesisAnalytics_20150814.DeleteApplicationOutput",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationOutputRequest(input, context));
@@ -307,7 +307,7 @@ export const serializeAws_json1_1DeleteApplicationReferenceDataSourceCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.DeleteApplicationReferenceDataSource",
+    "x-amz-target": "KinesisAnalytics_20150814.DeleteApplicationReferenceDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteApplicationReferenceDataSourceRequest(input, context));
@@ -320,7 +320,7 @@ export const serializeAws_json1_1DescribeApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.DescribeApplication",
+    "x-amz-target": "KinesisAnalytics_20150814.DescribeApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeApplicationRequest(input, context));
@@ -333,7 +333,7 @@ export const serializeAws_json1_1DiscoverInputSchemaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.DiscoverInputSchema",
+    "x-amz-target": "KinesisAnalytics_20150814.DiscoverInputSchema",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DiscoverInputSchemaRequest(input, context));
@@ -346,7 +346,7 @@ export const serializeAws_json1_1ListApplicationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.ListApplications",
+    "x-amz-target": "KinesisAnalytics_20150814.ListApplications",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListApplicationsRequest(input, context));
@@ -359,7 +359,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.ListTagsForResource",
+    "x-amz-target": "KinesisAnalytics_20150814.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -372,7 +372,7 @@ export const serializeAws_json1_1StartApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.StartApplication",
+    "x-amz-target": "KinesisAnalytics_20150814.StartApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartApplicationRequest(input, context));
@@ -385,7 +385,7 @@ export const serializeAws_json1_1StopApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.StopApplication",
+    "x-amz-target": "KinesisAnalytics_20150814.StopApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopApplicationRequest(input, context));
@@ -398,7 +398,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.TagResource",
+    "x-amz-target": "KinesisAnalytics_20150814.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -411,7 +411,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.UntagResource",
+    "x-amz-target": "KinesisAnalytics_20150814.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -424,7 +424,7 @@ export const serializeAws_json1_1UpdateApplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "KinesisAnalytics_20150814.UpdateApplication",
+    "x-amz-target": "KinesisAnalytics_20150814.UpdateApplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateApplicationRequest(input, context));

--- a/clients/client-kinesis/protocols/Aws_json1_1.ts
+++ b/clients/client-kinesis/protocols/Aws_json1_1.ts
@@ -156,7 +156,7 @@ export const serializeAws_json1_1AddTagsToStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.AddTagsToStream",
+    "x-amz-target": "Kinesis_20131202.AddTagsToStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsToStreamInput(input, context));
@@ -169,7 +169,7 @@ export const serializeAws_json1_1CreateStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.CreateStream",
+    "x-amz-target": "Kinesis_20131202.CreateStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateStreamInput(input, context));
@@ -182,7 +182,7 @@ export const serializeAws_json1_1DecreaseStreamRetentionPeriodCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.DecreaseStreamRetentionPeriod",
+    "x-amz-target": "Kinesis_20131202.DecreaseStreamRetentionPeriod",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DecreaseStreamRetentionPeriodInput(input, context));
@@ -195,7 +195,7 @@ export const serializeAws_json1_1DeleteStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.DeleteStream",
+    "x-amz-target": "Kinesis_20131202.DeleteStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteStreamInput(input, context));
@@ -208,7 +208,7 @@ export const serializeAws_json1_1DeregisterStreamConsumerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.DeregisterStreamConsumer",
+    "x-amz-target": "Kinesis_20131202.DeregisterStreamConsumer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterStreamConsumerInput(input, context));
@@ -221,7 +221,7 @@ export const serializeAws_json1_1DescribeLimitsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.DescribeLimits",
+    "x-amz-target": "Kinesis_20131202.DescribeLimits",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLimitsInput(input, context));
@@ -234,7 +234,7 @@ export const serializeAws_json1_1DescribeStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.DescribeStream",
+    "x-amz-target": "Kinesis_20131202.DescribeStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStreamInput(input, context));
@@ -247,7 +247,7 @@ export const serializeAws_json1_1DescribeStreamConsumerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.DescribeStreamConsumer",
+    "x-amz-target": "Kinesis_20131202.DescribeStreamConsumer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStreamConsumerInput(input, context));
@@ -260,7 +260,7 @@ export const serializeAws_json1_1DescribeStreamSummaryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.DescribeStreamSummary",
+    "x-amz-target": "Kinesis_20131202.DescribeStreamSummary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStreamSummaryInput(input, context));
@@ -273,7 +273,7 @@ export const serializeAws_json1_1DisableEnhancedMonitoringCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.DisableEnhancedMonitoring",
+    "x-amz-target": "Kinesis_20131202.DisableEnhancedMonitoring",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableEnhancedMonitoringInput(input, context));
@@ -286,7 +286,7 @@ export const serializeAws_json1_1EnableEnhancedMonitoringCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.EnableEnhancedMonitoring",
+    "x-amz-target": "Kinesis_20131202.EnableEnhancedMonitoring",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableEnhancedMonitoringInput(input, context));
@@ -299,7 +299,7 @@ export const serializeAws_json1_1GetRecordsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.GetRecords",
+    "x-amz-target": "Kinesis_20131202.GetRecords",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRecordsInput(input, context));
@@ -312,7 +312,7 @@ export const serializeAws_json1_1GetShardIteratorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.GetShardIterator",
+    "x-amz-target": "Kinesis_20131202.GetShardIterator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetShardIteratorInput(input, context));
@@ -325,7 +325,7 @@ export const serializeAws_json1_1IncreaseStreamRetentionPeriodCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.IncreaseStreamRetentionPeriod",
+    "x-amz-target": "Kinesis_20131202.IncreaseStreamRetentionPeriod",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1IncreaseStreamRetentionPeriodInput(input, context));
@@ -338,7 +338,7 @@ export const serializeAws_json1_1ListShardsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.ListShards",
+    "x-amz-target": "Kinesis_20131202.ListShards",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListShardsInput(input, context));
@@ -351,7 +351,7 @@ export const serializeAws_json1_1ListStreamConsumersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.ListStreamConsumers",
+    "x-amz-target": "Kinesis_20131202.ListStreamConsumers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListStreamConsumersInput(input, context));
@@ -364,7 +364,7 @@ export const serializeAws_json1_1ListStreamsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.ListStreams",
+    "x-amz-target": "Kinesis_20131202.ListStreams",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListStreamsInput(input, context));
@@ -377,7 +377,7 @@ export const serializeAws_json1_1ListTagsForStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.ListTagsForStream",
+    "x-amz-target": "Kinesis_20131202.ListTagsForStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForStreamInput(input, context));
@@ -390,7 +390,7 @@ export const serializeAws_json1_1MergeShardsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.MergeShards",
+    "x-amz-target": "Kinesis_20131202.MergeShards",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MergeShardsInput(input, context));
@@ -403,7 +403,7 @@ export const serializeAws_json1_1PutRecordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.PutRecord",
+    "x-amz-target": "Kinesis_20131202.PutRecord",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRecordInput(input, context));
@@ -416,7 +416,7 @@ export const serializeAws_json1_1PutRecordsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.PutRecords",
+    "x-amz-target": "Kinesis_20131202.PutRecords",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutRecordsInput(input, context));
@@ -429,7 +429,7 @@ export const serializeAws_json1_1RegisterStreamConsumerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.RegisterStreamConsumer",
+    "x-amz-target": "Kinesis_20131202.RegisterStreamConsumer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterStreamConsumerInput(input, context));
@@ -442,7 +442,7 @@ export const serializeAws_json1_1RemoveTagsFromStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.RemoveTagsFromStream",
+    "x-amz-target": "Kinesis_20131202.RemoveTagsFromStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsFromStreamInput(input, context));
@@ -455,7 +455,7 @@ export const serializeAws_json1_1SplitShardCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.SplitShard",
+    "x-amz-target": "Kinesis_20131202.SplitShard",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SplitShardInput(input, context));
@@ -468,7 +468,7 @@ export const serializeAws_json1_1StartStreamEncryptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.StartStreamEncryption",
+    "x-amz-target": "Kinesis_20131202.StartStreamEncryption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartStreamEncryptionInput(input, context));
@@ -481,7 +481,7 @@ export const serializeAws_json1_1StopStreamEncryptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.StopStreamEncryption",
+    "x-amz-target": "Kinesis_20131202.StopStreamEncryption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopStreamEncryptionInput(input, context));
@@ -494,7 +494,7 @@ export const serializeAws_json1_1SubscribeToShardCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.SubscribeToShard",
+    "x-amz-target": "Kinesis_20131202.SubscribeToShard",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SubscribeToShardInput(input, context));
@@ -507,7 +507,7 @@ export const serializeAws_json1_1UpdateShardCountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Kinesis_20131202.UpdateShardCount",
+    "x-amz-target": "Kinesis_20131202.UpdateShardCount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateShardCountInput(input, context));

--- a/clients/client-kms/protocols/Aws_json1_1.ts
+++ b/clients/client-kms/protocols/Aws_json1_1.ts
@@ -227,7 +227,7 @@ export const serializeAws_json1_1CancelKeyDeletionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.CancelKeyDeletion",
+    "x-amz-target": "TrentService.CancelKeyDeletion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelKeyDeletionRequest(input, context));
@@ -240,7 +240,7 @@ export const serializeAws_json1_1ConnectCustomKeyStoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.ConnectCustomKeyStore",
+    "x-amz-target": "TrentService.ConnectCustomKeyStore",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ConnectCustomKeyStoreRequest(input, context));
@@ -253,7 +253,7 @@ export const serializeAws_json1_1CreateAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.CreateAlias",
+    "x-amz-target": "TrentService.CreateAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAliasRequest(input, context));
@@ -266,7 +266,7 @@ export const serializeAws_json1_1CreateCustomKeyStoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.CreateCustomKeyStore",
+    "x-amz-target": "TrentService.CreateCustomKeyStore",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCustomKeyStoreRequest(input, context));
@@ -279,7 +279,7 @@ export const serializeAws_json1_1CreateGrantCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.CreateGrant",
+    "x-amz-target": "TrentService.CreateGrant",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGrantRequest(input, context));
@@ -292,7 +292,7 @@ export const serializeAws_json1_1CreateKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.CreateKey",
+    "x-amz-target": "TrentService.CreateKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateKeyRequest(input, context));
@@ -305,7 +305,7 @@ export const serializeAws_json1_1DecryptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.Decrypt",
+    "x-amz-target": "TrentService.Decrypt",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DecryptRequest(input, context));
@@ -318,7 +318,7 @@ export const serializeAws_json1_1DeleteAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.DeleteAlias",
+    "x-amz-target": "TrentService.DeleteAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAliasRequest(input, context));
@@ -331,7 +331,7 @@ export const serializeAws_json1_1DeleteCustomKeyStoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.DeleteCustomKeyStore",
+    "x-amz-target": "TrentService.DeleteCustomKeyStore",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCustomKeyStoreRequest(input, context));
@@ -344,7 +344,7 @@ export const serializeAws_json1_1DeleteImportedKeyMaterialCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.DeleteImportedKeyMaterial",
+    "x-amz-target": "TrentService.DeleteImportedKeyMaterial",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteImportedKeyMaterialRequest(input, context));
@@ -357,7 +357,7 @@ export const serializeAws_json1_1DescribeCustomKeyStoresCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.DescribeCustomKeyStores",
+    "x-amz-target": "TrentService.DescribeCustomKeyStores",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCustomKeyStoresRequest(input, context));
@@ -370,7 +370,7 @@ export const serializeAws_json1_1DescribeKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.DescribeKey",
+    "x-amz-target": "TrentService.DescribeKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeKeyRequest(input, context));
@@ -383,7 +383,7 @@ export const serializeAws_json1_1DisableKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.DisableKey",
+    "x-amz-target": "TrentService.DisableKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableKeyRequest(input, context));
@@ -396,7 +396,7 @@ export const serializeAws_json1_1DisableKeyRotationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.DisableKeyRotation",
+    "x-amz-target": "TrentService.DisableKeyRotation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableKeyRotationRequest(input, context));
@@ -409,7 +409,7 @@ export const serializeAws_json1_1DisconnectCustomKeyStoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.DisconnectCustomKeyStore",
+    "x-amz-target": "TrentService.DisconnectCustomKeyStore",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisconnectCustomKeyStoreRequest(input, context));
@@ -422,7 +422,7 @@ export const serializeAws_json1_1EnableKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.EnableKey",
+    "x-amz-target": "TrentService.EnableKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableKeyRequest(input, context));
@@ -435,7 +435,7 @@ export const serializeAws_json1_1EnableKeyRotationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.EnableKeyRotation",
+    "x-amz-target": "TrentService.EnableKeyRotation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableKeyRotationRequest(input, context));
@@ -448,7 +448,7 @@ export const serializeAws_json1_1EncryptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.Encrypt",
+    "x-amz-target": "TrentService.Encrypt",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EncryptRequest(input, context));
@@ -461,7 +461,7 @@ export const serializeAws_json1_1GenerateDataKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.GenerateDataKey",
+    "x-amz-target": "TrentService.GenerateDataKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GenerateDataKeyRequest(input, context));
@@ -474,7 +474,7 @@ export const serializeAws_json1_1GenerateDataKeyPairCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.GenerateDataKeyPair",
+    "x-amz-target": "TrentService.GenerateDataKeyPair",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GenerateDataKeyPairRequest(input, context));
@@ -487,7 +487,7 @@ export const serializeAws_json1_1GenerateDataKeyPairWithoutPlaintextCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.GenerateDataKeyPairWithoutPlaintext",
+    "x-amz-target": "TrentService.GenerateDataKeyPairWithoutPlaintext",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GenerateDataKeyPairWithoutPlaintextRequest(input, context));
@@ -500,7 +500,7 @@ export const serializeAws_json1_1GenerateDataKeyWithoutPlaintextCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.GenerateDataKeyWithoutPlaintext",
+    "x-amz-target": "TrentService.GenerateDataKeyWithoutPlaintext",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GenerateDataKeyWithoutPlaintextRequest(input, context));
@@ -513,7 +513,7 @@ export const serializeAws_json1_1GenerateRandomCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.GenerateRandom",
+    "x-amz-target": "TrentService.GenerateRandom",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GenerateRandomRequest(input, context));
@@ -526,7 +526,7 @@ export const serializeAws_json1_1GetKeyPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.GetKeyPolicy",
+    "x-amz-target": "TrentService.GetKeyPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetKeyPolicyRequest(input, context));
@@ -539,7 +539,7 @@ export const serializeAws_json1_1GetKeyRotationStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.GetKeyRotationStatus",
+    "x-amz-target": "TrentService.GetKeyRotationStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetKeyRotationStatusRequest(input, context));
@@ -552,7 +552,7 @@ export const serializeAws_json1_1GetParametersForImportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.GetParametersForImport",
+    "x-amz-target": "TrentService.GetParametersForImport",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetParametersForImportRequest(input, context));
@@ -565,7 +565,7 @@ export const serializeAws_json1_1GetPublicKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.GetPublicKey",
+    "x-amz-target": "TrentService.GetPublicKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPublicKeyRequest(input, context));
@@ -578,7 +578,7 @@ export const serializeAws_json1_1ImportKeyMaterialCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.ImportKeyMaterial",
+    "x-amz-target": "TrentService.ImportKeyMaterial",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportKeyMaterialRequest(input, context));
@@ -591,7 +591,7 @@ export const serializeAws_json1_1ListAliasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.ListAliases",
+    "x-amz-target": "TrentService.ListAliases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAliasesRequest(input, context));
@@ -604,7 +604,7 @@ export const serializeAws_json1_1ListGrantsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.ListGrants",
+    "x-amz-target": "TrentService.ListGrants",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGrantsRequest(input, context));
@@ -617,7 +617,7 @@ export const serializeAws_json1_1ListKeyPoliciesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.ListKeyPolicies",
+    "x-amz-target": "TrentService.ListKeyPolicies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListKeyPoliciesRequest(input, context));
@@ -630,7 +630,7 @@ export const serializeAws_json1_1ListKeysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.ListKeys",
+    "x-amz-target": "TrentService.ListKeys",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListKeysRequest(input, context));
@@ -643,7 +643,7 @@ export const serializeAws_json1_1ListResourceTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.ListResourceTags",
+    "x-amz-target": "TrentService.ListResourceTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourceTagsRequest(input, context));
@@ -656,7 +656,7 @@ export const serializeAws_json1_1ListRetirableGrantsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.ListRetirableGrants",
+    "x-amz-target": "TrentService.ListRetirableGrants",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRetirableGrantsRequest(input, context));
@@ -669,7 +669,7 @@ export const serializeAws_json1_1PutKeyPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.PutKeyPolicy",
+    "x-amz-target": "TrentService.PutKeyPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutKeyPolicyRequest(input, context));
@@ -682,7 +682,7 @@ export const serializeAws_json1_1ReEncryptCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.ReEncrypt",
+    "x-amz-target": "TrentService.ReEncrypt",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ReEncryptRequest(input, context));
@@ -695,7 +695,7 @@ export const serializeAws_json1_1RetireGrantCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.RetireGrant",
+    "x-amz-target": "TrentService.RetireGrant",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RetireGrantRequest(input, context));
@@ -708,7 +708,7 @@ export const serializeAws_json1_1RevokeGrantCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.RevokeGrant",
+    "x-amz-target": "TrentService.RevokeGrant",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RevokeGrantRequest(input, context));
@@ -721,7 +721,7 @@ export const serializeAws_json1_1ScheduleKeyDeletionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.ScheduleKeyDeletion",
+    "x-amz-target": "TrentService.ScheduleKeyDeletion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ScheduleKeyDeletionRequest(input, context));
@@ -734,7 +734,7 @@ export const serializeAws_json1_1SignCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.Sign",
+    "x-amz-target": "TrentService.Sign",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SignRequest(input, context));
@@ -747,7 +747,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.TagResource",
+    "x-amz-target": "TrentService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -760,7 +760,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.UntagResource",
+    "x-amz-target": "TrentService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -773,7 +773,7 @@ export const serializeAws_json1_1UpdateAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.UpdateAlias",
+    "x-amz-target": "TrentService.UpdateAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAliasRequest(input, context));
@@ -786,7 +786,7 @@ export const serializeAws_json1_1UpdateCustomKeyStoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.UpdateCustomKeyStore",
+    "x-amz-target": "TrentService.UpdateCustomKeyStore",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCustomKeyStoreRequest(input, context));
@@ -799,7 +799,7 @@ export const serializeAws_json1_1UpdateKeyDescriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.UpdateKeyDescription",
+    "x-amz-target": "TrentService.UpdateKeyDescription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateKeyDescriptionRequest(input, context));
@@ -812,7 +812,7 @@ export const serializeAws_json1_1VerifyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TrentService.Verify",
+    "x-amz-target": "TrentService.Verify",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1VerifyRequest(input, context));

--- a/clients/client-lakeformation/protocols/Aws_json1_1.ts
+++ b/clients/client-lakeformation/protocols/Aws_json1_1.ts
@@ -95,7 +95,7 @@ export const serializeAws_json1_1BatchGrantPermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.BatchGrantPermissions",
+    "x-amz-target": "AWSLakeFormation.BatchGrantPermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchGrantPermissionsRequest(input, context));
@@ -108,7 +108,7 @@ export const serializeAws_json1_1BatchRevokePermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.BatchRevokePermissions",
+    "x-amz-target": "AWSLakeFormation.BatchRevokePermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchRevokePermissionsRequest(input, context));
@@ -121,7 +121,7 @@ export const serializeAws_json1_1DeregisterResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.DeregisterResource",
+    "x-amz-target": "AWSLakeFormation.DeregisterResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterResourceRequest(input, context));
@@ -134,7 +134,7 @@ export const serializeAws_json1_1DescribeResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.DescribeResource",
+    "x-amz-target": "AWSLakeFormation.DescribeResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeResourceRequest(input, context));
@@ -147,7 +147,7 @@ export const serializeAws_json1_1GetDataLakeSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.GetDataLakeSettings",
+    "x-amz-target": "AWSLakeFormation.GetDataLakeSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDataLakeSettingsRequest(input, context));
@@ -160,7 +160,7 @@ export const serializeAws_json1_1GetEffectivePermissionsForPathCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.GetEffectivePermissionsForPath",
+    "x-amz-target": "AWSLakeFormation.GetEffectivePermissionsForPath",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetEffectivePermissionsForPathRequest(input, context));
@@ -173,7 +173,7 @@ export const serializeAws_json1_1GrantPermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.GrantPermissions",
+    "x-amz-target": "AWSLakeFormation.GrantPermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GrantPermissionsRequest(input, context));
@@ -186,7 +186,7 @@ export const serializeAws_json1_1ListPermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.ListPermissions",
+    "x-amz-target": "AWSLakeFormation.ListPermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPermissionsRequest(input, context));
@@ -199,7 +199,7 @@ export const serializeAws_json1_1ListResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.ListResources",
+    "x-amz-target": "AWSLakeFormation.ListResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourcesRequest(input, context));
@@ -212,7 +212,7 @@ export const serializeAws_json1_1PutDataLakeSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.PutDataLakeSettings",
+    "x-amz-target": "AWSLakeFormation.PutDataLakeSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutDataLakeSettingsRequest(input, context));
@@ -225,7 +225,7 @@ export const serializeAws_json1_1RegisterResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.RegisterResource",
+    "x-amz-target": "AWSLakeFormation.RegisterResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterResourceRequest(input, context));
@@ -238,7 +238,7 @@ export const serializeAws_json1_1RevokePermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.RevokePermissions",
+    "x-amz-target": "AWSLakeFormation.RevokePermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RevokePermissionsRequest(input, context));
@@ -251,7 +251,7 @@ export const serializeAws_json1_1UpdateResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLakeFormation.UpdateResource",
+    "x-amz-target": "AWSLakeFormation.UpdateResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateResourceRequest(input, context));

--- a/clients/client-lambda/protocols/Aws_restJson1.ts
+++ b/clients/client-lambda/protocols/Aws_restJson1.ts
@@ -1242,9 +1242,9 @@ export const serializeAws_restJson1InvokeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/octet-stream",
-    ...(isSerializableHeaderValue(input.InvocationType) && { "X-Amz-Invocation-Type": input.InvocationType! }),
-    ...(isSerializableHeaderValue(input.LogType) && { "X-Amz-Log-Type": input.LogType! }),
-    ...(isSerializableHeaderValue(input.ClientContext) && { "X-Amz-Client-Context": input.ClientContext! }),
+    ...(isSerializableHeaderValue(input.InvocationType) && { "x-amz-invocation-type": input.InvocationType! }),
+    ...(isSerializableHeaderValue(input.LogType) && { "x-amz-log-type": input.LogType! }),
+    ...(isSerializableHeaderValue(input.ClientContext) && { "x-amz-client-context": input.ClientContext! }),
   };
   let resolvedPath = "/2015-03-31/functions/{FunctionName}/invocations";
   if (input.FunctionName !== undefined) {

--- a/clients/client-lex-runtime-service/protocols/Aws_restJson1.ts
+++ b/clients/client-lex-runtime-service/protocols/Aws_restJson1.ts
@@ -152,8 +152,8 @@ export const serializeAws_restJson1PostContentCommand = async (
         "base64"
       ),
     }),
-    ...(isSerializableHeaderValue(input.contentType) && { "Content-Type": input.contentType! }),
-    ...(isSerializableHeaderValue(input.accept) && { Accept: input.accept! }),
+    ...(isSerializableHeaderValue(input.contentType) && { "content-type": input.contentType! }),
+    ...(isSerializableHeaderValue(input.accept) && { accept: input.accept! }),
     ...(isSerializableHeaderValue(input.activeContexts) && {
       "x-amz-lex-active-contexts": Buffer.from(__LazyJsonString.fromObject(input.activeContexts!)).toString("base64"),
     }),
@@ -271,7 +271,7 @@ export const serializeAws_restJson1PutSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.accept) && { Accept: input.accept! }),
+    ...(isSerializableHeaderValue(input.accept) && { accept: input.accept! }),
   };
   let resolvedPath = "/bot/{botName}/alias/{botAlias}/user/{userId}/session";
   if (input.botName !== undefined) {

--- a/clients/client-license-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-license-manager/protocols/Aws_json1_1.ts
@@ -242,7 +242,7 @@ export const serializeAws_json1_1AcceptGrantCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.AcceptGrant",
+    "x-amz-target": "AWSLicenseManager.AcceptGrant",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AcceptGrantRequest(input, context));
@@ -255,7 +255,7 @@ export const serializeAws_json1_1CheckInLicenseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.CheckInLicense",
+    "x-amz-target": "AWSLicenseManager.CheckInLicense",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CheckInLicenseRequest(input, context));
@@ -268,7 +268,7 @@ export const serializeAws_json1_1CheckoutBorrowLicenseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.CheckoutBorrowLicense",
+    "x-amz-target": "AWSLicenseManager.CheckoutBorrowLicense",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CheckoutBorrowLicenseRequest(input, context));
@@ -281,7 +281,7 @@ export const serializeAws_json1_1CheckoutLicenseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.CheckoutLicense",
+    "x-amz-target": "AWSLicenseManager.CheckoutLicense",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CheckoutLicenseRequest(input, context));
@@ -294,7 +294,7 @@ export const serializeAws_json1_1CreateGrantCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.CreateGrant",
+    "x-amz-target": "AWSLicenseManager.CreateGrant",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGrantRequest(input, context));
@@ -307,7 +307,7 @@ export const serializeAws_json1_1CreateGrantVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.CreateGrantVersion",
+    "x-amz-target": "AWSLicenseManager.CreateGrantVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGrantVersionRequest(input, context));
@@ -320,7 +320,7 @@ export const serializeAws_json1_1CreateLicenseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.CreateLicense",
+    "x-amz-target": "AWSLicenseManager.CreateLicense",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLicenseRequest(input, context));
@@ -333,7 +333,7 @@ export const serializeAws_json1_1CreateLicenseConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.CreateLicenseConfiguration",
+    "x-amz-target": "AWSLicenseManager.CreateLicenseConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLicenseConfigurationRequest(input, context));
@@ -346,7 +346,7 @@ export const serializeAws_json1_1CreateLicenseVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.CreateLicenseVersion",
+    "x-amz-target": "AWSLicenseManager.CreateLicenseVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLicenseVersionRequest(input, context));
@@ -359,7 +359,7 @@ export const serializeAws_json1_1CreateTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.CreateToken",
+    "x-amz-target": "AWSLicenseManager.CreateToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTokenRequest(input, context));
@@ -372,7 +372,7 @@ export const serializeAws_json1_1DeleteGrantCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.DeleteGrant",
+    "x-amz-target": "AWSLicenseManager.DeleteGrant",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteGrantRequest(input, context));
@@ -385,7 +385,7 @@ export const serializeAws_json1_1DeleteLicenseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.DeleteLicense",
+    "x-amz-target": "AWSLicenseManager.DeleteLicense",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLicenseRequest(input, context));
@@ -398,7 +398,7 @@ export const serializeAws_json1_1DeleteLicenseConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.DeleteLicenseConfiguration",
+    "x-amz-target": "AWSLicenseManager.DeleteLicenseConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLicenseConfigurationRequest(input, context));
@@ -411,7 +411,7 @@ export const serializeAws_json1_1DeleteTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.DeleteToken",
+    "x-amz-target": "AWSLicenseManager.DeleteToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTokenRequest(input, context));
@@ -424,7 +424,7 @@ export const serializeAws_json1_1ExtendLicenseConsumptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ExtendLicenseConsumption",
+    "x-amz-target": "AWSLicenseManager.ExtendLicenseConsumption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ExtendLicenseConsumptionRequest(input, context));
@@ -437,7 +437,7 @@ export const serializeAws_json1_1GetAccessTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.GetAccessToken",
+    "x-amz-target": "AWSLicenseManager.GetAccessToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAccessTokenRequest(input, context));
@@ -450,7 +450,7 @@ export const serializeAws_json1_1GetGrantCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.GetGrant",
+    "x-amz-target": "AWSLicenseManager.GetGrant",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetGrantRequest(input, context));
@@ -463,7 +463,7 @@ export const serializeAws_json1_1GetLicenseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.GetLicense",
+    "x-amz-target": "AWSLicenseManager.GetLicense",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLicenseRequest(input, context));
@@ -476,7 +476,7 @@ export const serializeAws_json1_1GetLicenseConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.GetLicenseConfiguration",
+    "x-amz-target": "AWSLicenseManager.GetLicenseConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLicenseConfigurationRequest(input, context));
@@ -489,7 +489,7 @@ export const serializeAws_json1_1GetLicenseUsageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.GetLicenseUsage",
+    "x-amz-target": "AWSLicenseManager.GetLicenseUsage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLicenseUsageRequest(input, context));
@@ -502,7 +502,7 @@ export const serializeAws_json1_1GetServiceSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.GetServiceSettings",
+    "x-amz-target": "AWSLicenseManager.GetServiceSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetServiceSettingsRequest(input, context));
@@ -515,7 +515,7 @@ export const serializeAws_json1_1ListAssociationsForLicenseConfigurationCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListAssociationsForLicenseConfiguration",
+    "x-amz-target": "AWSLicenseManager.ListAssociationsForLicenseConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssociationsForLicenseConfigurationRequest(input, context));
@@ -528,7 +528,7 @@ export const serializeAws_json1_1ListDistributedGrantsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListDistributedGrants",
+    "x-amz-target": "AWSLicenseManager.ListDistributedGrants",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDistributedGrantsRequest(input, context));
@@ -541,7 +541,7 @@ export const serializeAws_json1_1ListFailuresForLicenseConfigurationOperationsCo
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListFailuresForLicenseConfigurationOperations",
+    "x-amz-target": "AWSLicenseManager.ListFailuresForLicenseConfigurationOperations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListFailuresForLicenseConfigurationOperationsRequest(input, context));
@@ -554,7 +554,7 @@ export const serializeAws_json1_1ListLicenseConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListLicenseConfigurations",
+    "x-amz-target": "AWSLicenseManager.ListLicenseConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLicenseConfigurationsRequest(input, context));
@@ -567,7 +567,7 @@ export const serializeAws_json1_1ListLicensesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListLicenses",
+    "x-amz-target": "AWSLicenseManager.ListLicenses",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLicensesRequest(input, context));
@@ -580,7 +580,7 @@ export const serializeAws_json1_1ListLicenseSpecificationsForResourceCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListLicenseSpecificationsForResource",
+    "x-amz-target": "AWSLicenseManager.ListLicenseSpecificationsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLicenseSpecificationsForResourceRequest(input, context));
@@ -593,7 +593,7 @@ export const serializeAws_json1_1ListLicenseVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListLicenseVersions",
+    "x-amz-target": "AWSLicenseManager.ListLicenseVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLicenseVersionsRequest(input, context));
@@ -606,7 +606,7 @@ export const serializeAws_json1_1ListReceivedGrantsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListReceivedGrants",
+    "x-amz-target": "AWSLicenseManager.ListReceivedGrants",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListReceivedGrantsRequest(input, context));
@@ -619,7 +619,7 @@ export const serializeAws_json1_1ListReceivedLicensesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListReceivedLicenses",
+    "x-amz-target": "AWSLicenseManager.ListReceivedLicenses",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListReceivedLicensesRequest(input, context));
@@ -632,7 +632,7 @@ export const serializeAws_json1_1ListResourceInventoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListResourceInventory",
+    "x-amz-target": "AWSLicenseManager.ListResourceInventory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourceInventoryRequest(input, context));
@@ -645,7 +645,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListTagsForResource",
+    "x-amz-target": "AWSLicenseManager.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -658,7 +658,7 @@ export const serializeAws_json1_1ListTokensCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListTokens",
+    "x-amz-target": "AWSLicenseManager.ListTokens",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTokensRequest(input, context));
@@ -671,7 +671,7 @@ export const serializeAws_json1_1ListUsageForLicenseConfigurationCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.ListUsageForLicenseConfiguration",
+    "x-amz-target": "AWSLicenseManager.ListUsageForLicenseConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUsageForLicenseConfigurationRequest(input, context));
@@ -684,7 +684,7 @@ export const serializeAws_json1_1RejectGrantCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.RejectGrant",
+    "x-amz-target": "AWSLicenseManager.RejectGrant",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RejectGrantRequest(input, context));
@@ -697,7 +697,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.TagResource",
+    "x-amz-target": "AWSLicenseManager.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -710,7 +710,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.UntagResource",
+    "x-amz-target": "AWSLicenseManager.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -723,7 +723,7 @@ export const serializeAws_json1_1UpdateLicenseConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.UpdateLicenseConfiguration",
+    "x-amz-target": "AWSLicenseManager.UpdateLicenseConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateLicenseConfigurationRequest(input, context));
@@ -736,7 +736,7 @@ export const serializeAws_json1_1UpdateLicenseSpecificationsForResourceCommand =
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.UpdateLicenseSpecificationsForResource",
+    "x-amz-target": "AWSLicenseManager.UpdateLicenseSpecificationsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateLicenseSpecificationsForResourceRequest(input, context));
@@ -749,7 +749,7 @@ export const serializeAws_json1_1UpdateServiceSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSLicenseManager.UpdateServiceSettings",
+    "x-amz-target": "AWSLicenseManager.UpdateServiceSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateServiceSettingsRequest(input, context));

--- a/clients/client-lightsail/protocols/Aws_json1_1.ts
+++ b/clients/client-lightsail/protocols/Aws_json1_1.ts
@@ -754,7 +754,7 @@ export const serializeAws_json1_1AllocateStaticIpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.AllocateStaticIp",
+    "x-amz-target": "Lightsail_20161128.AllocateStaticIp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AllocateStaticIpRequest(input, context));
@@ -767,7 +767,7 @@ export const serializeAws_json1_1AttachCertificateToDistributionCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.AttachCertificateToDistribution",
+    "x-amz-target": "Lightsail_20161128.AttachCertificateToDistribution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AttachCertificateToDistributionRequest(input, context));
@@ -780,7 +780,7 @@ export const serializeAws_json1_1AttachDiskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.AttachDisk",
+    "x-amz-target": "Lightsail_20161128.AttachDisk",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AttachDiskRequest(input, context));
@@ -793,7 +793,7 @@ export const serializeAws_json1_1AttachInstancesToLoadBalancerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.AttachInstancesToLoadBalancer",
+    "x-amz-target": "Lightsail_20161128.AttachInstancesToLoadBalancer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AttachInstancesToLoadBalancerRequest(input, context));
@@ -806,7 +806,7 @@ export const serializeAws_json1_1AttachLoadBalancerTlsCertificateCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.AttachLoadBalancerTlsCertificate",
+    "x-amz-target": "Lightsail_20161128.AttachLoadBalancerTlsCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AttachLoadBalancerTlsCertificateRequest(input, context));
@@ -819,7 +819,7 @@ export const serializeAws_json1_1AttachStaticIpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.AttachStaticIp",
+    "x-amz-target": "Lightsail_20161128.AttachStaticIp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AttachStaticIpRequest(input, context));
@@ -832,7 +832,7 @@ export const serializeAws_json1_1CloseInstancePublicPortsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CloseInstancePublicPorts",
+    "x-amz-target": "Lightsail_20161128.CloseInstancePublicPorts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CloseInstancePublicPortsRequest(input, context));
@@ -845,7 +845,7 @@ export const serializeAws_json1_1CopySnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CopySnapshot",
+    "x-amz-target": "Lightsail_20161128.CopySnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CopySnapshotRequest(input, context));
@@ -858,7 +858,7 @@ export const serializeAws_json1_1CreateCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateCertificate",
+    "x-amz-target": "Lightsail_20161128.CreateCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCertificateRequest(input, context));
@@ -871,7 +871,7 @@ export const serializeAws_json1_1CreateCloudFormationStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateCloudFormationStack",
+    "x-amz-target": "Lightsail_20161128.CreateCloudFormationStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCloudFormationStackRequest(input, context));
@@ -884,7 +884,7 @@ export const serializeAws_json1_1CreateContactMethodCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateContactMethod",
+    "x-amz-target": "Lightsail_20161128.CreateContactMethod",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateContactMethodRequest(input, context));
@@ -897,7 +897,7 @@ export const serializeAws_json1_1CreateContainerServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateContainerService",
+    "x-amz-target": "Lightsail_20161128.CreateContainerService",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateContainerServiceRequest(input, context));
@@ -910,7 +910,7 @@ export const serializeAws_json1_1CreateContainerServiceDeploymentCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateContainerServiceDeployment",
+    "x-amz-target": "Lightsail_20161128.CreateContainerServiceDeployment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateContainerServiceDeploymentRequest(input, context));
@@ -923,7 +923,7 @@ export const serializeAws_json1_1CreateContainerServiceRegistryLoginCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateContainerServiceRegistryLogin",
+    "x-amz-target": "Lightsail_20161128.CreateContainerServiceRegistryLogin",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateContainerServiceRegistryLoginRequest(input, context));
@@ -936,7 +936,7 @@ export const serializeAws_json1_1CreateDiskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateDisk",
+    "x-amz-target": "Lightsail_20161128.CreateDisk",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDiskRequest(input, context));
@@ -949,7 +949,7 @@ export const serializeAws_json1_1CreateDiskFromSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateDiskFromSnapshot",
+    "x-amz-target": "Lightsail_20161128.CreateDiskFromSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDiskFromSnapshotRequest(input, context));
@@ -962,7 +962,7 @@ export const serializeAws_json1_1CreateDiskSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateDiskSnapshot",
+    "x-amz-target": "Lightsail_20161128.CreateDiskSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDiskSnapshotRequest(input, context));
@@ -975,7 +975,7 @@ export const serializeAws_json1_1CreateDistributionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateDistribution",
+    "x-amz-target": "Lightsail_20161128.CreateDistribution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDistributionRequest(input, context));
@@ -988,7 +988,7 @@ export const serializeAws_json1_1CreateDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateDomain",
+    "x-amz-target": "Lightsail_20161128.CreateDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDomainRequest(input, context));
@@ -1001,7 +1001,7 @@ export const serializeAws_json1_1CreateDomainEntryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateDomainEntry",
+    "x-amz-target": "Lightsail_20161128.CreateDomainEntry",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDomainEntryRequest(input, context));
@@ -1014,7 +1014,7 @@ export const serializeAws_json1_1CreateInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateInstances",
+    "x-amz-target": "Lightsail_20161128.CreateInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateInstancesRequest(input, context));
@@ -1027,7 +1027,7 @@ export const serializeAws_json1_1CreateInstancesFromSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateInstancesFromSnapshot",
+    "x-amz-target": "Lightsail_20161128.CreateInstancesFromSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateInstancesFromSnapshotRequest(input, context));
@@ -1040,7 +1040,7 @@ export const serializeAws_json1_1CreateInstanceSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateInstanceSnapshot",
+    "x-amz-target": "Lightsail_20161128.CreateInstanceSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateInstanceSnapshotRequest(input, context));
@@ -1053,7 +1053,7 @@ export const serializeAws_json1_1CreateKeyPairCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateKeyPair",
+    "x-amz-target": "Lightsail_20161128.CreateKeyPair",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateKeyPairRequest(input, context));
@@ -1066,7 +1066,7 @@ export const serializeAws_json1_1CreateLoadBalancerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateLoadBalancer",
+    "x-amz-target": "Lightsail_20161128.CreateLoadBalancer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLoadBalancerRequest(input, context));
@@ -1079,7 +1079,7 @@ export const serializeAws_json1_1CreateLoadBalancerTlsCertificateCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateLoadBalancerTlsCertificate",
+    "x-amz-target": "Lightsail_20161128.CreateLoadBalancerTlsCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLoadBalancerTlsCertificateRequest(input, context));
@@ -1092,7 +1092,7 @@ export const serializeAws_json1_1CreateRelationalDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateRelationalDatabase",
+    "x-amz-target": "Lightsail_20161128.CreateRelationalDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRelationalDatabaseRequest(input, context));
@@ -1105,7 +1105,7 @@ export const serializeAws_json1_1CreateRelationalDatabaseFromSnapshotCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateRelationalDatabaseFromSnapshot",
+    "x-amz-target": "Lightsail_20161128.CreateRelationalDatabaseFromSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRelationalDatabaseFromSnapshotRequest(input, context));
@@ -1118,7 +1118,7 @@ export const serializeAws_json1_1CreateRelationalDatabaseSnapshotCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.CreateRelationalDatabaseSnapshot",
+    "x-amz-target": "Lightsail_20161128.CreateRelationalDatabaseSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRelationalDatabaseSnapshotRequest(input, context));
@@ -1131,7 +1131,7 @@ export const serializeAws_json1_1DeleteAlarmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteAlarm",
+    "x-amz-target": "Lightsail_20161128.DeleteAlarm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAlarmRequest(input, context));
@@ -1144,7 +1144,7 @@ export const serializeAws_json1_1DeleteAutoSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteAutoSnapshot",
+    "x-amz-target": "Lightsail_20161128.DeleteAutoSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAutoSnapshotRequest(input, context));
@@ -1157,7 +1157,7 @@ export const serializeAws_json1_1DeleteCertificateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteCertificate",
+    "x-amz-target": "Lightsail_20161128.DeleteCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCertificateRequest(input, context));
@@ -1170,7 +1170,7 @@ export const serializeAws_json1_1DeleteContactMethodCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteContactMethod",
+    "x-amz-target": "Lightsail_20161128.DeleteContactMethod",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteContactMethodRequest(input, context));
@@ -1183,7 +1183,7 @@ export const serializeAws_json1_1DeleteContainerImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteContainerImage",
+    "x-amz-target": "Lightsail_20161128.DeleteContainerImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteContainerImageRequest(input, context));
@@ -1196,7 +1196,7 @@ export const serializeAws_json1_1DeleteContainerServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteContainerService",
+    "x-amz-target": "Lightsail_20161128.DeleteContainerService",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteContainerServiceRequest(input, context));
@@ -1209,7 +1209,7 @@ export const serializeAws_json1_1DeleteDiskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteDisk",
+    "x-amz-target": "Lightsail_20161128.DeleteDisk",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDiskRequest(input, context));
@@ -1222,7 +1222,7 @@ export const serializeAws_json1_1DeleteDiskSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteDiskSnapshot",
+    "x-amz-target": "Lightsail_20161128.DeleteDiskSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDiskSnapshotRequest(input, context));
@@ -1235,7 +1235,7 @@ export const serializeAws_json1_1DeleteDistributionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteDistribution",
+    "x-amz-target": "Lightsail_20161128.DeleteDistribution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDistributionRequest(input, context));
@@ -1248,7 +1248,7 @@ export const serializeAws_json1_1DeleteDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteDomain",
+    "x-amz-target": "Lightsail_20161128.DeleteDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDomainRequest(input, context));
@@ -1261,7 +1261,7 @@ export const serializeAws_json1_1DeleteDomainEntryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteDomainEntry",
+    "x-amz-target": "Lightsail_20161128.DeleteDomainEntry",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDomainEntryRequest(input, context));
@@ -1274,7 +1274,7 @@ export const serializeAws_json1_1DeleteInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteInstance",
+    "x-amz-target": "Lightsail_20161128.DeleteInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteInstanceRequest(input, context));
@@ -1287,7 +1287,7 @@ export const serializeAws_json1_1DeleteInstanceSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteInstanceSnapshot",
+    "x-amz-target": "Lightsail_20161128.DeleteInstanceSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteInstanceSnapshotRequest(input, context));
@@ -1300,7 +1300,7 @@ export const serializeAws_json1_1DeleteKeyPairCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteKeyPair",
+    "x-amz-target": "Lightsail_20161128.DeleteKeyPair",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteKeyPairRequest(input, context));
@@ -1313,7 +1313,7 @@ export const serializeAws_json1_1DeleteKnownHostKeysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteKnownHostKeys",
+    "x-amz-target": "Lightsail_20161128.DeleteKnownHostKeys",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteKnownHostKeysRequest(input, context));
@@ -1326,7 +1326,7 @@ export const serializeAws_json1_1DeleteLoadBalancerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteLoadBalancer",
+    "x-amz-target": "Lightsail_20161128.DeleteLoadBalancer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLoadBalancerRequest(input, context));
@@ -1339,7 +1339,7 @@ export const serializeAws_json1_1DeleteLoadBalancerTlsCertificateCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteLoadBalancerTlsCertificate",
+    "x-amz-target": "Lightsail_20161128.DeleteLoadBalancerTlsCertificate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLoadBalancerTlsCertificateRequest(input, context));
@@ -1352,7 +1352,7 @@ export const serializeAws_json1_1DeleteRelationalDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteRelationalDatabase",
+    "x-amz-target": "Lightsail_20161128.DeleteRelationalDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRelationalDatabaseRequest(input, context));
@@ -1365,7 +1365,7 @@ export const serializeAws_json1_1DeleteRelationalDatabaseSnapshotCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DeleteRelationalDatabaseSnapshot",
+    "x-amz-target": "Lightsail_20161128.DeleteRelationalDatabaseSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRelationalDatabaseSnapshotRequest(input, context));
@@ -1378,7 +1378,7 @@ export const serializeAws_json1_1DetachCertificateFromDistributionCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DetachCertificateFromDistribution",
+    "x-amz-target": "Lightsail_20161128.DetachCertificateFromDistribution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetachCertificateFromDistributionRequest(input, context));
@@ -1391,7 +1391,7 @@ export const serializeAws_json1_1DetachDiskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DetachDisk",
+    "x-amz-target": "Lightsail_20161128.DetachDisk",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetachDiskRequest(input, context));
@@ -1404,7 +1404,7 @@ export const serializeAws_json1_1DetachInstancesFromLoadBalancerCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DetachInstancesFromLoadBalancer",
+    "x-amz-target": "Lightsail_20161128.DetachInstancesFromLoadBalancer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetachInstancesFromLoadBalancerRequest(input, context));
@@ -1417,7 +1417,7 @@ export const serializeAws_json1_1DetachStaticIpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DetachStaticIp",
+    "x-amz-target": "Lightsail_20161128.DetachStaticIp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetachStaticIpRequest(input, context));
@@ -1430,7 +1430,7 @@ export const serializeAws_json1_1DisableAddOnCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DisableAddOn",
+    "x-amz-target": "Lightsail_20161128.DisableAddOn",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableAddOnRequest(input, context));
@@ -1443,7 +1443,7 @@ export const serializeAws_json1_1DownloadDefaultKeyPairCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.DownloadDefaultKeyPair",
+    "x-amz-target": "Lightsail_20161128.DownloadDefaultKeyPair",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DownloadDefaultKeyPairRequest(input, context));
@@ -1456,7 +1456,7 @@ export const serializeAws_json1_1EnableAddOnCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.EnableAddOn",
+    "x-amz-target": "Lightsail_20161128.EnableAddOn",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableAddOnRequest(input, context));
@@ -1469,7 +1469,7 @@ export const serializeAws_json1_1ExportSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.ExportSnapshot",
+    "x-amz-target": "Lightsail_20161128.ExportSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ExportSnapshotRequest(input, context));
@@ -1482,7 +1482,7 @@ export const serializeAws_json1_1GetActiveNamesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetActiveNames",
+    "x-amz-target": "Lightsail_20161128.GetActiveNames",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetActiveNamesRequest(input, context));
@@ -1495,7 +1495,7 @@ export const serializeAws_json1_1GetAlarmsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetAlarms",
+    "x-amz-target": "Lightsail_20161128.GetAlarms",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAlarmsRequest(input, context));
@@ -1508,7 +1508,7 @@ export const serializeAws_json1_1GetAutoSnapshotsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetAutoSnapshots",
+    "x-amz-target": "Lightsail_20161128.GetAutoSnapshots",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAutoSnapshotsRequest(input, context));
@@ -1521,7 +1521,7 @@ export const serializeAws_json1_1GetBlueprintsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetBlueprints",
+    "x-amz-target": "Lightsail_20161128.GetBlueprints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetBlueprintsRequest(input, context));
@@ -1534,7 +1534,7 @@ export const serializeAws_json1_1GetBundlesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetBundles",
+    "x-amz-target": "Lightsail_20161128.GetBundles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetBundlesRequest(input, context));
@@ -1547,7 +1547,7 @@ export const serializeAws_json1_1GetCertificatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetCertificates",
+    "x-amz-target": "Lightsail_20161128.GetCertificates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCertificatesRequest(input, context));
@@ -1560,7 +1560,7 @@ export const serializeAws_json1_1GetCloudFormationStackRecordsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetCloudFormationStackRecords",
+    "x-amz-target": "Lightsail_20161128.GetCloudFormationStackRecords",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCloudFormationStackRecordsRequest(input, context));
@@ -1573,7 +1573,7 @@ export const serializeAws_json1_1GetContactMethodsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetContactMethods",
+    "x-amz-target": "Lightsail_20161128.GetContactMethods",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContactMethodsRequest(input, context));
@@ -1586,7 +1586,7 @@ export const serializeAws_json1_1GetContainerAPIMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetContainerAPIMetadata",
+    "x-amz-target": "Lightsail_20161128.GetContainerAPIMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContainerAPIMetadataRequest(input, context));
@@ -1599,7 +1599,7 @@ export const serializeAws_json1_1GetContainerImagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetContainerImages",
+    "x-amz-target": "Lightsail_20161128.GetContainerImages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContainerImagesRequest(input, context));
@@ -1612,7 +1612,7 @@ export const serializeAws_json1_1GetContainerLogCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetContainerLog",
+    "x-amz-target": "Lightsail_20161128.GetContainerLog",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContainerLogRequest(input, context));
@@ -1625,7 +1625,7 @@ export const serializeAws_json1_1GetContainerServiceDeploymentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetContainerServiceDeployments",
+    "x-amz-target": "Lightsail_20161128.GetContainerServiceDeployments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContainerServiceDeploymentsRequest(input, context));
@@ -1638,7 +1638,7 @@ export const serializeAws_json1_1GetContainerServiceMetricDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetContainerServiceMetricData",
+    "x-amz-target": "Lightsail_20161128.GetContainerServiceMetricData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContainerServiceMetricDataRequest(input, context));
@@ -1651,7 +1651,7 @@ export const serializeAws_json1_1GetContainerServicePowersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetContainerServicePowers",
+    "x-amz-target": "Lightsail_20161128.GetContainerServicePowers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContainerServicePowersRequest(input, context));
@@ -1664,7 +1664,7 @@ export const serializeAws_json1_1GetContainerServicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetContainerServices",
+    "x-amz-target": "Lightsail_20161128.GetContainerServices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContainerServicesRequest(input, context));
@@ -1677,7 +1677,7 @@ export const serializeAws_json1_1GetDiskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetDisk",
+    "x-amz-target": "Lightsail_20161128.GetDisk",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDiskRequest(input, context));
@@ -1690,7 +1690,7 @@ export const serializeAws_json1_1GetDisksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetDisks",
+    "x-amz-target": "Lightsail_20161128.GetDisks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDisksRequest(input, context));
@@ -1703,7 +1703,7 @@ export const serializeAws_json1_1GetDiskSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetDiskSnapshot",
+    "x-amz-target": "Lightsail_20161128.GetDiskSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDiskSnapshotRequest(input, context));
@@ -1716,7 +1716,7 @@ export const serializeAws_json1_1GetDiskSnapshotsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetDiskSnapshots",
+    "x-amz-target": "Lightsail_20161128.GetDiskSnapshots",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDiskSnapshotsRequest(input, context));
@@ -1729,7 +1729,7 @@ export const serializeAws_json1_1GetDistributionBundlesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetDistributionBundles",
+    "x-amz-target": "Lightsail_20161128.GetDistributionBundles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDistributionBundlesRequest(input, context));
@@ -1742,7 +1742,7 @@ export const serializeAws_json1_1GetDistributionLatestCacheResetCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetDistributionLatestCacheReset",
+    "x-amz-target": "Lightsail_20161128.GetDistributionLatestCacheReset",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDistributionLatestCacheResetRequest(input, context));
@@ -1755,7 +1755,7 @@ export const serializeAws_json1_1GetDistributionMetricDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetDistributionMetricData",
+    "x-amz-target": "Lightsail_20161128.GetDistributionMetricData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDistributionMetricDataRequest(input, context));
@@ -1768,7 +1768,7 @@ export const serializeAws_json1_1GetDistributionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetDistributions",
+    "x-amz-target": "Lightsail_20161128.GetDistributions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDistributionsRequest(input, context));
@@ -1781,7 +1781,7 @@ export const serializeAws_json1_1GetDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetDomain",
+    "x-amz-target": "Lightsail_20161128.GetDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDomainRequest(input, context));
@@ -1794,7 +1794,7 @@ export const serializeAws_json1_1GetDomainsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetDomains",
+    "x-amz-target": "Lightsail_20161128.GetDomains",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDomainsRequest(input, context));
@@ -1807,7 +1807,7 @@ export const serializeAws_json1_1GetExportSnapshotRecordsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetExportSnapshotRecords",
+    "x-amz-target": "Lightsail_20161128.GetExportSnapshotRecords",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetExportSnapshotRecordsRequest(input, context));
@@ -1820,7 +1820,7 @@ export const serializeAws_json1_1GetInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetInstance",
+    "x-amz-target": "Lightsail_20161128.GetInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstanceRequest(input, context));
@@ -1833,7 +1833,7 @@ export const serializeAws_json1_1GetInstanceAccessDetailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetInstanceAccessDetails",
+    "x-amz-target": "Lightsail_20161128.GetInstanceAccessDetails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstanceAccessDetailsRequest(input, context));
@@ -1846,7 +1846,7 @@ export const serializeAws_json1_1GetInstanceMetricDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetInstanceMetricData",
+    "x-amz-target": "Lightsail_20161128.GetInstanceMetricData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstanceMetricDataRequest(input, context));
@@ -1859,7 +1859,7 @@ export const serializeAws_json1_1GetInstancePortStatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetInstancePortStates",
+    "x-amz-target": "Lightsail_20161128.GetInstancePortStates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstancePortStatesRequest(input, context));
@@ -1872,7 +1872,7 @@ export const serializeAws_json1_1GetInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetInstances",
+    "x-amz-target": "Lightsail_20161128.GetInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstancesRequest(input, context));
@@ -1885,7 +1885,7 @@ export const serializeAws_json1_1GetInstanceSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetInstanceSnapshot",
+    "x-amz-target": "Lightsail_20161128.GetInstanceSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstanceSnapshotRequest(input, context));
@@ -1898,7 +1898,7 @@ export const serializeAws_json1_1GetInstanceSnapshotsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetInstanceSnapshots",
+    "x-amz-target": "Lightsail_20161128.GetInstanceSnapshots",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstanceSnapshotsRequest(input, context));
@@ -1911,7 +1911,7 @@ export const serializeAws_json1_1GetInstanceStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetInstanceState",
+    "x-amz-target": "Lightsail_20161128.GetInstanceState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstanceStateRequest(input, context));
@@ -1924,7 +1924,7 @@ export const serializeAws_json1_1GetKeyPairCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetKeyPair",
+    "x-amz-target": "Lightsail_20161128.GetKeyPair",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetKeyPairRequest(input, context));
@@ -1937,7 +1937,7 @@ export const serializeAws_json1_1GetKeyPairsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetKeyPairs",
+    "x-amz-target": "Lightsail_20161128.GetKeyPairs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetKeyPairsRequest(input, context));
@@ -1950,7 +1950,7 @@ export const serializeAws_json1_1GetLoadBalancerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetLoadBalancer",
+    "x-amz-target": "Lightsail_20161128.GetLoadBalancer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLoadBalancerRequest(input, context));
@@ -1963,7 +1963,7 @@ export const serializeAws_json1_1GetLoadBalancerMetricDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetLoadBalancerMetricData",
+    "x-amz-target": "Lightsail_20161128.GetLoadBalancerMetricData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLoadBalancerMetricDataRequest(input, context));
@@ -1976,7 +1976,7 @@ export const serializeAws_json1_1GetLoadBalancersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetLoadBalancers",
+    "x-amz-target": "Lightsail_20161128.GetLoadBalancers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLoadBalancersRequest(input, context));
@@ -1989,7 +1989,7 @@ export const serializeAws_json1_1GetLoadBalancerTlsCertificatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetLoadBalancerTlsCertificates",
+    "x-amz-target": "Lightsail_20161128.GetLoadBalancerTlsCertificates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLoadBalancerTlsCertificatesRequest(input, context));
@@ -2002,7 +2002,7 @@ export const serializeAws_json1_1GetOperationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetOperation",
+    "x-amz-target": "Lightsail_20161128.GetOperation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOperationRequest(input, context));
@@ -2015,7 +2015,7 @@ export const serializeAws_json1_1GetOperationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetOperations",
+    "x-amz-target": "Lightsail_20161128.GetOperations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOperationsRequest(input, context));
@@ -2028,7 +2028,7 @@ export const serializeAws_json1_1GetOperationsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetOperationsForResource",
+    "x-amz-target": "Lightsail_20161128.GetOperationsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOperationsForResourceRequest(input, context));
@@ -2041,7 +2041,7 @@ export const serializeAws_json1_1GetRegionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRegions",
+    "x-amz-target": "Lightsail_20161128.GetRegions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRegionsRequest(input, context));
@@ -2054,7 +2054,7 @@ export const serializeAws_json1_1GetRelationalDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabase",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseRequest(input, context));
@@ -2067,7 +2067,7 @@ export const serializeAws_json1_1GetRelationalDatabaseBlueprintsCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabaseBlueprints",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseBlueprints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseBlueprintsRequest(input, context));
@@ -2080,7 +2080,7 @@ export const serializeAws_json1_1GetRelationalDatabaseBundlesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabaseBundles",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseBundles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseBundlesRequest(input, context));
@@ -2093,7 +2093,7 @@ export const serializeAws_json1_1GetRelationalDatabaseEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabaseEvents",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseEventsRequest(input, context));
@@ -2106,7 +2106,7 @@ export const serializeAws_json1_1GetRelationalDatabaseLogEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabaseLogEvents",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseLogEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseLogEventsRequest(input, context));
@@ -2119,7 +2119,7 @@ export const serializeAws_json1_1GetRelationalDatabaseLogStreamsCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabaseLogStreams",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseLogStreams",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseLogStreamsRequest(input, context));
@@ -2132,7 +2132,7 @@ export const serializeAws_json1_1GetRelationalDatabaseMasterUserPasswordCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabaseMasterUserPassword",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseMasterUserPassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseMasterUserPasswordRequest(input, context));
@@ -2145,7 +2145,7 @@ export const serializeAws_json1_1GetRelationalDatabaseMetricDataCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabaseMetricData",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseMetricData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseMetricDataRequest(input, context));
@@ -2158,7 +2158,7 @@ export const serializeAws_json1_1GetRelationalDatabaseParametersCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabaseParameters",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseParameters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseParametersRequest(input, context));
@@ -2171,7 +2171,7 @@ export const serializeAws_json1_1GetRelationalDatabasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabases",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabasesRequest(input, context));
@@ -2184,7 +2184,7 @@ export const serializeAws_json1_1GetRelationalDatabaseSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabaseSnapshot",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseSnapshotRequest(input, context));
@@ -2197,7 +2197,7 @@ export const serializeAws_json1_1GetRelationalDatabaseSnapshotsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetRelationalDatabaseSnapshots",
+    "x-amz-target": "Lightsail_20161128.GetRelationalDatabaseSnapshots",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRelationalDatabaseSnapshotsRequest(input, context));
@@ -2210,7 +2210,7 @@ export const serializeAws_json1_1GetStaticIpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetStaticIp",
+    "x-amz-target": "Lightsail_20161128.GetStaticIp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetStaticIpRequest(input, context));
@@ -2223,7 +2223,7 @@ export const serializeAws_json1_1GetStaticIpsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.GetStaticIps",
+    "x-amz-target": "Lightsail_20161128.GetStaticIps",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetStaticIpsRequest(input, context));
@@ -2236,7 +2236,7 @@ export const serializeAws_json1_1ImportKeyPairCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.ImportKeyPair",
+    "x-amz-target": "Lightsail_20161128.ImportKeyPair",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportKeyPairRequest(input, context));
@@ -2249,7 +2249,7 @@ export const serializeAws_json1_1IsVpcPeeredCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.IsVpcPeered",
+    "x-amz-target": "Lightsail_20161128.IsVpcPeered",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1IsVpcPeeredRequest(input, context));
@@ -2262,7 +2262,7 @@ export const serializeAws_json1_1OpenInstancePublicPortsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.OpenInstancePublicPorts",
+    "x-amz-target": "Lightsail_20161128.OpenInstancePublicPorts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1OpenInstancePublicPortsRequest(input, context));
@@ -2275,7 +2275,7 @@ export const serializeAws_json1_1PeerVpcCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.PeerVpc",
+    "x-amz-target": "Lightsail_20161128.PeerVpc",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PeerVpcRequest(input, context));
@@ -2288,7 +2288,7 @@ export const serializeAws_json1_1PutAlarmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.PutAlarm",
+    "x-amz-target": "Lightsail_20161128.PutAlarm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAlarmRequest(input, context));
@@ -2301,7 +2301,7 @@ export const serializeAws_json1_1PutInstancePublicPortsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.PutInstancePublicPorts",
+    "x-amz-target": "Lightsail_20161128.PutInstancePublicPorts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutInstancePublicPortsRequest(input, context));
@@ -2314,7 +2314,7 @@ export const serializeAws_json1_1RebootInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.RebootInstance",
+    "x-amz-target": "Lightsail_20161128.RebootInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RebootInstanceRequest(input, context));
@@ -2327,7 +2327,7 @@ export const serializeAws_json1_1RebootRelationalDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.RebootRelationalDatabase",
+    "x-amz-target": "Lightsail_20161128.RebootRelationalDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RebootRelationalDatabaseRequest(input, context));
@@ -2340,7 +2340,7 @@ export const serializeAws_json1_1RegisterContainerImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.RegisterContainerImage",
+    "x-amz-target": "Lightsail_20161128.RegisterContainerImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterContainerImageRequest(input, context));
@@ -2353,7 +2353,7 @@ export const serializeAws_json1_1ReleaseStaticIpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.ReleaseStaticIp",
+    "x-amz-target": "Lightsail_20161128.ReleaseStaticIp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ReleaseStaticIpRequest(input, context));
@@ -2366,7 +2366,7 @@ export const serializeAws_json1_1ResetDistributionCacheCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.ResetDistributionCache",
+    "x-amz-target": "Lightsail_20161128.ResetDistributionCache",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResetDistributionCacheRequest(input, context));
@@ -2379,7 +2379,7 @@ export const serializeAws_json1_1SendContactMethodVerificationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.SendContactMethodVerification",
+    "x-amz-target": "Lightsail_20161128.SendContactMethodVerification",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SendContactMethodVerificationRequest(input, context));
@@ -2392,7 +2392,7 @@ export const serializeAws_json1_1StartInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.StartInstance",
+    "x-amz-target": "Lightsail_20161128.StartInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartInstanceRequest(input, context));
@@ -2405,7 +2405,7 @@ export const serializeAws_json1_1StartRelationalDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.StartRelationalDatabase",
+    "x-amz-target": "Lightsail_20161128.StartRelationalDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartRelationalDatabaseRequest(input, context));
@@ -2418,7 +2418,7 @@ export const serializeAws_json1_1StopInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.StopInstance",
+    "x-amz-target": "Lightsail_20161128.StopInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopInstanceRequest(input, context));
@@ -2431,7 +2431,7 @@ export const serializeAws_json1_1StopRelationalDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.StopRelationalDatabase",
+    "x-amz-target": "Lightsail_20161128.StopRelationalDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopRelationalDatabaseRequest(input, context));
@@ -2444,7 +2444,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.TagResource",
+    "x-amz-target": "Lightsail_20161128.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -2457,7 +2457,7 @@ export const serializeAws_json1_1TestAlarmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.TestAlarm",
+    "x-amz-target": "Lightsail_20161128.TestAlarm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TestAlarmRequest(input, context));
@@ -2470,7 +2470,7 @@ export const serializeAws_json1_1UnpeerVpcCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.UnpeerVpc",
+    "x-amz-target": "Lightsail_20161128.UnpeerVpc",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UnpeerVpcRequest(input, context));
@@ -2483,7 +2483,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.UntagResource",
+    "x-amz-target": "Lightsail_20161128.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -2496,7 +2496,7 @@ export const serializeAws_json1_1UpdateContainerServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.UpdateContainerService",
+    "x-amz-target": "Lightsail_20161128.UpdateContainerService",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateContainerServiceRequest(input, context));
@@ -2509,7 +2509,7 @@ export const serializeAws_json1_1UpdateDistributionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.UpdateDistribution",
+    "x-amz-target": "Lightsail_20161128.UpdateDistribution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDistributionRequest(input, context));
@@ -2522,7 +2522,7 @@ export const serializeAws_json1_1UpdateDistributionBundleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.UpdateDistributionBundle",
+    "x-amz-target": "Lightsail_20161128.UpdateDistributionBundle",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDistributionBundleRequest(input, context));
@@ -2535,7 +2535,7 @@ export const serializeAws_json1_1UpdateDomainEntryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.UpdateDomainEntry",
+    "x-amz-target": "Lightsail_20161128.UpdateDomainEntry",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDomainEntryRequest(input, context));
@@ -2548,7 +2548,7 @@ export const serializeAws_json1_1UpdateLoadBalancerAttributeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.UpdateLoadBalancerAttribute",
+    "x-amz-target": "Lightsail_20161128.UpdateLoadBalancerAttribute",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateLoadBalancerAttributeRequest(input, context));
@@ -2561,7 +2561,7 @@ export const serializeAws_json1_1UpdateRelationalDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.UpdateRelationalDatabase",
+    "x-amz-target": "Lightsail_20161128.UpdateRelationalDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRelationalDatabaseRequest(input, context));
@@ -2574,7 +2574,7 @@ export const serializeAws_json1_1UpdateRelationalDatabaseParametersCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Lightsail_20161128.UpdateRelationalDatabaseParameters",
+    "x-amz-target": "Lightsail_20161128.UpdateRelationalDatabaseParameters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRelationalDatabaseParametersRequest(input, context));

--- a/clients/client-lookoutvision/protocols/Aws_restJson1.ts
+++ b/clients/client-lookoutvision/protocols/Aws_restJson1.ts
@@ -61,7 +61,7 @@ export const serializeAws_restJson1CreateDatasetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ClientToken) && { "X-Amzn-Client-Token": input.ClientToken! }),
+    ...(isSerializableHeaderValue(input.ClientToken) && { "x-amzn-client-token": input.ClientToken! }),
   };
   let resolvedPath = "/2020-11-20/projects/{ProjectName}/datasets";
   if (input.ProjectName !== undefined) {
@@ -99,7 +99,7 @@ export const serializeAws_restJson1CreateModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ClientToken) && { "X-Amzn-Client-Token": input.ClientToken! }),
+    ...(isSerializableHeaderValue(input.ClientToken) && { "x-amzn-client-token": input.ClientToken! }),
   };
   let resolvedPath = "/2020-11-20/projects/{ProjectName}/models";
   if (input.ProjectName !== undefined) {
@@ -139,7 +139,7 @@ export const serializeAws_restJson1CreateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ClientToken) && { "X-Amzn-Client-Token": input.ClientToken! }),
+    ...(isSerializableHeaderValue(input.ClientToken) && { "x-amzn-client-token": input.ClientToken! }),
   };
   let resolvedPath = "/2020-11-20/projects";
   let body: any;
@@ -163,7 +163,7 @@ export const serializeAws_restJson1DeleteDatasetCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.ClientToken) && { "X-Amzn-Client-Token": input.ClientToken! }),
+    ...(isSerializableHeaderValue(input.ClientToken) && { "x-amzn-client-token": input.ClientToken! }),
   };
   let resolvedPath = "/2020-11-20/projects/{ProjectName}/datasets/{DatasetType}";
   if (input.ProjectName !== undefined) {
@@ -202,7 +202,7 @@ export const serializeAws_restJson1DeleteModelCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.ClientToken) && { "X-Amzn-Client-Token": input.ClientToken! }),
+    ...(isSerializableHeaderValue(input.ClientToken) && { "x-amzn-client-token": input.ClientToken! }),
   };
   let resolvedPath = "/2020-11-20/projects/{ProjectName}/models/{ModelVersion}";
   if (input.ProjectName !== undefined) {
@@ -241,7 +241,7 @@ export const serializeAws_restJson1DeleteProjectCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.ClientToken) && { "X-Amzn-Client-Token": input.ClientToken! }),
+    ...(isSerializableHeaderValue(input.ClientToken) && { "x-amzn-client-token": input.ClientToken! }),
   };
   let resolvedPath = "/2020-11-20/projects/{ProjectName}";
   if (input.ProjectName !== undefined) {
@@ -525,7 +525,7 @@ export const serializeAws_restJson1StartModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ClientToken) && { "X-Amzn-Client-Token": input.ClientToken! }),
+    ...(isSerializableHeaderValue(input.ClientToken) && { "x-amzn-client-token": input.ClientToken! }),
   };
   let resolvedPath = "/2020-11-20/projects/{ProjectName}/models/{ModelVersion}/start";
   if (input.ProjectName !== undefined) {
@@ -568,7 +568,7 @@ export const serializeAws_restJson1StopModelCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.ClientToken) && { "X-Amzn-Client-Token": input.ClientToken! }),
+    ...(isSerializableHeaderValue(input.ClientToken) && { "x-amzn-client-token": input.ClientToken! }),
   };
   let resolvedPath = "/2020-11-20/projects/{ProjectName}/models/{ModelVersion}/stop";
   if (input.ProjectName !== undefined) {
@@ -608,7 +608,7 @@ export const serializeAws_restJson1UpdateDatasetEntriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.ClientToken) && { "X-Amzn-Client-Token": input.ClientToken! }),
+    ...(isSerializableHeaderValue(input.ClientToken) && { "x-amzn-client-token": input.ClientToken! }),
   };
   let resolvedPath = "/2020-11-20/projects/{ProjectName}/datasets/{DatasetType}/entries";
   if (input.ProjectName !== undefined) {

--- a/clients/client-machine-learning/protocols/Aws_json1_1.ts
+++ b/clients/client-machine-learning/protocols/Aws_json1_1.ts
@@ -159,7 +159,7 @@ export const serializeAws_json1_1AddTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.AddTags",
+    "x-amz-target": "AmazonML_20141212.AddTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsInput(input, context));
@@ -172,7 +172,7 @@ export const serializeAws_json1_1CreateBatchPredictionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.CreateBatchPrediction",
+    "x-amz-target": "AmazonML_20141212.CreateBatchPrediction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateBatchPredictionInput(input, context));
@@ -185,7 +185,7 @@ export const serializeAws_json1_1CreateDataSourceFromRDSCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.CreateDataSourceFromRDS",
+    "x-amz-target": "AmazonML_20141212.CreateDataSourceFromRDS",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDataSourceFromRDSInput(input, context));
@@ -198,7 +198,7 @@ export const serializeAws_json1_1CreateDataSourceFromRedshiftCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.CreateDataSourceFromRedshift",
+    "x-amz-target": "AmazonML_20141212.CreateDataSourceFromRedshift",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDataSourceFromRedshiftInput(input, context));
@@ -211,7 +211,7 @@ export const serializeAws_json1_1CreateDataSourceFromS3Command = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.CreateDataSourceFromS3",
+    "x-amz-target": "AmazonML_20141212.CreateDataSourceFromS3",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDataSourceFromS3Input(input, context));
@@ -224,7 +224,7 @@ export const serializeAws_json1_1CreateEvaluationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.CreateEvaluation",
+    "x-amz-target": "AmazonML_20141212.CreateEvaluation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEvaluationInput(input, context));
@@ -237,7 +237,7 @@ export const serializeAws_json1_1CreateMLModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.CreateMLModel",
+    "x-amz-target": "AmazonML_20141212.CreateMLModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateMLModelInput(input, context));
@@ -250,7 +250,7 @@ export const serializeAws_json1_1CreateRealtimeEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.CreateRealtimeEndpoint",
+    "x-amz-target": "AmazonML_20141212.CreateRealtimeEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRealtimeEndpointInput(input, context));
@@ -263,7 +263,7 @@ export const serializeAws_json1_1DeleteBatchPredictionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DeleteBatchPrediction",
+    "x-amz-target": "AmazonML_20141212.DeleteBatchPrediction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBatchPredictionInput(input, context));
@@ -276,7 +276,7 @@ export const serializeAws_json1_1DeleteDataSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DeleteDataSource",
+    "x-amz-target": "AmazonML_20141212.DeleteDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDataSourceInput(input, context));
@@ -289,7 +289,7 @@ export const serializeAws_json1_1DeleteEvaluationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DeleteEvaluation",
+    "x-amz-target": "AmazonML_20141212.DeleteEvaluation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEvaluationInput(input, context));
@@ -302,7 +302,7 @@ export const serializeAws_json1_1DeleteMLModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DeleteMLModel",
+    "x-amz-target": "AmazonML_20141212.DeleteMLModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMLModelInput(input, context));
@@ -315,7 +315,7 @@ export const serializeAws_json1_1DeleteRealtimeEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DeleteRealtimeEndpoint",
+    "x-amz-target": "AmazonML_20141212.DeleteRealtimeEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRealtimeEndpointInput(input, context));
@@ -328,7 +328,7 @@ export const serializeAws_json1_1DeleteTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DeleteTags",
+    "x-amz-target": "AmazonML_20141212.DeleteTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTagsInput(input, context));
@@ -341,7 +341,7 @@ export const serializeAws_json1_1DescribeBatchPredictionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DescribeBatchPredictions",
+    "x-amz-target": "AmazonML_20141212.DescribeBatchPredictions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBatchPredictionsInput(input, context));
@@ -354,7 +354,7 @@ export const serializeAws_json1_1DescribeDataSourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DescribeDataSources",
+    "x-amz-target": "AmazonML_20141212.DescribeDataSources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDataSourcesInput(input, context));
@@ -367,7 +367,7 @@ export const serializeAws_json1_1DescribeEvaluationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DescribeEvaluations",
+    "x-amz-target": "AmazonML_20141212.DescribeEvaluations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEvaluationsInput(input, context));
@@ -380,7 +380,7 @@ export const serializeAws_json1_1DescribeMLModelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DescribeMLModels",
+    "x-amz-target": "AmazonML_20141212.DescribeMLModels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMLModelsInput(input, context));
@@ -393,7 +393,7 @@ export const serializeAws_json1_1DescribeTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.DescribeTags",
+    "x-amz-target": "AmazonML_20141212.DescribeTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTagsInput(input, context));
@@ -406,7 +406,7 @@ export const serializeAws_json1_1GetBatchPredictionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.GetBatchPrediction",
+    "x-amz-target": "AmazonML_20141212.GetBatchPrediction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetBatchPredictionInput(input, context));
@@ -419,7 +419,7 @@ export const serializeAws_json1_1GetDataSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.GetDataSource",
+    "x-amz-target": "AmazonML_20141212.GetDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDataSourceInput(input, context));
@@ -432,7 +432,7 @@ export const serializeAws_json1_1GetEvaluationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.GetEvaluation",
+    "x-amz-target": "AmazonML_20141212.GetEvaluation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetEvaluationInput(input, context));
@@ -445,7 +445,7 @@ export const serializeAws_json1_1GetMLModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.GetMLModel",
+    "x-amz-target": "AmazonML_20141212.GetMLModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMLModelInput(input, context));
@@ -458,7 +458,7 @@ export const serializeAws_json1_1PredictCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.Predict",
+    "x-amz-target": "AmazonML_20141212.Predict",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PredictInput(input, context));
@@ -471,7 +471,7 @@ export const serializeAws_json1_1UpdateBatchPredictionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.UpdateBatchPrediction",
+    "x-amz-target": "AmazonML_20141212.UpdateBatchPrediction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateBatchPredictionInput(input, context));
@@ -484,7 +484,7 @@ export const serializeAws_json1_1UpdateDataSourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.UpdateDataSource",
+    "x-amz-target": "AmazonML_20141212.UpdateDataSource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDataSourceInput(input, context));
@@ -497,7 +497,7 @@ export const serializeAws_json1_1UpdateEvaluationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.UpdateEvaluation",
+    "x-amz-target": "AmazonML_20141212.UpdateEvaluation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateEvaluationInput(input, context));
@@ -510,7 +510,7 @@ export const serializeAws_json1_1UpdateMLModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonML_20141212.UpdateMLModel",
+    "x-amz-target": "AmazonML_20141212.UpdateMLModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMLModelInput(input, context));

--- a/clients/client-macie/protocols/Aws_json1_1.ts
+++ b/clients/client-macie/protocols/Aws_json1_1.ts
@@ -58,7 +58,7 @@ export const serializeAws_json1_1AssociateMemberAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MacieService.AssociateMemberAccount",
+    "x-amz-target": "MacieService.AssociateMemberAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateMemberAccountRequest(input, context));
@@ -71,7 +71,7 @@ export const serializeAws_json1_1AssociateS3ResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MacieService.AssociateS3Resources",
+    "x-amz-target": "MacieService.AssociateS3Resources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateS3ResourcesRequest(input, context));
@@ -84,7 +84,7 @@ export const serializeAws_json1_1DisassociateMemberAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MacieService.DisassociateMemberAccount",
+    "x-amz-target": "MacieService.DisassociateMemberAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateMemberAccountRequest(input, context));
@@ -97,7 +97,7 @@ export const serializeAws_json1_1DisassociateS3ResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MacieService.DisassociateS3Resources",
+    "x-amz-target": "MacieService.DisassociateS3Resources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateS3ResourcesRequest(input, context));
@@ -110,7 +110,7 @@ export const serializeAws_json1_1ListMemberAccountsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MacieService.ListMemberAccounts",
+    "x-amz-target": "MacieService.ListMemberAccounts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListMemberAccountsRequest(input, context));
@@ -123,7 +123,7 @@ export const serializeAws_json1_1ListS3ResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MacieService.ListS3Resources",
+    "x-amz-target": "MacieService.ListS3Resources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListS3ResourcesRequest(input, context));
@@ -136,7 +136,7 @@ export const serializeAws_json1_1UpdateS3ResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MacieService.UpdateS3Resources",
+    "x-amz-target": "MacieService.UpdateS3Resources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateS3ResourcesRequest(input, context));

--- a/clients/client-marketplace-commerce-analytics/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-commerce-analytics/protocols/Aws_json1_1.ts
@@ -26,7 +26,7 @@ export const serializeAws_json1_1GenerateDataSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MarketplaceCommerceAnalytics20150701.GenerateDataSet",
+    "x-amz-target": "MarketplaceCommerceAnalytics20150701.GenerateDataSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GenerateDataSetRequest(input, context));
@@ -39,7 +39,7 @@ export const serializeAws_json1_1StartSupportDataExportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MarketplaceCommerceAnalytics20150701.StartSupportDataExport",
+    "x-amz-target": "MarketplaceCommerceAnalytics20150701.StartSupportDataExport",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartSupportDataExportRequest(input, context));

--- a/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-entitlement-service/protocols/Aws_json1_1.ts
@@ -25,7 +25,7 @@ export const serializeAws_json1_1GetEntitlementsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMPEntitlementService.GetEntitlements",
+    "x-amz-target": "AWSMPEntitlementService.GetEntitlements",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetEntitlementsRequest(input, context));

--- a/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
+++ b/clients/client-marketplace-metering/protocols/Aws_json1_1.ts
@@ -49,7 +49,7 @@ export const serializeAws_json1_1BatchMeterUsageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMPMeteringService.BatchMeterUsage",
+    "x-amz-target": "AWSMPMeteringService.BatchMeterUsage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchMeterUsageRequest(input, context));
@@ -62,7 +62,7 @@ export const serializeAws_json1_1MeterUsageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMPMeteringService.MeterUsage",
+    "x-amz-target": "AWSMPMeteringService.MeterUsage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MeterUsageRequest(input, context));
@@ -75,7 +75,7 @@ export const serializeAws_json1_1RegisterUsageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMPMeteringService.RegisterUsage",
+    "x-amz-target": "AWSMPMeteringService.RegisterUsage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterUsageRequest(input, context));
@@ -88,7 +88,7 @@ export const serializeAws_json1_1ResolveCustomerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMPMeteringService.ResolveCustomer",
+    "x-amz-target": "AWSMPMeteringService.ResolveCustomer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResolveCustomerRequest(input, context));

--- a/clients/client-mediastore-data/protocols/Aws_restJson1.ts
+++ b/clients/client-mediastore-data/protocols/Aws_restJson1.ts
@@ -95,7 +95,7 @@ export const serializeAws_restJson1GetObjectCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.Range) && { Range: input.Range! }),
+    ...(isSerializableHeaderValue(input.Range) && { range: input.Range! }),
   };
   let resolvedPath = "/{Path+}";
   if (input.Path !== undefined) {
@@ -158,8 +158,8 @@ export const serializeAws_restJson1PutObjectCommand = async (
   const headers: any = {
     "content-type": "application/octet-stream",
     "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
-    ...(isSerializableHeaderValue(input.ContentType) && { "Content-Type": input.ContentType! }),
-    ...(isSerializableHeaderValue(input.CacheControl) && { "Cache-Control": input.CacheControl! }),
+    ...(isSerializableHeaderValue(input.ContentType) && { "content-type": input.ContentType! }),
+    ...(isSerializableHeaderValue(input.CacheControl) && { "cache-control": input.CacheControl! }),
     ...(isSerializableHeaderValue(input.StorageClass) && { "x-amz-storage-class": input.StorageClass! }),
   };
   let resolvedPath = "/{Path+}";

--- a/clients/client-mediastore/protocols/Aws_json1_1.ts
+++ b/clients/client-mediastore/protocols/Aws_json1_1.ts
@@ -100,7 +100,7 @@ export const serializeAws_json1_1CreateContainerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.CreateContainer",
+    "x-amz-target": "MediaStore_20170901.CreateContainer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateContainerInput(input, context));
@@ -113,7 +113,7 @@ export const serializeAws_json1_1DeleteContainerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.DeleteContainer",
+    "x-amz-target": "MediaStore_20170901.DeleteContainer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteContainerInput(input, context));
@@ -126,7 +126,7 @@ export const serializeAws_json1_1DeleteContainerPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.DeleteContainerPolicy",
+    "x-amz-target": "MediaStore_20170901.DeleteContainerPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteContainerPolicyInput(input, context));
@@ -139,7 +139,7 @@ export const serializeAws_json1_1DeleteCorsPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.DeleteCorsPolicy",
+    "x-amz-target": "MediaStore_20170901.DeleteCorsPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCorsPolicyInput(input, context));
@@ -152,7 +152,7 @@ export const serializeAws_json1_1DeleteLifecyclePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.DeleteLifecyclePolicy",
+    "x-amz-target": "MediaStore_20170901.DeleteLifecyclePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLifecyclePolicyInput(input, context));
@@ -165,7 +165,7 @@ export const serializeAws_json1_1DeleteMetricPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.DeleteMetricPolicy",
+    "x-amz-target": "MediaStore_20170901.DeleteMetricPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMetricPolicyInput(input, context));
@@ -178,7 +178,7 @@ export const serializeAws_json1_1DescribeContainerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.DescribeContainer",
+    "x-amz-target": "MediaStore_20170901.DescribeContainer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeContainerInput(input, context));
@@ -191,7 +191,7 @@ export const serializeAws_json1_1GetContainerPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.GetContainerPolicy",
+    "x-amz-target": "MediaStore_20170901.GetContainerPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContainerPolicyInput(input, context));
@@ -204,7 +204,7 @@ export const serializeAws_json1_1GetCorsPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.GetCorsPolicy",
+    "x-amz-target": "MediaStore_20170901.GetCorsPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCorsPolicyInput(input, context));
@@ -217,7 +217,7 @@ export const serializeAws_json1_1GetLifecyclePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.GetLifecyclePolicy",
+    "x-amz-target": "MediaStore_20170901.GetLifecyclePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLifecyclePolicyInput(input, context));
@@ -230,7 +230,7 @@ export const serializeAws_json1_1GetMetricPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.GetMetricPolicy",
+    "x-amz-target": "MediaStore_20170901.GetMetricPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMetricPolicyInput(input, context));
@@ -243,7 +243,7 @@ export const serializeAws_json1_1ListContainersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.ListContainers",
+    "x-amz-target": "MediaStore_20170901.ListContainers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListContainersInput(input, context));
@@ -256,7 +256,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.ListTagsForResource",
+    "x-amz-target": "MediaStore_20170901.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceInput(input, context));
@@ -269,7 +269,7 @@ export const serializeAws_json1_1PutContainerPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.PutContainerPolicy",
+    "x-amz-target": "MediaStore_20170901.PutContainerPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutContainerPolicyInput(input, context));
@@ -282,7 +282,7 @@ export const serializeAws_json1_1PutCorsPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.PutCorsPolicy",
+    "x-amz-target": "MediaStore_20170901.PutCorsPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutCorsPolicyInput(input, context));
@@ -295,7 +295,7 @@ export const serializeAws_json1_1PutLifecyclePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.PutLifecyclePolicy",
+    "x-amz-target": "MediaStore_20170901.PutLifecyclePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutLifecyclePolicyInput(input, context));
@@ -308,7 +308,7 @@ export const serializeAws_json1_1PutMetricPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.PutMetricPolicy",
+    "x-amz-target": "MediaStore_20170901.PutMetricPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutMetricPolicyInput(input, context));
@@ -321,7 +321,7 @@ export const serializeAws_json1_1StartAccessLoggingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.StartAccessLogging",
+    "x-amz-target": "MediaStore_20170901.StartAccessLogging",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartAccessLoggingInput(input, context));
@@ -334,7 +334,7 @@ export const serializeAws_json1_1StopAccessLoggingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.StopAccessLogging",
+    "x-amz-target": "MediaStore_20170901.StopAccessLogging",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopAccessLoggingInput(input, context));
@@ -347,7 +347,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.TagResource",
+    "x-amz-target": "MediaStore_20170901.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceInput(input, context));
@@ -360,7 +360,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MediaStore_20170901.UntagResource",
+    "x-amz-target": "MediaStore_20170901.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceInput(input, context));

--- a/clients/client-migration-hub/protocols/Aws_json1_1.ts
+++ b/clients/client-migration-hub/protocols/Aws_json1_1.ts
@@ -133,7 +133,7 @@ export const serializeAws_json1_1AssociateCreatedArtifactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.AssociateCreatedArtifact",
+    "x-amz-target": "AWSMigrationHub.AssociateCreatedArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateCreatedArtifactRequest(input, context));
@@ -146,7 +146,7 @@ export const serializeAws_json1_1AssociateDiscoveredResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.AssociateDiscoveredResource",
+    "x-amz-target": "AWSMigrationHub.AssociateDiscoveredResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateDiscoveredResourceRequest(input, context));
@@ -159,7 +159,7 @@ export const serializeAws_json1_1CreateProgressUpdateStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.CreateProgressUpdateStream",
+    "x-amz-target": "AWSMigrationHub.CreateProgressUpdateStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProgressUpdateStreamRequest(input, context));
@@ -172,7 +172,7 @@ export const serializeAws_json1_1DeleteProgressUpdateStreamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.DeleteProgressUpdateStream",
+    "x-amz-target": "AWSMigrationHub.DeleteProgressUpdateStream",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProgressUpdateStreamRequest(input, context));
@@ -185,7 +185,7 @@ export const serializeAws_json1_1DescribeApplicationStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.DescribeApplicationState",
+    "x-amz-target": "AWSMigrationHub.DescribeApplicationState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeApplicationStateRequest(input, context));
@@ -198,7 +198,7 @@ export const serializeAws_json1_1DescribeMigrationTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.DescribeMigrationTask",
+    "x-amz-target": "AWSMigrationHub.DescribeMigrationTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMigrationTaskRequest(input, context));
@@ -211,7 +211,7 @@ export const serializeAws_json1_1DisassociateCreatedArtifactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.DisassociateCreatedArtifact",
+    "x-amz-target": "AWSMigrationHub.DisassociateCreatedArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateCreatedArtifactRequest(input, context));
@@ -224,7 +224,7 @@ export const serializeAws_json1_1DisassociateDiscoveredResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.DisassociateDiscoveredResource",
+    "x-amz-target": "AWSMigrationHub.DisassociateDiscoveredResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateDiscoveredResourceRequest(input, context));
@@ -237,7 +237,7 @@ export const serializeAws_json1_1ImportMigrationTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.ImportMigrationTask",
+    "x-amz-target": "AWSMigrationHub.ImportMigrationTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportMigrationTaskRequest(input, context));
@@ -250,7 +250,7 @@ export const serializeAws_json1_1ListApplicationStatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.ListApplicationStates",
+    "x-amz-target": "AWSMigrationHub.ListApplicationStates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListApplicationStatesRequest(input, context));
@@ -263,7 +263,7 @@ export const serializeAws_json1_1ListCreatedArtifactsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.ListCreatedArtifacts",
+    "x-amz-target": "AWSMigrationHub.ListCreatedArtifacts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCreatedArtifactsRequest(input, context));
@@ -276,7 +276,7 @@ export const serializeAws_json1_1ListDiscoveredResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.ListDiscoveredResources",
+    "x-amz-target": "AWSMigrationHub.ListDiscoveredResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDiscoveredResourcesRequest(input, context));
@@ -289,7 +289,7 @@ export const serializeAws_json1_1ListMigrationTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.ListMigrationTasks",
+    "x-amz-target": "AWSMigrationHub.ListMigrationTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListMigrationTasksRequest(input, context));
@@ -302,7 +302,7 @@ export const serializeAws_json1_1ListProgressUpdateStreamsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.ListProgressUpdateStreams",
+    "x-amz-target": "AWSMigrationHub.ListProgressUpdateStreams",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProgressUpdateStreamsRequest(input, context));
@@ -315,7 +315,7 @@ export const serializeAws_json1_1NotifyApplicationStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.NotifyApplicationState",
+    "x-amz-target": "AWSMigrationHub.NotifyApplicationState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1NotifyApplicationStateRequest(input, context));
@@ -328,7 +328,7 @@ export const serializeAws_json1_1NotifyMigrationTaskStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.NotifyMigrationTaskState",
+    "x-amz-target": "AWSMigrationHub.NotifyMigrationTaskState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1NotifyMigrationTaskStateRequest(input, context));
@@ -341,7 +341,7 @@ export const serializeAws_json1_1PutResourceAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHub.PutResourceAttributes",
+    "x-amz-target": "AWSMigrationHub.PutResourceAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutResourceAttributesRequest(input, context));

--- a/clients/client-migrationhub-config/protocols/Aws_json1_1.ts
+++ b/clients/client-migrationhub-config/protocols/Aws_json1_1.ts
@@ -39,7 +39,7 @@ export const serializeAws_json1_1CreateHomeRegionControlCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHubMultiAccountService.CreateHomeRegionControl",
+    "x-amz-target": "AWSMigrationHubMultiAccountService.CreateHomeRegionControl",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateHomeRegionControlRequest(input, context));
@@ -52,7 +52,7 @@ export const serializeAws_json1_1DescribeHomeRegionControlsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHubMultiAccountService.DescribeHomeRegionControls",
+    "x-amz-target": "AWSMigrationHubMultiAccountService.DescribeHomeRegionControls",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeHomeRegionControlsRequest(input, context));
@@ -65,7 +65,7 @@ export const serializeAws_json1_1GetHomeRegionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSMigrationHubMultiAccountService.GetHomeRegion",
+    "x-amz-target": "AWSMigrationHubMultiAccountService.GetHomeRegion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetHomeRegionRequest(input, context));

--- a/clients/client-mturk/protocols/Aws_json1_1.ts
+++ b/clients/client-mturk/protocols/Aws_json1_1.ts
@@ -219,7 +219,7 @@ export const serializeAws_json1_1AcceptQualificationRequestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.AcceptQualificationRequest",
+    "x-amz-target": "MTurkRequesterServiceV20170117.AcceptQualificationRequest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AcceptQualificationRequestRequest(input, context));
@@ -232,7 +232,7 @@ export const serializeAws_json1_1ApproveAssignmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ApproveAssignment",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ApproveAssignment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ApproveAssignmentRequest(input, context));
@@ -245,7 +245,7 @@ export const serializeAws_json1_1AssociateQualificationWithWorkerCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.AssociateQualificationWithWorker",
+    "x-amz-target": "MTurkRequesterServiceV20170117.AssociateQualificationWithWorker",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateQualificationWithWorkerRequest(input, context));
@@ -258,7 +258,7 @@ export const serializeAws_json1_1CreateAdditionalAssignmentsForHITCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.CreateAdditionalAssignmentsForHIT",
+    "x-amz-target": "MTurkRequesterServiceV20170117.CreateAdditionalAssignmentsForHIT",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAdditionalAssignmentsForHITRequest(input, context));
@@ -271,7 +271,7 @@ export const serializeAws_json1_1CreateHITCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.CreateHIT",
+    "x-amz-target": "MTurkRequesterServiceV20170117.CreateHIT",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateHITRequest(input, context));
@@ -284,7 +284,7 @@ export const serializeAws_json1_1CreateHITTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.CreateHITType",
+    "x-amz-target": "MTurkRequesterServiceV20170117.CreateHITType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateHITTypeRequest(input, context));
@@ -297,7 +297,7 @@ export const serializeAws_json1_1CreateHITWithHITTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.CreateHITWithHITType",
+    "x-amz-target": "MTurkRequesterServiceV20170117.CreateHITWithHITType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateHITWithHITTypeRequest(input, context));
@@ -310,7 +310,7 @@ export const serializeAws_json1_1CreateQualificationTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.CreateQualificationType",
+    "x-amz-target": "MTurkRequesterServiceV20170117.CreateQualificationType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateQualificationTypeRequest(input, context));
@@ -323,7 +323,7 @@ export const serializeAws_json1_1CreateWorkerBlockCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.CreateWorkerBlock",
+    "x-amz-target": "MTurkRequesterServiceV20170117.CreateWorkerBlock",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWorkerBlockRequest(input, context));
@@ -336,7 +336,7 @@ export const serializeAws_json1_1DeleteHITCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.DeleteHIT",
+    "x-amz-target": "MTurkRequesterServiceV20170117.DeleteHIT",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteHITRequest(input, context));
@@ -349,7 +349,7 @@ export const serializeAws_json1_1DeleteQualificationTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.DeleteQualificationType",
+    "x-amz-target": "MTurkRequesterServiceV20170117.DeleteQualificationType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteQualificationTypeRequest(input, context));
@@ -362,7 +362,7 @@ export const serializeAws_json1_1DeleteWorkerBlockCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.DeleteWorkerBlock",
+    "x-amz-target": "MTurkRequesterServiceV20170117.DeleteWorkerBlock",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWorkerBlockRequest(input, context));
@@ -375,7 +375,7 @@ export const serializeAws_json1_1DisassociateQualificationFromWorkerCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.DisassociateQualificationFromWorker",
+    "x-amz-target": "MTurkRequesterServiceV20170117.DisassociateQualificationFromWorker",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateQualificationFromWorkerRequest(input, context));
@@ -388,7 +388,7 @@ export const serializeAws_json1_1GetAccountBalanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.GetAccountBalance",
+    "x-amz-target": "MTurkRequesterServiceV20170117.GetAccountBalance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAccountBalanceRequest(input, context));
@@ -401,7 +401,7 @@ export const serializeAws_json1_1GetAssignmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.GetAssignment",
+    "x-amz-target": "MTurkRequesterServiceV20170117.GetAssignment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAssignmentRequest(input, context));
@@ -414,7 +414,7 @@ export const serializeAws_json1_1GetFileUploadURLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.GetFileUploadURL",
+    "x-amz-target": "MTurkRequesterServiceV20170117.GetFileUploadURL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetFileUploadURLRequest(input, context));
@@ -427,7 +427,7 @@ export const serializeAws_json1_1GetHITCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.GetHIT",
+    "x-amz-target": "MTurkRequesterServiceV20170117.GetHIT",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetHITRequest(input, context));
@@ -440,7 +440,7 @@ export const serializeAws_json1_1GetQualificationScoreCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.GetQualificationScore",
+    "x-amz-target": "MTurkRequesterServiceV20170117.GetQualificationScore",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetQualificationScoreRequest(input, context));
@@ -453,7 +453,7 @@ export const serializeAws_json1_1GetQualificationTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.GetQualificationType",
+    "x-amz-target": "MTurkRequesterServiceV20170117.GetQualificationType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetQualificationTypeRequest(input, context));
@@ -466,7 +466,7 @@ export const serializeAws_json1_1ListAssignmentsForHITCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ListAssignmentsForHIT",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ListAssignmentsForHIT",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssignmentsForHITRequest(input, context));
@@ -479,7 +479,7 @@ export const serializeAws_json1_1ListBonusPaymentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ListBonusPayments",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ListBonusPayments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBonusPaymentsRequest(input, context));
@@ -492,7 +492,7 @@ export const serializeAws_json1_1ListHITsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ListHITs",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ListHITs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListHITsRequest(input, context));
@@ -505,7 +505,7 @@ export const serializeAws_json1_1ListHITsForQualificationTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ListHITsForQualificationType",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ListHITsForQualificationType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListHITsForQualificationTypeRequest(input, context));
@@ -518,7 +518,7 @@ export const serializeAws_json1_1ListQualificationRequestsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ListQualificationRequests",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ListQualificationRequests",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListQualificationRequestsRequest(input, context));
@@ -531,7 +531,7 @@ export const serializeAws_json1_1ListQualificationTypesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ListQualificationTypes",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ListQualificationTypes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListQualificationTypesRequest(input, context));
@@ -544,7 +544,7 @@ export const serializeAws_json1_1ListReviewableHITsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ListReviewableHITs",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ListReviewableHITs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListReviewableHITsRequest(input, context));
@@ -557,7 +557,7 @@ export const serializeAws_json1_1ListReviewPolicyResultsForHITCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ListReviewPolicyResultsForHIT",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ListReviewPolicyResultsForHIT",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListReviewPolicyResultsForHITRequest(input, context));
@@ -570,7 +570,7 @@ export const serializeAws_json1_1ListWorkerBlocksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ListWorkerBlocks",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ListWorkerBlocks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListWorkerBlocksRequest(input, context));
@@ -583,7 +583,7 @@ export const serializeAws_json1_1ListWorkersWithQualificationTypeCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.ListWorkersWithQualificationType",
+    "x-amz-target": "MTurkRequesterServiceV20170117.ListWorkersWithQualificationType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListWorkersWithQualificationTypeRequest(input, context));
@@ -596,7 +596,7 @@ export const serializeAws_json1_1NotifyWorkersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.NotifyWorkers",
+    "x-amz-target": "MTurkRequesterServiceV20170117.NotifyWorkers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1NotifyWorkersRequest(input, context));
@@ -609,7 +609,7 @@ export const serializeAws_json1_1RejectAssignmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.RejectAssignment",
+    "x-amz-target": "MTurkRequesterServiceV20170117.RejectAssignment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RejectAssignmentRequest(input, context));
@@ -622,7 +622,7 @@ export const serializeAws_json1_1RejectQualificationRequestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.RejectQualificationRequest",
+    "x-amz-target": "MTurkRequesterServiceV20170117.RejectQualificationRequest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RejectQualificationRequestRequest(input, context));
@@ -635,7 +635,7 @@ export const serializeAws_json1_1SendBonusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.SendBonus",
+    "x-amz-target": "MTurkRequesterServiceV20170117.SendBonus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SendBonusRequest(input, context));
@@ -648,7 +648,7 @@ export const serializeAws_json1_1SendTestEventNotificationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.SendTestEventNotification",
+    "x-amz-target": "MTurkRequesterServiceV20170117.SendTestEventNotification",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SendTestEventNotificationRequest(input, context));
@@ -661,7 +661,7 @@ export const serializeAws_json1_1UpdateExpirationForHITCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.UpdateExpirationForHIT",
+    "x-amz-target": "MTurkRequesterServiceV20170117.UpdateExpirationForHIT",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateExpirationForHITRequest(input, context));
@@ -674,7 +674,7 @@ export const serializeAws_json1_1UpdateHITReviewStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.UpdateHITReviewStatus",
+    "x-amz-target": "MTurkRequesterServiceV20170117.UpdateHITReviewStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateHITReviewStatusRequest(input, context));
@@ -687,7 +687,7 @@ export const serializeAws_json1_1UpdateHITTypeOfHITCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.UpdateHITTypeOfHIT",
+    "x-amz-target": "MTurkRequesterServiceV20170117.UpdateHITTypeOfHIT",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateHITTypeOfHITRequest(input, context));
@@ -700,7 +700,7 @@ export const serializeAws_json1_1UpdateNotificationSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.UpdateNotificationSettings",
+    "x-amz-target": "MTurkRequesterServiceV20170117.UpdateNotificationSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateNotificationSettingsRequest(input, context));
@@ -713,7 +713,7 @@ export const serializeAws_json1_1UpdateQualificationTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "MTurkRequesterServiceV20170117.UpdateQualificationType",
+    "x-amz-target": "MTurkRequesterServiceV20170117.UpdateQualificationType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateQualificationTypeRequest(input, context));

--- a/clients/client-network-firewall/protocols/Aws_json1_0.ts
+++ b/clients/client-network-firewall/protocols/Aws_json1_0.ts
@@ -202,7 +202,7 @@ export const serializeAws_json1_0AssociateFirewallPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.AssociateFirewallPolicy",
+    "x-amz-target": "NetworkFirewall_20201112.AssociateFirewallPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0AssociateFirewallPolicyRequest(input, context));
@@ -215,7 +215,7 @@ export const serializeAws_json1_0AssociateSubnetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.AssociateSubnets",
+    "x-amz-target": "NetworkFirewall_20201112.AssociateSubnets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0AssociateSubnetsRequest(input, context));
@@ -228,7 +228,7 @@ export const serializeAws_json1_0CreateFirewallCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.CreateFirewall",
+    "x-amz-target": "NetworkFirewall_20201112.CreateFirewall",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateFirewallRequest(input, context));
@@ -241,7 +241,7 @@ export const serializeAws_json1_0CreateFirewallPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.CreateFirewallPolicy",
+    "x-amz-target": "NetworkFirewall_20201112.CreateFirewallPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateFirewallPolicyRequest(input, context));
@@ -254,7 +254,7 @@ export const serializeAws_json1_0CreateRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.CreateRuleGroup",
+    "x-amz-target": "NetworkFirewall_20201112.CreateRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateRuleGroupRequest(input, context));
@@ -267,7 +267,7 @@ export const serializeAws_json1_0DeleteFirewallCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.DeleteFirewall",
+    "x-amz-target": "NetworkFirewall_20201112.DeleteFirewall",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteFirewallRequest(input, context));
@@ -280,7 +280,7 @@ export const serializeAws_json1_0DeleteFirewallPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.DeleteFirewallPolicy",
+    "x-amz-target": "NetworkFirewall_20201112.DeleteFirewallPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteFirewallPolicyRequest(input, context));
@@ -293,7 +293,7 @@ export const serializeAws_json1_0DeleteResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.DeleteResourcePolicy",
+    "x-amz-target": "NetworkFirewall_20201112.DeleteResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteResourcePolicyRequest(input, context));
@@ -306,7 +306,7 @@ export const serializeAws_json1_0DeleteRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.DeleteRuleGroup",
+    "x-amz-target": "NetworkFirewall_20201112.DeleteRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteRuleGroupRequest(input, context));
@@ -319,7 +319,7 @@ export const serializeAws_json1_0DescribeFirewallCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.DescribeFirewall",
+    "x-amz-target": "NetworkFirewall_20201112.DescribeFirewall",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeFirewallRequest(input, context));
@@ -332,7 +332,7 @@ export const serializeAws_json1_0DescribeFirewallPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.DescribeFirewallPolicy",
+    "x-amz-target": "NetworkFirewall_20201112.DescribeFirewallPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeFirewallPolicyRequest(input, context));
@@ -345,7 +345,7 @@ export const serializeAws_json1_0DescribeLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.DescribeLoggingConfiguration",
+    "x-amz-target": "NetworkFirewall_20201112.DescribeLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeLoggingConfigurationRequest(input, context));
@@ -358,7 +358,7 @@ export const serializeAws_json1_0DescribeResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.DescribeResourcePolicy",
+    "x-amz-target": "NetworkFirewall_20201112.DescribeResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeResourcePolicyRequest(input, context));
@@ -371,7 +371,7 @@ export const serializeAws_json1_0DescribeRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.DescribeRuleGroup",
+    "x-amz-target": "NetworkFirewall_20201112.DescribeRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeRuleGroupRequest(input, context));
@@ -384,7 +384,7 @@ export const serializeAws_json1_0DisassociateSubnetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.DisassociateSubnets",
+    "x-amz-target": "NetworkFirewall_20201112.DisassociateSubnets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DisassociateSubnetsRequest(input, context));
@@ -397,7 +397,7 @@ export const serializeAws_json1_0ListFirewallPoliciesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.ListFirewallPolicies",
+    "x-amz-target": "NetworkFirewall_20201112.ListFirewallPolicies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListFirewallPoliciesRequest(input, context));
@@ -410,7 +410,7 @@ export const serializeAws_json1_0ListFirewallsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.ListFirewalls",
+    "x-amz-target": "NetworkFirewall_20201112.ListFirewalls",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListFirewallsRequest(input, context));
@@ -423,7 +423,7 @@ export const serializeAws_json1_0ListRuleGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.ListRuleGroups",
+    "x-amz-target": "NetworkFirewall_20201112.ListRuleGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListRuleGroupsRequest(input, context));
@@ -436,7 +436,7 @@ export const serializeAws_json1_0ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.ListTagsForResource",
+    "x-amz-target": "NetworkFirewall_20201112.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListTagsForResourceRequest(input, context));
@@ -449,7 +449,7 @@ export const serializeAws_json1_0PutResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.PutResourcePolicy",
+    "x-amz-target": "NetworkFirewall_20201112.PutResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0PutResourcePolicyRequest(input, context));
@@ -462,7 +462,7 @@ export const serializeAws_json1_0TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.TagResource",
+    "x-amz-target": "NetworkFirewall_20201112.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0TagResourceRequest(input, context));
@@ -475,7 +475,7 @@ export const serializeAws_json1_0UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.UntagResource",
+    "x-amz-target": "NetworkFirewall_20201112.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UntagResourceRequest(input, context));
@@ -488,7 +488,7 @@ export const serializeAws_json1_0UpdateFirewallDeleteProtectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.UpdateFirewallDeleteProtection",
+    "x-amz-target": "NetworkFirewall_20201112.UpdateFirewallDeleteProtection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateFirewallDeleteProtectionRequest(input, context));
@@ -501,7 +501,7 @@ export const serializeAws_json1_0UpdateFirewallDescriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.UpdateFirewallDescription",
+    "x-amz-target": "NetworkFirewall_20201112.UpdateFirewallDescription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateFirewallDescriptionRequest(input, context));
@@ -514,7 +514,7 @@ export const serializeAws_json1_0UpdateFirewallPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.UpdateFirewallPolicy",
+    "x-amz-target": "NetworkFirewall_20201112.UpdateFirewallPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateFirewallPolicyRequest(input, context));
@@ -527,7 +527,7 @@ export const serializeAws_json1_0UpdateFirewallPolicyChangeProtectionCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.UpdateFirewallPolicyChangeProtection",
+    "x-amz-target": "NetworkFirewall_20201112.UpdateFirewallPolicyChangeProtection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateFirewallPolicyChangeProtectionRequest(input, context));
@@ -540,7 +540,7 @@ export const serializeAws_json1_0UpdateLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.UpdateLoggingConfiguration",
+    "x-amz-target": "NetworkFirewall_20201112.UpdateLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateLoggingConfigurationRequest(input, context));
@@ -553,7 +553,7 @@ export const serializeAws_json1_0UpdateRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.UpdateRuleGroup",
+    "x-amz-target": "NetworkFirewall_20201112.UpdateRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateRuleGroupRequest(input, context));
@@ -566,7 +566,7 @@ export const serializeAws_json1_0UpdateSubnetChangeProtectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "NetworkFirewall_20201112.UpdateSubnetChangeProtection",
+    "x-amz-target": "NetworkFirewall_20201112.UpdateSubnetChangeProtection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateSubnetChangeProtectionRequest(input, context));

--- a/clients/client-opsworks/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworks/protocols/Aws_json1_1.ts
@@ -324,7 +324,7 @@ export const serializeAws_json1_1AssignInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.AssignInstance",
+    "x-amz-target": "OpsWorks_20130218.AssignInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssignInstanceRequest(input, context));
@@ -337,7 +337,7 @@ export const serializeAws_json1_1AssignVolumeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.AssignVolume",
+    "x-amz-target": "OpsWorks_20130218.AssignVolume",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssignVolumeRequest(input, context));
@@ -350,7 +350,7 @@ export const serializeAws_json1_1AssociateElasticIpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.AssociateElasticIp",
+    "x-amz-target": "OpsWorks_20130218.AssociateElasticIp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateElasticIpRequest(input, context));
@@ -363,7 +363,7 @@ export const serializeAws_json1_1AttachElasticLoadBalancerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.AttachElasticLoadBalancer",
+    "x-amz-target": "OpsWorks_20130218.AttachElasticLoadBalancer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AttachElasticLoadBalancerRequest(input, context));
@@ -376,7 +376,7 @@ export const serializeAws_json1_1CloneStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.CloneStack",
+    "x-amz-target": "OpsWorks_20130218.CloneStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CloneStackRequest(input, context));
@@ -389,7 +389,7 @@ export const serializeAws_json1_1CreateAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.CreateApp",
+    "x-amz-target": "OpsWorks_20130218.CreateApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAppRequest(input, context));
@@ -402,7 +402,7 @@ export const serializeAws_json1_1CreateDeploymentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.CreateDeployment",
+    "x-amz-target": "OpsWorks_20130218.CreateDeployment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDeploymentRequest(input, context));
@@ -415,7 +415,7 @@ export const serializeAws_json1_1CreateInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.CreateInstance",
+    "x-amz-target": "OpsWorks_20130218.CreateInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateInstanceRequest(input, context));
@@ -428,7 +428,7 @@ export const serializeAws_json1_1CreateLayerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.CreateLayer",
+    "x-amz-target": "OpsWorks_20130218.CreateLayer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLayerRequest(input, context));
@@ -441,7 +441,7 @@ export const serializeAws_json1_1CreateStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.CreateStack",
+    "x-amz-target": "OpsWorks_20130218.CreateStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateStackRequest(input, context));
@@ -454,7 +454,7 @@ export const serializeAws_json1_1CreateUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.CreateUserProfile",
+    "x-amz-target": "OpsWorks_20130218.CreateUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserProfileRequest(input, context));
@@ -467,7 +467,7 @@ export const serializeAws_json1_1DeleteAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DeleteApp",
+    "x-amz-target": "OpsWorks_20130218.DeleteApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAppRequest(input, context));
@@ -480,7 +480,7 @@ export const serializeAws_json1_1DeleteInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DeleteInstance",
+    "x-amz-target": "OpsWorks_20130218.DeleteInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteInstanceRequest(input, context));
@@ -493,7 +493,7 @@ export const serializeAws_json1_1DeleteLayerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DeleteLayer",
+    "x-amz-target": "OpsWorks_20130218.DeleteLayer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLayerRequest(input, context));
@@ -506,7 +506,7 @@ export const serializeAws_json1_1DeleteStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DeleteStack",
+    "x-amz-target": "OpsWorks_20130218.DeleteStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteStackRequest(input, context));
@@ -519,7 +519,7 @@ export const serializeAws_json1_1DeleteUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DeleteUserProfile",
+    "x-amz-target": "OpsWorks_20130218.DeleteUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserProfileRequest(input, context));
@@ -532,7 +532,7 @@ export const serializeAws_json1_1DeregisterEcsClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DeregisterEcsCluster",
+    "x-amz-target": "OpsWorks_20130218.DeregisterEcsCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterEcsClusterRequest(input, context));
@@ -545,7 +545,7 @@ export const serializeAws_json1_1DeregisterElasticIpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DeregisterElasticIp",
+    "x-amz-target": "OpsWorks_20130218.DeregisterElasticIp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterElasticIpRequest(input, context));
@@ -558,7 +558,7 @@ export const serializeAws_json1_1DeregisterInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DeregisterInstance",
+    "x-amz-target": "OpsWorks_20130218.DeregisterInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterInstanceRequest(input, context));
@@ -571,7 +571,7 @@ export const serializeAws_json1_1DeregisterRdsDbInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DeregisterRdsDbInstance",
+    "x-amz-target": "OpsWorks_20130218.DeregisterRdsDbInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterRdsDbInstanceRequest(input, context));
@@ -584,7 +584,7 @@ export const serializeAws_json1_1DeregisterVolumeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DeregisterVolume",
+    "x-amz-target": "OpsWorks_20130218.DeregisterVolume",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterVolumeRequest(input, context));
@@ -597,7 +597,7 @@ export const serializeAws_json1_1DescribeAgentVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeAgentVersions",
+    "x-amz-target": "OpsWorks_20130218.DescribeAgentVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAgentVersionsRequest(input, context));
@@ -610,7 +610,7 @@ export const serializeAws_json1_1DescribeAppsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeApps",
+    "x-amz-target": "OpsWorks_20130218.DescribeApps",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAppsRequest(input, context));
@@ -623,7 +623,7 @@ export const serializeAws_json1_1DescribeCommandsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeCommands",
+    "x-amz-target": "OpsWorks_20130218.DescribeCommands",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCommandsRequest(input, context));
@@ -636,7 +636,7 @@ export const serializeAws_json1_1DescribeDeploymentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeDeployments",
+    "x-amz-target": "OpsWorks_20130218.DescribeDeployments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDeploymentsRequest(input, context));
@@ -649,7 +649,7 @@ export const serializeAws_json1_1DescribeEcsClustersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeEcsClusters",
+    "x-amz-target": "OpsWorks_20130218.DescribeEcsClusters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEcsClustersRequest(input, context));
@@ -662,7 +662,7 @@ export const serializeAws_json1_1DescribeElasticIpsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeElasticIps",
+    "x-amz-target": "OpsWorks_20130218.DescribeElasticIps",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeElasticIpsRequest(input, context));
@@ -675,7 +675,7 @@ export const serializeAws_json1_1DescribeElasticLoadBalancersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeElasticLoadBalancers",
+    "x-amz-target": "OpsWorks_20130218.DescribeElasticLoadBalancers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeElasticLoadBalancersRequest(input, context));
@@ -688,7 +688,7 @@ export const serializeAws_json1_1DescribeInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeInstances",
+    "x-amz-target": "OpsWorks_20130218.DescribeInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInstancesRequest(input, context));
@@ -701,7 +701,7 @@ export const serializeAws_json1_1DescribeLayersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeLayers",
+    "x-amz-target": "OpsWorks_20130218.DescribeLayers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLayersRequest(input, context));
@@ -714,7 +714,7 @@ export const serializeAws_json1_1DescribeLoadBasedAutoScalingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeLoadBasedAutoScaling",
+    "x-amz-target": "OpsWorks_20130218.DescribeLoadBasedAutoScaling",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLoadBasedAutoScalingRequest(input, context));
@@ -727,7 +727,7 @@ export const serializeAws_json1_1DescribeMyUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeMyUserProfile",
+    "x-amz-target": "OpsWorks_20130218.DescribeMyUserProfile",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -738,7 +738,7 @@ export const serializeAws_json1_1DescribeOperatingSystemsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeOperatingSystems",
+    "x-amz-target": "OpsWorks_20130218.DescribeOperatingSystems",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -749,7 +749,7 @@ export const serializeAws_json1_1DescribePermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribePermissions",
+    "x-amz-target": "OpsWorks_20130218.DescribePermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePermissionsRequest(input, context));
@@ -762,7 +762,7 @@ export const serializeAws_json1_1DescribeRaidArraysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeRaidArrays",
+    "x-amz-target": "OpsWorks_20130218.DescribeRaidArrays",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRaidArraysRequest(input, context));
@@ -775,7 +775,7 @@ export const serializeAws_json1_1DescribeRdsDbInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeRdsDbInstances",
+    "x-amz-target": "OpsWorks_20130218.DescribeRdsDbInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRdsDbInstancesRequest(input, context));
@@ -788,7 +788,7 @@ export const serializeAws_json1_1DescribeServiceErrorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeServiceErrors",
+    "x-amz-target": "OpsWorks_20130218.DescribeServiceErrors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeServiceErrorsRequest(input, context));
@@ -801,7 +801,7 @@ export const serializeAws_json1_1DescribeStackProvisioningParametersCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeStackProvisioningParameters",
+    "x-amz-target": "OpsWorks_20130218.DescribeStackProvisioningParameters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStackProvisioningParametersRequest(input, context));
@@ -814,7 +814,7 @@ export const serializeAws_json1_1DescribeStacksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeStacks",
+    "x-amz-target": "OpsWorks_20130218.DescribeStacks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStacksRequest(input, context));
@@ -827,7 +827,7 @@ export const serializeAws_json1_1DescribeStackSummaryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeStackSummary",
+    "x-amz-target": "OpsWorks_20130218.DescribeStackSummary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStackSummaryRequest(input, context));
@@ -840,7 +840,7 @@ export const serializeAws_json1_1DescribeTimeBasedAutoScalingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeTimeBasedAutoScaling",
+    "x-amz-target": "OpsWorks_20130218.DescribeTimeBasedAutoScaling",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTimeBasedAutoScalingRequest(input, context));
@@ -853,7 +853,7 @@ export const serializeAws_json1_1DescribeUserProfilesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeUserProfiles",
+    "x-amz-target": "OpsWorks_20130218.DescribeUserProfiles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserProfilesRequest(input, context));
@@ -866,7 +866,7 @@ export const serializeAws_json1_1DescribeVolumesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DescribeVolumes",
+    "x-amz-target": "OpsWorks_20130218.DescribeVolumes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeVolumesRequest(input, context));
@@ -879,7 +879,7 @@ export const serializeAws_json1_1DetachElasticLoadBalancerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DetachElasticLoadBalancer",
+    "x-amz-target": "OpsWorks_20130218.DetachElasticLoadBalancer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetachElasticLoadBalancerRequest(input, context));
@@ -892,7 +892,7 @@ export const serializeAws_json1_1DisassociateElasticIpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.DisassociateElasticIp",
+    "x-amz-target": "OpsWorks_20130218.DisassociateElasticIp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateElasticIpRequest(input, context));
@@ -905,7 +905,7 @@ export const serializeAws_json1_1GetHostnameSuggestionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.GetHostnameSuggestion",
+    "x-amz-target": "OpsWorks_20130218.GetHostnameSuggestion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetHostnameSuggestionRequest(input, context));
@@ -918,7 +918,7 @@ export const serializeAws_json1_1GrantAccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.GrantAccess",
+    "x-amz-target": "OpsWorks_20130218.GrantAccess",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GrantAccessRequest(input, context));
@@ -931,7 +931,7 @@ export const serializeAws_json1_1ListTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.ListTags",
+    "x-amz-target": "OpsWorks_20130218.ListTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsRequest(input, context));
@@ -944,7 +944,7 @@ export const serializeAws_json1_1RebootInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.RebootInstance",
+    "x-amz-target": "OpsWorks_20130218.RebootInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RebootInstanceRequest(input, context));
@@ -957,7 +957,7 @@ export const serializeAws_json1_1RegisterEcsClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.RegisterEcsCluster",
+    "x-amz-target": "OpsWorks_20130218.RegisterEcsCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterEcsClusterRequest(input, context));
@@ -970,7 +970,7 @@ export const serializeAws_json1_1RegisterElasticIpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.RegisterElasticIp",
+    "x-amz-target": "OpsWorks_20130218.RegisterElasticIp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterElasticIpRequest(input, context));
@@ -983,7 +983,7 @@ export const serializeAws_json1_1RegisterInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.RegisterInstance",
+    "x-amz-target": "OpsWorks_20130218.RegisterInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterInstanceRequest(input, context));
@@ -996,7 +996,7 @@ export const serializeAws_json1_1RegisterRdsDbInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.RegisterRdsDbInstance",
+    "x-amz-target": "OpsWorks_20130218.RegisterRdsDbInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterRdsDbInstanceRequest(input, context));
@@ -1009,7 +1009,7 @@ export const serializeAws_json1_1RegisterVolumeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.RegisterVolume",
+    "x-amz-target": "OpsWorks_20130218.RegisterVolume",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterVolumeRequest(input, context));
@@ -1022,7 +1022,7 @@ export const serializeAws_json1_1SetLoadBasedAutoScalingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.SetLoadBasedAutoScaling",
+    "x-amz-target": "OpsWorks_20130218.SetLoadBasedAutoScaling",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetLoadBasedAutoScalingRequest(input, context));
@@ -1035,7 +1035,7 @@ export const serializeAws_json1_1SetPermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.SetPermission",
+    "x-amz-target": "OpsWorks_20130218.SetPermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetPermissionRequest(input, context));
@@ -1048,7 +1048,7 @@ export const serializeAws_json1_1SetTimeBasedAutoScalingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.SetTimeBasedAutoScaling",
+    "x-amz-target": "OpsWorks_20130218.SetTimeBasedAutoScaling",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetTimeBasedAutoScalingRequest(input, context));
@@ -1061,7 +1061,7 @@ export const serializeAws_json1_1StartInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.StartInstance",
+    "x-amz-target": "OpsWorks_20130218.StartInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartInstanceRequest(input, context));
@@ -1074,7 +1074,7 @@ export const serializeAws_json1_1StartStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.StartStack",
+    "x-amz-target": "OpsWorks_20130218.StartStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartStackRequest(input, context));
@@ -1087,7 +1087,7 @@ export const serializeAws_json1_1StopInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.StopInstance",
+    "x-amz-target": "OpsWorks_20130218.StopInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopInstanceRequest(input, context));
@@ -1100,7 +1100,7 @@ export const serializeAws_json1_1StopStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.StopStack",
+    "x-amz-target": "OpsWorks_20130218.StopStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopStackRequest(input, context));
@@ -1113,7 +1113,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.TagResource",
+    "x-amz-target": "OpsWorks_20130218.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -1126,7 +1126,7 @@ export const serializeAws_json1_1UnassignInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UnassignInstance",
+    "x-amz-target": "OpsWorks_20130218.UnassignInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UnassignInstanceRequest(input, context));
@@ -1139,7 +1139,7 @@ export const serializeAws_json1_1UnassignVolumeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UnassignVolume",
+    "x-amz-target": "OpsWorks_20130218.UnassignVolume",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UnassignVolumeRequest(input, context));
@@ -1152,7 +1152,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UntagResource",
+    "x-amz-target": "OpsWorks_20130218.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -1165,7 +1165,7 @@ export const serializeAws_json1_1UpdateAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UpdateApp",
+    "x-amz-target": "OpsWorks_20130218.UpdateApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAppRequest(input, context));
@@ -1178,7 +1178,7 @@ export const serializeAws_json1_1UpdateElasticIpCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UpdateElasticIp",
+    "x-amz-target": "OpsWorks_20130218.UpdateElasticIp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateElasticIpRequest(input, context));
@@ -1191,7 +1191,7 @@ export const serializeAws_json1_1UpdateInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UpdateInstance",
+    "x-amz-target": "OpsWorks_20130218.UpdateInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateInstanceRequest(input, context));
@@ -1204,7 +1204,7 @@ export const serializeAws_json1_1UpdateLayerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UpdateLayer",
+    "x-amz-target": "OpsWorks_20130218.UpdateLayer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateLayerRequest(input, context));
@@ -1217,7 +1217,7 @@ export const serializeAws_json1_1UpdateMyUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UpdateMyUserProfile",
+    "x-amz-target": "OpsWorks_20130218.UpdateMyUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMyUserProfileRequest(input, context));
@@ -1230,7 +1230,7 @@ export const serializeAws_json1_1UpdateRdsDbInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UpdateRdsDbInstance",
+    "x-amz-target": "OpsWorks_20130218.UpdateRdsDbInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRdsDbInstanceRequest(input, context));
@@ -1243,7 +1243,7 @@ export const serializeAws_json1_1UpdateStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UpdateStack",
+    "x-amz-target": "OpsWorks_20130218.UpdateStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateStackRequest(input, context));
@@ -1256,7 +1256,7 @@ export const serializeAws_json1_1UpdateUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UpdateUserProfile",
+    "x-amz-target": "OpsWorks_20130218.UpdateUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateUserProfileRequest(input, context));
@@ -1269,7 +1269,7 @@ export const serializeAws_json1_1UpdateVolumeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorks_20130218.UpdateVolume",
+    "x-amz-target": "OpsWorks_20130218.UpdateVolume",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateVolumeRequest(input, context));

--- a/clients/client-opsworkscm/protocols/Aws_json1_1.ts
+++ b/clients/client-opsworkscm/protocols/Aws_json1_1.ts
@@ -100,7 +100,7 @@ export const serializeAws_json1_1AssociateNodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.AssociateNode",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.AssociateNode",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateNodeRequest(input, context));
@@ -113,7 +113,7 @@ export const serializeAws_json1_1CreateBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.CreateBackup",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.CreateBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateBackupRequest(input, context));
@@ -126,7 +126,7 @@ export const serializeAws_json1_1CreateServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.CreateServer",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.CreateServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateServerRequest(input, context));
@@ -139,7 +139,7 @@ export const serializeAws_json1_1DeleteBackupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.DeleteBackup",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.DeleteBackup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBackupRequest(input, context));
@@ -152,7 +152,7 @@ export const serializeAws_json1_1DeleteServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.DeleteServer",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.DeleteServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteServerRequest(input, context));
@@ -165,7 +165,7 @@ export const serializeAws_json1_1DescribeAccountAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.DescribeAccountAttributes",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeAccountAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAccountAttributesRequest(input, context));
@@ -178,7 +178,7 @@ export const serializeAws_json1_1DescribeBackupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.DescribeBackups",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeBackups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBackupsRequest(input, context));
@@ -191,7 +191,7 @@ export const serializeAws_json1_1DescribeEventsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.DescribeEvents",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeEvents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventsRequest(input, context));
@@ -204,7 +204,7 @@ export const serializeAws_json1_1DescribeNodeAssociationStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.DescribeNodeAssociationStatus",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeNodeAssociationStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeNodeAssociationStatusRequest(input, context));
@@ -217,7 +217,7 @@ export const serializeAws_json1_1DescribeServersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.DescribeServers",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.DescribeServers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeServersRequest(input, context));
@@ -230,7 +230,7 @@ export const serializeAws_json1_1DisassociateNodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.DisassociateNode",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.DisassociateNode",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateNodeRequest(input, context));
@@ -243,7 +243,7 @@ export const serializeAws_json1_1ExportServerEngineAttributeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.ExportServerEngineAttribute",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.ExportServerEngineAttribute",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ExportServerEngineAttributeRequest(input, context));
@@ -256,7 +256,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.ListTagsForResource",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -269,7 +269,7 @@ export const serializeAws_json1_1RestoreServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.RestoreServer",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.RestoreServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RestoreServerRequest(input, context));
@@ -282,7 +282,7 @@ export const serializeAws_json1_1StartMaintenanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.StartMaintenance",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.StartMaintenance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartMaintenanceRequest(input, context));
@@ -295,7 +295,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.TagResource",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -308,7 +308,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.UntagResource",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -321,7 +321,7 @@ export const serializeAws_json1_1UpdateServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.UpdateServer",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.UpdateServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateServerRequest(input, context));
@@ -334,7 +334,7 @@ export const serializeAws_json1_1UpdateServerEngineAttributesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "OpsWorksCM_V2016_11_01.UpdateServerEngineAttributes",
+    "x-amz-target": "OpsWorksCM_V2016_11_01.UpdateServerEngineAttributes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateServerEngineAttributesRequest(input, context));

--- a/clients/client-organizations/protocols/Aws_json1_1.ts
+++ b/clients/client-organizations/protocols/Aws_json1_1.ts
@@ -292,7 +292,7 @@ export const serializeAws_json1_1AcceptHandshakeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.AcceptHandshake",
+    "x-amz-target": "AWSOrganizationsV20161128.AcceptHandshake",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AcceptHandshakeRequest(input, context));
@@ -305,7 +305,7 @@ export const serializeAws_json1_1AttachPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.AttachPolicy",
+    "x-amz-target": "AWSOrganizationsV20161128.AttachPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AttachPolicyRequest(input, context));
@@ -318,7 +318,7 @@ export const serializeAws_json1_1CancelHandshakeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.CancelHandshake",
+    "x-amz-target": "AWSOrganizationsV20161128.CancelHandshake",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelHandshakeRequest(input, context));
@@ -331,7 +331,7 @@ export const serializeAws_json1_1CreateAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.CreateAccount",
+    "x-amz-target": "AWSOrganizationsV20161128.CreateAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAccountRequest(input, context));
@@ -344,7 +344,7 @@ export const serializeAws_json1_1CreateGovCloudAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.CreateGovCloudAccount",
+    "x-amz-target": "AWSOrganizationsV20161128.CreateGovCloudAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGovCloudAccountRequest(input, context));
@@ -357,7 +357,7 @@ export const serializeAws_json1_1CreateOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.CreateOrganization",
+    "x-amz-target": "AWSOrganizationsV20161128.CreateOrganization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateOrganizationRequest(input, context));
@@ -370,7 +370,7 @@ export const serializeAws_json1_1CreateOrganizationalUnitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.CreateOrganizationalUnit",
+    "x-amz-target": "AWSOrganizationsV20161128.CreateOrganizationalUnit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateOrganizationalUnitRequest(input, context));
@@ -383,7 +383,7 @@ export const serializeAws_json1_1CreatePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.CreatePolicy",
+    "x-amz-target": "AWSOrganizationsV20161128.CreatePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePolicyRequest(input, context));
@@ -396,7 +396,7 @@ export const serializeAws_json1_1DeclineHandshakeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DeclineHandshake",
+    "x-amz-target": "AWSOrganizationsV20161128.DeclineHandshake",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeclineHandshakeRequest(input, context));
@@ -409,7 +409,7 @@ export const serializeAws_json1_1DeleteOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DeleteOrganization",
+    "x-amz-target": "AWSOrganizationsV20161128.DeleteOrganization",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -420,7 +420,7 @@ export const serializeAws_json1_1DeleteOrganizationalUnitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DeleteOrganizationalUnit",
+    "x-amz-target": "AWSOrganizationsV20161128.DeleteOrganizationalUnit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteOrganizationalUnitRequest(input, context));
@@ -433,7 +433,7 @@ export const serializeAws_json1_1DeletePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DeletePolicy",
+    "x-amz-target": "AWSOrganizationsV20161128.DeletePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePolicyRequest(input, context));
@@ -446,7 +446,7 @@ export const serializeAws_json1_1DeregisterDelegatedAdministratorCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DeregisterDelegatedAdministrator",
+    "x-amz-target": "AWSOrganizationsV20161128.DeregisterDelegatedAdministrator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterDelegatedAdministratorRequest(input, context));
@@ -459,7 +459,7 @@ export const serializeAws_json1_1DescribeAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DescribeAccount",
+    "x-amz-target": "AWSOrganizationsV20161128.DescribeAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAccountRequest(input, context));
@@ -472,7 +472,7 @@ export const serializeAws_json1_1DescribeCreateAccountStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DescribeCreateAccountStatus",
+    "x-amz-target": "AWSOrganizationsV20161128.DescribeCreateAccountStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCreateAccountStatusRequest(input, context));
@@ -485,7 +485,7 @@ export const serializeAws_json1_1DescribeEffectivePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DescribeEffectivePolicy",
+    "x-amz-target": "AWSOrganizationsV20161128.DescribeEffectivePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEffectivePolicyRequest(input, context));
@@ -498,7 +498,7 @@ export const serializeAws_json1_1DescribeHandshakeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DescribeHandshake",
+    "x-amz-target": "AWSOrganizationsV20161128.DescribeHandshake",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeHandshakeRequest(input, context));
@@ -511,7 +511,7 @@ export const serializeAws_json1_1DescribeOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DescribeOrganization",
+    "x-amz-target": "AWSOrganizationsV20161128.DescribeOrganization",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -522,7 +522,7 @@ export const serializeAws_json1_1DescribeOrganizationalUnitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DescribeOrganizationalUnit",
+    "x-amz-target": "AWSOrganizationsV20161128.DescribeOrganizationalUnit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeOrganizationalUnitRequest(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1DescribePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DescribePolicy",
+    "x-amz-target": "AWSOrganizationsV20161128.DescribePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePolicyRequest(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1DetachPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DetachPolicy",
+    "x-amz-target": "AWSOrganizationsV20161128.DetachPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetachPolicyRequest(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1DisableAWSServiceAccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DisableAWSServiceAccess",
+    "x-amz-target": "AWSOrganizationsV20161128.DisableAWSServiceAccess",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableAWSServiceAccessRequest(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_1DisablePolicyTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.DisablePolicyType",
+    "x-amz-target": "AWSOrganizationsV20161128.DisablePolicyType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisablePolicyTypeRequest(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_1EnableAllFeaturesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.EnableAllFeatures",
+    "x-amz-target": "AWSOrganizationsV20161128.EnableAllFeatures",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableAllFeaturesRequest(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_1EnableAWSServiceAccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.EnableAWSServiceAccess",
+    "x-amz-target": "AWSOrganizationsV20161128.EnableAWSServiceAccess",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableAWSServiceAccessRequest(input, context));
@@ -613,7 +613,7 @@ export const serializeAws_json1_1EnablePolicyTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.EnablePolicyType",
+    "x-amz-target": "AWSOrganizationsV20161128.EnablePolicyType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnablePolicyTypeRequest(input, context));
@@ -626,7 +626,7 @@ export const serializeAws_json1_1InviteAccountToOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.InviteAccountToOrganization",
+    "x-amz-target": "AWSOrganizationsV20161128.InviteAccountToOrganization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1InviteAccountToOrganizationRequest(input, context));
@@ -639,7 +639,7 @@ export const serializeAws_json1_1LeaveOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.LeaveOrganization",
+    "x-amz-target": "AWSOrganizationsV20161128.LeaveOrganization",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -650,7 +650,7 @@ export const serializeAws_json1_1ListAccountsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListAccounts",
+    "x-amz-target": "AWSOrganizationsV20161128.ListAccounts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAccountsRequest(input, context));
@@ -663,7 +663,7 @@ export const serializeAws_json1_1ListAccountsForParentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListAccountsForParent",
+    "x-amz-target": "AWSOrganizationsV20161128.ListAccountsForParent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAccountsForParentRequest(input, context));
@@ -676,7 +676,7 @@ export const serializeAws_json1_1ListAWSServiceAccessForOrganizationCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListAWSServiceAccessForOrganization",
+    "x-amz-target": "AWSOrganizationsV20161128.ListAWSServiceAccessForOrganization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAWSServiceAccessForOrganizationRequest(input, context));
@@ -689,7 +689,7 @@ export const serializeAws_json1_1ListChildrenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListChildren",
+    "x-amz-target": "AWSOrganizationsV20161128.ListChildren",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListChildrenRequest(input, context));
@@ -702,7 +702,7 @@ export const serializeAws_json1_1ListCreateAccountStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListCreateAccountStatus",
+    "x-amz-target": "AWSOrganizationsV20161128.ListCreateAccountStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCreateAccountStatusRequest(input, context));
@@ -715,7 +715,7 @@ export const serializeAws_json1_1ListDelegatedAdministratorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListDelegatedAdministrators",
+    "x-amz-target": "AWSOrganizationsV20161128.ListDelegatedAdministrators",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDelegatedAdministratorsRequest(input, context));
@@ -728,7 +728,7 @@ export const serializeAws_json1_1ListDelegatedServicesForAccountCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListDelegatedServicesForAccount",
+    "x-amz-target": "AWSOrganizationsV20161128.ListDelegatedServicesForAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDelegatedServicesForAccountRequest(input, context));
@@ -741,7 +741,7 @@ export const serializeAws_json1_1ListHandshakesForAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListHandshakesForAccount",
+    "x-amz-target": "AWSOrganizationsV20161128.ListHandshakesForAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListHandshakesForAccountRequest(input, context));
@@ -754,7 +754,7 @@ export const serializeAws_json1_1ListHandshakesForOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListHandshakesForOrganization",
+    "x-amz-target": "AWSOrganizationsV20161128.ListHandshakesForOrganization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListHandshakesForOrganizationRequest(input, context));
@@ -767,7 +767,7 @@ export const serializeAws_json1_1ListOrganizationalUnitsForParentCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListOrganizationalUnitsForParent",
+    "x-amz-target": "AWSOrganizationsV20161128.ListOrganizationalUnitsForParent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListOrganizationalUnitsForParentRequest(input, context));
@@ -780,7 +780,7 @@ export const serializeAws_json1_1ListParentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListParents",
+    "x-amz-target": "AWSOrganizationsV20161128.ListParents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListParentsRequest(input, context));
@@ -793,7 +793,7 @@ export const serializeAws_json1_1ListPoliciesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListPolicies",
+    "x-amz-target": "AWSOrganizationsV20161128.ListPolicies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPoliciesRequest(input, context));
@@ -806,7 +806,7 @@ export const serializeAws_json1_1ListPoliciesForTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListPoliciesForTarget",
+    "x-amz-target": "AWSOrganizationsV20161128.ListPoliciesForTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPoliciesForTargetRequest(input, context));
@@ -819,7 +819,7 @@ export const serializeAws_json1_1ListRootsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListRoots",
+    "x-amz-target": "AWSOrganizationsV20161128.ListRoots",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRootsRequest(input, context));
@@ -832,7 +832,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListTagsForResource",
+    "x-amz-target": "AWSOrganizationsV20161128.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -845,7 +845,7 @@ export const serializeAws_json1_1ListTargetsForPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.ListTargetsForPolicy",
+    "x-amz-target": "AWSOrganizationsV20161128.ListTargetsForPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTargetsForPolicyRequest(input, context));
@@ -858,7 +858,7 @@ export const serializeAws_json1_1MoveAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.MoveAccount",
+    "x-amz-target": "AWSOrganizationsV20161128.MoveAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MoveAccountRequest(input, context));
@@ -871,7 +871,7 @@ export const serializeAws_json1_1RegisterDelegatedAdministratorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.RegisterDelegatedAdministrator",
+    "x-amz-target": "AWSOrganizationsV20161128.RegisterDelegatedAdministrator",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterDelegatedAdministratorRequest(input, context));
@@ -884,7 +884,7 @@ export const serializeAws_json1_1RemoveAccountFromOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.RemoveAccountFromOrganization",
+    "x-amz-target": "AWSOrganizationsV20161128.RemoveAccountFromOrganization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveAccountFromOrganizationRequest(input, context));
@@ -897,7 +897,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.TagResource",
+    "x-amz-target": "AWSOrganizationsV20161128.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -910,7 +910,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.UntagResource",
+    "x-amz-target": "AWSOrganizationsV20161128.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -923,7 +923,7 @@ export const serializeAws_json1_1UpdateOrganizationalUnitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.UpdateOrganizationalUnit",
+    "x-amz-target": "AWSOrganizationsV20161128.UpdateOrganizationalUnit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateOrganizationalUnitRequest(input, context));
@@ -936,7 +936,7 @@ export const serializeAws_json1_1UpdatePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSOrganizationsV20161128.UpdatePolicy",
+    "x-amz-target": "AWSOrganizationsV20161128.UpdatePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePolicyRequest(input, context));

--- a/clients/client-personalize/protocols/Aws_json1_1.ts
+++ b/clients/client-personalize/protocols/Aws_json1_1.ts
@@ -227,7 +227,7 @@ export const serializeAws_json1_1CreateBatchInferenceJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.CreateBatchInferenceJob",
+    "x-amz-target": "AmazonPersonalize.CreateBatchInferenceJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateBatchInferenceJobRequest(input, context));
@@ -240,7 +240,7 @@ export const serializeAws_json1_1CreateCampaignCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.CreateCampaign",
+    "x-amz-target": "AmazonPersonalize.CreateCampaign",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCampaignRequest(input, context));
@@ -253,7 +253,7 @@ export const serializeAws_json1_1CreateDatasetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.CreateDataset",
+    "x-amz-target": "AmazonPersonalize.CreateDataset",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDatasetRequest(input, context));
@@ -266,7 +266,7 @@ export const serializeAws_json1_1CreateDatasetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.CreateDatasetGroup",
+    "x-amz-target": "AmazonPersonalize.CreateDatasetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDatasetGroupRequest(input, context));
@@ -279,7 +279,7 @@ export const serializeAws_json1_1CreateDatasetImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.CreateDatasetImportJob",
+    "x-amz-target": "AmazonPersonalize.CreateDatasetImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDatasetImportJobRequest(input, context));
@@ -292,7 +292,7 @@ export const serializeAws_json1_1CreateEventTrackerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.CreateEventTracker",
+    "x-amz-target": "AmazonPersonalize.CreateEventTracker",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEventTrackerRequest(input, context));
@@ -305,7 +305,7 @@ export const serializeAws_json1_1CreateFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.CreateFilter",
+    "x-amz-target": "AmazonPersonalize.CreateFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateFilterRequest(input, context));
@@ -318,7 +318,7 @@ export const serializeAws_json1_1CreateSchemaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.CreateSchema",
+    "x-amz-target": "AmazonPersonalize.CreateSchema",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSchemaRequest(input, context));
@@ -331,7 +331,7 @@ export const serializeAws_json1_1CreateSolutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.CreateSolution",
+    "x-amz-target": "AmazonPersonalize.CreateSolution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSolutionRequest(input, context));
@@ -344,7 +344,7 @@ export const serializeAws_json1_1CreateSolutionVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.CreateSolutionVersion",
+    "x-amz-target": "AmazonPersonalize.CreateSolutionVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSolutionVersionRequest(input, context));
@@ -357,7 +357,7 @@ export const serializeAws_json1_1DeleteCampaignCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DeleteCampaign",
+    "x-amz-target": "AmazonPersonalize.DeleteCampaign",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCampaignRequest(input, context));
@@ -370,7 +370,7 @@ export const serializeAws_json1_1DeleteDatasetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DeleteDataset",
+    "x-amz-target": "AmazonPersonalize.DeleteDataset",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDatasetRequest(input, context));
@@ -383,7 +383,7 @@ export const serializeAws_json1_1DeleteDatasetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DeleteDatasetGroup",
+    "x-amz-target": "AmazonPersonalize.DeleteDatasetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDatasetGroupRequest(input, context));
@@ -396,7 +396,7 @@ export const serializeAws_json1_1DeleteEventTrackerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DeleteEventTracker",
+    "x-amz-target": "AmazonPersonalize.DeleteEventTracker",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEventTrackerRequest(input, context));
@@ -409,7 +409,7 @@ export const serializeAws_json1_1DeleteFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DeleteFilter",
+    "x-amz-target": "AmazonPersonalize.DeleteFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFilterRequest(input, context));
@@ -422,7 +422,7 @@ export const serializeAws_json1_1DeleteSchemaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DeleteSchema",
+    "x-amz-target": "AmazonPersonalize.DeleteSchema",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSchemaRequest(input, context));
@@ -435,7 +435,7 @@ export const serializeAws_json1_1DeleteSolutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DeleteSolution",
+    "x-amz-target": "AmazonPersonalize.DeleteSolution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSolutionRequest(input, context));
@@ -448,7 +448,7 @@ export const serializeAws_json1_1DescribeAlgorithmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeAlgorithm",
+    "x-amz-target": "AmazonPersonalize.DescribeAlgorithm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAlgorithmRequest(input, context));
@@ -461,7 +461,7 @@ export const serializeAws_json1_1DescribeBatchInferenceJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeBatchInferenceJob",
+    "x-amz-target": "AmazonPersonalize.DescribeBatchInferenceJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBatchInferenceJobRequest(input, context));
@@ -474,7 +474,7 @@ export const serializeAws_json1_1DescribeCampaignCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeCampaign",
+    "x-amz-target": "AmazonPersonalize.DescribeCampaign",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCampaignRequest(input, context));
@@ -487,7 +487,7 @@ export const serializeAws_json1_1DescribeDatasetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeDataset",
+    "x-amz-target": "AmazonPersonalize.DescribeDataset",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDatasetRequest(input, context));
@@ -500,7 +500,7 @@ export const serializeAws_json1_1DescribeDatasetGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeDatasetGroup",
+    "x-amz-target": "AmazonPersonalize.DescribeDatasetGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDatasetGroupRequest(input, context));
@@ -513,7 +513,7 @@ export const serializeAws_json1_1DescribeDatasetImportJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeDatasetImportJob",
+    "x-amz-target": "AmazonPersonalize.DescribeDatasetImportJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDatasetImportJobRequest(input, context));
@@ -526,7 +526,7 @@ export const serializeAws_json1_1DescribeEventTrackerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeEventTracker",
+    "x-amz-target": "AmazonPersonalize.DescribeEventTracker",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEventTrackerRequest(input, context));
@@ -539,7 +539,7 @@ export const serializeAws_json1_1DescribeFeatureTransformationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeFeatureTransformation",
+    "x-amz-target": "AmazonPersonalize.DescribeFeatureTransformation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFeatureTransformationRequest(input, context));
@@ -552,7 +552,7 @@ export const serializeAws_json1_1DescribeFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeFilter",
+    "x-amz-target": "AmazonPersonalize.DescribeFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFilterRequest(input, context));
@@ -565,7 +565,7 @@ export const serializeAws_json1_1DescribeRecipeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeRecipe",
+    "x-amz-target": "AmazonPersonalize.DescribeRecipe",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRecipeRequest(input, context));
@@ -578,7 +578,7 @@ export const serializeAws_json1_1DescribeSchemaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeSchema",
+    "x-amz-target": "AmazonPersonalize.DescribeSchema",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSchemaRequest(input, context));
@@ -591,7 +591,7 @@ export const serializeAws_json1_1DescribeSolutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeSolution",
+    "x-amz-target": "AmazonPersonalize.DescribeSolution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSolutionRequest(input, context));
@@ -604,7 +604,7 @@ export const serializeAws_json1_1DescribeSolutionVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.DescribeSolutionVersion",
+    "x-amz-target": "AmazonPersonalize.DescribeSolutionVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSolutionVersionRequest(input, context));
@@ -617,7 +617,7 @@ export const serializeAws_json1_1GetSolutionMetricsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.GetSolutionMetrics",
+    "x-amz-target": "AmazonPersonalize.GetSolutionMetrics",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSolutionMetricsRequest(input, context));
@@ -630,7 +630,7 @@ export const serializeAws_json1_1ListBatchInferenceJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListBatchInferenceJobs",
+    "x-amz-target": "AmazonPersonalize.ListBatchInferenceJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBatchInferenceJobsRequest(input, context));
@@ -643,7 +643,7 @@ export const serializeAws_json1_1ListCampaignsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListCampaigns",
+    "x-amz-target": "AmazonPersonalize.ListCampaigns",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCampaignsRequest(input, context));
@@ -656,7 +656,7 @@ export const serializeAws_json1_1ListDatasetGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListDatasetGroups",
+    "x-amz-target": "AmazonPersonalize.ListDatasetGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDatasetGroupsRequest(input, context));
@@ -669,7 +669,7 @@ export const serializeAws_json1_1ListDatasetImportJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListDatasetImportJobs",
+    "x-amz-target": "AmazonPersonalize.ListDatasetImportJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDatasetImportJobsRequest(input, context));
@@ -682,7 +682,7 @@ export const serializeAws_json1_1ListDatasetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListDatasets",
+    "x-amz-target": "AmazonPersonalize.ListDatasets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDatasetsRequest(input, context));
@@ -695,7 +695,7 @@ export const serializeAws_json1_1ListEventTrackersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListEventTrackers",
+    "x-amz-target": "AmazonPersonalize.ListEventTrackers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEventTrackersRequest(input, context));
@@ -708,7 +708,7 @@ export const serializeAws_json1_1ListFiltersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListFilters",
+    "x-amz-target": "AmazonPersonalize.ListFilters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListFiltersRequest(input, context));
@@ -721,7 +721,7 @@ export const serializeAws_json1_1ListRecipesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListRecipes",
+    "x-amz-target": "AmazonPersonalize.ListRecipes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRecipesRequest(input, context));
@@ -734,7 +734,7 @@ export const serializeAws_json1_1ListSchemasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListSchemas",
+    "x-amz-target": "AmazonPersonalize.ListSchemas",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSchemasRequest(input, context));
@@ -747,7 +747,7 @@ export const serializeAws_json1_1ListSolutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListSolutions",
+    "x-amz-target": "AmazonPersonalize.ListSolutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSolutionsRequest(input, context));
@@ -760,7 +760,7 @@ export const serializeAws_json1_1ListSolutionVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.ListSolutionVersions",
+    "x-amz-target": "AmazonPersonalize.ListSolutionVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSolutionVersionsRequest(input, context));
@@ -773,7 +773,7 @@ export const serializeAws_json1_1UpdateCampaignCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonPersonalize.UpdateCampaign",
+    "x-amz-target": "AmazonPersonalize.UpdateCampaign",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCampaignRequest(input, context));

--- a/clients/client-pi/protocols/Aws_json1_1.ts
+++ b/clients/client-pi/protocols/Aws_json1_1.ts
@@ -35,7 +35,7 @@ export const serializeAws_json1_1DescribeDimensionKeysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PerformanceInsightsv20180227.DescribeDimensionKeys",
+    "x-amz-target": "PerformanceInsightsv20180227.DescribeDimensionKeys",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDimensionKeysRequest(input, context));
@@ -48,7 +48,7 @@ export const serializeAws_json1_1GetResourceMetricsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "PerformanceInsightsv20180227.GetResourceMetrics",
+    "x-amz-target": "PerformanceInsightsv20180227.GetResourceMetrics",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResourceMetricsRequest(input, context));

--- a/clients/client-pricing/protocols/Aws_json1_1.ts
+++ b/clients/client-pricing/protocols/Aws_json1_1.ts
@@ -33,7 +33,7 @@ export const serializeAws_json1_1DescribeServicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPriceListService.DescribeServices",
+    "x-amz-target": "AWSPriceListService.DescribeServices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeServicesRequest(input, context));
@@ -46,7 +46,7 @@ export const serializeAws_json1_1GetAttributeValuesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPriceListService.GetAttributeValues",
+    "x-amz-target": "AWSPriceListService.GetAttributeValues",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAttributeValuesRequest(input, context));
@@ -59,7 +59,7 @@ export const serializeAws_json1_1GetProductsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSPriceListService.GetProducts",
+    "x-amz-target": "AWSPriceListService.GetProducts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetProductsRequest(input, context));

--- a/clients/client-qldb-session/protocols/Aws_json1_0.ts
+++ b/clients/client-qldb-session/protocols/Aws_json1_0.ts
@@ -40,7 +40,7 @@ export const serializeAws_json1_0SendCommandCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "QLDBSession.SendCommand",
+    "x-amz-target": "QLDBSession.SendCommand",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0SendCommandRequest(input, context));

--- a/clients/client-redshift-data/protocols/Aws_json1_1.ts
+++ b/clients/client-redshift-data/protocols/Aws_json1_1.ts
@@ -51,7 +51,7 @@ export const serializeAws_json1_1CancelStatementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RedshiftData.CancelStatement",
+    "x-amz-target": "RedshiftData.CancelStatement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelStatementRequest(input, context));
@@ -64,7 +64,7 @@ export const serializeAws_json1_1DescribeStatementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RedshiftData.DescribeStatement",
+    "x-amz-target": "RedshiftData.DescribeStatement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStatementRequest(input, context));
@@ -77,7 +77,7 @@ export const serializeAws_json1_1DescribeTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RedshiftData.DescribeTable",
+    "x-amz-target": "RedshiftData.DescribeTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTableRequest(input, context));
@@ -90,7 +90,7 @@ export const serializeAws_json1_1ExecuteStatementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RedshiftData.ExecuteStatement",
+    "x-amz-target": "RedshiftData.ExecuteStatement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ExecuteStatementInput(input, context));
@@ -103,7 +103,7 @@ export const serializeAws_json1_1GetStatementResultCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RedshiftData.GetStatementResult",
+    "x-amz-target": "RedshiftData.GetStatementResult",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetStatementResultRequest(input, context));
@@ -116,7 +116,7 @@ export const serializeAws_json1_1ListDatabasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RedshiftData.ListDatabases",
+    "x-amz-target": "RedshiftData.ListDatabases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDatabasesRequest(input, context));
@@ -129,7 +129,7 @@ export const serializeAws_json1_1ListSchemasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RedshiftData.ListSchemas",
+    "x-amz-target": "RedshiftData.ListSchemas",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSchemasRequest(input, context));
@@ -142,7 +142,7 @@ export const serializeAws_json1_1ListStatementsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RedshiftData.ListStatements",
+    "x-amz-target": "RedshiftData.ListStatements",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListStatementsRequest(input, context));
@@ -155,7 +155,7 @@ export const serializeAws_json1_1ListTablesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RedshiftData.ListTables",
+    "x-amz-target": "RedshiftData.ListTables",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTablesRequest(input, context));

--- a/clients/client-rekognition/protocols/Aws_json1_1.ts
+++ b/clients/client-rekognition/protocols/Aws_json1_1.ts
@@ -331,7 +331,7 @@ export const serializeAws_json1_1CompareFacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.CompareFaces",
+    "x-amz-target": "RekognitionService.CompareFaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CompareFacesRequest(input, context));
@@ -344,7 +344,7 @@ export const serializeAws_json1_1CreateCollectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.CreateCollection",
+    "x-amz-target": "RekognitionService.CreateCollection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCollectionRequest(input, context));
@@ -357,7 +357,7 @@ export const serializeAws_json1_1CreateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.CreateProject",
+    "x-amz-target": "RekognitionService.CreateProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProjectRequest(input, context));
@@ -370,7 +370,7 @@ export const serializeAws_json1_1CreateProjectVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.CreateProjectVersion",
+    "x-amz-target": "RekognitionService.CreateProjectVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProjectVersionRequest(input, context));
@@ -383,7 +383,7 @@ export const serializeAws_json1_1CreateStreamProcessorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.CreateStreamProcessor",
+    "x-amz-target": "RekognitionService.CreateStreamProcessor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateStreamProcessorRequest(input, context));
@@ -396,7 +396,7 @@ export const serializeAws_json1_1DeleteCollectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DeleteCollection",
+    "x-amz-target": "RekognitionService.DeleteCollection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCollectionRequest(input, context));
@@ -409,7 +409,7 @@ export const serializeAws_json1_1DeleteFacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DeleteFaces",
+    "x-amz-target": "RekognitionService.DeleteFaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFacesRequest(input, context));
@@ -422,7 +422,7 @@ export const serializeAws_json1_1DeleteProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DeleteProject",
+    "x-amz-target": "RekognitionService.DeleteProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProjectRequest(input, context));
@@ -435,7 +435,7 @@ export const serializeAws_json1_1DeleteProjectVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DeleteProjectVersion",
+    "x-amz-target": "RekognitionService.DeleteProjectVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProjectVersionRequest(input, context));
@@ -448,7 +448,7 @@ export const serializeAws_json1_1DeleteStreamProcessorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DeleteStreamProcessor",
+    "x-amz-target": "RekognitionService.DeleteStreamProcessor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteStreamProcessorRequest(input, context));
@@ -461,7 +461,7 @@ export const serializeAws_json1_1DescribeCollectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DescribeCollection",
+    "x-amz-target": "RekognitionService.DescribeCollection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCollectionRequest(input, context));
@@ -474,7 +474,7 @@ export const serializeAws_json1_1DescribeProjectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DescribeProjects",
+    "x-amz-target": "RekognitionService.DescribeProjects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProjectsRequest(input, context));
@@ -487,7 +487,7 @@ export const serializeAws_json1_1DescribeProjectVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DescribeProjectVersions",
+    "x-amz-target": "RekognitionService.DescribeProjectVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProjectVersionsRequest(input, context));
@@ -500,7 +500,7 @@ export const serializeAws_json1_1DescribeStreamProcessorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DescribeStreamProcessor",
+    "x-amz-target": "RekognitionService.DescribeStreamProcessor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStreamProcessorRequest(input, context));
@@ -513,7 +513,7 @@ export const serializeAws_json1_1DetectCustomLabelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DetectCustomLabels",
+    "x-amz-target": "RekognitionService.DetectCustomLabels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectCustomLabelsRequest(input, context));
@@ -526,7 +526,7 @@ export const serializeAws_json1_1DetectFacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DetectFaces",
+    "x-amz-target": "RekognitionService.DetectFaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectFacesRequest(input, context));
@@ -539,7 +539,7 @@ export const serializeAws_json1_1DetectLabelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DetectLabels",
+    "x-amz-target": "RekognitionService.DetectLabels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectLabelsRequest(input, context));
@@ -552,7 +552,7 @@ export const serializeAws_json1_1DetectModerationLabelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DetectModerationLabels",
+    "x-amz-target": "RekognitionService.DetectModerationLabels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectModerationLabelsRequest(input, context));
@@ -565,7 +565,7 @@ export const serializeAws_json1_1DetectProtectiveEquipmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DetectProtectiveEquipment",
+    "x-amz-target": "RekognitionService.DetectProtectiveEquipment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectProtectiveEquipmentRequest(input, context));
@@ -578,7 +578,7 @@ export const serializeAws_json1_1DetectTextCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.DetectText",
+    "x-amz-target": "RekognitionService.DetectText",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectTextRequest(input, context));
@@ -591,7 +591,7 @@ export const serializeAws_json1_1GetCelebrityInfoCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.GetCelebrityInfo",
+    "x-amz-target": "RekognitionService.GetCelebrityInfo",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCelebrityInfoRequest(input, context));
@@ -604,7 +604,7 @@ export const serializeAws_json1_1GetCelebrityRecognitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.GetCelebrityRecognition",
+    "x-amz-target": "RekognitionService.GetCelebrityRecognition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCelebrityRecognitionRequest(input, context));
@@ -617,7 +617,7 @@ export const serializeAws_json1_1GetContentModerationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.GetContentModeration",
+    "x-amz-target": "RekognitionService.GetContentModeration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContentModerationRequest(input, context));
@@ -630,7 +630,7 @@ export const serializeAws_json1_1GetFaceDetectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.GetFaceDetection",
+    "x-amz-target": "RekognitionService.GetFaceDetection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetFaceDetectionRequest(input, context));
@@ -643,7 +643,7 @@ export const serializeAws_json1_1GetFaceSearchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.GetFaceSearch",
+    "x-amz-target": "RekognitionService.GetFaceSearch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetFaceSearchRequest(input, context));
@@ -656,7 +656,7 @@ export const serializeAws_json1_1GetLabelDetectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.GetLabelDetection",
+    "x-amz-target": "RekognitionService.GetLabelDetection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLabelDetectionRequest(input, context));
@@ -669,7 +669,7 @@ export const serializeAws_json1_1GetPersonTrackingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.GetPersonTracking",
+    "x-amz-target": "RekognitionService.GetPersonTracking",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPersonTrackingRequest(input, context));
@@ -682,7 +682,7 @@ export const serializeAws_json1_1GetSegmentDetectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.GetSegmentDetection",
+    "x-amz-target": "RekognitionService.GetSegmentDetection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSegmentDetectionRequest(input, context));
@@ -695,7 +695,7 @@ export const serializeAws_json1_1GetTextDetectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.GetTextDetection",
+    "x-amz-target": "RekognitionService.GetTextDetection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTextDetectionRequest(input, context));
@@ -708,7 +708,7 @@ export const serializeAws_json1_1IndexFacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.IndexFaces",
+    "x-amz-target": "RekognitionService.IndexFaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1IndexFacesRequest(input, context));
@@ -721,7 +721,7 @@ export const serializeAws_json1_1ListCollectionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.ListCollections",
+    "x-amz-target": "RekognitionService.ListCollections",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCollectionsRequest(input, context));
@@ -734,7 +734,7 @@ export const serializeAws_json1_1ListFacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.ListFaces",
+    "x-amz-target": "RekognitionService.ListFaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListFacesRequest(input, context));
@@ -747,7 +747,7 @@ export const serializeAws_json1_1ListStreamProcessorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.ListStreamProcessors",
+    "x-amz-target": "RekognitionService.ListStreamProcessors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListStreamProcessorsRequest(input, context));
@@ -760,7 +760,7 @@ export const serializeAws_json1_1RecognizeCelebritiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.RecognizeCelebrities",
+    "x-amz-target": "RekognitionService.RecognizeCelebrities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RecognizeCelebritiesRequest(input, context));
@@ -773,7 +773,7 @@ export const serializeAws_json1_1SearchFacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.SearchFaces",
+    "x-amz-target": "RekognitionService.SearchFaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchFacesRequest(input, context));
@@ -786,7 +786,7 @@ export const serializeAws_json1_1SearchFacesByImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.SearchFacesByImage",
+    "x-amz-target": "RekognitionService.SearchFacesByImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchFacesByImageRequest(input, context));
@@ -799,7 +799,7 @@ export const serializeAws_json1_1StartCelebrityRecognitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StartCelebrityRecognition",
+    "x-amz-target": "RekognitionService.StartCelebrityRecognition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartCelebrityRecognitionRequest(input, context));
@@ -812,7 +812,7 @@ export const serializeAws_json1_1StartContentModerationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StartContentModeration",
+    "x-amz-target": "RekognitionService.StartContentModeration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartContentModerationRequest(input, context));
@@ -825,7 +825,7 @@ export const serializeAws_json1_1StartFaceDetectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StartFaceDetection",
+    "x-amz-target": "RekognitionService.StartFaceDetection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartFaceDetectionRequest(input, context));
@@ -838,7 +838,7 @@ export const serializeAws_json1_1StartFaceSearchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StartFaceSearch",
+    "x-amz-target": "RekognitionService.StartFaceSearch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartFaceSearchRequest(input, context));
@@ -851,7 +851,7 @@ export const serializeAws_json1_1StartLabelDetectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StartLabelDetection",
+    "x-amz-target": "RekognitionService.StartLabelDetection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartLabelDetectionRequest(input, context));
@@ -864,7 +864,7 @@ export const serializeAws_json1_1StartPersonTrackingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StartPersonTracking",
+    "x-amz-target": "RekognitionService.StartPersonTracking",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartPersonTrackingRequest(input, context));
@@ -877,7 +877,7 @@ export const serializeAws_json1_1StartProjectVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StartProjectVersion",
+    "x-amz-target": "RekognitionService.StartProjectVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartProjectVersionRequest(input, context));
@@ -890,7 +890,7 @@ export const serializeAws_json1_1StartSegmentDetectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StartSegmentDetection",
+    "x-amz-target": "RekognitionService.StartSegmentDetection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartSegmentDetectionRequest(input, context));
@@ -903,7 +903,7 @@ export const serializeAws_json1_1StartStreamProcessorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StartStreamProcessor",
+    "x-amz-target": "RekognitionService.StartStreamProcessor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartStreamProcessorRequest(input, context));
@@ -916,7 +916,7 @@ export const serializeAws_json1_1StartTextDetectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StartTextDetection",
+    "x-amz-target": "RekognitionService.StartTextDetection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartTextDetectionRequest(input, context));
@@ -929,7 +929,7 @@ export const serializeAws_json1_1StopProjectVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StopProjectVersion",
+    "x-amz-target": "RekognitionService.StopProjectVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopProjectVersionRequest(input, context));
@@ -942,7 +942,7 @@ export const serializeAws_json1_1StopStreamProcessorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "RekognitionService.StopStreamProcessor",
+    "x-amz-target": "RekognitionService.StopStreamProcessor",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopStreamProcessorRequest(input, context));

--- a/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
+++ b/clients/client-resource-groups-tagging-api/protocols/Aws_json1_1.ts
@@ -62,7 +62,7 @@ export const serializeAws_json1_1DescribeReportCreationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ResourceGroupsTaggingAPI_20170126.DescribeReportCreation",
+    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.DescribeReportCreation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReportCreationInput(input, context));
@@ -75,7 +75,7 @@ export const serializeAws_json1_1GetComplianceSummaryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ResourceGroupsTaggingAPI_20170126.GetComplianceSummary",
+    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.GetComplianceSummary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetComplianceSummaryInput(input, context));
@@ -88,7 +88,7 @@ export const serializeAws_json1_1GetResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ResourceGroupsTaggingAPI_20170126.GetResources",
+    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.GetResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResourcesInput(input, context));
@@ -101,7 +101,7 @@ export const serializeAws_json1_1GetTagKeysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ResourceGroupsTaggingAPI_20170126.GetTagKeys",
+    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.GetTagKeys",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTagKeysInput(input, context));
@@ -114,7 +114,7 @@ export const serializeAws_json1_1GetTagValuesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ResourceGroupsTaggingAPI_20170126.GetTagValues",
+    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.GetTagValues",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTagValuesInput(input, context));
@@ -127,7 +127,7 @@ export const serializeAws_json1_1StartReportCreationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ResourceGroupsTaggingAPI_20170126.StartReportCreation",
+    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.StartReportCreation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartReportCreationInput(input, context));
@@ -140,7 +140,7 @@ export const serializeAws_json1_1TagResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ResourceGroupsTaggingAPI_20170126.TagResources",
+    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.TagResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourcesInput(input, context));
@@ -153,7 +153,7 @@ export const serializeAws_json1_1UntagResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ResourceGroupsTaggingAPI_20170126.UntagResources",
+    "x-amz-target": "ResourceGroupsTaggingAPI_20170126.UntagResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourcesInput(input, context));

--- a/clients/client-route-53-domains/protocols/Aws_json1_1.ts
+++ b/clients/client-route-53-domains/protocols/Aws_json1_1.ts
@@ -172,7 +172,7 @@ export const serializeAws_json1_1AcceptDomainTransferFromAnotherAwsAccountComman
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.AcceptDomainTransferFromAnotherAwsAccount",
+    "x-amz-target": "Route53Domains_v20140515.AcceptDomainTransferFromAnotherAwsAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AcceptDomainTransferFromAnotherAwsAccountRequest(input, context));
@@ -185,7 +185,7 @@ export const serializeAws_json1_1CancelDomainTransferToAnotherAwsAccountCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.CancelDomainTransferToAnotherAwsAccount",
+    "x-amz-target": "Route53Domains_v20140515.CancelDomainTransferToAnotherAwsAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelDomainTransferToAnotherAwsAccountRequest(input, context));
@@ -198,7 +198,7 @@ export const serializeAws_json1_1CheckDomainAvailabilityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.CheckDomainAvailability",
+    "x-amz-target": "Route53Domains_v20140515.CheckDomainAvailability",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CheckDomainAvailabilityRequest(input, context));
@@ -211,7 +211,7 @@ export const serializeAws_json1_1CheckDomainTransferabilityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.CheckDomainTransferability",
+    "x-amz-target": "Route53Domains_v20140515.CheckDomainTransferability",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CheckDomainTransferabilityRequest(input, context));
@@ -224,7 +224,7 @@ export const serializeAws_json1_1DeleteTagsForDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.DeleteTagsForDomain",
+    "x-amz-target": "Route53Domains_v20140515.DeleteTagsForDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTagsForDomainRequest(input, context));
@@ -237,7 +237,7 @@ export const serializeAws_json1_1DisableDomainAutoRenewCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.DisableDomainAutoRenew",
+    "x-amz-target": "Route53Domains_v20140515.DisableDomainAutoRenew",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableDomainAutoRenewRequest(input, context));
@@ -250,7 +250,7 @@ export const serializeAws_json1_1DisableDomainTransferLockCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.DisableDomainTransferLock",
+    "x-amz-target": "Route53Domains_v20140515.DisableDomainTransferLock",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableDomainTransferLockRequest(input, context));
@@ -263,7 +263,7 @@ export const serializeAws_json1_1EnableDomainAutoRenewCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.EnableDomainAutoRenew",
+    "x-amz-target": "Route53Domains_v20140515.EnableDomainAutoRenew",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableDomainAutoRenewRequest(input, context));
@@ -276,7 +276,7 @@ export const serializeAws_json1_1EnableDomainTransferLockCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.EnableDomainTransferLock",
+    "x-amz-target": "Route53Domains_v20140515.EnableDomainTransferLock",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableDomainTransferLockRequest(input, context));
@@ -289,7 +289,7 @@ export const serializeAws_json1_1GetContactReachabilityStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.GetContactReachabilityStatus",
+    "x-amz-target": "Route53Domains_v20140515.GetContactReachabilityStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetContactReachabilityStatusRequest(input, context));
@@ -302,7 +302,7 @@ export const serializeAws_json1_1GetDomainDetailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.GetDomainDetail",
+    "x-amz-target": "Route53Domains_v20140515.GetDomainDetail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDomainDetailRequest(input, context));
@@ -315,7 +315,7 @@ export const serializeAws_json1_1GetDomainSuggestionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.GetDomainSuggestions",
+    "x-amz-target": "Route53Domains_v20140515.GetDomainSuggestions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDomainSuggestionsRequest(input, context));
@@ -328,7 +328,7 @@ export const serializeAws_json1_1GetOperationDetailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.GetOperationDetail",
+    "x-amz-target": "Route53Domains_v20140515.GetOperationDetail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOperationDetailRequest(input, context));
@@ -341,7 +341,7 @@ export const serializeAws_json1_1ListDomainsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.ListDomains",
+    "x-amz-target": "Route53Domains_v20140515.ListDomains",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDomainsRequest(input, context));
@@ -354,7 +354,7 @@ export const serializeAws_json1_1ListOperationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.ListOperations",
+    "x-amz-target": "Route53Domains_v20140515.ListOperations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListOperationsRequest(input, context));
@@ -367,7 +367,7 @@ export const serializeAws_json1_1ListTagsForDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.ListTagsForDomain",
+    "x-amz-target": "Route53Domains_v20140515.ListTagsForDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForDomainRequest(input, context));
@@ -380,7 +380,7 @@ export const serializeAws_json1_1RegisterDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.RegisterDomain",
+    "x-amz-target": "Route53Domains_v20140515.RegisterDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterDomainRequest(input, context));
@@ -393,7 +393,7 @@ export const serializeAws_json1_1RejectDomainTransferFromAnotherAwsAccountComman
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.RejectDomainTransferFromAnotherAwsAccount",
+    "x-amz-target": "Route53Domains_v20140515.RejectDomainTransferFromAnotherAwsAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RejectDomainTransferFromAnotherAwsAccountRequest(input, context));
@@ -406,7 +406,7 @@ export const serializeAws_json1_1RenewDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.RenewDomain",
+    "x-amz-target": "Route53Domains_v20140515.RenewDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RenewDomainRequest(input, context));
@@ -419,7 +419,7 @@ export const serializeAws_json1_1ResendContactReachabilityEmailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.ResendContactReachabilityEmail",
+    "x-amz-target": "Route53Domains_v20140515.ResendContactReachabilityEmail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResendContactReachabilityEmailRequest(input, context));
@@ -432,7 +432,7 @@ export const serializeAws_json1_1RetrieveDomainAuthCodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.RetrieveDomainAuthCode",
+    "x-amz-target": "Route53Domains_v20140515.RetrieveDomainAuthCode",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RetrieveDomainAuthCodeRequest(input, context));
@@ -445,7 +445,7 @@ export const serializeAws_json1_1TransferDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.TransferDomain",
+    "x-amz-target": "Route53Domains_v20140515.TransferDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TransferDomainRequest(input, context));
@@ -458,7 +458,7 @@ export const serializeAws_json1_1TransferDomainToAnotherAwsAccountCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.TransferDomainToAnotherAwsAccount",
+    "x-amz-target": "Route53Domains_v20140515.TransferDomainToAnotherAwsAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TransferDomainToAnotherAwsAccountRequest(input, context));
@@ -471,7 +471,7 @@ export const serializeAws_json1_1UpdateDomainContactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.UpdateDomainContact",
+    "x-amz-target": "Route53Domains_v20140515.UpdateDomainContact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDomainContactRequest(input, context));
@@ -484,7 +484,7 @@ export const serializeAws_json1_1UpdateDomainContactPrivacyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.UpdateDomainContactPrivacy",
+    "x-amz-target": "Route53Domains_v20140515.UpdateDomainContactPrivacy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDomainContactPrivacyRequest(input, context));
@@ -497,7 +497,7 @@ export const serializeAws_json1_1UpdateDomainNameserversCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.UpdateDomainNameservers",
+    "x-amz-target": "Route53Domains_v20140515.UpdateDomainNameservers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDomainNameserversRequest(input, context));
@@ -510,7 +510,7 @@ export const serializeAws_json1_1UpdateTagsForDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.UpdateTagsForDomain",
+    "x-amz-target": "Route53Domains_v20140515.UpdateTagsForDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTagsForDomainRequest(input, context));
@@ -523,7 +523,7 @@ export const serializeAws_json1_1ViewBillingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Domains_v20140515.ViewBilling",
+    "x-amz-target": "Route53Domains_v20140515.ViewBilling",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ViewBillingRequest(input, context));

--- a/clients/client-route53resolver/protocols/Aws_json1_1.ts
+++ b/clients/client-route53resolver/protocols/Aws_json1_1.ts
@@ -214,7 +214,7 @@ export const serializeAws_json1_1AssociateResolverEndpointIpAddressCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.AssociateResolverEndpointIpAddress",
+    "x-amz-target": "Route53Resolver.AssociateResolverEndpointIpAddress",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateResolverEndpointIpAddressRequest(input, context));
@@ -227,7 +227,7 @@ export const serializeAws_json1_1AssociateResolverQueryLogConfigCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.AssociateResolverQueryLogConfig",
+    "x-amz-target": "Route53Resolver.AssociateResolverQueryLogConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateResolverQueryLogConfigRequest(input, context));
@@ -240,7 +240,7 @@ export const serializeAws_json1_1AssociateResolverRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.AssociateResolverRule",
+    "x-amz-target": "Route53Resolver.AssociateResolverRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateResolverRuleRequest(input, context));
@@ -253,7 +253,7 @@ export const serializeAws_json1_1CreateResolverEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.CreateResolverEndpoint",
+    "x-amz-target": "Route53Resolver.CreateResolverEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateResolverEndpointRequest(input, context));
@@ -266,7 +266,7 @@ export const serializeAws_json1_1CreateResolverQueryLogConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.CreateResolverQueryLogConfig",
+    "x-amz-target": "Route53Resolver.CreateResolverQueryLogConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateResolverQueryLogConfigRequest(input, context));
@@ -279,7 +279,7 @@ export const serializeAws_json1_1CreateResolverRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.CreateResolverRule",
+    "x-amz-target": "Route53Resolver.CreateResolverRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateResolverRuleRequest(input, context));
@@ -292,7 +292,7 @@ export const serializeAws_json1_1DeleteResolverEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.DeleteResolverEndpoint",
+    "x-amz-target": "Route53Resolver.DeleteResolverEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResolverEndpointRequest(input, context));
@@ -305,7 +305,7 @@ export const serializeAws_json1_1DeleteResolverQueryLogConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.DeleteResolverQueryLogConfig",
+    "x-amz-target": "Route53Resolver.DeleteResolverQueryLogConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResolverQueryLogConfigRequest(input, context));
@@ -318,7 +318,7 @@ export const serializeAws_json1_1DeleteResolverRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.DeleteResolverRule",
+    "x-amz-target": "Route53Resolver.DeleteResolverRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResolverRuleRequest(input, context));
@@ -331,7 +331,7 @@ export const serializeAws_json1_1DisassociateResolverEndpointIpAddressCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.DisassociateResolverEndpointIpAddress",
+    "x-amz-target": "Route53Resolver.DisassociateResolverEndpointIpAddress",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateResolverEndpointIpAddressRequest(input, context));
@@ -344,7 +344,7 @@ export const serializeAws_json1_1DisassociateResolverQueryLogConfigCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.DisassociateResolverQueryLogConfig",
+    "x-amz-target": "Route53Resolver.DisassociateResolverQueryLogConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateResolverQueryLogConfigRequest(input, context));
@@ -357,7 +357,7 @@ export const serializeAws_json1_1DisassociateResolverRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.DisassociateResolverRule",
+    "x-amz-target": "Route53Resolver.DisassociateResolverRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateResolverRuleRequest(input, context));
@@ -370,7 +370,7 @@ export const serializeAws_json1_1GetResolverEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.GetResolverEndpoint",
+    "x-amz-target": "Route53Resolver.GetResolverEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResolverEndpointRequest(input, context));
@@ -383,7 +383,7 @@ export const serializeAws_json1_1GetResolverQueryLogConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.GetResolverQueryLogConfig",
+    "x-amz-target": "Route53Resolver.GetResolverQueryLogConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResolverQueryLogConfigRequest(input, context));
@@ -396,7 +396,7 @@ export const serializeAws_json1_1GetResolverQueryLogConfigAssociationCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.GetResolverQueryLogConfigAssociation",
+    "x-amz-target": "Route53Resolver.GetResolverQueryLogConfigAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResolverQueryLogConfigAssociationRequest(input, context));
@@ -409,7 +409,7 @@ export const serializeAws_json1_1GetResolverQueryLogConfigPolicyCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.GetResolverQueryLogConfigPolicy",
+    "x-amz-target": "Route53Resolver.GetResolverQueryLogConfigPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResolverQueryLogConfigPolicyRequest(input, context));
@@ -422,7 +422,7 @@ export const serializeAws_json1_1GetResolverRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.GetResolverRule",
+    "x-amz-target": "Route53Resolver.GetResolverRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResolverRuleRequest(input, context));
@@ -435,7 +435,7 @@ export const serializeAws_json1_1GetResolverRuleAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.GetResolverRuleAssociation",
+    "x-amz-target": "Route53Resolver.GetResolverRuleAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResolverRuleAssociationRequest(input, context));
@@ -448,7 +448,7 @@ export const serializeAws_json1_1GetResolverRulePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.GetResolverRulePolicy",
+    "x-amz-target": "Route53Resolver.GetResolverRulePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResolverRulePolicyRequest(input, context));
@@ -461,7 +461,7 @@ export const serializeAws_json1_1ListResolverEndpointIpAddressesCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.ListResolverEndpointIpAddresses",
+    "x-amz-target": "Route53Resolver.ListResolverEndpointIpAddresses",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResolverEndpointIpAddressesRequest(input, context));
@@ -474,7 +474,7 @@ export const serializeAws_json1_1ListResolverEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.ListResolverEndpoints",
+    "x-amz-target": "Route53Resolver.ListResolverEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResolverEndpointsRequest(input, context));
@@ -487,7 +487,7 @@ export const serializeAws_json1_1ListResolverQueryLogConfigAssociationsCommand =
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.ListResolverQueryLogConfigAssociations",
+    "x-amz-target": "Route53Resolver.ListResolverQueryLogConfigAssociations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResolverQueryLogConfigAssociationsRequest(input, context));
@@ -500,7 +500,7 @@ export const serializeAws_json1_1ListResolverQueryLogConfigsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.ListResolverQueryLogConfigs",
+    "x-amz-target": "Route53Resolver.ListResolverQueryLogConfigs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResolverQueryLogConfigsRequest(input, context));
@@ -513,7 +513,7 @@ export const serializeAws_json1_1ListResolverRuleAssociationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.ListResolverRuleAssociations",
+    "x-amz-target": "Route53Resolver.ListResolverRuleAssociations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResolverRuleAssociationsRequest(input, context));
@@ -526,7 +526,7 @@ export const serializeAws_json1_1ListResolverRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.ListResolverRules",
+    "x-amz-target": "Route53Resolver.ListResolverRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResolverRulesRequest(input, context));
@@ -539,7 +539,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.ListTagsForResource",
+    "x-amz-target": "Route53Resolver.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -552,7 +552,7 @@ export const serializeAws_json1_1PutResolverQueryLogConfigPolicyCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.PutResolverQueryLogConfigPolicy",
+    "x-amz-target": "Route53Resolver.PutResolverQueryLogConfigPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutResolverQueryLogConfigPolicyRequest(input, context));
@@ -565,7 +565,7 @@ export const serializeAws_json1_1PutResolverRulePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.PutResolverRulePolicy",
+    "x-amz-target": "Route53Resolver.PutResolverRulePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutResolverRulePolicyRequest(input, context));
@@ -578,7 +578,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.TagResource",
+    "x-amz-target": "Route53Resolver.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -591,7 +591,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.UntagResource",
+    "x-amz-target": "Route53Resolver.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -604,7 +604,7 @@ export const serializeAws_json1_1UpdateResolverEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.UpdateResolverEndpoint",
+    "x-amz-target": "Route53Resolver.UpdateResolverEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateResolverEndpointRequest(input, context));
@@ -617,7 +617,7 @@ export const serializeAws_json1_1UpdateResolverRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53Resolver.UpdateResolverRule",
+    "x-amz-target": "Route53Resolver.UpdateResolverRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateResolverRuleRequest(input, context));

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -515,11 +515,11 @@ export const serializeAws_restXmlCopyObjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     ...(isSerializableHeaderValue(input.ACL) && { "x-amz-acl": input.ACL! }),
-    ...(isSerializableHeaderValue(input.CacheControl) && { "Cache-Control": input.CacheControl! }),
-    ...(isSerializableHeaderValue(input.ContentDisposition) && { "Content-Disposition": input.ContentDisposition! }),
-    ...(isSerializableHeaderValue(input.ContentEncoding) && { "Content-Encoding": input.ContentEncoding! }),
-    ...(isSerializableHeaderValue(input.ContentLanguage) && { "Content-Language": input.ContentLanguage! }),
-    ...(isSerializableHeaderValue(input.ContentType) && { "Content-Type": input.ContentType! }),
+    ...(isSerializableHeaderValue(input.CacheControl) && { "cache-control": input.CacheControl! }),
+    ...(isSerializableHeaderValue(input.ContentDisposition) && { "content-disposition": input.ContentDisposition! }),
+    ...(isSerializableHeaderValue(input.ContentEncoding) && { "content-encoding": input.ContentEncoding! }),
+    ...(isSerializableHeaderValue(input.ContentLanguage) && { "content-language": input.ContentLanguage! }),
+    ...(isSerializableHeaderValue(input.ContentType) && { "content-type": input.ContentType! }),
     ...(isSerializableHeaderValue(input.CopySource) && { "x-amz-copy-source": input.CopySource! }),
     ...(isSerializableHeaderValue(input.CopySourceIfMatch) && {
       "x-amz-copy-source-if-match": input.CopySourceIfMatch!,
@@ -533,7 +533,7 @@ export const serializeAws_restXmlCopyObjectCommand = async (
     ...(isSerializableHeaderValue(input.CopySourceIfUnmodifiedSince) && {
       "x-amz-copy-source-if-unmodified-since": __dateToUtcString(input.CopySourceIfUnmodifiedSince!).toString(),
     }),
-    ...(isSerializableHeaderValue(input.Expires) && { Expires: __dateToUtcString(input.Expires!).toString() }),
+    ...(isSerializableHeaderValue(input.Expires) && { expires: __dateToUtcString(input.Expires!).toString() }),
     ...(isSerializableHeaderValue(input.GrantFullControl) && { "x-amz-grant-full-control": input.GrantFullControl! }),
     ...(isSerializableHeaderValue(input.GrantRead) && { "x-amz-grant-read": input.GrantRead! }),
     ...(isSerializableHeaderValue(input.GrantReadACP) && { "x-amz-grant-read-acp": input.GrantReadACP! }),
@@ -554,7 +554,7 @@ export const serializeAws_restXmlCopyObjectCommand = async (
       "x-amz-server-side-encryption-customer-key": input.SSECustomerKey!,
     }),
     ...(isSerializableHeaderValue(input.SSECustomerKeyMD5) && {
-      "x-amz-server-side-encryption-customer-key-MD5": input.SSECustomerKeyMD5!,
+      "x-amz-server-side-encryption-customer-key-md5": input.SSECustomerKeyMD5!,
     }),
     ...(isSerializableHeaderValue(input.SSEKMSKeyId) && {
       "x-amz-server-side-encryption-aws-kms-key-id": input.SSEKMSKeyId!,
@@ -572,7 +572,7 @@ export const serializeAws_restXmlCopyObjectCommand = async (
       "x-amz-copy-source-server-side-encryption-customer-key": input.CopySourceSSECustomerKey!,
     }),
     ...(isSerializableHeaderValue(input.CopySourceSSECustomerKeyMD5) && {
-      "x-amz-copy-source-server-side-encryption-customer-key-MD5": input.CopySourceSSECustomerKeyMD5!,
+      "x-amz-copy-source-server-side-encryption-customer-key-md5": input.CopySourceSSECustomerKeyMD5!,
     }),
     ...(isSerializableHeaderValue(input.RequestPayer) && { "x-amz-request-payer": input.RequestPayer! }),
     ...(isSerializableHeaderValue(input.Tagging) && { "x-amz-tagging": input.Tagging! }),
@@ -691,12 +691,12 @@ export const serializeAws_restXmlCreateMultipartUploadCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     ...(isSerializableHeaderValue(input.ACL) && { "x-amz-acl": input.ACL! }),
-    ...(isSerializableHeaderValue(input.CacheControl) && { "Cache-Control": input.CacheControl! }),
-    ...(isSerializableHeaderValue(input.ContentDisposition) && { "Content-Disposition": input.ContentDisposition! }),
-    ...(isSerializableHeaderValue(input.ContentEncoding) && { "Content-Encoding": input.ContentEncoding! }),
-    ...(isSerializableHeaderValue(input.ContentLanguage) && { "Content-Language": input.ContentLanguage! }),
-    ...(isSerializableHeaderValue(input.ContentType) && { "Content-Type": input.ContentType! }),
-    ...(isSerializableHeaderValue(input.Expires) && { Expires: __dateToUtcString(input.Expires!).toString() }),
+    ...(isSerializableHeaderValue(input.CacheControl) && { "cache-control": input.CacheControl! }),
+    ...(isSerializableHeaderValue(input.ContentDisposition) && { "content-disposition": input.ContentDisposition! }),
+    ...(isSerializableHeaderValue(input.ContentEncoding) && { "content-encoding": input.ContentEncoding! }),
+    ...(isSerializableHeaderValue(input.ContentLanguage) && { "content-language": input.ContentLanguage! }),
+    ...(isSerializableHeaderValue(input.ContentType) && { "content-type": input.ContentType! }),
+    ...(isSerializableHeaderValue(input.Expires) && { expires: __dateToUtcString(input.Expires!).toString() }),
     ...(isSerializableHeaderValue(input.GrantFullControl) && { "x-amz-grant-full-control": input.GrantFullControl! }),
     ...(isSerializableHeaderValue(input.GrantRead) && { "x-amz-grant-read": input.GrantRead! }),
     ...(isSerializableHeaderValue(input.GrantReadACP) && { "x-amz-grant-read-acp": input.GrantReadACP! }),
@@ -715,7 +715,7 @@ export const serializeAws_restXmlCreateMultipartUploadCommand = async (
       "x-amz-server-side-encryption-customer-key": input.SSECustomerKey!,
     }),
     ...(isSerializableHeaderValue(input.SSECustomerKeyMD5) && {
-      "x-amz-server-side-encryption-customer-key-MD5": input.SSECustomerKeyMD5!,
+      "x-amz-server-side-encryption-customer-key-md5": input.SSECustomerKeyMD5!,
     }),
     ...(isSerializableHeaderValue(input.SSEKMSKeyId) && {
       "x-amz-server-side-encryption-aws-kms-key-id": input.SSEKMSKeyId!,
@@ -2175,15 +2175,15 @@ export const serializeAws_restXmlGetObjectCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
     ...(isSerializableHeaderValue(input.IfModifiedSince) && {
-      "If-Modified-Since": __dateToUtcString(input.IfModifiedSince!).toString(),
+      "if-modified-since": __dateToUtcString(input.IfModifiedSince!).toString(),
     }),
-    ...(isSerializableHeaderValue(input.IfNoneMatch) && { "If-None-Match": input.IfNoneMatch! }),
+    ...(isSerializableHeaderValue(input.IfNoneMatch) && { "if-none-match": input.IfNoneMatch! }),
     ...(isSerializableHeaderValue(input.IfUnmodifiedSince) && {
-      "If-Unmodified-Since": __dateToUtcString(input.IfUnmodifiedSince!).toString(),
+      "if-unmodified-since": __dateToUtcString(input.IfUnmodifiedSince!).toString(),
     }),
-    ...(isSerializableHeaderValue(input.Range) && { Range: input.Range! }),
+    ...(isSerializableHeaderValue(input.Range) && { range: input.Range! }),
     ...(isSerializableHeaderValue(input.SSECustomerAlgorithm) && {
       "x-amz-server-side-encryption-customer-algorithm": input.SSECustomerAlgorithm!,
     }),
@@ -2191,7 +2191,7 @@ export const serializeAws_restXmlGetObjectCommand = async (
       "x-amz-server-side-encryption-customer-key": input.SSECustomerKey!,
     }),
     ...(isSerializableHeaderValue(input.SSECustomerKeyMD5) && {
-      "x-amz-server-side-encryption-customer-key-MD5": input.SSECustomerKeyMD5!,
+      "x-amz-server-side-encryption-customer-key-md5": input.SSECustomerKeyMD5!,
     }),
     ...(isSerializableHeaderValue(input.RequestPayer) && { "x-amz-request-payer": input.RequestPayer! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
@@ -2624,15 +2624,15 @@ export const serializeAws_restXmlHeadObjectCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.IfMatch) && { "If-Match": input.IfMatch! }),
+    ...(isSerializableHeaderValue(input.IfMatch) && { "if-match": input.IfMatch! }),
     ...(isSerializableHeaderValue(input.IfModifiedSince) && {
-      "If-Modified-Since": __dateToUtcString(input.IfModifiedSince!).toString(),
+      "if-modified-since": __dateToUtcString(input.IfModifiedSince!).toString(),
     }),
-    ...(isSerializableHeaderValue(input.IfNoneMatch) && { "If-None-Match": input.IfNoneMatch! }),
+    ...(isSerializableHeaderValue(input.IfNoneMatch) && { "if-none-match": input.IfNoneMatch! }),
     ...(isSerializableHeaderValue(input.IfUnmodifiedSince) && {
-      "If-Unmodified-Since": __dateToUtcString(input.IfUnmodifiedSince!).toString(),
+      "if-unmodified-since": __dateToUtcString(input.IfUnmodifiedSince!).toString(),
     }),
-    ...(isSerializableHeaderValue(input.Range) && { Range: input.Range! }),
+    ...(isSerializableHeaderValue(input.Range) && { range: input.Range! }),
     ...(isSerializableHeaderValue(input.SSECustomerAlgorithm) && {
       "x-amz-server-side-encryption-customer-algorithm": input.SSECustomerAlgorithm!,
     }),
@@ -2640,7 +2640,7 @@ export const serializeAws_restXmlHeadObjectCommand = async (
       "x-amz-server-side-encryption-customer-key": input.SSECustomerKey!,
     }),
     ...(isSerializableHeaderValue(input.SSECustomerKeyMD5) && {
-      "x-amz-server-side-encryption-customer-key-MD5": input.SSECustomerKeyMD5!,
+      "x-amz-server-side-encryption-customer-key-md5": input.SSECustomerKeyMD5!,
     }),
     ...(isSerializableHeaderValue(input.RequestPayer) && { "x-amz-request-payer": input.RequestPayer! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
@@ -3133,7 +3133,7 @@ export const serializeAws_restXmlPutBucketAclCommand = async (
   const headers: any = {
     "content-type": "application/xml",
     ...(isSerializableHeaderValue(input.ACL) && { "x-amz-acl": input.ACL! }),
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.GrantFullControl) && { "x-amz-grant-full-control": input.GrantFullControl! }),
     ...(isSerializableHeaderValue(input.GrantRead) && { "x-amz-grant-read": input.GrantRead! }),
     ...(isSerializableHeaderValue(input.GrantReadACP) && { "x-amz-grant-read-acp": input.GrantReadACP! }),
@@ -3228,7 +3228,7 @@ export const serializeAws_restXmlPutBucketCorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -3273,7 +3273,7 @@ export const serializeAws_restXmlPutBucketEncryptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -3449,7 +3449,7 @@ export const serializeAws_restXmlPutBucketLoggingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -3583,7 +3583,7 @@ export const serializeAws_restXmlPutBucketOwnershipControlsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -3628,7 +3628,7 @@ export const serializeAws_restXmlPutBucketPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "text/plain",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ConfirmRemoveSelfBucketAccess) && {
       "x-amz-confirm-remove-self-bucket-access": input.ConfirmRemoveSelfBucketAccess!.toString(),
     }),
@@ -3674,7 +3674,7 @@ export const serializeAws_restXmlPutBucketReplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.Token) && { "x-amz-bucket-object-lock-token": input.Token! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
@@ -3720,7 +3720,7 @@ export const serializeAws_restXmlPutBucketRequestPaymentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -3765,7 +3765,7 @@ export const serializeAws_restXmlPutBucketTaggingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -3810,7 +3810,7 @@ export const serializeAws_restXmlPutBucketVersioningCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.MFA) && { "x-amz-mfa": input.MFA! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
@@ -3856,7 +3856,7 @@ export const serializeAws_restXmlPutBucketWebsiteCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -3902,14 +3902,14 @@ export const serializeAws_restXmlPutObjectCommand = async (
   const headers: any = {
     "content-type": "application/octet-stream",
     ...(isSerializableHeaderValue(input.ACL) && { "x-amz-acl": input.ACL! }),
-    ...(isSerializableHeaderValue(input.CacheControl) && { "Cache-Control": input.CacheControl! }),
-    ...(isSerializableHeaderValue(input.ContentDisposition) && { "Content-Disposition": input.ContentDisposition! }),
-    ...(isSerializableHeaderValue(input.ContentEncoding) && { "Content-Encoding": input.ContentEncoding! }),
-    ...(isSerializableHeaderValue(input.ContentLanguage) && { "Content-Language": input.ContentLanguage! }),
-    ...(isSerializableHeaderValue(input.ContentLength) && { "Content-Length": input.ContentLength!.toString() }),
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
-    ...(isSerializableHeaderValue(input.ContentType) && { "Content-Type": input.ContentType! }),
-    ...(isSerializableHeaderValue(input.Expires) && { Expires: __dateToUtcString(input.Expires!).toString() }),
+    ...(isSerializableHeaderValue(input.CacheControl) && { "cache-control": input.CacheControl! }),
+    ...(isSerializableHeaderValue(input.ContentDisposition) && { "content-disposition": input.ContentDisposition! }),
+    ...(isSerializableHeaderValue(input.ContentEncoding) && { "content-encoding": input.ContentEncoding! }),
+    ...(isSerializableHeaderValue(input.ContentLanguage) && { "content-language": input.ContentLanguage! }),
+    ...(isSerializableHeaderValue(input.ContentLength) && { "content-length": input.ContentLength!.toString() }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentType) && { "content-type": input.ContentType! }),
+    ...(isSerializableHeaderValue(input.Expires) && { expires: __dateToUtcString(input.Expires!).toString() }),
     ...(isSerializableHeaderValue(input.GrantFullControl) && { "x-amz-grant-full-control": input.GrantFullControl! }),
     ...(isSerializableHeaderValue(input.GrantRead) && { "x-amz-grant-read": input.GrantRead! }),
     ...(isSerializableHeaderValue(input.GrantReadACP) && { "x-amz-grant-read-acp": input.GrantReadACP! }),
@@ -3928,7 +3928,7 @@ export const serializeAws_restXmlPutObjectCommand = async (
       "x-amz-server-side-encryption-customer-key": input.SSECustomerKey!,
     }),
     ...(isSerializableHeaderValue(input.SSECustomerKeyMD5) && {
-      "x-amz-server-side-encryption-customer-key-MD5": input.SSECustomerKeyMD5!,
+      "x-amz-server-side-encryption-customer-key-md5": input.SSECustomerKeyMD5!,
     }),
     ...(isSerializableHeaderValue(input.SSEKMSKeyId) && {
       "x-amz-server-side-encryption-aws-kms-key-id": input.SSEKMSKeyId!,
@@ -4013,7 +4013,7 @@ export const serializeAws_restXmlPutObjectAclCommand = async (
   const headers: any = {
     "content-type": "application/xml",
     ...(isSerializableHeaderValue(input.ACL) && { "x-amz-acl": input.ACL! }),
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.GrantFullControl) && { "x-amz-grant-full-control": input.GrantFullControl! }),
     ...(isSerializableHeaderValue(input.GrantRead) && { "x-amz-grant-read": input.GrantRead! }),
     ...(isSerializableHeaderValue(input.GrantReadACP) && { "x-amz-grant-read-acp": input.GrantReadACP! }),
@@ -4081,7 +4081,7 @@ export const serializeAws_restXmlPutObjectLegalHoldCommand = async (
   const headers: any = {
     "content-type": "application/xml",
     ...(isSerializableHeaderValue(input.RequestPayer) && { "x-amz-request-payer": input.RequestPayer! }),
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -4144,7 +4144,7 @@ export const serializeAws_restXmlPutObjectLockConfigurationCommand = async (
     "content-type": "application/xml",
     ...(isSerializableHeaderValue(input.RequestPayer) && { "x-amz-request-payer": input.RequestPayer! }),
     ...(isSerializableHeaderValue(input.Token) && { "x-amz-bucket-object-lock-token": input.Token! }),
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -4193,7 +4193,7 @@ export const serializeAws_restXmlPutObjectRetentionCommand = async (
     ...(isSerializableHeaderValue(input.BypassGovernanceRetention) && {
       "x-amz-bypass-governance-retention": input.BypassGovernanceRetention!.toString(),
     }),
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -4254,7 +4254,7 @@ export const serializeAws_restXmlPutObjectTaggingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -4315,7 +4315,7 @@ export const serializeAws_restXmlPutPublicAccessBlockCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
@@ -4428,7 +4428,7 @@ export const serializeAws_restXmlSelectObjectContentCommand = async (
       "x-amz-server-side-encryption-customer-key": input.SSECustomerKey!,
     }),
     ...(isSerializableHeaderValue(input.SSECustomerKeyMD5) && {
-      "x-amz-server-side-encryption-customer-key-MD5": input.SSECustomerKeyMD5!,
+      "x-amz-server-side-encryption-customer-key-md5": input.SSECustomerKeyMD5!,
     }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
@@ -4517,8 +4517,8 @@ export const serializeAws_restXmlUploadPartCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/octet-stream",
-    ...(isSerializableHeaderValue(input.ContentLength) && { "Content-Length": input.ContentLength!.toString() }),
-    ...(isSerializableHeaderValue(input.ContentMD5) && { "Content-MD5": input.ContentMD5! }),
+    ...(isSerializableHeaderValue(input.ContentLength) && { "content-length": input.ContentLength!.toString() }),
+    ...(isSerializableHeaderValue(input.ContentMD5) && { "content-md5": input.ContentMD5! }),
     ...(isSerializableHeaderValue(input.SSECustomerAlgorithm) && {
       "x-amz-server-side-encryption-customer-algorithm": input.SSECustomerAlgorithm!,
     }),
@@ -4526,7 +4526,7 @@ export const serializeAws_restXmlUploadPartCommand = async (
       "x-amz-server-side-encryption-customer-key": input.SSECustomerKey!,
     }),
     ...(isSerializableHeaderValue(input.SSECustomerKeyMD5) && {
-      "x-amz-server-side-encryption-customer-key-MD5": input.SSECustomerKeyMD5!,
+      "x-amz-server-side-encryption-customer-key-md5": input.SSECustomerKeyMD5!,
     }),
     ...(isSerializableHeaderValue(input.RequestPayer) && { "x-amz-request-payer": input.RequestPayer! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {
@@ -4608,7 +4608,7 @@ export const serializeAws_restXmlUploadPartCopyCommand = async (
       "x-amz-server-side-encryption-customer-key": input.SSECustomerKey!,
     }),
     ...(isSerializableHeaderValue(input.SSECustomerKeyMD5) && {
-      "x-amz-server-side-encryption-customer-key-MD5": input.SSECustomerKeyMD5!,
+      "x-amz-server-side-encryption-customer-key-md5": input.SSECustomerKeyMD5!,
     }),
     ...(isSerializableHeaderValue(input.CopySourceSSECustomerAlgorithm) && {
       "x-amz-copy-source-server-side-encryption-customer-algorithm": input.CopySourceSSECustomerAlgorithm!,
@@ -4617,7 +4617,7 @@ export const serializeAws_restXmlUploadPartCopyCommand = async (
       "x-amz-copy-source-server-side-encryption-customer-key": input.CopySourceSSECustomerKey!,
     }),
     ...(isSerializableHeaderValue(input.CopySourceSSECustomerKeyMD5) && {
-      "x-amz-copy-source-server-side-encryption-customer-key-MD5": input.CopySourceSSECustomerKeyMD5!,
+      "x-amz-copy-source-server-side-encryption-customer-key-md5": input.CopySourceSSECustomerKeyMD5!,
     }),
     ...(isSerializableHeaderValue(input.RequestPayer) && { "x-amz-request-payer": input.RequestPayer! }),
     ...(isSerializableHeaderValue(input.ExpectedBucketOwner) && {

--- a/clients/client-s3/protocols/Aws_restXml.ts
+++ b/clients/client-s3/protocols/Aws_restXml.ts
@@ -592,10 +592,13 @@ export const serializeAws_restXmlCopyObjectCommand = async (
       "x-amz-source-expected-bucket-owner": input.ExpectedSourceBucketOwner!,
     }),
     ...(input.Metadata !== undefined &&
-      Object.keys(input.Metadata).reduce((acc: any, suffix: string) => {
-        acc["x-amz-meta-" + suffix] = input.Metadata![suffix];
-        return acc;
-      }, {})),
+      Object.keys(input.Metadata).reduce(
+        (acc: any, suffix: string) => ({
+          ...acc,
+          [`x-amz-meta-${suffix.toLowerCase()}`]: input.Metadata![suffix],
+        }),
+        {}
+      )),
   };
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
@@ -741,10 +744,13 @@ export const serializeAws_restXmlCreateMultipartUploadCommand = async (
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
     ...(input.Metadata !== undefined &&
-      Object.keys(input.Metadata).reduce((acc: any, suffix: string) => {
-        acc["x-amz-meta-" + suffix] = input.Metadata![suffix];
-        return acc;
-      }, {})),
+      Object.keys(input.Metadata).reduce(
+        (acc: any, suffix: string) => ({
+          ...acc,
+          [`x-amz-meta-${suffix.toLowerCase()}`]: input.Metadata![suffix],
+        }),
+        {}
+      )),
   };
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {
@@ -3954,10 +3960,13 @@ export const serializeAws_restXmlPutObjectCommand = async (
       "x-amz-expected-bucket-owner": input.ExpectedBucketOwner!,
     }),
     ...(input.Metadata !== undefined &&
-      Object.keys(input.Metadata).reduce((acc: any, suffix: string) => {
-        acc["x-amz-meta-" + suffix] = input.Metadata![suffix];
-        return acc;
-      }, {})),
+      Object.keys(input.Metadata).reduce(
+        (acc: any, suffix: string) => ({
+          ...acc,
+          [`x-amz-meta-${suffix.toLowerCase()}`]: input.Metadata![suffix],
+        }),
+        {}
+      )),
   };
   let resolvedPath = "/{Bucket}/{Key+}";
   if (input.Bucket !== undefined) {

--- a/clients/client-sagemaker-runtime/protocols/Aws_restJson1.ts
+++ b/clients/client-sagemaker-runtime/protocols/Aws_restJson1.ts
@@ -18,14 +18,14 @@ export const serializeAws_restJson1InvokeEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/octet-stream",
-    ...(isSerializableHeaderValue(input.ContentType) && { "Content-Type": input.ContentType! }),
-    ...(isSerializableHeaderValue(input.Accept) && { Accept: input.Accept! }),
+    ...(isSerializableHeaderValue(input.ContentType) && { "content-type": input.ContentType! }),
+    ...(isSerializableHeaderValue(input.Accept) && { accept: input.Accept! }),
     ...(isSerializableHeaderValue(input.CustomAttributes) && {
-      "X-Amzn-SageMaker-Custom-Attributes": input.CustomAttributes!,
+      "x-amzn-sagemaker-custom-attributes": input.CustomAttributes!,
     }),
-    ...(isSerializableHeaderValue(input.TargetModel) && { "X-Amzn-SageMaker-Target-Model": input.TargetModel! }),
-    ...(isSerializableHeaderValue(input.TargetVariant) && { "X-Amzn-SageMaker-Target-Variant": input.TargetVariant! }),
-    ...(isSerializableHeaderValue(input.InferenceId) && { "X-Amzn-SageMaker-Inference-Id": input.InferenceId! }),
+    ...(isSerializableHeaderValue(input.TargetModel) && { "x-amzn-sagemaker-target-model": input.TargetModel! }),
+    ...(isSerializableHeaderValue(input.TargetVariant) && { "x-amzn-sagemaker-target-variant": input.TargetVariant! }),
+    ...(isSerializableHeaderValue(input.InferenceId) && { "x-amzn-sagemaker-inference-id": input.InferenceId! }),
   };
   let resolvedPath = "/endpoints/{EndpointName}/invocations";
   if (input.EndpointName !== undefined) {

--- a/clients/client-sagemaker/protocols/Aws_json1_1.ts
+++ b/clients/client-sagemaker/protocols/Aws_json1_1.ts
@@ -1333,7 +1333,7 @@ export const serializeAws_json1_1AddAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.AddAssociation",
+    "x-amz-target": "SageMaker.AddAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddAssociationRequest(input, context));
@@ -1346,7 +1346,7 @@ export const serializeAws_json1_1AddTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.AddTags",
+    "x-amz-target": "SageMaker.AddTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsInput(input, context));
@@ -1359,7 +1359,7 @@ export const serializeAws_json1_1AssociateTrialComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.AssociateTrialComponent",
+    "x-amz-target": "SageMaker.AssociateTrialComponent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateTrialComponentRequest(input, context));
@@ -1372,7 +1372,7 @@ export const serializeAws_json1_1CreateActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateAction",
+    "x-amz-target": "SageMaker.CreateAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateActionRequest(input, context));
@@ -1385,7 +1385,7 @@ export const serializeAws_json1_1CreateAlgorithmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateAlgorithm",
+    "x-amz-target": "SageMaker.CreateAlgorithm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAlgorithmInput(input, context));
@@ -1398,7 +1398,7 @@ export const serializeAws_json1_1CreateAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateApp",
+    "x-amz-target": "SageMaker.CreateApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAppRequest(input, context));
@@ -1411,7 +1411,7 @@ export const serializeAws_json1_1CreateAppImageConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateAppImageConfig",
+    "x-amz-target": "SageMaker.CreateAppImageConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAppImageConfigRequest(input, context));
@@ -1424,7 +1424,7 @@ export const serializeAws_json1_1CreateArtifactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateArtifact",
+    "x-amz-target": "SageMaker.CreateArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateArtifactRequest(input, context));
@@ -1437,7 +1437,7 @@ export const serializeAws_json1_1CreateAutoMLJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateAutoMLJob",
+    "x-amz-target": "SageMaker.CreateAutoMLJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAutoMLJobRequest(input, context));
@@ -1450,7 +1450,7 @@ export const serializeAws_json1_1CreateCodeRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateCodeRepository",
+    "x-amz-target": "SageMaker.CreateCodeRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCodeRepositoryInput(input, context));
@@ -1463,7 +1463,7 @@ export const serializeAws_json1_1CreateCompilationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateCompilationJob",
+    "x-amz-target": "SageMaker.CreateCompilationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCompilationJobRequest(input, context));
@@ -1476,7 +1476,7 @@ export const serializeAws_json1_1CreateContextCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateContext",
+    "x-amz-target": "SageMaker.CreateContext",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateContextRequest(input, context));
@@ -1489,7 +1489,7 @@ export const serializeAws_json1_1CreateDataQualityJobDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateDataQualityJobDefinition",
+    "x-amz-target": "SageMaker.CreateDataQualityJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDataQualityJobDefinitionRequest(input, context));
@@ -1502,7 +1502,7 @@ export const serializeAws_json1_1CreateDeviceFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateDeviceFleet",
+    "x-amz-target": "SageMaker.CreateDeviceFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDeviceFleetRequest(input, context));
@@ -1515,7 +1515,7 @@ export const serializeAws_json1_1CreateDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateDomain",
+    "x-amz-target": "SageMaker.CreateDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDomainRequest(input, context));
@@ -1528,7 +1528,7 @@ export const serializeAws_json1_1CreateEdgePackagingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateEdgePackagingJob",
+    "x-amz-target": "SageMaker.CreateEdgePackagingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEdgePackagingJobRequest(input, context));
@@ -1541,7 +1541,7 @@ export const serializeAws_json1_1CreateEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateEndpoint",
+    "x-amz-target": "SageMaker.CreateEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEndpointInput(input, context));
@@ -1554,7 +1554,7 @@ export const serializeAws_json1_1CreateEndpointConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateEndpointConfig",
+    "x-amz-target": "SageMaker.CreateEndpointConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateEndpointConfigInput(input, context));
@@ -1567,7 +1567,7 @@ export const serializeAws_json1_1CreateExperimentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateExperiment",
+    "x-amz-target": "SageMaker.CreateExperiment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateExperimentRequest(input, context));
@@ -1580,7 +1580,7 @@ export const serializeAws_json1_1CreateFeatureGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateFeatureGroup",
+    "x-amz-target": "SageMaker.CreateFeatureGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateFeatureGroupRequest(input, context));
@@ -1593,7 +1593,7 @@ export const serializeAws_json1_1CreateFlowDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateFlowDefinition",
+    "x-amz-target": "SageMaker.CreateFlowDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateFlowDefinitionRequest(input, context));
@@ -1606,7 +1606,7 @@ export const serializeAws_json1_1CreateHumanTaskUiCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateHumanTaskUi",
+    "x-amz-target": "SageMaker.CreateHumanTaskUi",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateHumanTaskUiRequest(input, context));
@@ -1619,7 +1619,7 @@ export const serializeAws_json1_1CreateHyperParameterTuningJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateHyperParameterTuningJob",
+    "x-amz-target": "SageMaker.CreateHyperParameterTuningJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateHyperParameterTuningJobRequest(input, context));
@@ -1632,7 +1632,7 @@ export const serializeAws_json1_1CreateImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateImage",
+    "x-amz-target": "SageMaker.CreateImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateImageRequest(input, context));
@@ -1645,7 +1645,7 @@ export const serializeAws_json1_1CreateImageVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateImageVersion",
+    "x-amz-target": "SageMaker.CreateImageVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateImageVersionRequest(input, context));
@@ -1658,7 +1658,7 @@ export const serializeAws_json1_1CreateLabelingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateLabelingJob",
+    "x-amz-target": "SageMaker.CreateLabelingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLabelingJobRequest(input, context));
@@ -1671,7 +1671,7 @@ export const serializeAws_json1_1CreateModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateModel",
+    "x-amz-target": "SageMaker.CreateModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateModelInput(input, context));
@@ -1684,7 +1684,7 @@ export const serializeAws_json1_1CreateModelBiasJobDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateModelBiasJobDefinition",
+    "x-amz-target": "SageMaker.CreateModelBiasJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateModelBiasJobDefinitionRequest(input, context));
@@ -1697,7 +1697,7 @@ export const serializeAws_json1_1CreateModelExplainabilityJobDefinitionCommand =
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateModelExplainabilityJobDefinition",
+    "x-amz-target": "SageMaker.CreateModelExplainabilityJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateModelExplainabilityJobDefinitionRequest(input, context));
@@ -1710,7 +1710,7 @@ export const serializeAws_json1_1CreateModelPackageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateModelPackage",
+    "x-amz-target": "SageMaker.CreateModelPackage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateModelPackageInput(input, context));
@@ -1723,7 +1723,7 @@ export const serializeAws_json1_1CreateModelPackageGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateModelPackageGroup",
+    "x-amz-target": "SageMaker.CreateModelPackageGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateModelPackageGroupInput(input, context));
@@ -1736,7 +1736,7 @@ export const serializeAws_json1_1CreateModelQualityJobDefinitionCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateModelQualityJobDefinition",
+    "x-amz-target": "SageMaker.CreateModelQualityJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateModelQualityJobDefinitionRequest(input, context));
@@ -1749,7 +1749,7 @@ export const serializeAws_json1_1CreateMonitoringScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateMonitoringSchedule",
+    "x-amz-target": "SageMaker.CreateMonitoringSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateMonitoringScheduleRequest(input, context));
@@ -1762,7 +1762,7 @@ export const serializeAws_json1_1CreateNotebookInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateNotebookInstance",
+    "x-amz-target": "SageMaker.CreateNotebookInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateNotebookInstanceInput(input, context));
@@ -1775,7 +1775,7 @@ export const serializeAws_json1_1CreateNotebookInstanceLifecycleConfigCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateNotebookInstanceLifecycleConfig",
+    "x-amz-target": "SageMaker.CreateNotebookInstanceLifecycleConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateNotebookInstanceLifecycleConfigInput(input, context));
@@ -1788,7 +1788,7 @@ export const serializeAws_json1_1CreatePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreatePipeline",
+    "x-amz-target": "SageMaker.CreatePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePipelineRequest(input, context));
@@ -1801,7 +1801,7 @@ export const serializeAws_json1_1CreatePresignedDomainUrlCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreatePresignedDomainUrl",
+    "x-amz-target": "SageMaker.CreatePresignedDomainUrl",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePresignedDomainUrlRequest(input, context));
@@ -1814,7 +1814,7 @@ export const serializeAws_json1_1CreatePresignedNotebookInstanceUrlCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreatePresignedNotebookInstanceUrl",
+    "x-amz-target": "SageMaker.CreatePresignedNotebookInstanceUrl",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePresignedNotebookInstanceUrlInput(input, context));
@@ -1827,7 +1827,7 @@ export const serializeAws_json1_1CreateProcessingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateProcessingJob",
+    "x-amz-target": "SageMaker.CreateProcessingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProcessingJobRequest(input, context));
@@ -1840,7 +1840,7 @@ export const serializeAws_json1_1CreateProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateProject",
+    "x-amz-target": "SageMaker.CreateProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProjectInput(input, context));
@@ -1853,7 +1853,7 @@ export const serializeAws_json1_1CreateTrainingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateTrainingJob",
+    "x-amz-target": "SageMaker.CreateTrainingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTrainingJobRequest(input, context));
@@ -1866,7 +1866,7 @@ export const serializeAws_json1_1CreateTransformJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateTransformJob",
+    "x-amz-target": "SageMaker.CreateTransformJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTransformJobRequest(input, context));
@@ -1879,7 +1879,7 @@ export const serializeAws_json1_1CreateTrialCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateTrial",
+    "x-amz-target": "SageMaker.CreateTrial",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTrialRequest(input, context));
@@ -1892,7 +1892,7 @@ export const serializeAws_json1_1CreateTrialComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateTrialComponent",
+    "x-amz-target": "SageMaker.CreateTrialComponent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTrialComponentRequest(input, context));
@@ -1905,7 +1905,7 @@ export const serializeAws_json1_1CreateUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateUserProfile",
+    "x-amz-target": "SageMaker.CreateUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserProfileRequest(input, context));
@@ -1918,7 +1918,7 @@ export const serializeAws_json1_1CreateWorkforceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateWorkforce",
+    "x-amz-target": "SageMaker.CreateWorkforce",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWorkforceRequest(input, context));
@@ -1931,7 +1931,7 @@ export const serializeAws_json1_1CreateWorkteamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.CreateWorkteam",
+    "x-amz-target": "SageMaker.CreateWorkteam",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWorkteamRequest(input, context));
@@ -1944,7 +1944,7 @@ export const serializeAws_json1_1DeleteActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteAction",
+    "x-amz-target": "SageMaker.DeleteAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteActionRequest(input, context));
@@ -1957,7 +1957,7 @@ export const serializeAws_json1_1DeleteAlgorithmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteAlgorithm",
+    "x-amz-target": "SageMaker.DeleteAlgorithm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAlgorithmInput(input, context));
@@ -1970,7 +1970,7 @@ export const serializeAws_json1_1DeleteAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteApp",
+    "x-amz-target": "SageMaker.DeleteApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAppRequest(input, context));
@@ -1983,7 +1983,7 @@ export const serializeAws_json1_1DeleteAppImageConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteAppImageConfig",
+    "x-amz-target": "SageMaker.DeleteAppImageConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAppImageConfigRequest(input, context));
@@ -1996,7 +1996,7 @@ export const serializeAws_json1_1DeleteArtifactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteArtifact",
+    "x-amz-target": "SageMaker.DeleteArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteArtifactRequest(input, context));
@@ -2009,7 +2009,7 @@ export const serializeAws_json1_1DeleteAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteAssociation",
+    "x-amz-target": "SageMaker.DeleteAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAssociationRequest(input, context));
@@ -2022,7 +2022,7 @@ export const serializeAws_json1_1DeleteCodeRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteCodeRepository",
+    "x-amz-target": "SageMaker.DeleteCodeRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteCodeRepositoryInput(input, context));
@@ -2035,7 +2035,7 @@ export const serializeAws_json1_1DeleteContextCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteContext",
+    "x-amz-target": "SageMaker.DeleteContext",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteContextRequest(input, context));
@@ -2048,7 +2048,7 @@ export const serializeAws_json1_1DeleteDataQualityJobDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteDataQualityJobDefinition",
+    "x-amz-target": "SageMaker.DeleteDataQualityJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDataQualityJobDefinitionRequest(input, context));
@@ -2061,7 +2061,7 @@ export const serializeAws_json1_1DeleteDeviceFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteDeviceFleet",
+    "x-amz-target": "SageMaker.DeleteDeviceFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDeviceFleetRequest(input, context));
@@ -2074,7 +2074,7 @@ export const serializeAws_json1_1DeleteDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteDomain",
+    "x-amz-target": "SageMaker.DeleteDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDomainRequest(input, context));
@@ -2087,7 +2087,7 @@ export const serializeAws_json1_1DeleteEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteEndpoint",
+    "x-amz-target": "SageMaker.DeleteEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEndpointInput(input, context));
@@ -2100,7 +2100,7 @@ export const serializeAws_json1_1DeleteEndpointConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteEndpointConfig",
+    "x-amz-target": "SageMaker.DeleteEndpointConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteEndpointConfigInput(input, context));
@@ -2113,7 +2113,7 @@ export const serializeAws_json1_1DeleteExperimentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteExperiment",
+    "x-amz-target": "SageMaker.DeleteExperiment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteExperimentRequest(input, context));
@@ -2126,7 +2126,7 @@ export const serializeAws_json1_1DeleteFeatureGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteFeatureGroup",
+    "x-amz-target": "SageMaker.DeleteFeatureGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFeatureGroupRequest(input, context));
@@ -2139,7 +2139,7 @@ export const serializeAws_json1_1DeleteFlowDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteFlowDefinition",
+    "x-amz-target": "SageMaker.DeleteFlowDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFlowDefinitionRequest(input, context));
@@ -2152,7 +2152,7 @@ export const serializeAws_json1_1DeleteHumanTaskUiCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteHumanTaskUi",
+    "x-amz-target": "SageMaker.DeleteHumanTaskUi",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteHumanTaskUiRequest(input, context));
@@ -2165,7 +2165,7 @@ export const serializeAws_json1_1DeleteImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteImage",
+    "x-amz-target": "SageMaker.DeleteImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteImageRequest(input, context));
@@ -2178,7 +2178,7 @@ export const serializeAws_json1_1DeleteImageVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteImageVersion",
+    "x-amz-target": "SageMaker.DeleteImageVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteImageVersionRequest(input, context));
@@ -2191,7 +2191,7 @@ export const serializeAws_json1_1DeleteModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteModel",
+    "x-amz-target": "SageMaker.DeleteModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteModelInput(input, context));
@@ -2204,7 +2204,7 @@ export const serializeAws_json1_1DeleteModelBiasJobDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteModelBiasJobDefinition",
+    "x-amz-target": "SageMaker.DeleteModelBiasJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteModelBiasJobDefinitionRequest(input, context));
@@ -2217,7 +2217,7 @@ export const serializeAws_json1_1DeleteModelExplainabilityJobDefinitionCommand =
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteModelExplainabilityJobDefinition",
+    "x-amz-target": "SageMaker.DeleteModelExplainabilityJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteModelExplainabilityJobDefinitionRequest(input, context));
@@ -2230,7 +2230,7 @@ export const serializeAws_json1_1DeleteModelPackageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteModelPackage",
+    "x-amz-target": "SageMaker.DeleteModelPackage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteModelPackageInput(input, context));
@@ -2243,7 +2243,7 @@ export const serializeAws_json1_1DeleteModelPackageGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteModelPackageGroup",
+    "x-amz-target": "SageMaker.DeleteModelPackageGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteModelPackageGroupInput(input, context));
@@ -2256,7 +2256,7 @@ export const serializeAws_json1_1DeleteModelPackageGroupPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteModelPackageGroupPolicy",
+    "x-amz-target": "SageMaker.DeleteModelPackageGroupPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteModelPackageGroupPolicyInput(input, context));
@@ -2269,7 +2269,7 @@ export const serializeAws_json1_1DeleteModelQualityJobDefinitionCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteModelQualityJobDefinition",
+    "x-amz-target": "SageMaker.DeleteModelQualityJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteModelQualityJobDefinitionRequest(input, context));
@@ -2282,7 +2282,7 @@ export const serializeAws_json1_1DeleteMonitoringScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteMonitoringSchedule",
+    "x-amz-target": "SageMaker.DeleteMonitoringSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMonitoringScheduleRequest(input, context));
@@ -2295,7 +2295,7 @@ export const serializeAws_json1_1DeleteNotebookInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteNotebookInstance",
+    "x-amz-target": "SageMaker.DeleteNotebookInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteNotebookInstanceInput(input, context));
@@ -2308,7 +2308,7 @@ export const serializeAws_json1_1DeleteNotebookInstanceLifecycleConfigCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteNotebookInstanceLifecycleConfig",
+    "x-amz-target": "SageMaker.DeleteNotebookInstanceLifecycleConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteNotebookInstanceLifecycleConfigInput(input, context));
@@ -2321,7 +2321,7 @@ export const serializeAws_json1_1DeletePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeletePipeline",
+    "x-amz-target": "SageMaker.DeletePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePipelineRequest(input, context));
@@ -2334,7 +2334,7 @@ export const serializeAws_json1_1DeleteProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteProject",
+    "x-amz-target": "SageMaker.DeleteProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProjectInput(input, context));
@@ -2347,7 +2347,7 @@ export const serializeAws_json1_1DeleteTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteTags",
+    "x-amz-target": "SageMaker.DeleteTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTagsInput(input, context));
@@ -2360,7 +2360,7 @@ export const serializeAws_json1_1DeleteTrialCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteTrial",
+    "x-amz-target": "SageMaker.DeleteTrial",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTrialRequest(input, context));
@@ -2373,7 +2373,7 @@ export const serializeAws_json1_1DeleteTrialComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteTrialComponent",
+    "x-amz-target": "SageMaker.DeleteTrialComponent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTrialComponentRequest(input, context));
@@ -2386,7 +2386,7 @@ export const serializeAws_json1_1DeleteUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteUserProfile",
+    "x-amz-target": "SageMaker.DeleteUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserProfileRequest(input, context));
@@ -2399,7 +2399,7 @@ export const serializeAws_json1_1DeleteWorkforceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteWorkforce",
+    "x-amz-target": "SageMaker.DeleteWorkforce",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWorkforceRequest(input, context));
@@ -2412,7 +2412,7 @@ export const serializeAws_json1_1DeleteWorkteamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeleteWorkteam",
+    "x-amz-target": "SageMaker.DeleteWorkteam",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWorkteamRequest(input, context));
@@ -2425,7 +2425,7 @@ export const serializeAws_json1_1DeregisterDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DeregisterDevices",
+    "x-amz-target": "SageMaker.DeregisterDevices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterDevicesRequest(input, context));
@@ -2438,7 +2438,7 @@ export const serializeAws_json1_1DescribeActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeAction",
+    "x-amz-target": "SageMaker.DescribeAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeActionRequest(input, context));
@@ -2451,7 +2451,7 @@ export const serializeAws_json1_1DescribeAlgorithmCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeAlgorithm",
+    "x-amz-target": "SageMaker.DescribeAlgorithm",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAlgorithmInput(input, context));
@@ -2464,7 +2464,7 @@ export const serializeAws_json1_1DescribeAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeApp",
+    "x-amz-target": "SageMaker.DescribeApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAppRequest(input, context));
@@ -2477,7 +2477,7 @@ export const serializeAws_json1_1DescribeAppImageConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeAppImageConfig",
+    "x-amz-target": "SageMaker.DescribeAppImageConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAppImageConfigRequest(input, context));
@@ -2490,7 +2490,7 @@ export const serializeAws_json1_1DescribeArtifactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeArtifact",
+    "x-amz-target": "SageMaker.DescribeArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeArtifactRequest(input, context));
@@ -2503,7 +2503,7 @@ export const serializeAws_json1_1DescribeAutoMLJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeAutoMLJob",
+    "x-amz-target": "SageMaker.DescribeAutoMLJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAutoMLJobRequest(input, context));
@@ -2516,7 +2516,7 @@ export const serializeAws_json1_1DescribeCodeRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeCodeRepository",
+    "x-amz-target": "SageMaker.DescribeCodeRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCodeRepositoryInput(input, context));
@@ -2529,7 +2529,7 @@ export const serializeAws_json1_1DescribeCompilationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeCompilationJob",
+    "x-amz-target": "SageMaker.DescribeCompilationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCompilationJobRequest(input, context));
@@ -2542,7 +2542,7 @@ export const serializeAws_json1_1DescribeContextCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeContext",
+    "x-amz-target": "SageMaker.DescribeContext",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeContextRequest(input, context));
@@ -2555,7 +2555,7 @@ export const serializeAws_json1_1DescribeDataQualityJobDefinitionCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeDataQualityJobDefinition",
+    "x-amz-target": "SageMaker.DescribeDataQualityJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDataQualityJobDefinitionRequest(input, context));
@@ -2568,7 +2568,7 @@ export const serializeAws_json1_1DescribeDeviceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeDevice",
+    "x-amz-target": "SageMaker.DescribeDevice",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDeviceRequest(input, context));
@@ -2581,7 +2581,7 @@ export const serializeAws_json1_1DescribeDeviceFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeDeviceFleet",
+    "x-amz-target": "SageMaker.DescribeDeviceFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDeviceFleetRequest(input, context));
@@ -2594,7 +2594,7 @@ export const serializeAws_json1_1DescribeDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeDomain",
+    "x-amz-target": "SageMaker.DescribeDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDomainRequest(input, context));
@@ -2607,7 +2607,7 @@ export const serializeAws_json1_1DescribeEdgePackagingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeEdgePackagingJob",
+    "x-amz-target": "SageMaker.DescribeEdgePackagingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEdgePackagingJobRequest(input, context));
@@ -2620,7 +2620,7 @@ export const serializeAws_json1_1DescribeEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeEndpoint",
+    "x-amz-target": "SageMaker.DescribeEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEndpointInput(input, context));
@@ -2633,7 +2633,7 @@ export const serializeAws_json1_1DescribeEndpointConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeEndpointConfig",
+    "x-amz-target": "SageMaker.DescribeEndpointConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEndpointConfigInput(input, context));
@@ -2646,7 +2646,7 @@ export const serializeAws_json1_1DescribeExperimentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeExperiment",
+    "x-amz-target": "SageMaker.DescribeExperiment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeExperimentRequest(input, context));
@@ -2659,7 +2659,7 @@ export const serializeAws_json1_1DescribeFeatureGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeFeatureGroup",
+    "x-amz-target": "SageMaker.DescribeFeatureGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFeatureGroupRequest(input, context));
@@ -2672,7 +2672,7 @@ export const serializeAws_json1_1DescribeFlowDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeFlowDefinition",
+    "x-amz-target": "SageMaker.DescribeFlowDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeFlowDefinitionRequest(input, context));
@@ -2685,7 +2685,7 @@ export const serializeAws_json1_1DescribeHumanTaskUiCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeHumanTaskUi",
+    "x-amz-target": "SageMaker.DescribeHumanTaskUi",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeHumanTaskUiRequest(input, context));
@@ -2698,7 +2698,7 @@ export const serializeAws_json1_1DescribeHyperParameterTuningJobCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeHyperParameterTuningJob",
+    "x-amz-target": "SageMaker.DescribeHyperParameterTuningJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeHyperParameterTuningJobRequest(input, context));
@@ -2711,7 +2711,7 @@ export const serializeAws_json1_1DescribeImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeImage",
+    "x-amz-target": "SageMaker.DescribeImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeImageRequest(input, context));
@@ -2724,7 +2724,7 @@ export const serializeAws_json1_1DescribeImageVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeImageVersion",
+    "x-amz-target": "SageMaker.DescribeImageVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeImageVersionRequest(input, context));
@@ -2737,7 +2737,7 @@ export const serializeAws_json1_1DescribeLabelingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeLabelingJob",
+    "x-amz-target": "SageMaker.DescribeLabelingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLabelingJobRequest(input, context));
@@ -2750,7 +2750,7 @@ export const serializeAws_json1_1DescribeModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeModel",
+    "x-amz-target": "SageMaker.DescribeModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeModelInput(input, context));
@@ -2763,7 +2763,7 @@ export const serializeAws_json1_1DescribeModelBiasJobDefinitionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeModelBiasJobDefinition",
+    "x-amz-target": "SageMaker.DescribeModelBiasJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeModelBiasJobDefinitionRequest(input, context));
@@ -2776,7 +2776,7 @@ export const serializeAws_json1_1DescribeModelExplainabilityJobDefinitionCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeModelExplainabilityJobDefinition",
+    "x-amz-target": "SageMaker.DescribeModelExplainabilityJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeModelExplainabilityJobDefinitionRequest(input, context));
@@ -2789,7 +2789,7 @@ export const serializeAws_json1_1DescribeModelPackageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeModelPackage",
+    "x-amz-target": "SageMaker.DescribeModelPackage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeModelPackageInput(input, context));
@@ -2802,7 +2802,7 @@ export const serializeAws_json1_1DescribeModelPackageGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeModelPackageGroup",
+    "x-amz-target": "SageMaker.DescribeModelPackageGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeModelPackageGroupInput(input, context));
@@ -2815,7 +2815,7 @@ export const serializeAws_json1_1DescribeModelQualityJobDefinitionCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeModelQualityJobDefinition",
+    "x-amz-target": "SageMaker.DescribeModelQualityJobDefinition",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeModelQualityJobDefinitionRequest(input, context));
@@ -2828,7 +2828,7 @@ export const serializeAws_json1_1DescribeMonitoringScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeMonitoringSchedule",
+    "x-amz-target": "SageMaker.DescribeMonitoringSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMonitoringScheduleRequest(input, context));
@@ -2841,7 +2841,7 @@ export const serializeAws_json1_1DescribeNotebookInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeNotebookInstance",
+    "x-amz-target": "SageMaker.DescribeNotebookInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeNotebookInstanceInput(input, context));
@@ -2854,7 +2854,7 @@ export const serializeAws_json1_1DescribeNotebookInstanceLifecycleConfigCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeNotebookInstanceLifecycleConfig",
+    "x-amz-target": "SageMaker.DescribeNotebookInstanceLifecycleConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeNotebookInstanceLifecycleConfigInput(input, context));
@@ -2867,7 +2867,7 @@ export const serializeAws_json1_1DescribePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribePipeline",
+    "x-amz-target": "SageMaker.DescribePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePipelineRequest(input, context));
@@ -2880,7 +2880,7 @@ export const serializeAws_json1_1DescribePipelineDefinitionForExecutionCommand =
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribePipelineDefinitionForExecution",
+    "x-amz-target": "SageMaker.DescribePipelineDefinitionForExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePipelineDefinitionForExecutionRequest(input, context));
@@ -2893,7 +2893,7 @@ export const serializeAws_json1_1DescribePipelineExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribePipelineExecution",
+    "x-amz-target": "SageMaker.DescribePipelineExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePipelineExecutionRequest(input, context));
@@ -2906,7 +2906,7 @@ export const serializeAws_json1_1DescribeProcessingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeProcessingJob",
+    "x-amz-target": "SageMaker.DescribeProcessingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProcessingJobRequest(input, context));
@@ -2919,7 +2919,7 @@ export const serializeAws_json1_1DescribeProjectCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeProject",
+    "x-amz-target": "SageMaker.DescribeProject",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProjectInput(input, context));
@@ -2932,7 +2932,7 @@ export const serializeAws_json1_1DescribeSubscribedWorkteamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeSubscribedWorkteam",
+    "x-amz-target": "SageMaker.DescribeSubscribedWorkteam",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSubscribedWorkteamRequest(input, context));
@@ -2945,7 +2945,7 @@ export const serializeAws_json1_1DescribeTrainingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeTrainingJob",
+    "x-amz-target": "SageMaker.DescribeTrainingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTrainingJobRequest(input, context));
@@ -2958,7 +2958,7 @@ export const serializeAws_json1_1DescribeTransformJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeTransformJob",
+    "x-amz-target": "SageMaker.DescribeTransformJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTransformJobRequest(input, context));
@@ -2971,7 +2971,7 @@ export const serializeAws_json1_1DescribeTrialCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeTrial",
+    "x-amz-target": "SageMaker.DescribeTrial",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTrialRequest(input, context));
@@ -2984,7 +2984,7 @@ export const serializeAws_json1_1DescribeTrialComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeTrialComponent",
+    "x-amz-target": "SageMaker.DescribeTrialComponent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTrialComponentRequest(input, context));
@@ -2997,7 +2997,7 @@ export const serializeAws_json1_1DescribeUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeUserProfile",
+    "x-amz-target": "SageMaker.DescribeUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserProfileRequest(input, context));
@@ -3010,7 +3010,7 @@ export const serializeAws_json1_1DescribeWorkforceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeWorkforce",
+    "x-amz-target": "SageMaker.DescribeWorkforce",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeWorkforceRequest(input, context));
@@ -3023,7 +3023,7 @@ export const serializeAws_json1_1DescribeWorkteamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DescribeWorkteam",
+    "x-amz-target": "SageMaker.DescribeWorkteam",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeWorkteamRequest(input, context));
@@ -3036,7 +3036,7 @@ export const serializeAws_json1_1DisableSagemakerServicecatalogPortfolioCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DisableSagemakerServicecatalogPortfolio",
+    "x-amz-target": "SageMaker.DisableSagemakerServicecatalogPortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableSagemakerServicecatalogPortfolioInput(input, context));
@@ -3049,7 +3049,7 @@ export const serializeAws_json1_1DisassociateTrialComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.DisassociateTrialComponent",
+    "x-amz-target": "SageMaker.DisassociateTrialComponent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateTrialComponentRequest(input, context));
@@ -3062,7 +3062,7 @@ export const serializeAws_json1_1EnableSagemakerServicecatalogPortfolioCommand =
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.EnableSagemakerServicecatalogPortfolio",
+    "x-amz-target": "SageMaker.EnableSagemakerServicecatalogPortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableSagemakerServicecatalogPortfolioInput(input, context));
@@ -3075,7 +3075,7 @@ export const serializeAws_json1_1GetDeviceFleetReportCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.GetDeviceFleetReport",
+    "x-amz-target": "SageMaker.GetDeviceFleetReport",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeviceFleetReportRequest(input, context));
@@ -3088,7 +3088,7 @@ export const serializeAws_json1_1GetModelPackageGroupPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.GetModelPackageGroupPolicy",
+    "x-amz-target": "SageMaker.GetModelPackageGroupPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetModelPackageGroupPolicyInput(input, context));
@@ -3101,7 +3101,7 @@ export const serializeAws_json1_1GetSagemakerServicecatalogPortfolioStatusComman
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.GetSagemakerServicecatalogPortfolioStatus",
+    "x-amz-target": "SageMaker.GetSagemakerServicecatalogPortfolioStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSagemakerServicecatalogPortfolioStatusInput(input, context));
@@ -3114,7 +3114,7 @@ export const serializeAws_json1_1GetSearchSuggestionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.GetSearchSuggestions",
+    "x-amz-target": "SageMaker.GetSearchSuggestions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSearchSuggestionsRequest(input, context));
@@ -3127,7 +3127,7 @@ export const serializeAws_json1_1ListActionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListActions",
+    "x-amz-target": "SageMaker.ListActions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListActionsRequest(input, context));
@@ -3140,7 +3140,7 @@ export const serializeAws_json1_1ListAlgorithmsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListAlgorithms",
+    "x-amz-target": "SageMaker.ListAlgorithms",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAlgorithmsInput(input, context));
@@ -3153,7 +3153,7 @@ export const serializeAws_json1_1ListAppImageConfigsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListAppImageConfigs",
+    "x-amz-target": "SageMaker.ListAppImageConfigs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAppImageConfigsRequest(input, context));
@@ -3166,7 +3166,7 @@ export const serializeAws_json1_1ListAppsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListApps",
+    "x-amz-target": "SageMaker.ListApps",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAppsRequest(input, context));
@@ -3179,7 +3179,7 @@ export const serializeAws_json1_1ListArtifactsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListArtifacts",
+    "x-amz-target": "SageMaker.ListArtifacts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListArtifactsRequest(input, context));
@@ -3192,7 +3192,7 @@ export const serializeAws_json1_1ListAssociationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListAssociations",
+    "x-amz-target": "SageMaker.ListAssociations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssociationsRequest(input, context));
@@ -3205,7 +3205,7 @@ export const serializeAws_json1_1ListAutoMLJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListAutoMLJobs",
+    "x-amz-target": "SageMaker.ListAutoMLJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAutoMLJobsRequest(input, context));
@@ -3218,7 +3218,7 @@ export const serializeAws_json1_1ListCandidatesForAutoMLJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListCandidatesForAutoMLJob",
+    "x-amz-target": "SageMaker.ListCandidatesForAutoMLJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCandidatesForAutoMLJobRequest(input, context));
@@ -3231,7 +3231,7 @@ export const serializeAws_json1_1ListCodeRepositoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListCodeRepositories",
+    "x-amz-target": "SageMaker.ListCodeRepositories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCodeRepositoriesInput(input, context));
@@ -3244,7 +3244,7 @@ export const serializeAws_json1_1ListCompilationJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListCompilationJobs",
+    "x-amz-target": "SageMaker.ListCompilationJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCompilationJobsRequest(input, context));
@@ -3257,7 +3257,7 @@ export const serializeAws_json1_1ListContextsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListContexts",
+    "x-amz-target": "SageMaker.ListContexts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListContextsRequest(input, context));
@@ -3270,7 +3270,7 @@ export const serializeAws_json1_1ListDataQualityJobDefinitionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListDataQualityJobDefinitions",
+    "x-amz-target": "SageMaker.ListDataQualityJobDefinitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDataQualityJobDefinitionsRequest(input, context));
@@ -3283,7 +3283,7 @@ export const serializeAws_json1_1ListDeviceFleetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListDeviceFleets",
+    "x-amz-target": "SageMaker.ListDeviceFleets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDeviceFleetsRequest(input, context));
@@ -3296,7 +3296,7 @@ export const serializeAws_json1_1ListDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListDevices",
+    "x-amz-target": "SageMaker.ListDevices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDevicesRequest(input, context));
@@ -3309,7 +3309,7 @@ export const serializeAws_json1_1ListDomainsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListDomains",
+    "x-amz-target": "SageMaker.ListDomains",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDomainsRequest(input, context));
@@ -3322,7 +3322,7 @@ export const serializeAws_json1_1ListEdgePackagingJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListEdgePackagingJobs",
+    "x-amz-target": "SageMaker.ListEdgePackagingJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEdgePackagingJobsRequest(input, context));
@@ -3335,7 +3335,7 @@ export const serializeAws_json1_1ListEndpointConfigsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListEndpointConfigs",
+    "x-amz-target": "SageMaker.ListEndpointConfigs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEndpointConfigsInput(input, context));
@@ -3348,7 +3348,7 @@ export const serializeAws_json1_1ListEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListEndpoints",
+    "x-amz-target": "SageMaker.ListEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListEndpointsInput(input, context));
@@ -3361,7 +3361,7 @@ export const serializeAws_json1_1ListExperimentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListExperiments",
+    "x-amz-target": "SageMaker.ListExperiments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListExperimentsRequest(input, context));
@@ -3374,7 +3374,7 @@ export const serializeAws_json1_1ListFeatureGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListFeatureGroups",
+    "x-amz-target": "SageMaker.ListFeatureGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListFeatureGroupsRequest(input, context));
@@ -3387,7 +3387,7 @@ export const serializeAws_json1_1ListFlowDefinitionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListFlowDefinitions",
+    "x-amz-target": "SageMaker.ListFlowDefinitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListFlowDefinitionsRequest(input, context));
@@ -3400,7 +3400,7 @@ export const serializeAws_json1_1ListHumanTaskUisCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListHumanTaskUis",
+    "x-amz-target": "SageMaker.ListHumanTaskUis",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListHumanTaskUisRequest(input, context));
@@ -3413,7 +3413,7 @@ export const serializeAws_json1_1ListHyperParameterTuningJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListHyperParameterTuningJobs",
+    "x-amz-target": "SageMaker.ListHyperParameterTuningJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListHyperParameterTuningJobsRequest(input, context));
@@ -3426,7 +3426,7 @@ export const serializeAws_json1_1ListImagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListImages",
+    "x-amz-target": "SageMaker.ListImages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListImagesRequest(input, context));
@@ -3439,7 +3439,7 @@ export const serializeAws_json1_1ListImageVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListImageVersions",
+    "x-amz-target": "SageMaker.ListImageVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListImageVersionsRequest(input, context));
@@ -3452,7 +3452,7 @@ export const serializeAws_json1_1ListLabelingJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListLabelingJobs",
+    "x-amz-target": "SageMaker.ListLabelingJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLabelingJobsRequest(input, context));
@@ -3465,7 +3465,7 @@ export const serializeAws_json1_1ListLabelingJobsForWorkteamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListLabelingJobsForWorkteam",
+    "x-amz-target": "SageMaker.ListLabelingJobsForWorkteam",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLabelingJobsForWorkteamRequest(input, context));
@@ -3478,7 +3478,7 @@ export const serializeAws_json1_1ListModelBiasJobDefinitionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListModelBiasJobDefinitions",
+    "x-amz-target": "SageMaker.ListModelBiasJobDefinitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListModelBiasJobDefinitionsRequest(input, context));
@@ -3491,7 +3491,7 @@ export const serializeAws_json1_1ListModelExplainabilityJobDefinitionsCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListModelExplainabilityJobDefinitions",
+    "x-amz-target": "SageMaker.ListModelExplainabilityJobDefinitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListModelExplainabilityJobDefinitionsRequest(input, context));
@@ -3504,7 +3504,7 @@ export const serializeAws_json1_1ListModelPackageGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListModelPackageGroups",
+    "x-amz-target": "SageMaker.ListModelPackageGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListModelPackageGroupsInput(input, context));
@@ -3517,7 +3517,7 @@ export const serializeAws_json1_1ListModelPackagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListModelPackages",
+    "x-amz-target": "SageMaker.ListModelPackages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListModelPackagesInput(input, context));
@@ -3530,7 +3530,7 @@ export const serializeAws_json1_1ListModelQualityJobDefinitionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListModelQualityJobDefinitions",
+    "x-amz-target": "SageMaker.ListModelQualityJobDefinitions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListModelQualityJobDefinitionsRequest(input, context));
@@ -3543,7 +3543,7 @@ export const serializeAws_json1_1ListModelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListModels",
+    "x-amz-target": "SageMaker.ListModels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListModelsInput(input, context));
@@ -3556,7 +3556,7 @@ export const serializeAws_json1_1ListMonitoringExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListMonitoringExecutions",
+    "x-amz-target": "SageMaker.ListMonitoringExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListMonitoringExecutionsRequest(input, context));
@@ -3569,7 +3569,7 @@ export const serializeAws_json1_1ListMonitoringSchedulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListMonitoringSchedules",
+    "x-amz-target": "SageMaker.ListMonitoringSchedules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListMonitoringSchedulesRequest(input, context));
@@ -3582,7 +3582,7 @@ export const serializeAws_json1_1ListNotebookInstanceLifecycleConfigsCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListNotebookInstanceLifecycleConfigs",
+    "x-amz-target": "SageMaker.ListNotebookInstanceLifecycleConfigs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListNotebookInstanceLifecycleConfigsInput(input, context));
@@ -3595,7 +3595,7 @@ export const serializeAws_json1_1ListNotebookInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListNotebookInstances",
+    "x-amz-target": "SageMaker.ListNotebookInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListNotebookInstancesInput(input, context));
@@ -3608,7 +3608,7 @@ export const serializeAws_json1_1ListPipelineExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListPipelineExecutions",
+    "x-amz-target": "SageMaker.ListPipelineExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPipelineExecutionsRequest(input, context));
@@ -3621,7 +3621,7 @@ export const serializeAws_json1_1ListPipelineExecutionStepsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListPipelineExecutionSteps",
+    "x-amz-target": "SageMaker.ListPipelineExecutionSteps",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPipelineExecutionStepsRequest(input, context));
@@ -3634,7 +3634,7 @@ export const serializeAws_json1_1ListPipelineParametersForExecutionCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListPipelineParametersForExecution",
+    "x-amz-target": "SageMaker.ListPipelineParametersForExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPipelineParametersForExecutionRequest(input, context));
@@ -3647,7 +3647,7 @@ export const serializeAws_json1_1ListPipelinesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListPipelines",
+    "x-amz-target": "SageMaker.ListPipelines",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPipelinesRequest(input, context));
@@ -3660,7 +3660,7 @@ export const serializeAws_json1_1ListProcessingJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListProcessingJobs",
+    "x-amz-target": "SageMaker.ListProcessingJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProcessingJobsRequest(input, context));
@@ -3673,7 +3673,7 @@ export const serializeAws_json1_1ListProjectsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListProjects",
+    "x-amz-target": "SageMaker.ListProjects",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProjectsInput(input, context));
@@ -3686,7 +3686,7 @@ export const serializeAws_json1_1ListSubscribedWorkteamsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListSubscribedWorkteams",
+    "x-amz-target": "SageMaker.ListSubscribedWorkteams",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSubscribedWorkteamsRequest(input, context));
@@ -3699,7 +3699,7 @@ export const serializeAws_json1_1ListTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListTags",
+    "x-amz-target": "SageMaker.ListTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsInput(input, context));
@@ -3712,7 +3712,7 @@ export const serializeAws_json1_1ListTrainingJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListTrainingJobs",
+    "x-amz-target": "SageMaker.ListTrainingJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTrainingJobsRequest(input, context));
@@ -3725,7 +3725,7 @@ export const serializeAws_json1_1ListTrainingJobsForHyperParameterTuningJobComma
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListTrainingJobsForHyperParameterTuningJob",
+    "x-amz-target": "SageMaker.ListTrainingJobsForHyperParameterTuningJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTrainingJobsForHyperParameterTuningJobRequest(input, context));
@@ -3738,7 +3738,7 @@ export const serializeAws_json1_1ListTransformJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListTransformJobs",
+    "x-amz-target": "SageMaker.ListTransformJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTransformJobsRequest(input, context));
@@ -3751,7 +3751,7 @@ export const serializeAws_json1_1ListTrialComponentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListTrialComponents",
+    "x-amz-target": "SageMaker.ListTrialComponents",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTrialComponentsRequest(input, context));
@@ -3764,7 +3764,7 @@ export const serializeAws_json1_1ListTrialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListTrials",
+    "x-amz-target": "SageMaker.ListTrials",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTrialsRequest(input, context));
@@ -3777,7 +3777,7 @@ export const serializeAws_json1_1ListUserProfilesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListUserProfiles",
+    "x-amz-target": "SageMaker.ListUserProfiles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUserProfilesRequest(input, context));
@@ -3790,7 +3790,7 @@ export const serializeAws_json1_1ListWorkforcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListWorkforces",
+    "x-amz-target": "SageMaker.ListWorkforces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListWorkforcesRequest(input, context));
@@ -3803,7 +3803,7 @@ export const serializeAws_json1_1ListWorkteamsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.ListWorkteams",
+    "x-amz-target": "SageMaker.ListWorkteams",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListWorkteamsRequest(input, context));
@@ -3816,7 +3816,7 @@ export const serializeAws_json1_1PutModelPackageGroupPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.PutModelPackageGroupPolicy",
+    "x-amz-target": "SageMaker.PutModelPackageGroupPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutModelPackageGroupPolicyInput(input, context));
@@ -3829,7 +3829,7 @@ export const serializeAws_json1_1RegisterDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.RegisterDevices",
+    "x-amz-target": "SageMaker.RegisterDevices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterDevicesRequest(input, context));
@@ -3842,7 +3842,7 @@ export const serializeAws_json1_1RenderUiTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.RenderUiTemplate",
+    "x-amz-target": "SageMaker.RenderUiTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RenderUiTemplateRequest(input, context));
@@ -3855,7 +3855,7 @@ export const serializeAws_json1_1SearchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.Search",
+    "x-amz-target": "SageMaker.Search",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchRequest(input, context));
@@ -3868,7 +3868,7 @@ export const serializeAws_json1_1StartMonitoringScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StartMonitoringSchedule",
+    "x-amz-target": "SageMaker.StartMonitoringSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartMonitoringScheduleRequest(input, context));
@@ -3881,7 +3881,7 @@ export const serializeAws_json1_1StartNotebookInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StartNotebookInstance",
+    "x-amz-target": "SageMaker.StartNotebookInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartNotebookInstanceInput(input, context));
@@ -3894,7 +3894,7 @@ export const serializeAws_json1_1StartPipelineExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StartPipelineExecution",
+    "x-amz-target": "SageMaker.StartPipelineExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartPipelineExecutionRequest(input, context));
@@ -3907,7 +3907,7 @@ export const serializeAws_json1_1StopAutoMLJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopAutoMLJob",
+    "x-amz-target": "SageMaker.StopAutoMLJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopAutoMLJobRequest(input, context));
@@ -3920,7 +3920,7 @@ export const serializeAws_json1_1StopCompilationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopCompilationJob",
+    "x-amz-target": "SageMaker.StopCompilationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopCompilationJobRequest(input, context));
@@ -3933,7 +3933,7 @@ export const serializeAws_json1_1StopEdgePackagingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopEdgePackagingJob",
+    "x-amz-target": "SageMaker.StopEdgePackagingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopEdgePackagingJobRequest(input, context));
@@ -3946,7 +3946,7 @@ export const serializeAws_json1_1StopHyperParameterTuningJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopHyperParameterTuningJob",
+    "x-amz-target": "SageMaker.StopHyperParameterTuningJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopHyperParameterTuningJobRequest(input, context));
@@ -3959,7 +3959,7 @@ export const serializeAws_json1_1StopLabelingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopLabelingJob",
+    "x-amz-target": "SageMaker.StopLabelingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopLabelingJobRequest(input, context));
@@ -3972,7 +3972,7 @@ export const serializeAws_json1_1StopMonitoringScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopMonitoringSchedule",
+    "x-amz-target": "SageMaker.StopMonitoringSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopMonitoringScheduleRequest(input, context));
@@ -3985,7 +3985,7 @@ export const serializeAws_json1_1StopNotebookInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopNotebookInstance",
+    "x-amz-target": "SageMaker.StopNotebookInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopNotebookInstanceInput(input, context));
@@ -3998,7 +3998,7 @@ export const serializeAws_json1_1StopPipelineExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopPipelineExecution",
+    "x-amz-target": "SageMaker.StopPipelineExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopPipelineExecutionRequest(input, context));
@@ -4011,7 +4011,7 @@ export const serializeAws_json1_1StopProcessingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopProcessingJob",
+    "x-amz-target": "SageMaker.StopProcessingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopProcessingJobRequest(input, context));
@@ -4024,7 +4024,7 @@ export const serializeAws_json1_1StopTrainingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopTrainingJob",
+    "x-amz-target": "SageMaker.StopTrainingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopTrainingJobRequest(input, context));
@@ -4037,7 +4037,7 @@ export const serializeAws_json1_1StopTransformJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.StopTransformJob",
+    "x-amz-target": "SageMaker.StopTransformJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopTransformJobRequest(input, context));
@@ -4050,7 +4050,7 @@ export const serializeAws_json1_1UpdateActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateAction",
+    "x-amz-target": "SageMaker.UpdateAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateActionRequest(input, context));
@@ -4063,7 +4063,7 @@ export const serializeAws_json1_1UpdateAppImageConfigCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateAppImageConfig",
+    "x-amz-target": "SageMaker.UpdateAppImageConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAppImageConfigRequest(input, context));
@@ -4076,7 +4076,7 @@ export const serializeAws_json1_1UpdateArtifactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateArtifact",
+    "x-amz-target": "SageMaker.UpdateArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateArtifactRequest(input, context));
@@ -4089,7 +4089,7 @@ export const serializeAws_json1_1UpdateCodeRepositoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateCodeRepository",
+    "x-amz-target": "SageMaker.UpdateCodeRepository",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateCodeRepositoryInput(input, context));
@@ -4102,7 +4102,7 @@ export const serializeAws_json1_1UpdateContextCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateContext",
+    "x-amz-target": "SageMaker.UpdateContext",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateContextRequest(input, context));
@@ -4115,7 +4115,7 @@ export const serializeAws_json1_1UpdateDeviceFleetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateDeviceFleet",
+    "x-amz-target": "SageMaker.UpdateDeviceFleet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDeviceFleetRequest(input, context));
@@ -4128,7 +4128,7 @@ export const serializeAws_json1_1UpdateDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateDevices",
+    "x-amz-target": "SageMaker.UpdateDevices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDevicesRequest(input, context));
@@ -4141,7 +4141,7 @@ export const serializeAws_json1_1UpdateDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateDomain",
+    "x-amz-target": "SageMaker.UpdateDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDomainRequest(input, context));
@@ -4154,7 +4154,7 @@ export const serializeAws_json1_1UpdateEndpointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateEndpoint",
+    "x-amz-target": "SageMaker.UpdateEndpoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateEndpointInput(input, context));
@@ -4167,7 +4167,7 @@ export const serializeAws_json1_1UpdateEndpointWeightsAndCapacitiesCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateEndpointWeightsAndCapacities",
+    "x-amz-target": "SageMaker.UpdateEndpointWeightsAndCapacities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateEndpointWeightsAndCapacitiesInput(input, context));
@@ -4180,7 +4180,7 @@ export const serializeAws_json1_1UpdateExperimentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateExperiment",
+    "x-amz-target": "SageMaker.UpdateExperiment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateExperimentRequest(input, context));
@@ -4193,7 +4193,7 @@ export const serializeAws_json1_1UpdateImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateImage",
+    "x-amz-target": "SageMaker.UpdateImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateImageRequest(input, context));
@@ -4206,7 +4206,7 @@ export const serializeAws_json1_1UpdateModelPackageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateModelPackage",
+    "x-amz-target": "SageMaker.UpdateModelPackage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateModelPackageInput(input, context));
@@ -4219,7 +4219,7 @@ export const serializeAws_json1_1UpdateMonitoringScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateMonitoringSchedule",
+    "x-amz-target": "SageMaker.UpdateMonitoringSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMonitoringScheduleRequest(input, context));
@@ -4232,7 +4232,7 @@ export const serializeAws_json1_1UpdateNotebookInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateNotebookInstance",
+    "x-amz-target": "SageMaker.UpdateNotebookInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateNotebookInstanceInput(input, context));
@@ -4245,7 +4245,7 @@ export const serializeAws_json1_1UpdateNotebookInstanceLifecycleConfigCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateNotebookInstanceLifecycleConfig",
+    "x-amz-target": "SageMaker.UpdateNotebookInstanceLifecycleConfig",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateNotebookInstanceLifecycleConfigInput(input, context));
@@ -4258,7 +4258,7 @@ export const serializeAws_json1_1UpdatePipelineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdatePipeline",
+    "x-amz-target": "SageMaker.UpdatePipeline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePipelineRequest(input, context));
@@ -4271,7 +4271,7 @@ export const serializeAws_json1_1UpdatePipelineExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdatePipelineExecution",
+    "x-amz-target": "SageMaker.UpdatePipelineExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePipelineExecutionRequest(input, context));
@@ -4284,7 +4284,7 @@ export const serializeAws_json1_1UpdateTrainingJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateTrainingJob",
+    "x-amz-target": "SageMaker.UpdateTrainingJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTrainingJobRequest(input, context));
@@ -4297,7 +4297,7 @@ export const serializeAws_json1_1UpdateTrialCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateTrial",
+    "x-amz-target": "SageMaker.UpdateTrial",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTrialRequest(input, context));
@@ -4310,7 +4310,7 @@ export const serializeAws_json1_1UpdateTrialComponentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateTrialComponent",
+    "x-amz-target": "SageMaker.UpdateTrialComponent",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTrialComponentRequest(input, context));
@@ -4323,7 +4323,7 @@ export const serializeAws_json1_1UpdateUserProfileCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateUserProfile",
+    "x-amz-target": "SageMaker.UpdateUserProfile",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateUserProfileRequest(input, context));
@@ -4336,7 +4336,7 @@ export const serializeAws_json1_1UpdateWorkforceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateWorkforce",
+    "x-amz-target": "SageMaker.UpdateWorkforce",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateWorkforceRequest(input, context));
@@ -4349,7 +4349,7 @@ export const serializeAws_json1_1UpdateWorkteamCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SageMaker.UpdateWorkteam",
+    "x-amz-target": "SageMaker.UpdateWorkteam",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateWorkteamRequest(input, context));

--- a/clients/client-secrets-manager/protocols/Aws_json1_1.ts
+++ b/clients/client-secrets-manager/protocols/Aws_json1_1.ts
@@ -102,7 +102,7 @@ export const serializeAws_json1_1CancelRotateSecretCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.CancelRotateSecret",
+    "x-amz-target": "secretsmanager.CancelRotateSecret",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelRotateSecretRequest(input, context));
@@ -115,7 +115,7 @@ export const serializeAws_json1_1CreateSecretCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.CreateSecret",
+    "x-amz-target": "secretsmanager.CreateSecret",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSecretRequest(input, context));
@@ -128,7 +128,7 @@ export const serializeAws_json1_1DeleteResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.DeleteResourcePolicy",
+    "x-amz-target": "secretsmanager.DeleteResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResourcePolicyRequest(input, context));
@@ -141,7 +141,7 @@ export const serializeAws_json1_1DeleteSecretCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.DeleteSecret",
+    "x-amz-target": "secretsmanager.DeleteSecret",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSecretRequest(input, context));
@@ -154,7 +154,7 @@ export const serializeAws_json1_1DescribeSecretCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.DescribeSecret",
+    "x-amz-target": "secretsmanager.DescribeSecret",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSecretRequest(input, context));
@@ -167,7 +167,7 @@ export const serializeAws_json1_1GetRandomPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.GetRandomPassword",
+    "x-amz-target": "secretsmanager.GetRandomPassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRandomPasswordRequest(input, context));
@@ -180,7 +180,7 @@ export const serializeAws_json1_1GetResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.GetResourcePolicy",
+    "x-amz-target": "secretsmanager.GetResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetResourcePolicyRequest(input, context));
@@ -193,7 +193,7 @@ export const serializeAws_json1_1GetSecretValueCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.GetSecretValue",
+    "x-amz-target": "secretsmanager.GetSecretValue",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSecretValueRequest(input, context));
@@ -206,7 +206,7 @@ export const serializeAws_json1_1ListSecretsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.ListSecrets",
+    "x-amz-target": "secretsmanager.ListSecrets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSecretsRequest(input, context));
@@ -219,7 +219,7 @@ export const serializeAws_json1_1ListSecretVersionIdsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.ListSecretVersionIds",
+    "x-amz-target": "secretsmanager.ListSecretVersionIds",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSecretVersionIdsRequest(input, context));
@@ -232,7 +232,7 @@ export const serializeAws_json1_1PutResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.PutResourcePolicy",
+    "x-amz-target": "secretsmanager.PutResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutResourcePolicyRequest(input, context));
@@ -245,7 +245,7 @@ export const serializeAws_json1_1PutSecretValueCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.PutSecretValue",
+    "x-amz-target": "secretsmanager.PutSecretValue",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutSecretValueRequest(input, context));
@@ -258,7 +258,7 @@ export const serializeAws_json1_1RestoreSecretCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.RestoreSecret",
+    "x-amz-target": "secretsmanager.RestoreSecret",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RestoreSecretRequest(input, context));
@@ -271,7 +271,7 @@ export const serializeAws_json1_1RotateSecretCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.RotateSecret",
+    "x-amz-target": "secretsmanager.RotateSecret",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RotateSecretRequest(input, context));
@@ -284,7 +284,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.TagResource",
+    "x-amz-target": "secretsmanager.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -297,7 +297,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.UntagResource",
+    "x-amz-target": "secretsmanager.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -310,7 +310,7 @@ export const serializeAws_json1_1UpdateSecretCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.UpdateSecret",
+    "x-amz-target": "secretsmanager.UpdateSecret",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSecretRequest(input, context));
@@ -323,7 +323,7 @@ export const serializeAws_json1_1UpdateSecretVersionStageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.UpdateSecretVersionStage",
+    "x-amz-target": "secretsmanager.UpdateSecretVersionStage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSecretVersionStageRequest(input, context));
@@ -336,7 +336,7 @@ export const serializeAws_json1_1ValidateResourcePolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "secretsmanager.ValidateResourcePolicy",
+    "x-amz-target": "secretsmanager.ValidateResourcePolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ValidateResourcePolicyRequest(input, context));

--- a/clients/client-service-catalog/protocols/Aws_json1_1.ts
+++ b/clients/client-service-catalog/protocols/Aws_json1_1.ts
@@ -519,7 +519,7 @@ export const serializeAws_json1_1AcceptPortfolioShareCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.AcceptPortfolioShare",
+    "x-amz-target": "AWS242ServiceCatalogService.AcceptPortfolioShare",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AcceptPortfolioShareInput(input, context));
@@ -532,7 +532,7 @@ export const serializeAws_json1_1AssociateBudgetWithResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.AssociateBudgetWithResource",
+    "x-amz-target": "AWS242ServiceCatalogService.AssociateBudgetWithResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateBudgetWithResourceInput(input, context));
@@ -545,7 +545,7 @@ export const serializeAws_json1_1AssociatePrincipalWithPortfolioCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.AssociatePrincipalWithPortfolio",
+    "x-amz-target": "AWS242ServiceCatalogService.AssociatePrincipalWithPortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociatePrincipalWithPortfolioInput(input, context));
@@ -558,7 +558,7 @@ export const serializeAws_json1_1AssociateProductWithPortfolioCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.AssociateProductWithPortfolio",
+    "x-amz-target": "AWS242ServiceCatalogService.AssociateProductWithPortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateProductWithPortfolioInput(input, context));
@@ -571,7 +571,7 @@ export const serializeAws_json1_1AssociateServiceActionWithProvisioningArtifactC
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.AssociateServiceActionWithProvisioningArtifact",
+    "x-amz-target": "AWS242ServiceCatalogService.AssociateServiceActionWithProvisioningArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateServiceActionWithProvisioningArtifactInput(input, context));
@@ -584,7 +584,7 @@ export const serializeAws_json1_1AssociateTagOptionWithResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.AssociateTagOptionWithResource",
+    "x-amz-target": "AWS242ServiceCatalogService.AssociateTagOptionWithResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateTagOptionWithResourceInput(input, context));
@@ -597,7 +597,7 @@ export const serializeAws_json1_1BatchAssociateServiceActionWithProvisioningArti
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.BatchAssociateServiceActionWithProvisioningArtifact",
+    "x-amz-target": "AWS242ServiceCatalogService.BatchAssociateServiceActionWithProvisioningArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1BatchAssociateServiceActionWithProvisioningArtifactInput(input, context));
@@ -610,7 +610,7 @@ export const serializeAws_json1_1BatchDisassociateServiceActionFromProvisioningA
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.BatchDisassociateServiceActionFromProvisioningArtifact",
+    "x-amz-target": "AWS242ServiceCatalogService.BatchDisassociateServiceActionFromProvisioningArtifact",
   };
   let body: any;
   body = JSON.stringify(
@@ -625,7 +625,7 @@ export const serializeAws_json1_1CopyProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.CopyProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.CopyProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CopyProductInput(input, context));
@@ -638,7 +638,7 @@ export const serializeAws_json1_1CreateConstraintCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.CreateConstraint",
+    "x-amz-target": "AWS242ServiceCatalogService.CreateConstraint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateConstraintInput(input, context));
@@ -651,7 +651,7 @@ export const serializeAws_json1_1CreatePortfolioCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.CreatePortfolio",
+    "x-amz-target": "AWS242ServiceCatalogService.CreatePortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePortfolioInput(input, context));
@@ -664,7 +664,7 @@ export const serializeAws_json1_1CreatePortfolioShareCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.CreatePortfolioShare",
+    "x-amz-target": "AWS242ServiceCatalogService.CreatePortfolioShare",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePortfolioShareInput(input, context));
@@ -677,7 +677,7 @@ export const serializeAws_json1_1CreateProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.CreateProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.CreateProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProductInput(input, context));
@@ -690,7 +690,7 @@ export const serializeAws_json1_1CreateProvisionedProductPlanCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.CreateProvisionedProductPlan",
+    "x-amz-target": "AWS242ServiceCatalogService.CreateProvisionedProductPlan",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProvisionedProductPlanInput(input, context));
@@ -703,7 +703,7 @@ export const serializeAws_json1_1CreateProvisioningArtifactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.CreateProvisioningArtifact",
+    "x-amz-target": "AWS242ServiceCatalogService.CreateProvisioningArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProvisioningArtifactInput(input, context));
@@ -716,7 +716,7 @@ export const serializeAws_json1_1CreateServiceActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.CreateServiceAction",
+    "x-amz-target": "AWS242ServiceCatalogService.CreateServiceAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateServiceActionInput(input, context));
@@ -729,7 +729,7 @@ export const serializeAws_json1_1CreateTagOptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.CreateTagOption",
+    "x-amz-target": "AWS242ServiceCatalogService.CreateTagOption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTagOptionInput(input, context));
@@ -742,7 +742,7 @@ export const serializeAws_json1_1DeleteConstraintCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DeleteConstraint",
+    "x-amz-target": "AWS242ServiceCatalogService.DeleteConstraint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConstraintInput(input, context));
@@ -755,7 +755,7 @@ export const serializeAws_json1_1DeletePortfolioCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DeletePortfolio",
+    "x-amz-target": "AWS242ServiceCatalogService.DeletePortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePortfolioInput(input, context));
@@ -768,7 +768,7 @@ export const serializeAws_json1_1DeletePortfolioShareCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DeletePortfolioShare",
+    "x-amz-target": "AWS242ServiceCatalogService.DeletePortfolioShare",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePortfolioShareInput(input, context));
@@ -781,7 +781,7 @@ export const serializeAws_json1_1DeleteProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DeleteProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.DeleteProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProductInput(input, context));
@@ -794,7 +794,7 @@ export const serializeAws_json1_1DeleteProvisionedProductPlanCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DeleteProvisionedProductPlan",
+    "x-amz-target": "AWS242ServiceCatalogService.DeleteProvisionedProductPlan",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProvisionedProductPlanInput(input, context));
@@ -807,7 +807,7 @@ export const serializeAws_json1_1DeleteProvisioningArtifactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DeleteProvisioningArtifact",
+    "x-amz-target": "AWS242ServiceCatalogService.DeleteProvisioningArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProvisioningArtifactInput(input, context));
@@ -820,7 +820,7 @@ export const serializeAws_json1_1DeleteServiceActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DeleteServiceAction",
+    "x-amz-target": "AWS242ServiceCatalogService.DeleteServiceAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteServiceActionInput(input, context));
@@ -833,7 +833,7 @@ export const serializeAws_json1_1DeleteTagOptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DeleteTagOption",
+    "x-amz-target": "AWS242ServiceCatalogService.DeleteTagOption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTagOptionInput(input, context));
@@ -846,7 +846,7 @@ export const serializeAws_json1_1DescribeConstraintCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeConstraint",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeConstraint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConstraintInput(input, context));
@@ -859,7 +859,7 @@ export const serializeAws_json1_1DescribeCopyProductStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeCopyProductStatus",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeCopyProductStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCopyProductStatusInput(input, context));
@@ -872,7 +872,7 @@ export const serializeAws_json1_1DescribePortfolioCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribePortfolio",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribePortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePortfolioInput(input, context));
@@ -885,7 +885,7 @@ export const serializeAws_json1_1DescribePortfolioShareStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribePortfolioShareStatus",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribePortfolioShareStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePortfolioShareStatusInput(input, context));
@@ -898,7 +898,7 @@ export const serializeAws_json1_1DescribeProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProductInput(input, context));
@@ -911,7 +911,7 @@ export const serializeAws_json1_1DescribeProductAsAdminCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeProductAsAdmin",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeProductAsAdmin",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProductAsAdminInput(input, context));
@@ -924,7 +924,7 @@ export const serializeAws_json1_1DescribeProductViewCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeProductView",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeProductView",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProductViewInput(input, context));
@@ -937,7 +937,7 @@ export const serializeAws_json1_1DescribeProvisionedProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeProvisionedProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeProvisionedProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProvisionedProductInput(input, context));
@@ -950,7 +950,7 @@ export const serializeAws_json1_1DescribeProvisionedProductPlanCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeProvisionedProductPlan",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeProvisionedProductPlan",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProvisionedProductPlanInput(input, context));
@@ -963,7 +963,7 @@ export const serializeAws_json1_1DescribeProvisioningArtifactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeProvisioningArtifact",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeProvisioningArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProvisioningArtifactInput(input, context));
@@ -976,7 +976,7 @@ export const serializeAws_json1_1DescribeProvisioningParametersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeProvisioningParameters",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeProvisioningParameters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProvisioningParametersInput(input, context));
@@ -989,7 +989,7 @@ export const serializeAws_json1_1DescribeRecordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeRecord",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeRecord",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeRecordInput(input, context));
@@ -1002,7 +1002,7 @@ export const serializeAws_json1_1DescribeServiceActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeServiceAction",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeServiceAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeServiceActionInput(input, context));
@@ -1015,7 +1015,7 @@ export const serializeAws_json1_1DescribeServiceActionExecutionParametersCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeServiceActionExecutionParameters",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeServiceActionExecutionParameters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeServiceActionExecutionParametersInput(input, context));
@@ -1028,7 +1028,7 @@ export const serializeAws_json1_1DescribeTagOptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DescribeTagOption",
+    "x-amz-target": "AWS242ServiceCatalogService.DescribeTagOption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTagOptionInput(input, context));
@@ -1041,7 +1041,7 @@ export const serializeAws_json1_1DisableAWSOrganizationsAccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DisableAWSOrganizationsAccess",
+    "x-amz-target": "AWS242ServiceCatalogService.DisableAWSOrganizationsAccess",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableAWSOrganizationsAccessInput(input, context));
@@ -1054,7 +1054,7 @@ export const serializeAws_json1_1DisassociateBudgetFromResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DisassociateBudgetFromResource",
+    "x-amz-target": "AWS242ServiceCatalogService.DisassociateBudgetFromResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateBudgetFromResourceInput(input, context));
@@ -1067,7 +1067,7 @@ export const serializeAws_json1_1DisassociatePrincipalFromPortfolioCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DisassociatePrincipalFromPortfolio",
+    "x-amz-target": "AWS242ServiceCatalogService.DisassociatePrincipalFromPortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociatePrincipalFromPortfolioInput(input, context));
@@ -1080,7 +1080,7 @@ export const serializeAws_json1_1DisassociateProductFromPortfolioCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DisassociateProductFromPortfolio",
+    "x-amz-target": "AWS242ServiceCatalogService.DisassociateProductFromPortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateProductFromPortfolioInput(input, context));
@@ -1093,7 +1093,7 @@ export const serializeAws_json1_1DisassociateServiceActionFromProvisioningArtifa
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DisassociateServiceActionFromProvisioningArtifact",
+    "x-amz-target": "AWS242ServiceCatalogService.DisassociateServiceActionFromProvisioningArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateServiceActionFromProvisioningArtifactInput(input, context));
@@ -1106,7 +1106,7 @@ export const serializeAws_json1_1DisassociateTagOptionFromResourceCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.DisassociateTagOptionFromResource",
+    "x-amz-target": "AWS242ServiceCatalogService.DisassociateTagOptionFromResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateTagOptionFromResourceInput(input, context));
@@ -1119,7 +1119,7 @@ export const serializeAws_json1_1EnableAWSOrganizationsAccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.EnableAWSOrganizationsAccess",
+    "x-amz-target": "AWS242ServiceCatalogService.EnableAWSOrganizationsAccess",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableAWSOrganizationsAccessInput(input, context));
@@ -1132,7 +1132,7 @@ export const serializeAws_json1_1ExecuteProvisionedProductPlanCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ExecuteProvisionedProductPlan",
+    "x-amz-target": "AWS242ServiceCatalogService.ExecuteProvisionedProductPlan",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ExecuteProvisionedProductPlanInput(input, context));
@@ -1145,7 +1145,7 @@ export const serializeAws_json1_1ExecuteProvisionedProductServiceActionCommand =
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ExecuteProvisionedProductServiceAction",
+    "x-amz-target": "AWS242ServiceCatalogService.ExecuteProvisionedProductServiceAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ExecuteProvisionedProductServiceActionInput(input, context));
@@ -1158,7 +1158,7 @@ export const serializeAws_json1_1GetAWSOrganizationsAccessStatusCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.GetAWSOrganizationsAccessStatus",
+    "x-amz-target": "AWS242ServiceCatalogService.GetAWSOrganizationsAccessStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAWSOrganizationsAccessStatusInput(input, context));
@@ -1171,7 +1171,7 @@ export const serializeAws_json1_1GetProvisionedProductOutputsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.GetProvisionedProductOutputs",
+    "x-amz-target": "AWS242ServiceCatalogService.GetProvisionedProductOutputs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetProvisionedProductOutputsInput(input, context));
@@ -1184,7 +1184,7 @@ export const serializeAws_json1_1ImportAsProvisionedProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ImportAsProvisionedProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.ImportAsProvisionedProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportAsProvisionedProductInput(input, context));
@@ -1197,7 +1197,7 @@ export const serializeAws_json1_1ListAcceptedPortfolioSharesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListAcceptedPortfolioShares",
+    "x-amz-target": "AWS242ServiceCatalogService.ListAcceptedPortfolioShares",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAcceptedPortfolioSharesInput(input, context));
@@ -1210,7 +1210,7 @@ export const serializeAws_json1_1ListBudgetsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListBudgetsForResource",
+    "x-amz-target": "AWS242ServiceCatalogService.ListBudgetsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListBudgetsForResourceInput(input, context));
@@ -1223,7 +1223,7 @@ export const serializeAws_json1_1ListConstraintsForPortfolioCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListConstraintsForPortfolio",
+    "x-amz-target": "AWS242ServiceCatalogService.ListConstraintsForPortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListConstraintsForPortfolioInput(input, context));
@@ -1236,7 +1236,7 @@ export const serializeAws_json1_1ListLaunchPathsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListLaunchPaths",
+    "x-amz-target": "AWS242ServiceCatalogService.ListLaunchPaths",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLaunchPathsInput(input, context));
@@ -1249,7 +1249,7 @@ export const serializeAws_json1_1ListOrganizationPortfolioAccessCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListOrganizationPortfolioAccess",
+    "x-amz-target": "AWS242ServiceCatalogService.ListOrganizationPortfolioAccess",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListOrganizationPortfolioAccessInput(input, context));
@@ -1262,7 +1262,7 @@ export const serializeAws_json1_1ListPortfolioAccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListPortfolioAccess",
+    "x-amz-target": "AWS242ServiceCatalogService.ListPortfolioAccess",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPortfolioAccessInput(input, context));
@@ -1275,7 +1275,7 @@ export const serializeAws_json1_1ListPortfoliosCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListPortfolios",
+    "x-amz-target": "AWS242ServiceCatalogService.ListPortfolios",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPortfoliosInput(input, context));
@@ -1288,7 +1288,7 @@ export const serializeAws_json1_1ListPortfoliosForProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListPortfoliosForProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.ListPortfoliosForProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPortfoliosForProductInput(input, context));
@@ -1301,7 +1301,7 @@ export const serializeAws_json1_1ListPrincipalsForPortfolioCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListPrincipalsForPortfolio",
+    "x-amz-target": "AWS242ServiceCatalogService.ListPrincipalsForPortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPrincipalsForPortfolioInput(input, context));
@@ -1314,7 +1314,7 @@ export const serializeAws_json1_1ListProvisionedProductPlansCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListProvisionedProductPlans",
+    "x-amz-target": "AWS242ServiceCatalogService.ListProvisionedProductPlans",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProvisionedProductPlansInput(input, context));
@@ -1327,7 +1327,7 @@ export const serializeAws_json1_1ListProvisioningArtifactsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListProvisioningArtifacts",
+    "x-amz-target": "AWS242ServiceCatalogService.ListProvisioningArtifacts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProvisioningArtifactsInput(input, context));
@@ -1340,7 +1340,7 @@ export const serializeAws_json1_1ListProvisioningArtifactsForServiceActionComman
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListProvisioningArtifactsForServiceAction",
+    "x-amz-target": "AWS242ServiceCatalogService.ListProvisioningArtifactsForServiceAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProvisioningArtifactsForServiceActionInput(input, context));
@@ -1353,7 +1353,7 @@ export const serializeAws_json1_1ListRecordHistoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListRecordHistory",
+    "x-amz-target": "AWS242ServiceCatalogService.ListRecordHistory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRecordHistoryInput(input, context));
@@ -1366,7 +1366,7 @@ export const serializeAws_json1_1ListResourcesForTagOptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListResourcesForTagOption",
+    "x-amz-target": "AWS242ServiceCatalogService.ListResourcesForTagOption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourcesForTagOptionInput(input, context));
@@ -1379,7 +1379,7 @@ export const serializeAws_json1_1ListServiceActionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListServiceActions",
+    "x-amz-target": "AWS242ServiceCatalogService.ListServiceActions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListServiceActionsInput(input, context));
@@ -1392,7 +1392,7 @@ export const serializeAws_json1_1ListServiceActionsForProvisioningArtifactComman
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListServiceActionsForProvisioningArtifact",
+    "x-amz-target": "AWS242ServiceCatalogService.ListServiceActionsForProvisioningArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListServiceActionsForProvisioningArtifactInput(input, context));
@@ -1405,7 +1405,7 @@ export const serializeAws_json1_1ListStackInstancesForProvisionedProductCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListStackInstancesForProvisionedProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.ListStackInstancesForProvisionedProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListStackInstancesForProvisionedProductInput(input, context));
@@ -1418,7 +1418,7 @@ export const serializeAws_json1_1ListTagOptionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ListTagOptions",
+    "x-amz-target": "AWS242ServiceCatalogService.ListTagOptions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagOptionsInput(input, context));
@@ -1431,7 +1431,7 @@ export const serializeAws_json1_1ProvisionProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ProvisionProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.ProvisionProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ProvisionProductInput(input, context));
@@ -1444,7 +1444,7 @@ export const serializeAws_json1_1RejectPortfolioShareCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.RejectPortfolioShare",
+    "x-amz-target": "AWS242ServiceCatalogService.RejectPortfolioShare",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RejectPortfolioShareInput(input, context));
@@ -1457,7 +1457,7 @@ export const serializeAws_json1_1ScanProvisionedProductsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.ScanProvisionedProducts",
+    "x-amz-target": "AWS242ServiceCatalogService.ScanProvisionedProducts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ScanProvisionedProductsInput(input, context));
@@ -1470,7 +1470,7 @@ export const serializeAws_json1_1SearchProductsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.SearchProducts",
+    "x-amz-target": "AWS242ServiceCatalogService.SearchProducts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchProductsInput(input, context));
@@ -1483,7 +1483,7 @@ export const serializeAws_json1_1SearchProductsAsAdminCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.SearchProductsAsAdmin",
+    "x-amz-target": "AWS242ServiceCatalogService.SearchProductsAsAdmin",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchProductsAsAdminInput(input, context));
@@ -1496,7 +1496,7 @@ export const serializeAws_json1_1SearchProvisionedProductsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.SearchProvisionedProducts",
+    "x-amz-target": "AWS242ServiceCatalogService.SearchProvisionedProducts",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SearchProvisionedProductsInput(input, context));
@@ -1509,7 +1509,7 @@ export const serializeAws_json1_1TerminateProvisionedProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.TerminateProvisionedProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.TerminateProvisionedProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TerminateProvisionedProductInput(input, context));
@@ -1522,7 +1522,7 @@ export const serializeAws_json1_1UpdateConstraintCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.UpdateConstraint",
+    "x-amz-target": "AWS242ServiceCatalogService.UpdateConstraint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateConstraintInput(input, context));
@@ -1535,7 +1535,7 @@ export const serializeAws_json1_1UpdatePortfolioCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.UpdatePortfolio",
+    "x-amz-target": "AWS242ServiceCatalogService.UpdatePortfolio",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePortfolioInput(input, context));
@@ -1548,7 +1548,7 @@ export const serializeAws_json1_1UpdateProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.UpdateProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.UpdateProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateProductInput(input, context));
@@ -1561,7 +1561,7 @@ export const serializeAws_json1_1UpdateProvisionedProductCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.UpdateProvisionedProduct",
+    "x-amz-target": "AWS242ServiceCatalogService.UpdateProvisionedProduct",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateProvisionedProductInput(input, context));
@@ -1574,7 +1574,7 @@ export const serializeAws_json1_1UpdateProvisionedProductPropertiesCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.UpdateProvisionedProductProperties",
+    "x-amz-target": "AWS242ServiceCatalogService.UpdateProvisionedProductProperties",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateProvisionedProductPropertiesInput(input, context));
@@ -1587,7 +1587,7 @@ export const serializeAws_json1_1UpdateProvisioningArtifactCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.UpdateProvisioningArtifact",
+    "x-amz-target": "AWS242ServiceCatalogService.UpdateProvisioningArtifact",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateProvisioningArtifactInput(input, context));
@@ -1600,7 +1600,7 @@ export const serializeAws_json1_1UpdateServiceActionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.UpdateServiceAction",
+    "x-amz-target": "AWS242ServiceCatalogService.UpdateServiceAction",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateServiceActionInput(input, context));
@@ -1613,7 +1613,7 @@ export const serializeAws_json1_1UpdateTagOptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWS242ServiceCatalogService.UpdateTagOption",
+    "x-amz-target": "AWS242ServiceCatalogService.UpdateTagOption",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateTagOptionInput(input, context));

--- a/clients/client-service-quotas/protocols/Aws_json1_1.ts
+++ b/clients/client-service-quotas/protocols/Aws_json1_1.ts
@@ -125,7 +125,7 @@ export const serializeAws_json1_1AssociateServiceQuotaTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.AssociateServiceQuotaTemplate",
+    "x-amz-target": "ServiceQuotasV20190624.AssociateServiceQuotaTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateServiceQuotaTemplateRequest(input, context));
@@ -138,7 +138,7 @@ export const serializeAws_json1_1DeleteServiceQuotaIncreaseRequestFromTemplateCo
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.DeleteServiceQuotaIncreaseRequestFromTemplate",
+    "x-amz-target": "ServiceQuotasV20190624.DeleteServiceQuotaIncreaseRequestFromTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteServiceQuotaIncreaseRequestFromTemplateRequest(input, context));
@@ -151,7 +151,7 @@ export const serializeAws_json1_1DisassociateServiceQuotaTemplateCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.DisassociateServiceQuotaTemplate",
+    "x-amz-target": "ServiceQuotasV20190624.DisassociateServiceQuotaTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateServiceQuotaTemplateRequest(input, context));
@@ -164,7 +164,7 @@ export const serializeAws_json1_1GetAssociationForServiceQuotaTemplateCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.GetAssociationForServiceQuotaTemplate",
+    "x-amz-target": "ServiceQuotasV20190624.GetAssociationForServiceQuotaTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAssociationForServiceQuotaTemplateRequest(input, context));
@@ -177,7 +177,7 @@ export const serializeAws_json1_1GetAWSDefaultServiceQuotaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.GetAWSDefaultServiceQuota",
+    "x-amz-target": "ServiceQuotasV20190624.GetAWSDefaultServiceQuota",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAWSDefaultServiceQuotaRequest(input, context));
@@ -190,7 +190,7 @@ export const serializeAws_json1_1GetRequestedServiceQuotaChangeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.GetRequestedServiceQuotaChange",
+    "x-amz-target": "ServiceQuotasV20190624.GetRequestedServiceQuotaChange",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRequestedServiceQuotaChangeRequest(input, context));
@@ -203,7 +203,7 @@ export const serializeAws_json1_1GetServiceQuotaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.GetServiceQuota",
+    "x-amz-target": "ServiceQuotasV20190624.GetServiceQuota",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetServiceQuotaRequest(input, context));
@@ -216,7 +216,7 @@ export const serializeAws_json1_1GetServiceQuotaIncreaseRequestFromTemplateComma
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.GetServiceQuotaIncreaseRequestFromTemplate",
+    "x-amz-target": "ServiceQuotasV20190624.GetServiceQuotaIncreaseRequestFromTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetServiceQuotaIncreaseRequestFromTemplateRequest(input, context));
@@ -229,7 +229,7 @@ export const serializeAws_json1_1ListAWSDefaultServiceQuotasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.ListAWSDefaultServiceQuotas",
+    "x-amz-target": "ServiceQuotasV20190624.ListAWSDefaultServiceQuotas",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAWSDefaultServiceQuotasRequest(input, context));
@@ -242,7 +242,7 @@ export const serializeAws_json1_1ListRequestedServiceQuotaChangeHistoryCommand =
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.ListRequestedServiceQuotaChangeHistory",
+    "x-amz-target": "ServiceQuotasV20190624.ListRequestedServiceQuotaChangeHistory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRequestedServiceQuotaChangeHistoryRequest(input, context));
@@ -255,7 +255,7 @@ export const serializeAws_json1_1ListRequestedServiceQuotaChangeHistoryByQuotaCo
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.ListRequestedServiceQuotaChangeHistoryByQuota",
+    "x-amz-target": "ServiceQuotasV20190624.ListRequestedServiceQuotaChangeHistoryByQuota",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRequestedServiceQuotaChangeHistoryByQuotaRequest(input, context));
@@ -268,7 +268,7 @@ export const serializeAws_json1_1ListServiceQuotaIncreaseRequestsInTemplateComma
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.ListServiceQuotaIncreaseRequestsInTemplate",
+    "x-amz-target": "ServiceQuotasV20190624.ListServiceQuotaIncreaseRequestsInTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListServiceQuotaIncreaseRequestsInTemplateRequest(input, context));
@@ -281,7 +281,7 @@ export const serializeAws_json1_1ListServiceQuotasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.ListServiceQuotas",
+    "x-amz-target": "ServiceQuotasV20190624.ListServiceQuotas",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListServiceQuotasRequest(input, context));
@@ -294,7 +294,7 @@ export const serializeAws_json1_1ListServicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.ListServices",
+    "x-amz-target": "ServiceQuotasV20190624.ListServices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListServicesRequest(input, context));
@@ -307,7 +307,7 @@ export const serializeAws_json1_1PutServiceQuotaIncreaseRequestIntoTemplateComma
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.PutServiceQuotaIncreaseRequestIntoTemplate",
+    "x-amz-target": "ServiceQuotasV20190624.PutServiceQuotaIncreaseRequestIntoTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutServiceQuotaIncreaseRequestIntoTemplateRequest(input, context));
@@ -320,7 +320,7 @@ export const serializeAws_json1_1RequestServiceQuotaIncreaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "ServiceQuotasV20190624.RequestServiceQuotaIncrease",
+    "x-amz-target": "ServiceQuotasV20190624.RequestServiceQuotaIncrease",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RequestServiceQuotaIncreaseRequest(input, context));

--- a/clients/client-servicediscovery/protocols/Aws_json1_1.ts
+++ b/clients/client-servicediscovery/protocols/Aws_json1_1.ts
@@ -145,7 +145,7 @@ export const serializeAws_json1_1CreateHttpNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.CreateHttpNamespace",
+    "x-amz-target": "Route53AutoNaming_v20170314.CreateHttpNamespace",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateHttpNamespaceRequest(input, context));
@@ -158,7 +158,7 @@ export const serializeAws_json1_1CreatePrivateDnsNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.CreatePrivateDnsNamespace",
+    "x-amz-target": "Route53AutoNaming_v20170314.CreatePrivateDnsNamespace",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePrivateDnsNamespaceRequest(input, context));
@@ -171,7 +171,7 @@ export const serializeAws_json1_1CreatePublicDnsNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.CreatePublicDnsNamespace",
+    "x-amz-target": "Route53AutoNaming_v20170314.CreatePublicDnsNamespace",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePublicDnsNamespaceRequest(input, context));
@@ -184,7 +184,7 @@ export const serializeAws_json1_1CreateServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.CreateService",
+    "x-amz-target": "Route53AutoNaming_v20170314.CreateService",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateServiceRequest(input, context));
@@ -197,7 +197,7 @@ export const serializeAws_json1_1DeleteNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.DeleteNamespace",
+    "x-amz-target": "Route53AutoNaming_v20170314.DeleteNamespace",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteNamespaceRequest(input, context));
@@ -210,7 +210,7 @@ export const serializeAws_json1_1DeleteServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.DeleteService",
+    "x-amz-target": "Route53AutoNaming_v20170314.DeleteService",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteServiceRequest(input, context));
@@ -223,7 +223,7 @@ export const serializeAws_json1_1DeregisterInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.DeregisterInstance",
+    "x-amz-target": "Route53AutoNaming_v20170314.DeregisterInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterInstanceRequest(input, context));
@@ -236,7 +236,7 @@ export const serializeAws_json1_1DiscoverInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.DiscoverInstances",
+    "x-amz-target": "Route53AutoNaming_v20170314.DiscoverInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DiscoverInstancesRequest(input, context));
@@ -256,7 +256,7 @@ export const serializeAws_json1_1GetInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.GetInstance",
+    "x-amz-target": "Route53AutoNaming_v20170314.GetInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstanceRequest(input, context));
@@ -269,7 +269,7 @@ export const serializeAws_json1_1GetInstancesHealthStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.GetInstancesHealthStatus",
+    "x-amz-target": "Route53AutoNaming_v20170314.GetInstancesHealthStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInstancesHealthStatusRequest(input, context));
@@ -282,7 +282,7 @@ export const serializeAws_json1_1GetNamespaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.GetNamespace",
+    "x-amz-target": "Route53AutoNaming_v20170314.GetNamespace",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetNamespaceRequest(input, context));
@@ -295,7 +295,7 @@ export const serializeAws_json1_1GetOperationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.GetOperation",
+    "x-amz-target": "Route53AutoNaming_v20170314.GetOperation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOperationRequest(input, context));
@@ -308,7 +308,7 @@ export const serializeAws_json1_1GetServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.GetService",
+    "x-amz-target": "Route53AutoNaming_v20170314.GetService",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetServiceRequest(input, context));
@@ -321,7 +321,7 @@ export const serializeAws_json1_1ListInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.ListInstances",
+    "x-amz-target": "Route53AutoNaming_v20170314.ListInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListInstancesRequest(input, context));
@@ -334,7 +334,7 @@ export const serializeAws_json1_1ListNamespacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.ListNamespaces",
+    "x-amz-target": "Route53AutoNaming_v20170314.ListNamespaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListNamespacesRequest(input, context));
@@ -347,7 +347,7 @@ export const serializeAws_json1_1ListOperationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.ListOperations",
+    "x-amz-target": "Route53AutoNaming_v20170314.ListOperations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListOperationsRequest(input, context));
@@ -360,7 +360,7 @@ export const serializeAws_json1_1ListServicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.ListServices",
+    "x-amz-target": "Route53AutoNaming_v20170314.ListServices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListServicesRequest(input, context));
@@ -373,7 +373,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.ListTagsForResource",
+    "x-amz-target": "Route53AutoNaming_v20170314.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -386,7 +386,7 @@ export const serializeAws_json1_1RegisterInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.RegisterInstance",
+    "x-amz-target": "Route53AutoNaming_v20170314.RegisterInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterInstanceRequest(input, context));
@@ -399,7 +399,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.TagResource",
+    "x-amz-target": "Route53AutoNaming_v20170314.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -412,7 +412,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.UntagResource",
+    "x-amz-target": "Route53AutoNaming_v20170314.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -425,7 +425,7 @@ export const serializeAws_json1_1UpdateInstanceCustomHealthStatusCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.UpdateInstanceCustomHealthStatus",
+    "x-amz-target": "Route53AutoNaming_v20170314.UpdateInstanceCustomHealthStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateInstanceCustomHealthStatusRequest(input, context));
@@ -438,7 +438,7 @@ export const serializeAws_json1_1UpdateServiceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Route53AutoNaming_v20170314.UpdateService",
+    "x-amz-target": "Route53AutoNaming_v20170314.UpdateService",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateServiceRequest(input, context));

--- a/clients/client-sfn/protocols/Aws_json1_0.ts
+++ b/clients/client-sfn/protocols/Aws_json1_0.ts
@@ -166,7 +166,7 @@ export const serializeAws_json1_0CreateActivityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.CreateActivity",
+    "x-amz-target": "AWSStepFunctions.CreateActivity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateActivityInput(input, context));
@@ -179,7 +179,7 @@ export const serializeAws_json1_0CreateStateMachineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.CreateStateMachine",
+    "x-amz-target": "AWSStepFunctions.CreateStateMachine",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateStateMachineInput(input, context));
@@ -192,7 +192,7 @@ export const serializeAws_json1_0DeleteActivityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.DeleteActivity",
+    "x-amz-target": "AWSStepFunctions.DeleteActivity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteActivityInput(input, context));
@@ -205,7 +205,7 @@ export const serializeAws_json1_0DeleteStateMachineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.DeleteStateMachine",
+    "x-amz-target": "AWSStepFunctions.DeleteStateMachine",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteStateMachineInput(input, context));
@@ -218,7 +218,7 @@ export const serializeAws_json1_0DescribeActivityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.DescribeActivity",
+    "x-amz-target": "AWSStepFunctions.DescribeActivity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeActivityInput(input, context));
@@ -231,7 +231,7 @@ export const serializeAws_json1_0DescribeExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.DescribeExecution",
+    "x-amz-target": "AWSStepFunctions.DescribeExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeExecutionInput(input, context));
@@ -244,7 +244,7 @@ export const serializeAws_json1_0DescribeStateMachineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.DescribeStateMachine",
+    "x-amz-target": "AWSStepFunctions.DescribeStateMachine",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeStateMachineInput(input, context));
@@ -257,7 +257,7 @@ export const serializeAws_json1_0DescribeStateMachineForExecutionCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.DescribeStateMachineForExecution",
+    "x-amz-target": "AWSStepFunctions.DescribeStateMachineForExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeStateMachineForExecutionInput(input, context));
@@ -270,7 +270,7 @@ export const serializeAws_json1_0GetActivityTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.GetActivityTask",
+    "x-amz-target": "AWSStepFunctions.GetActivityTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetActivityTaskInput(input, context));
@@ -283,7 +283,7 @@ export const serializeAws_json1_0GetExecutionHistoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.GetExecutionHistory",
+    "x-amz-target": "AWSStepFunctions.GetExecutionHistory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetExecutionHistoryInput(input, context));
@@ -296,7 +296,7 @@ export const serializeAws_json1_0ListActivitiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.ListActivities",
+    "x-amz-target": "AWSStepFunctions.ListActivities",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListActivitiesInput(input, context));
@@ -309,7 +309,7 @@ export const serializeAws_json1_0ListExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.ListExecutions",
+    "x-amz-target": "AWSStepFunctions.ListExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListExecutionsInput(input, context));
@@ -322,7 +322,7 @@ export const serializeAws_json1_0ListStateMachinesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.ListStateMachines",
+    "x-amz-target": "AWSStepFunctions.ListStateMachines",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListStateMachinesInput(input, context));
@@ -335,7 +335,7 @@ export const serializeAws_json1_0ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.ListTagsForResource",
+    "x-amz-target": "AWSStepFunctions.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListTagsForResourceInput(input, context));
@@ -348,7 +348,7 @@ export const serializeAws_json1_0SendTaskFailureCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.SendTaskFailure",
+    "x-amz-target": "AWSStepFunctions.SendTaskFailure",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0SendTaskFailureInput(input, context));
@@ -361,7 +361,7 @@ export const serializeAws_json1_0SendTaskHeartbeatCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.SendTaskHeartbeat",
+    "x-amz-target": "AWSStepFunctions.SendTaskHeartbeat",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0SendTaskHeartbeatInput(input, context));
@@ -374,7 +374,7 @@ export const serializeAws_json1_0SendTaskSuccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.SendTaskSuccess",
+    "x-amz-target": "AWSStepFunctions.SendTaskSuccess",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0SendTaskSuccessInput(input, context));
@@ -387,7 +387,7 @@ export const serializeAws_json1_0StartExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.StartExecution",
+    "x-amz-target": "AWSStepFunctions.StartExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0StartExecutionInput(input, context));
@@ -400,7 +400,7 @@ export const serializeAws_json1_0StartSyncExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.StartSyncExecution",
+    "x-amz-target": "AWSStepFunctions.StartSyncExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0StartSyncExecutionInput(input, context));
@@ -420,7 +420,7 @@ export const serializeAws_json1_0StopExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.StopExecution",
+    "x-amz-target": "AWSStepFunctions.StopExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0StopExecutionInput(input, context));
@@ -433,7 +433,7 @@ export const serializeAws_json1_0TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.TagResource",
+    "x-amz-target": "AWSStepFunctions.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0TagResourceInput(input, context));
@@ -446,7 +446,7 @@ export const serializeAws_json1_0UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.UntagResource",
+    "x-amz-target": "AWSStepFunctions.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UntagResourceInput(input, context));
@@ -459,7 +459,7 @@ export const serializeAws_json1_0UpdateStateMachineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "AWSStepFunctions.UpdateStateMachine",
+    "x-amz-target": "AWSStepFunctions.UpdateStateMachine",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateStateMachineInput(input, context));

--- a/clients/client-shield/protocols/Aws_json1_1.ts
+++ b/clients/client-shield/protocols/Aws_json1_1.ts
@@ -200,7 +200,7 @@ export const serializeAws_json1_1AssociateDRTLogBucketCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.AssociateDRTLogBucket",
+    "x-amz-target": "AWSShield_20160616.AssociateDRTLogBucket",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateDRTLogBucketRequest(input, context));
@@ -213,7 +213,7 @@ export const serializeAws_json1_1AssociateDRTRoleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.AssociateDRTRole",
+    "x-amz-target": "AWSShield_20160616.AssociateDRTRole",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateDRTRoleRequest(input, context));
@@ -226,7 +226,7 @@ export const serializeAws_json1_1AssociateHealthCheckCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.AssociateHealthCheck",
+    "x-amz-target": "AWSShield_20160616.AssociateHealthCheck",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateHealthCheckRequest(input, context));
@@ -239,7 +239,7 @@ export const serializeAws_json1_1AssociateProactiveEngagementDetailsCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.AssociateProactiveEngagementDetails",
+    "x-amz-target": "AWSShield_20160616.AssociateProactiveEngagementDetails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateProactiveEngagementDetailsRequest(input, context));
@@ -252,7 +252,7 @@ export const serializeAws_json1_1CreateProtectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.CreateProtection",
+    "x-amz-target": "AWSShield_20160616.CreateProtection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProtectionRequest(input, context));
@@ -265,7 +265,7 @@ export const serializeAws_json1_1CreateProtectionGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.CreateProtectionGroup",
+    "x-amz-target": "AWSShield_20160616.CreateProtectionGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateProtectionGroupRequest(input, context));
@@ -278,7 +278,7 @@ export const serializeAws_json1_1CreateSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.CreateSubscription",
+    "x-amz-target": "AWSShield_20160616.CreateSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSubscriptionRequest(input, context));
@@ -291,7 +291,7 @@ export const serializeAws_json1_1DeleteProtectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DeleteProtection",
+    "x-amz-target": "AWSShield_20160616.DeleteProtection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProtectionRequest(input, context));
@@ -304,7 +304,7 @@ export const serializeAws_json1_1DeleteProtectionGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DeleteProtectionGroup",
+    "x-amz-target": "AWSShield_20160616.DeleteProtectionGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteProtectionGroupRequest(input, context));
@@ -317,7 +317,7 @@ export const serializeAws_json1_1DeleteSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DeleteSubscription",
+    "x-amz-target": "AWSShield_20160616.DeleteSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSubscriptionRequest(input, context));
@@ -330,7 +330,7 @@ export const serializeAws_json1_1DescribeAttackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DescribeAttack",
+    "x-amz-target": "AWSShield_20160616.DescribeAttack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAttackRequest(input, context));
@@ -343,7 +343,7 @@ export const serializeAws_json1_1DescribeAttackStatisticsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DescribeAttackStatistics",
+    "x-amz-target": "AWSShield_20160616.DescribeAttackStatistics",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAttackStatisticsRequest(input, context));
@@ -356,7 +356,7 @@ export const serializeAws_json1_1DescribeDRTAccessCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DescribeDRTAccess",
+    "x-amz-target": "AWSShield_20160616.DescribeDRTAccess",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDRTAccessRequest(input, context));
@@ -369,7 +369,7 @@ export const serializeAws_json1_1DescribeEmergencyContactSettingsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DescribeEmergencyContactSettings",
+    "x-amz-target": "AWSShield_20160616.DescribeEmergencyContactSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEmergencyContactSettingsRequest(input, context));
@@ -382,7 +382,7 @@ export const serializeAws_json1_1DescribeProtectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DescribeProtection",
+    "x-amz-target": "AWSShield_20160616.DescribeProtection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProtectionRequest(input, context));
@@ -395,7 +395,7 @@ export const serializeAws_json1_1DescribeProtectionGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DescribeProtectionGroup",
+    "x-amz-target": "AWSShield_20160616.DescribeProtectionGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeProtectionGroupRequest(input, context));
@@ -408,7 +408,7 @@ export const serializeAws_json1_1DescribeSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DescribeSubscription",
+    "x-amz-target": "AWSShield_20160616.DescribeSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSubscriptionRequest(input, context));
@@ -421,7 +421,7 @@ export const serializeAws_json1_1DisableProactiveEngagementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DisableProactiveEngagement",
+    "x-amz-target": "AWSShield_20160616.DisableProactiveEngagement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableProactiveEngagementRequest(input, context));
@@ -434,7 +434,7 @@ export const serializeAws_json1_1DisassociateDRTLogBucketCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DisassociateDRTLogBucket",
+    "x-amz-target": "AWSShield_20160616.DisassociateDRTLogBucket",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateDRTLogBucketRequest(input, context));
@@ -447,7 +447,7 @@ export const serializeAws_json1_1DisassociateDRTRoleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DisassociateDRTRole",
+    "x-amz-target": "AWSShield_20160616.DisassociateDRTRole",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateDRTRoleRequest(input, context));
@@ -460,7 +460,7 @@ export const serializeAws_json1_1DisassociateHealthCheckCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.DisassociateHealthCheck",
+    "x-amz-target": "AWSShield_20160616.DisassociateHealthCheck",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateHealthCheckRequest(input, context));
@@ -473,7 +473,7 @@ export const serializeAws_json1_1EnableProactiveEngagementCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.EnableProactiveEngagement",
+    "x-amz-target": "AWSShield_20160616.EnableProactiveEngagement",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1EnableProactiveEngagementRequest(input, context));
@@ -486,7 +486,7 @@ export const serializeAws_json1_1GetSubscriptionStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.GetSubscriptionState",
+    "x-amz-target": "AWSShield_20160616.GetSubscriptionState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSubscriptionStateRequest(input, context));
@@ -499,7 +499,7 @@ export const serializeAws_json1_1ListAttacksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.ListAttacks",
+    "x-amz-target": "AWSShield_20160616.ListAttacks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAttacksRequest(input, context));
@@ -512,7 +512,7 @@ export const serializeAws_json1_1ListProtectionGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.ListProtectionGroups",
+    "x-amz-target": "AWSShield_20160616.ListProtectionGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProtectionGroupsRequest(input, context));
@@ -525,7 +525,7 @@ export const serializeAws_json1_1ListProtectionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.ListProtections",
+    "x-amz-target": "AWSShield_20160616.ListProtections",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListProtectionsRequest(input, context));
@@ -538,7 +538,7 @@ export const serializeAws_json1_1ListResourcesInProtectionGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.ListResourcesInProtectionGroup",
+    "x-amz-target": "AWSShield_20160616.ListResourcesInProtectionGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourcesInProtectionGroupRequest(input, context));
@@ -551,7 +551,7 @@ export const serializeAws_json1_1UpdateEmergencyContactSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.UpdateEmergencyContactSettings",
+    "x-amz-target": "AWSShield_20160616.UpdateEmergencyContactSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateEmergencyContactSettingsRequest(input, context));
@@ -564,7 +564,7 @@ export const serializeAws_json1_1UpdateProtectionGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.UpdateProtectionGroup",
+    "x-amz-target": "AWSShield_20160616.UpdateProtectionGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateProtectionGroupRequest(input, context));
@@ -577,7 +577,7 @@ export const serializeAws_json1_1UpdateSubscriptionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShield_20160616.UpdateSubscription",
+    "x-amz-target": "AWSShield_20160616.UpdateSubscription",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSubscriptionRequest(input, context));

--- a/clients/client-sms/protocols/Aws_json1_1.ts
+++ b/clients/client-sms/protocols/Aws_json1_1.ts
@@ -223,7 +223,7 @@ export const serializeAws_json1_1CreateAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.CreateApp",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.CreateApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAppRequest(input, context));
@@ -236,7 +236,7 @@ export const serializeAws_json1_1CreateReplicationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.CreateReplicationJob",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.CreateReplicationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateReplicationJobRequest(input, context));
@@ -249,7 +249,7 @@ export const serializeAws_json1_1DeleteAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.DeleteApp",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAppRequest(input, context));
@@ -262,7 +262,7 @@ export const serializeAws_json1_1DeleteAppLaunchConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.DeleteAppLaunchConfiguration",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteAppLaunchConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAppLaunchConfigurationRequest(input, context));
@@ -275,7 +275,7 @@ export const serializeAws_json1_1DeleteAppReplicationConfigurationCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.DeleteAppReplicationConfiguration",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteAppReplicationConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAppReplicationConfigurationRequest(input, context));
@@ -288,7 +288,7 @@ export const serializeAws_json1_1DeleteAppValidationConfigurationCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.DeleteAppValidationConfiguration",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteAppValidationConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAppValidationConfigurationRequest(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_1DeleteReplicationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.DeleteReplicationJob",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteReplicationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteReplicationJobRequest(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_1DeleteServerCatalogCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.DeleteServerCatalog",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DeleteServerCatalog",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteServerCatalogRequest(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1DisassociateConnectorCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.DisassociateConnector",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.DisassociateConnector",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateConnectorRequest(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1GenerateChangeSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GenerateChangeSet",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GenerateChangeSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GenerateChangeSetRequest(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1GenerateTemplateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GenerateTemplate",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GenerateTemplate",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GenerateTemplateRequest(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_1GetAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GetApp",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAppRequest(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_1GetAppLaunchConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GetAppLaunchConfiguration",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetAppLaunchConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAppLaunchConfigurationRequest(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_1GetAppReplicationConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GetAppReplicationConfiguration",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetAppReplicationConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAppReplicationConfigurationRequest(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_1GetAppValidationConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GetAppValidationConfiguration",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetAppValidationConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAppValidationConfigurationRequest(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_1GetAppValidationOutputCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GetAppValidationOutput",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetAppValidationOutput",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAppValidationOutputRequest(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_1GetConnectorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GetConnectors",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetConnectors",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetConnectorsRequest(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_1GetReplicationJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GetReplicationJobs",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetReplicationJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetReplicationJobsRequest(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_1GetReplicationRunsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GetReplicationRuns",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetReplicationRuns",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetReplicationRunsRequest(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_1GetServersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.GetServers",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.GetServers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetServersRequest(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_1ImportAppCatalogCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.ImportAppCatalog",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.ImportAppCatalog",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportAppCatalogRequest(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_1ImportServerCatalogCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.ImportServerCatalog",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.ImportServerCatalog",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportServerCatalogRequest(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_1LaunchAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.LaunchApp",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.LaunchApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1LaunchAppRequest(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_1ListAppsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.ListApps",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.ListApps",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAppsRequest(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1NotifyAppValidationOutputCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.NotifyAppValidationOutput",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.NotifyAppValidationOutput",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1NotifyAppValidationOutputRequest(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1PutAppLaunchConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.PutAppLaunchConfiguration",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.PutAppLaunchConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAppLaunchConfigurationRequest(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1PutAppReplicationConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.PutAppReplicationConfiguration",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.PutAppReplicationConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAppReplicationConfigurationRequest(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_1PutAppValidationConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.PutAppValidationConfiguration",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.PutAppValidationConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAppValidationConfigurationRequest(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_1StartAppReplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.StartAppReplication",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.StartAppReplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartAppReplicationRequest(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_1StartOnDemandAppReplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.StartOnDemandAppReplication",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.StartOnDemandAppReplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartOnDemandAppReplicationRequest(input, context));
@@ -613,7 +613,7 @@ export const serializeAws_json1_1StartOnDemandReplicationRunCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.StartOnDemandReplicationRun",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.StartOnDemandReplicationRun",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartOnDemandReplicationRunRequest(input, context));
@@ -626,7 +626,7 @@ export const serializeAws_json1_1StopAppReplicationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.StopAppReplication",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.StopAppReplication",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopAppReplicationRequest(input, context));
@@ -639,7 +639,7 @@ export const serializeAws_json1_1TerminateAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.TerminateApp",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.TerminateApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TerminateAppRequest(input, context));
@@ -652,7 +652,7 @@ export const serializeAws_json1_1UpdateAppCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.UpdateApp",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.UpdateApp",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAppRequest(input, context));
@@ -665,7 +665,7 @@ export const serializeAws_json1_1UpdateReplicationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSServerMigrationService_V2016_10_24.UpdateReplicationJob",
+    "x-amz-target": "AWSServerMigrationService_V2016_10_24.UpdateReplicationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateReplicationJobRequest(input, context));

--- a/clients/client-snowball/protocols/Aws_json1_1.ts
+++ b/clients/client-snowball/protocols/Aws_json1_1.ts
@@ -128,7 +128,7 @@ export const serializeAws_json1_1CancelClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.CancelCluster",
+    "x-amz-target": "AWSIESnowballJobManagementService.CancelCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelClusterRequest(input, context));
@@ -141,7 +141,7 @@ export const serializeAws_json1_1CancelJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.CancelJob",
+    "x-amz-target": "AWSIESnowballJobManagementService.CancelJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelJobRequest(input, context));
@@ -154,7 +154,7 @@ export const serializeAws_json1_1CreateAddressCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.CreateAddress",
+    "x-amz-target": "AWSIESnowballJobManagementService.CreateAddress",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAddressRequest(input, context));
@@ -167,7 +167,7 @@ export const serializeAws_json1_1CreateClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.CreateCluster",
+    "x-amz-target": "AWSIESnowballJobManagementService.CreateCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateClusterRequest(input, context));
@@ -180,7 +180,7 @@ export const serializeAws_json1_1CreateJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.CreateJob",
+    "x-amz-target": "AWSIESnowballJobManagementService.CreateJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateJobRequest(input, context));
@@ -193,7 +193,7 @@ export const serializeAws_json1_1CreateReturnShippingLabelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.CreateReturnShippingLabel",
+    "x-amz-target": "AWSIESnowballJobManagementService.CreateReturnShippingLabel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateReturnShippingLabelRequest(input, context));
@@ -206,7 +206,7 @@ export const serializeAws_json1_1DescribeAddressCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.DescribeAddress",
+    "x-amz-target": "AWSIESnowballJobManagementService.DescribeAddress",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAddressRequest(input, context));
@@ -219,7 +219,7 @@ export const serializeAws_json1_1DescribeAddressesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.DescribeAddresses",
+    "x-amz-target": "AWSIESnowballJobManagementService.DescribeAddresses",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAddressesRequest(input, context));
@@ -232,7 +232,7 @@ export const serializeAws_json1_1DescribeClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.DescribeCluster",
+    "x-amz-target": "AWSIESnowballJobManagementService.DescribeCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeClusterRequest(input, context));
@@ -245,7 +245,7 @@ export const serializeAws_json1_1DescribeJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.DescribeJob",
+    "x-amz-target": "AWSIESnowballJobManagementService.DescribeJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeJobRequest(input, context));
@@ -258,7 +258,7 @@ export const serializeAws_json1_1DescribeReturnShippingLabelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.DescribeReturnShippingLabel",
+    "x-amz-target": "AWSIESnowballJobManagementService.DescribeReturnShippingLabel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeReturnShippingLabelRequest(input, context));
@@ -271,7 +271,7 @@ export const serializeAws_json1_1GetJobManifestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.GetJobManifest",
+    "x-amz-target": "AWSIESnowballJobManagementService.GetJobManifest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetJobManifestRequest(input, context));
@@ -284,7 +284,7 @@ export const serializeAws_json1_1GetJobUnlockCodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.GetJobUnlockCode",
+    "x-amz-target": "AWSIESnowballJobManagementService.GetJobUnlockCode",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetJobUnlockCodeRequest(input, context));
@@ -297,7 +297,7 @@ export const serializeAws_json1_1GetSnowballUsageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.GetSnowballUsage",
+    "x-amz-target": "AWSIESnowballJobManagementService.GetSnowballUsage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSnowballUsageRequest(input, context));
@@ -310,7 +310,7 @@ export const serializeAws_json1_1GetSoftwareUpdatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.GetSoftwareUpdates",
+    "x-amz-target": "AWSIESnowballJobManagementService.GetSoftwareUpdates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSoftwareUpdatesRequest(input, context));
@@ -323,7 +323,7 @@ export const serializeAws_json1_1ListClusterJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.ListClusterJobs",
+    "x-amz-target": "AWSIESnowballJobManagementService.ListClusterJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListClusterJobsRequest(input, context));
@@ -336,7 +336,7 @@ export const serializeAws_json1_1ListClustersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.ListClusters",
+    "x-amz-target": "AWSIESnowballJobManagementService.ListClusters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListClustersRequest(input, context));
@@ -349,7 +349,7 @@ export const serializeAws_json1_1ListCompatibleImagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.ListCompatibleImages",
+    "x-amz-target": "AWSIESnowballJobManagementService.ListCompatibleImages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCompatibleImagesRequest(input, context));
@@ -362,7 +362,7 @@ export const serializeAws_json1_1ListJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.ListJobs",
+    "x-amz-target": "AWSIESnowballJobManagementService.ListJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListJobsRequest(input, context));
@@ -375,7 +375,7 @@ export const serializeAws_json1_1UpdateClusterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.UpdateCluster",
+    "x-amz-target": "AWSIESnowballJobManagementService.UpdateCluster",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateClusterRequest(input, context));
@@ -388,7 +388,7 @@ export const serializeAws_json1_1UpdateJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.UpdateJob",
+    "x-amz-target": "AWSIESnowballJobManagementService.UpdateJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateJobRequest(input, context));
@@ -401,7 +401,7 @@ export const serializeAws_json1_1UpdateJobShipmentStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSIESnowballJobManagementService.UpdateJobShipmentState",
+    "x-amz-target": "AWSIESnowballJobManagementService.UpdateJobShipmentState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateJobShipmentStateRequest(input, context));

--- a/clients/client-ssm/protocols/Aws_json1_1.ts
+++ b/clients/client-ssm/protocols/Aws_json1_1.ts
@@ -906,7 +906,7 @@ export const serializeAws_json1_1AddTagsToResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.AddTagsToResource",
+    "x-amz-target": "AmazonSSM.AddTagsToResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsToResourceRequest(input, context));
@@ -919,7 +919,7 @@ export const serializeAws_json1_1CancelCommandCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CancelCommand",
+    "x-amz-target": "AmazonSSM.CancelCommand",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelCommandRequest(input, context));
@@ -932,7 +932,7 @@ export const serializeAws_json1_1CancelMaintenanceWindowExecutionCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CancelMaintenanceWindowExecution",
+    "x-amz-target": "AmazonSSM.CancelMaintenanceWindowExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelMaintenanceWindowExecutionRequest(input, context));
@@ -945,7 +945,7 @@ export const serializeAws_json1_1CreateActivationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CreateActivation",
+    "x-amz-target": "AmazonSSM.CreateActivation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateActivationRequest(input, context));
@@ -958,7 +958,7 @@ export const serializeAws_json1_1CreateAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CreateAssociation",
+    "x-amz-target": "AmazonSSM.CreateAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAssociationRequest(input, context));
@@ -971,7 +971,7 @@ export const serializeAws_json1_1CreateAssociationBatchCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CreateAssociationBatch",
+    "x-amz-target": "AmazonSSM.CreateAssociationBatch",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAssociationBatchRequest(input, context));
@@ -984,7 +984,7 @@ export const serializeAws_json1_1CreateDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CreateDocument",
+    "x-amz-target": "AmazonSSM.CreateDocument",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateDocumentRequest(input, context));
@@ -997,7 +997,7 @@ export const serializeAws_json1_1CreateMaintenanceWindowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CreateMaintenanceWindow",
+    "x-amz-target": "AmazonSSM.CreateMaintenanceWindow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateMaintenanceWindowRequest(input, context));
@@ -1010,7 +1010,7 @@ export const serializeAws_json1_1CreateOpsItemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CreateOpsItem",
+    "x-amz-target": "AmazonSSM.CreateOpsItem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateOpsItemRequest(input, context));
@@ -1023,7 +1023,7 @@ export const serializeAws_json1_1CreateOpsMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CreateOpsMetadata",
+    "x-amz-target": "AmazonSSM.CreateOpsMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateOpsMetadataRequest(input, context));
@@ -1036,7 +1036,7 @@ export const serializeAws_json1_1CreatePatchBaselineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CreatePatchBaseline",
+    "x-amz-target": "AmazonSSM.CreatePatchBaseline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePatchBaselineRequest(input, context));
@@ -1049,7 +1049,7 @@ export const serializeAws_json1_1CreateResourceDataSyncCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.CreateResourceDataSync",
+    "x-amz-target": "AmazonSSM.CreateResourceDataSync",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateResourceDataSyncRequest(input, context));
@@ -1062,7 +1062,7 @@ export const serializeAws_json1_1DeleteActivationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeleteActivation",
+    "x-amz-target": "AmazonSSM.DeleteActivation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteActivationRequest(input, context));
@@ -1075,7 +1075,7 @@ export const serializeAws_json1_1DeleteAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeleteAssociation",
+    "x-amz-target": "AmazonSSM.DeleteAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAssociationRequest(input, context));
@@ -1088,7 +1088,7 @@ export const serializeAws_json1_1DeleteDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeleteDocument",
+    "x-amz-target": "AmazonSSM.DeleteDocument",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteDocumentRequest(input, context));
@@ -1101,7 +1101,7 @@ export const serializeAws_json1_1DeleteInventoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeleteInventory",
+    "x-amz-target": "AmazonSSM.DeleteInventory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteInventoryRequest(input, context));
@@ -1114,7 +1114,7 @@ export const serializeAws_json1_1DeleteMaintenanceWindowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeleteMaintenanceWindow",
+    "x-amz-target": "AmazonSSM.DeleteMaintenanceWindow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMaintenanceWindowRequest(input, context));
@@ -1127,7 +1127,7 @@ export const serializeAws_json1_1DeleteOpsMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeleteOpsMetadata",
+    "x-amz-target": "AmazonSSM.DeleteOpsMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteOpsMetadataRequest(input, context));
@@ -1140,7 +1140,7 @@ export const serializeAws_json1_1DeleteParameterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeleteParameter",
+    "x-amz-target": "AmazonSSM.DeleteParameter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteParameterRequest(input, context));
@@ -1153,7 +1153,7 @@ export const serializeAws_json1_1DeleteParametersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeleteParameters",
+    "x-amz-target": "AmazonSSM.DeleteParameters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteParametersRequest(input, context));
@@ -1166,7 +1166,7 @@ export const serializeAws_json1_1DeletePatchBaselineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeletePatchBaseline",
+    "x-amz-target": "AmazonSSM.DeletePatchBaseline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePatchBaselineRequest(input, context));
@@ -1179,7 +1179,7 @@ export const serializeAws_json1_1DeleteResourceDataSyncCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeleteResourceDataSync",
+    "x-amz-target": "AmazonSSM.DeleteResourceDataSync",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResourceDataSyncRequest(input, context));
@@ -1192,7 +1192,7 @@ export const serializeAws_json1_1DeregisterManagedInstanceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeregisterManagedInstance",
+    "x-amz-target": "AmazonSSM.DeregisterManagedInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterManagedInstanceRequest(input, context));
@@ -1205,7 +1205,7 @@ export const serializeAws_json1_1DeregisterPatchBaselineForPatchGroupCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeregisterPatchBaselineForPatchGroup",
+    "x-amz-target": "AmazonSSM.DeregisterPatchBaselineForPatchGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterPatchBaselineForPatchGroupRequest(input, context));
@@ -1218,7 +1218,7 @@ export const serializeAws_json1_1DeregisterTargetFromMaintenanceWindowCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeregisterTargetFromMaintenanceWindow",
+    "x-amz-target": "AmazonSSM.DeregisterTargetFromMaintenanceWindow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterTargetFromMaintenanceWindowRequest(input, context));
@@ -1231,7 +1231,7 @@ export const serializeAws_json1_1DeregisterTaskFromMaintenanceWindowCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DeregisterTaskFromMaintenanceWindow",
+    "x-amz-target": "AmazonSSM.DeregisterTaskFromMaintenanceWindow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterTaskFromMaintenanceWindowRequest(input, context));
@@ -1244,7 +1244,7 @@ export const serializeAws_json1_1DescribeActivationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeActivations",
+    "x-amz-target": "AmazonSSM.DescribeActivations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeActivationsRequest(input, context));
@@ -1257,7 +1257,7 @@ export const serializeAws_json1_1DescribeAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeAssociation",
+    "x-amz-target": "AmazonSSM.DescribeAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAssociationRequest(input, context));
@@ -1270,7 +1270,7 @@ export const serializeAws_json1_1DescribeAssociationExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeAssociationExecutions",
+    "x-amz-target": "AmazonSSM.DescribeAssociationExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAssociationExecutionsRequest(input, context));
@@ -1283,7 +1283,7 @@ export const serializeAws_json1_1DescribeAssociationExecutionTargetsCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeAssociationExecutionTargets",
+    "x-amz-target": "AmazonSSM.DescribeAssociationExecutionTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAssociationExecutionTargetsRequest(input, context));
@@ -1296,7 +1296,7 @@ export const serializeAws_json1_1DescribeAutomationExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeAutomationExecutions",
+    "x-amz-target": "AmazonSSM.DescribeAutomationExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAutomationExecutionsRequest(input, context));
@@ -1309,7 +1309,7 @@ export const serializeAws_json1_1DescribeAutomationStepExecutionsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeAutomationStepExecutions",
+    "x-amz-target": "AmazonSSM.DescribeAutomationStepExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAutomationStepExecutionsRequest(input, context));
@@ -1322,7 +1322,7 @@ export const serializeAws_json1_1DescribeAvailablePatchesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeAvailablePatches",
+    "x-amz-target": "AmazonSSM.DescribeAvailablePatches",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAvailablePatchesRequest(input, context));
@@ -1335,7 +1335,7 @@ export const serializeAws_json1_1DescribeDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeDocument",
+    "x-amz-target": "AmazonSSM.DescribeDocument",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDocumentRequest(input, context));
@@ -1348,7 +1348,7 @@ export const serializeAws_json1_1DescribeDocumentPermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeDocumentPermission",
+    "x-amz-target": "AmazonSSM.DescribeDocumentPermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeDocumentPermissionRequest(input, context));
@@ -1361,7 +1361,7 @@ export const serializeAws_json1_1DescribeEffectiveInstanceAssociationsCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeEffectiveInstanceAssociations",
+    "x-amz-target": "AmazonSSM.DescribeEffectiveInstanceAssociations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEffectiveInstanceAssociationsRequest(input, context));
@@ -1374,7 +1374,7 @@ export const serializeAws_json1_1DescribeEffectivePatchesForPatchBaselineCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeEffectivePatchesForPatchBaseline",
+    "x-amz-target": "AmazonSSM.DescribeEffectivePatchesForPatchBaseline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeEffectivePatchesForPatchBaselineRequest(input, context));
@@ -1387,7 +1387,7 @@ export const serializeAws_json1_1DescribeInstanceAssociationsStatusCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeInstanceAssociationsStatus",
+    "x-amz-target": "AmazonSSM.DescribeInstanceAssociationsStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInstanceAssociationsStatusRequest(input, context));
@@ -1400,7 +1400,7 @@ export const serializeAws_json1_1DescribeInstanceInformationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeInstanceInformation",
+    "x-amz-target": "AmazonSSM.DescribeInstanceInformation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInstanceInformationRequest(input, context));
@@ -1413,7 +1413,7 @@ export const serializeAws_json1_1DescribeInstancePatchesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeInstancePatches",
+    "x-amz-target": "AmazonSSM.DescribeInstancePatches",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInstancePatchesRequest(input, context));
@@ -1426,7 +1426,7 @@ export const serializeAws_json1_1DescribeInstancePatchStatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeInstancePatchStates",
+    "x-amz-target": "AmazonSSM.DescribeInstancePatchStates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInstancePatchStatesRequest(input, context));
@@ -1439,7 +1439,7 @@ export const serializeAws_json1_1DescribeInstancePatchStatesForPatchGroupCommand
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeInstancePatchStatesForPatchGroup",
+    "x-amz-target": "AmazonSSM.DescribeInstancePatchStatesForPatchGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInstancePatchStatesForPatchGroupRequest(input, context));
@@ -1452,7 +1452,7 @@ export const serializeAws_json1_1DescribeInventoryDeletionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeInventoryDeletions",
+    "x-amz-target": "AmazonSSM.DescribeInventoryDeletions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInventoryDeletionsRequest(input, context));
@@ -1465,7 +1465,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowExecutionsCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeMaintenanceWindowExecutions",
+    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMaintenanceWindowExecutionsRequest(input, context));
@@ -1478,7 +1478,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowExecutionTaskInvocatio
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeMaintenanceWindowExecutionTaskInvocations",
+    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowExecutionTaskInvocations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMaintenanceWindowExecutionTaskInvocationsRequest(input, context));
@@ -1491,7 +1491,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowExecutionTasksCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeMaintenanceWindowExecutionTasks",
+    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowExecutionTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMaintenanceWindowExecutionTasksRequest(input, context));
@@ -1504,7 +1504,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeMaintenanceWindows",
+    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindows",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMaintenanceWindowsRequest(input, context));
@@ -1517,7 +1517,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowScheduleCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeMaintenanceWindowSchedule",
+    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMaintenanceWindowScheduleRequest(input, context));
@@ -1530,7 +1530,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowsForTargetCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeMaintenanceWindowsForTarget",
+    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowsForTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMaintenanceWindowsForTargetRequest(input, context));
@@ -1543,7 +1543,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowTargetsCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeMaintenanceWindowTargets",
+    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowTargets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMaintenanceWindowTargetsRequest(input, context));
@@ -1556,7 +1556,7 @@ export const serializeAws_json1_1DescribeMaintenanceWindowTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeMaintenanceWindowTasks",
+    "x-amz-target": "AmazonSSM.DescribeMaintenanceWindowTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMaintenanceWindowTasksRequest(input, context));
@@ -1569,7 +1569,7 @@ export const serializeAws_json1_1DescribeOpsItemsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeOpsItems",
+    "x-amz-target": "AmazonSSM.DescribeOpsItems",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeOpsItemsRequest(input, context));
@@ -1582,7 +1582,7 @@ export const serializeAws_json1_1DescribeParametersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeParameters",
+    "x-amz-target": "AmazonSSM.DescribeParameters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeParametersRequest(input, context));
@@ -1595,7 +1595,7 @@ export const serializeAws_json1_1DescribePatchBaselinesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribePatchBaselines",
+    "x-amz-target": "AmazonSSM.DescribePatchBaselines",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePatchBaselinesRequest(input, context));
@@ -1608,7 +1608,7 @@ export const serializeAws_json1_1DescribePatchGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribePatchGroups",
+    "x-amz-target": "AmazonSSM.DescribePatchGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePatchGroupsRequest(input, context));
@@ -1621,7 +1621,7 @@ export const serializeAws_json1_1DescribePatchGroupStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribePatchGroupState",
+    "x-amz-target": "AmazonSSM.DescribePatchGroupState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePatchGroupStateRequest(input, context));
@@ -1634,7 +1634,7 @@ export const serializeAws_json1_1DescribePatchPropertiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribePatchProperties",
+    "x-amz-target": "AmazonSSM.DescribePatchProperties",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePatchPropertiesRequest(input, context));
@@ -1647,7 +1647,7 @@ export const serializeAws_json1_1DescribeSessionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.DescribeSessions",
+    "x-amz-target": "AmazonSSM.DescribeSessions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSessionsRequest(input, context));
@@ -1660,7 +1660,7 @@ export const serializeAws_json1_1GetAutomationExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetAutomationExecution",
+    "x-amz-target": "AmazonSSM.GetAutomationExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetAutomationExecutionRequest(input, context));
@@ -1673,7 +1673,7 @@ export const serializeAws_json1_1GetCalendarStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetCalendarState",
+    "x-amz-target": "AmazonSSM.GetCalendarState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCalendarStateRequest(input, context));
@@ -1686,7 +1686,7 @@ export const serializeAws_json1_1GetCommandInvocationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetCommandInvocation",
+    "x-amz-target": "AmazonSSM.GetCommandInvocation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetCommandInvocationRequest(input, context));
@@ -1699,7 +1699,7 @@ export const serializeAws_json1_1GetConnectionStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetConnectionStatus",
+    "x-amz-target": "AmazonSSM.GetConnectionStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetConnectionStatusRequest(input, context));
@@ -1712,7 +1712,7 @@ export const serializeAws_json1_1GetDefaultPatchBaselineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetDefaultPatchBaseline",
+    "x-amz-target": "AmazonSSM.GetDefaultPatchBaseline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDefaultPatchBaselineRequest(input, context));
@@ -1725,7 +1725,7 @@ export const serializeAws_json1_1GetDeployablePatchSnapshotForInstanceCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetDeployablePatchSnapshotForInstance",
+    "x-amz-target": "AmazonSSM.GetDeployablePatchSnapshotForInstance",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDeployablePatchSnapshotForInstanceRequest(input, context));
@@ -1738,7 +1738,7 @@ export const serializeAws_json1_1GetDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetDocument",
+    "x-amz-target": "AmazonSSM.GetDocument",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDocumentRequest(input, context));
@@ -1751,7 +1751,7 @@ export const serializeAws_json1_1GetInventoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetInventory",
+    "x-amz-target": "AmazonSSM.GetInventory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInventoryRequest(input, context));
@@ -1764,7 +1764,7 @@ export const serializeAws_json1_1GetInventorySchemaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetInventorySchema",
+    "x-amz-target": "AmazonSSM.GetInventorySchema",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInventorySchemaRequest(input, context));
@@ -1777,7 +1777,7 @@ export const serializeAws_json1_1GetMaintenanceWindowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetMaintenanceWindow",
+    "x-amz-target": "AmazonSSM.GetMaintenanceWindow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMaintenanceWindowRequest(input, context));
@@ -1790,7 +1790,7 @@ export const serializeAws_json1_1GetMaintenanceWindowExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetMaintenanceWindowExecution",
+    "x-amz-target": "AmazonSSM.GetMaintenanceWindowExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMaintenanceWindowExecutionRequest(input, context));
@@ -1803,7 +1803,7 @@ export const serializeAws_json1_1GetMaintenanceWindowExecutionTaskCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetMaintenanceWindowExecutionTask",
+    "x-amz-target": "AmazonSSM.GetMaintenanceWindowExecutionTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMaintenanceWindowExecutionTaskRequest(input, context));
@@ -1816,7 +1816,7 @@ export const serializeAws_json1_1GetMaintenanceWindowExecutionTaskInvocationComm
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetMaintenanceWindowExecutionTaskInvocation",
+    "x-amz-target": "AmazonSSM.GetMaintenanceWindowExecutionTaskInvocation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMaintenanceWindowExecutionTaskInvocationRequest(input, context));
@@ -1829,7 +1829,7 @@ export const serializeAws_json1_1GetMaintenanceWindowTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetMaintenanceWindowTask",
+    "x-amz-target": "AmazonSSM.GetMaintenanceWindowTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMaintenanceWindowTaskRequest(input, context));
@@ -1842,7 +1842,7 @@ export const serializeAws_json1_1GetOpsItemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetOpsItem",
+    "x-amz-target": "AmazonSSM.GetOpsItem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOpsItemRequest(input, context));
@@ -1855,7 +1855,7 @@ export const serializeAws_json1_1GetOpsMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetOpsMetadata",
+    "x-amz-target": "AmazonSSM.GetOpsMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOpsMetadataRequest(input, context));
@@ -1868,7 +1868,7 @@ export const serializeAws_json1_1GetOpsSummaryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetOpsSummary",
+    "x-amz-target": "AmazonSSM.GetOpsSummary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetOpsSummaryRequest(input, context));
@@ -1881,7 +1881,7 @@ export const serializeAws_json1_1GetParameterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetParameter",
+    "x-amz-target": "AmazonSSM.GetParameter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetParameterRequest(input, context));
@@ -1894,7 +1894,7 @@ export const serializeAws_json1_1GetParameterHistoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetParameterHistory",
+    "x-amz-target": "AmazonSSM.GetParameterHistory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetParameterHistoryRequest(input, context));
@@ -1907,7 +1907,7 @@ export const serializeAws_json1_1GetParametersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetParameters",
+    "x-amz-target": "AmazonSSM.GetParameters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetParametersRequest(input, context));
@@ -1920,7 +1920,7 @@ export const serializeAws_json1_1GetParametersByPathCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetParametersByPath",
+    "x-amz-target": "AmazonSSM.GetParametersByPath",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetParametersByPathRequest(input, context));
@@ -1933,7 +1933,7 @@ export const serializeAws_json1_1GetPatchBaselineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetPatchBaseline",
+    "x-amz-target": "AmazonSSM.GetPatchBaseline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPatchBaselineRequest(input, context));
@@ -1946,7 +1946,7 @@ export const serializeAws_json1_1GetPatchBaselineForPatchGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetPatchBaselineForPatchGroup",
+    "x-amz-target": "AmazonSSM.GetPatchBaselineForPatchGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPatchBaselineForPatchGroupRequest(input, context));
@@ -1959,7 +1959,7 @@ export const serializeAws_json1_1GetServiceSettingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.GetServiceSetting",
+    "x-amz-target": "AmazonSSM.GetServiceSetting",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetServiceSettingRequest(input, context));
@@ -1972,7 +1972,7 @@ export const serializeAws_json1_1LabelParameterVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.LabelParameterVersion",
+    "x-amz-target": "AmazonSSM.LabelParameterVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1LabelParameterVersionRequest(input, context));
@@ -1985,7 +1985,7 @@ export const serializeAws_json1_1ListAssociationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListAssociations",
+    "x-amz-target": "AmazonSSM.ListAssociations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssociationsRequest(input, context));
@@ -1998,7 +1998,7 @@ export const serializeAws_json1_1ListAssociationVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListAssociationVersions",
+    "x-amz-target": "AmazonSSM.ListAssociationVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAssociationVersionsRequest(input, context));
@@ -2011,7 +2011,7 @@ export const serializeAws_json1_1ListCommandInvocationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListCommandInvocations",
+    "x-amz-target": "AmazonSSM.ListCommandInvocations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCommandInvocationsRequest(input, context));
@@ -2024,7 +2024,7 @@ export const serializeAws_json1_1ListCommandsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListCommands",
+    "x-amz-target": "AmazonSSM.ListCommands",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListCommandsRequest(input, context));
@@ -2037,7 +2037,7 @@ export const serializeAws_json1_1ListComplianceItemsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListComplianceItems",
+    "x-amz-target": "AmazonSSM.ListComplianceItems",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListComplianceItemsRequest(input, context));
@@ -2050,7 +2050,7 @@ export const serializeAws_json1_1ListComplianceSummariesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListComplianceSummaries",
+    "x-amz-target": "AmazonSSM.ListComplianceSummaries",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListComplianceSummariesRequest(input, context));
@@ -2063,7 +2063,7 @@ export const serializeAws_json1_1ListDocumentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListDocuments",
+    "x-amz-target": "AmazonSSM.ListDocuments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDocumentsRequest(input, context));
@@ -2076,7 +2076,7 @@ export const serializeAws_json1_1ListDocumentVersionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListDocumentVersions",
+    "x-amz-target": "AmazonSSM.ListDocumentVersions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListDocumentVersionsRequest(input, context));
@@ -2089,7 +2089,7 @@ export const serializeAws_json1_1ListInventoryEntriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListInventoryEntries",
+    "x-amz-target": "AmazonSSM.ListInventoryEntries",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListInventoryEntriesRequest(input, context));
@@ -2102,7 +2102,7 @@ export const serializeAws_json1_1ListOpsMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListOpsMetadata",
+    "x-amz-target": "AmazonSSM.ListOpsMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListOpsMetadataRequest(input, context));
@@ -2115,7 +2115,7 @@ export const serializeAws_json1_1ListResourceComplianceSummariesCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListResourceComplianceSummaries",
+    "x-amz-target": "AmazonSSM.ListResourceComplianceSummaries",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourceComplianceSummariesRequest(input, context));
@@ -2128,7 +2128,7 @@ export const serializeAws_json1_1ListResourceDataSyncCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListResourceDataSync",
+    "x-amz-target": "AmazonSSM.ListResourceDataSync",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourceDataSyncRequest(input, context));
@@ -2141,7 +2141,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ListTagsForResource",
+    "x-amz-target": "AmazonSSM.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -2154,7 +2154,7 @@ export const serializeAws_json1_1ModifyDocumentPermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ModifyDocumentPermission",
+    "x-amz-target": "AmazonSSM.ModifyDocumentPermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyDocumentPermissionRequest(input, context));
@@ -2167,7 +2167,7 @@ export const serializeAws_json1_1PutComplianceItemsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.PutComplianceItems",
+    "x-amz-target": "AmazonSSM.PutComplianceItems",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutComplianceItemsRequest(input, context));
@@ -2180,7 +2180,7 @@ export const serializeAws_json1_1PutInventoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.PutInventory",
+    "x-amz-target": "AmazonSSM.PutInventory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutInventoryRequest(input, context));
@@ -2193,7 +2193,7 @@ export const serializeAws_json1_1PutParameterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.PutParameter",
+    "x-amz-target": "AmazonSSM.PutParameter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutParameterRequest(input, context));
@@ -2206,7 +2206,7 @@ export const serializeAws_json1_1RegisterDefaultPatchBaselineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.RegisterDefaultPatchBaseline",
+    "x-amz-target": "AmazonSSM.RegisterDefaultPatchBaseline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterDefaultPatchBaselineRequest(input, context));
@@ -2219,7 +2219,7 @@ export const serializeAws_json1_1RegisterPatchBaselineForPatchGroupCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.RegisterPatchBaselineForPatchGroup",
+    "x-amz-target": "AmazonSSM.RegisterPatchBaselineForPatchGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterPatchBaselineForPatchGroupRequest(input, context));
@@ -2232,7 +2232,7 @@ export const serializeAws_json1_1RegisterTargetWithMaintenanceWindowCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.RegisterTargetWithMaintenanceWindow",
+    "x-amz-target": "AmazonSSM.RegisterTargetWithMaintenanceWindow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterTargetWithMaintenanceWindowRequest(input, context));
@@ -2245,7 +2245,7 @@ export const serializeAws_json1_1RegisterTaskWithMaintenanceWindowCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.RegisterTaskWithMaintenanceWindow",
+    "x-amz-target": "AmazonSSM.RegisterTaskWithMaintenanceWindow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterTaskWithMaintenanceWindowRequest(input, context));
@@ -2258,7 +2258,7 @@ export const serializeAws_json1_1RemoveTagsFromResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.RemoveTagsFromResource",
+    "x-amz-target": "AmazonSSM.RemoveTagsFromResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsFromResourceRequest(input, context));
@@ -2271,7 +2271,7 @@ export const serializeAws_json1_1ResetServiceSettingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ResetServiceSetting",
+    "x-amz-target": "AmazonSSM.ResetServiceSetting",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResetServiceSettingRequest(input, context));
@@ -2284,7 +2284,7 @@ export const serializeAws_json1_1ResumeSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.ResumeSession",
+    "x-amz-target": "AmazonSSM.ResumeSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResumeSessionRequest(input, context));
@@ -2297,7 +2297,7 @@ export const serializeAws_json1_1SendAutomationSignalCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.SendAutomationSignal",
+    "x-amz-target": "AmazonSSM.SendAutomationSignal",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SendAutomationSignalRequest(input, context));
@@ -2310,7 +2310,7 @@ export const serializeAws_json1_1SendCommandCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.SendCommand",
+    "x-amz-target": "AmazonSSM.SendCommand",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SendCommandRequest(input, context));
@@ -2323,7 +2323,7 @@ export const serializeAws_json1_1StartAssociationsOnceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.StartAssociationsOnce",
+    "x-amz-target": "AmazonSSM.StartAssociationsOnce",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartAssociationsOnceRequest(input, context));
@@ -2336,7 +2336,7 @@ export const serializeAws_json1_1StartAutomationExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.StartAutomationExecution",
+    "x-amz-target": "AmazonSSM.StartAutomationExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartAutomationExecutionRequest(input, context));
@@ -2349,7 +2349,7 @@ export const serializeAws_json1_1StartSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.StartSession",
+    "x-amz-target": "AmazonSSM.StartSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartSessionRequest(input, context));
@@ -2362,7 +2362,7 @@ export const serializeAws_json1_1StopAutomationExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.StopAutomationExecution",
+    "x-amz-target": "AmazonSSM.StopAutomationExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopAutomationExecutionRequest(input, context));
@@ -2375,7 +2375,7 @@ export const serializeAws_json1_1TerminateSessionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.TerminateSession",
+    "x-amz-target": "AmazonSSM.TerminateSession",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TerminateSessionRequest(input, context));
@@ -2388,7 +2388,7 @@ export const serializeAws_json1_1UpdateAssociationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateAssociation",
+    "x-amz-target": "AmazonSSM.UpdateAssociation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAssociationRequest(input, context));
@@ -2401,7 +2401,7 @@ export const serializeAws_json1_1UpdateAssociationStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateAssociationStatus",
+    "x-amz-target": "AmazonSSM.UpdateAssociationStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAssociationStatusRequest(input, context));
@@ -2414,7 +2414,7 @@ export const serializeAws_json1_1UpdateDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateDocument",
+    "x-amz-target": "AmazonSSM.UpdateDocument",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDocumentRequest(input, context));
@@ -2427,7 +2427,7 @@ export const serializeAws_json1_1UpdateDocumentDefaultVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateDocumentDefaultVersion",
+    "x-amz-target": "AmazonSSM.UpdateDocumentDefaultVersion",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateDocumentDefaultVersionRequest(input, context));
@@ -2440,7 +2440,7 @@ export const serializeAws_json1_1UpdateMaintenanceWindowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateMaintenanceWindow",
+    "x-amz-target": "AmazonSSM.UpdateMaintenanceWindow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMaintenanceWindowRequest(input, context));
@@ -2453,7 +2453,7 @@ export const serializeAws_json1_1UpdateMaintenanceWindowTargetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateMaintenanceWindowTarget",
+    "x-amz-target": "AmazonSSM.UpdateMaintenanceWindowTarget",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMaintenanceWindowTargetRequest(input, context));
@@ -2466,7 +2466,7 @@ export const serializeAws_json1_1UpdateMaintenanceWindowTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateMaintenanceWindowTask",
+    "x-amz-target": "AmazonSSM.UpdateMaintenanceWindowTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMaintenanceWindowTaskRequest(input, context));
@@ -2479,7 +2479,7 @@ export const serializeAws_json1_1UpdateManagedInstanceRoleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateManagedInstanceRole",
+    "x-amz-target": "AmazonSSM.UpdateManagedInstanceRole",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateManagedInstanceRoleRequest(input, context));
@@ -2492,7 +2492,7 @@ export const serializeAws_json1_1UpdateOpsItemCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateOpsItem",
+    "x-amz-target": "AmazonSSM.UpdateOpsItem",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateOpsItemRequest(input, context));
@@ -2505,7 +2505,7 @@ export const serializeAws_json1_1UpdateOpsMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateOpsMetadata",
+    "x-amz-target": "AmazonSSM.UpdateOpsMetadata",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateOpsMetadataRequest(input, context));
@@ -2518,7 +2518,7 @@ export const serializeAws_json1_1UpdatePatchBaselineCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdatePatchBaseline",
+    "x-amz-target": "AmazonSSM.UpdatePatchBaseline",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePatchBaselineRequest(input, context));
@@ -2531,7 +2531,7 @@ export const serializeAws_json1_1UpdateResourceDataSyncCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateResourceDataSync",
+    "x-amz-target": "AmazonSSM.UpdateResourceDataSync",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateResourceDataSyncRequest(input, context));
@@ -2544,7 +2544,7 @@ export const serializeAws_json1_1UpdateServiceSettingCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AmazonSSM.UpdateServiceSetting",
+    "x-amz-target": "AmazonSSM.UpdateServiceSetting",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateServiceSettingRequest(input, context));

--- a/clients/client-sso-admin/protocols/Aws_json1_1.ts
+++ b/clients/client-sso-admin/protocols/Aws_json1_1.ts
@@ -210,7 +210,7 @@ export const serializeAws_json1_1AttachManagedPolicyToPermissionSetCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.AttachManagedPolicyToPermissionSet",
+    "x-amz-target": "SWBExternalService.AttachManagedPolicyToPermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AttachManagedPolicyToPermissionSetRequest(input, context));
@@ -223,7 +223,7 @@ export const serializeAws_json1_1CreateAccountAssignmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.CreateAccountAssignment",
+    "x-amz-target": "SWBExternalService.CreateAccountAssignment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAccountAssignmentRequest(input, context));
@@ -236,7 +236,7 @@ export const serializeAws_json1_1CreateInstanceAccessControlAttributeConfigurati
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.CreateInstanceAccessControlAttributeConfiguration",
+    "x-amz-target": "SWBExternalService.CreateInstanceAccessControlAttributeConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateInstanceAccessControlAttributeConfigurationRequest(input, context));
@@ -249,7 +249,7 @@ export const serializeAws_json1_1CreatePermissionSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.CreatePermissionSet",
+    "x-amz-target": "SWBExternalService.CreatePermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreatePermissionSetRequest(input, context));
@@ -262,7 +262,7 @@ export const serializeAws_json1_1DeleteAccountAssignmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.DeleteAccountAssignment",
+    "x-amz-target": "SWBExternalService.DeleteAccountAssignment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAccountAssignmentRequest(input, context));
@@ -275,7 +275,7 @@ export const serializeAws_json1_1DeleteInlinePolicyFromPermissionSetCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.DeleteInlinePolicyFromPermissionSet",
+    "x-amz-target": "SWBExternalService.DeleteInlinePolicyFromPermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteInlinePolicyFromPermissionSetRequest(input, context));
@@ -288,7 +288,7 @@ export const serializeAws_json1_1DeleteInstanceAccessControlAttributeConfigurati
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.DeleteInstanceAccessControlAttributeConfiguration",
+    "x-amz-target": "SWBExternalService.DeleteInstanceAccessControlAttributeConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteInstanceAccessControlAttributeConfigurationRequest(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_1DeletePermissionSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.DeletePermissionSet",
+    "x-amz-target": "SWBExternalService.DeletePermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePermissionSetRequest(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_1DescribeAccountAssignmentCreationStatusCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.DescribeAccountAssignmentCreationStatus",
+    "x-amz-target": "SWBExternalService.DescribeAccountAssignmentCreationStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAccountAssignmentCreationStatusRequest(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1DescribeAccountAssignmentDeletionStatusCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.DescribeAccountAssignmentDeletionStatus",
+    "x-amz-target": "SWBExternalService.DescribeAccountAssignmentDeletionStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAccountAssignmentDeletionStatusRequest(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1DescribeInstanceAccessControlAttributeConfigura
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.DescribeInstanceAccessControlAttributeConfiguration",
+    "x-amz-target": "SWBExternalService.DescribeInstanceAccessControlAttributeConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeInstanceAccessControlAttributeConfigurationRequest(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1DescribePermissionSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.DescribePermissionSet",
+    "x-amz-target": "SWBExternalService.DescribePermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePermissionSetRequest(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_1DescribePermissionSetProvisioningStatusCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.DescribePermissionSetProvisioningStatus",
+    "x-amz-target": "SWBExternalService.DescribePermissionSetProvisioningStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribePermissionSetProvisioningStatusRequest(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_1DetachManagedPolicyFromPermissionSetCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.DetachManagedPolicyFromPermissionSet",
+    "x-amz-target": "SWBExternalService.DetachManagedPolicyFromPermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetachManagedPolicyFromPermissionSetRequest(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_1GetInlinePolicyForPermissionSetCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.GetInlinePolicyForPermissionSet",
+    "x-amz-target": "SWBExternalService.GetInlinePolicyForPermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetInlinePolicyForPermissionSetRequest(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_1ListAccountAssignmentCreationStatusCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ListAccountAssignmentCreationStatus",
+    "x-amz-target": "SWBExternalService.ListAccountAssignmentCreationStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAccountAssignmentCreationStatusRequest(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_1ListAccountAssignmentDeletionStatusCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ListAccountAssignmentDeletionStatus",
+    "x-amz-target": "SWBExternalService.ListAccountAssignmentDeletionStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAccountAssignmentDeletionStatusRequest(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_1ListAccountAssignmentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ListAccountAssignments",
+    "x-amz-target": "SWBExternalService.ListAccountAssignments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAccountAssignmentsRequest(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_1ListAccountsForProvisionedPermissionSetCommand 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ListAccountsForProvisionedPermissionSet",
+    "x-amz-target": "SWBExternalService.ListAccountsForProvisionedPermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAccountsForProvisionedPermissionSetRequest(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_1ListInstancesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ListInstances",
+    "x-amz-target": "SWBExternalService.ListInstances",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListInstancesRequest(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_1ListManagedPoliciesInPermissionSetCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ListManagedPoliciesInPermissionSet",
+    "x-amz-target": "SWBExternalService.ListManagedPoliciesInPermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListManagedPoliciesInPermissionSetRequest(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_1ListPermissionSetProvisioningStatusCommand = as
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ListPermissionSetProvisioningStatus",
+    "x-amz-target": "SWBExternalService.ListPermissionSetProvisioningStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPermissionSetProvisioningStatusRequest(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_1ListPermissionSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ListPermissionSets",
+    "x-amz-target": "SWBExternalService.ListPermissionSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPermissionSetsRequest(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_1ListPermissionSetsProvisionedToAccountCommand =
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ListPermissionSetsProvisionedToAccount",
+    "x-amz-target": "SWBExternalService.ListPermissionSetsProvisionedToAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListPermissionSetsProvisionedToAccountRequest(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ListTagsForResource",
+    "x-amz-target": "SWBExternalService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1ProvisionPermissionSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.ProvisionPermissionSet",
+    "x-amz-target": "SWBExternalService.ProvisionPermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ProvisionPermissionSetRequest(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1PutInlinePolicyToPermissionSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.PutInlinePolicyToPermissionSet",
+    "x-amz-target": "SWBExternalService.PutInlinePolicyToPermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutInlinePolicyToPermissionSetRequest(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.TagResource",
+    "x-amz-target": "SWBExternalService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.UntagResource",
+    "x-amz-target": "SWBExternalService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_1UpdateInstanceAccessControlAttributeConfigurati
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.UpdateInstanceAccessControlAttributeConfiguration",
+    "x-amz-target": "SWBExternalService.UpdateInstanceAccessControlAttributeConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateInstanceAccessControlAttributeConfigurationRequest(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_1UpdatePermissionSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "SWBExternalService.UpdatePermissionSet",
+    "x-amz-target": "SWBExternalService.UpdatePermissionSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePermissionSetRequest(input, context));

--- a/clients/client-storage-gateway/protocols/Aws_json1_1.ts
+++ b/clients/client-storage-gateway/protocols/Aws_json1_1.ts
@@ -432,7 +432,7 @@ export const serializeAws_json1_1ActivateGatewayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ActivateGateway",
+    "x-amz-target": "StorageGateway_20130630.ActivateGateway",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ActivateGatewayInput(input, context));
@@ -445,7 +445,7 @@ export const serializeAws_json1_1AddCacheCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.AddCache",
+    "x-amz-target": "StorageGateway_20130630.AddCache",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddCacheInput(input, context));
@@ -458,7 +458,7 @@ export const serializeAws_json1_1AddTagsToResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.AddTagsToResource",
+    "x-amz-target": "StorageGateway_20130630.AddTagsToResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddTagsToResourceInput(input, context));
@@ -471,7 +471,7 @@ export const serializeAws_json1_1AddUploadBufferCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.AddUploadBuffer",
+    "x-amz-target": "StorageGateway_20130630.AddUploadBuffer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddUploadBufferInput(input, context));
@@ -484,7 +484,7 @@ export const serializeAws_json1_1AddWorkingStorageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.AddWorkingStorage",
+    "x-amz-target": "StorageGateway_20130630.AddWorkingStorage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddWorkingStorageInput(input, context));
@@ -497,7 +497,7 @@ export const serializeAws_json1_1AssignTapePoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.AssignTapePool",
+    "x-amz-target": "StorageGateway_20130630.AssignTapePool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssignTapePoolInput(input, context));
@@ -510,7 +510,7 @@ export const serializeAws_json1_1AttachVolumeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.AttachVolume",
+    "x-amz-target": "StorageGateway_20130630.AttachVolume",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AttachVolumeInput(input, context));
@@ -523,7 +523,7 @@ export const serializeAws_json1_1CancelArchivalCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CancelArchival",
+    "x-amz-target": "StorageGateway_20130630.CancelArchival",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelArchivalInput(input, context));
@@ -536,7 +536,7 @@ export const serializeAws_json1_1CancelRetrievalCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CancelRetrieval",
+    "x-amz-target": "StorageGateway_20130630.CancelRetrieval",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CancelRetrievalInput(input, context));
@@ -549,7 +549,7 @@ export const serializeAws_json1_1CreateCachediSCSIVolumeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CreateCachediSCSIVolume",
+    "x-amz-target": "StorageGateway_20130630.CreateCachediSCSIVolume",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCachediSCSIVolumeInput(input, context));
@@ -562,7 +562,7 @@ export const serializeAws_json1_1CreateNFSFileShareCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CreateNFSFileShare",
+    "x-amz-target": "StorageGateway_20130630.CreateNFSFileShare",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateNFSFileShareInput(input, context));
@@ -575,7 +575,7 @@ export const serializeAws_json1_1CreateSMBFileShareCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CreateSMBFileShare",
+    "x-amz-target": "StorageGateway_20130630.CreateSMBFileShare",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSMBFileShareInput(input, context));
@@ -588,7 +588,7 @@ export const serializeAws_json1_1CreateSnapshotCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CreateSnapshot",
+    "x-amz-target": "StorageGateway_20130630.CreateSnapshot",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSnapshotInput(input, context));
@@ -601,7 +601,7 @@ export const serializeAws_json1_1CreateSnapshotFromVolumeRecoveryPointCommand = 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CreateSnapshotFromVolumeRecoveryPoint",
+    "x-amz-target": "StorageGateway_20130630.CreateSnapshotFromVolumeRecoveryPoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSnapshotFromVolumeRecoveryPointInput(input, context));
@@ -614,7 +614,7 @@ export const serializeAws_json1_1CreateStorediSCSIVolumeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CreateStorediSCSIVolume",
+    "x-amz-target": "StorageGateway_20130630.CreateStorediSCSIVolume",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateStorediSCSIVolumeInput(input, context));
@@ -627,7 +627,7 @@ export const serializeAws_json1_1CreateTapePoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CreateTapePool",
+    "x-amz-target": "StorageGateway_20130630.CreateTapePool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTapePoolInput(input, context));
@@ -640,7 +640,7 @@ export const serializeAws_json1_1CreateTapesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CreateTapes",
+    "x-amz-target": "StorageGateway_20130630.CreateTapes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTapesInput(input, context));
@@ -653,7 +653,7 @@ export const serializeAws_json1_1CreateTapeWithBarcodeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.CreateTapeWithBarcode",
+    "x-amz-target": "StorageGateway_20130630.CreateTapeWithBarcode",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTapeWithBarcodeInput(input, context));
@@ -666,7 +666,7 @@ export const serializeAws_json1_1DeleteAutomaticTapeCreationPolicyCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DeleteAutomaticTapeCreationPolicy",
+    "x-amz-target": "StorageGateway_20130630.DeleteAutomaticTapeCreationPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAutomaticTapeCreationPolicyInput(input, context));
@@ -679,7 +679,7 @@ export const serializeAws_json1_1DeleteBandwidthRateLimitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DeleteBandwidthRateLimit",
+    "x-amz-target": "StorageGateway_20130630.DeleteBandwidthRateLimit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteBandwidthRateLimitInput(input, context));
@@ -692,7 +692,7 @@ export const serializeAws_json1_1DeleteChapCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DeleteChapCredentials",
+    "x-amz-target": "StorageGateway_20130630.DeleteChapCredentials",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteChapCredentialsInput(input, context));
@@ -705,7 +705,7 @@ export const serializeAws_json1_1DeleteFileShareCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DeleteFileShare",
+    "x-amz-target": "StorageGateway_20130630.DeleteFileShare",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFileShareInput(input, context));
@@ -718,7 +718,7 @@ export const serializeAws_json1_1DeleteGatewayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DeleteGateway",
+    "x-amz-target": "StorageGateway_20130630.DeleteGateway",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteGatewayInput(input, context));
@@ -731,7 +731,7 @@ export const serializeAws_json1_1DeleteSnapshotScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DeleteSnapshotSchedule",
+    "x-amz-target": "StorageGateway_20130630.DeleteSnapshotSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSnapshotScheduleInput(input, context));
@@ -744,7 +744,7 @@ export const serializeAws_json1_1DeleteTapeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DeleteTape",
+    "x-amz-target": "StorageGateway_20130630.DeleteTape",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTapeInput(input, context));
@@ -757,7 +757,7 @@ export const serializeAws_json1_1DeleteTapeArchiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DeleteTapeArchive",
+    "x-amz-target": "StorageGateway_20130630.DeleteTapeArchive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTapeArchiveInput(input, context));
@@ -770,7 +770,7 @@ export const serializeAws_json1_1DeleteTapePoolCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DeleteTapePool",
+    "x-amz-target": "StorageGateway_20130630.DeleteTapePool",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTapePoolInput(input, context));
@@ -783,7 +783,7 @@ export const serializeAws_json1_1DeleteVolumeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DeleteVolume",
+    "x-amz-target": "StorageGateway_20130630.DeleteVolume",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteVolumeInput(input, context));
@@ -796,7 +796,7 @@ export const serializeAws_json1_1DescribeAvailabilityMonitorTestCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeAvailabilityMonitorTest",
+    "x-amz-target": "StorageGateway_20130630.DescribeAvailabilityMonitorTest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAvailabilityMonitorTestInput(input, context));
@@ -809,7 +809,7 @@ export const serializeAws_json1_1DescribeBandwidthRateLimitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeBandwidthRateLimit",
+    "x-amz-target": "StorageGateway_20130630.DescribeBandwidthRateLimit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBandwidthRateLimitInput(input, context));
@@ -822,7 +822,7 @@ export const serializeAws_json1_1DescribeBandwidthRateLimitScheduleCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeBandwidthRateLimitSchedule",
+    "x-amz-target": "StorageGateway_20130630.DescribeBandwidthRateLimitSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeBandwidthRateLimitScheduleInput(input, context));
@@ -835,7 +835,7 @@ export const serializeAws_json1_1DescribeCacheCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeCache",
+    "x-amz-target": "StorageGateway_20130630.DescribeCache",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCacheInput(input, context));
@@ -848,7 +848,7 @@ export const serializeAws_json1_1DescribeCachediSCSIVolumesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeCachediSCSIVolumes",
+    "x-amz-target": "StorageGateway_20130630.DescribeCachediSCSIVolumes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCachediSCSIVolumesInput(input, context));
@@ -861,7 +861,7 @@ export const serializeAws_json1_1DescribeChapCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeChapCredentials",
+    "x-amz-target": "StorageGateway_20130630.DescribeChapCredentials",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeChapCredentialsInput(input, context));
@@ -874,7 +874,7 @@ export const serializeAws_json1_1DescribeGatewayInformationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeGatewayInformation",
+    "x-amz-target": "StorageGateway_20130630.DescribeGatewayInformation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeGatewayInformationInput(input, context));
@@ -887,7 +887,7 @@ export const serializeAws_json1_1DescribeMaintenanceStartTimeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeMaintenanceStartTime",
+    "x-amz-target": "StorageGateway_20130630.DescribeMaintenanceStartTime",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeMaintenanceStartTimeInput(input, context));
@@ -900,7 +900,7 @@ export const serializeAws_json1_1DescribeNFSFileSharesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeNFSFileShares",
+    "x-amz-target": "StorageGateway_20130630.DescribeNFSFileShares",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeNFSFileSharesInput(input, context));
@@ -913,7 +913,7 @@ export const serializeAws_json1_1DescribeSMBFileSharesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeSMBFileShares",
+    "x-amz-target": "StorageGateway_20130630.DescribeSMBFileShares",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSMBFileSharesInput(input, context));
@@ -926,7 +926,7 @@ export const serializeAws_json1_1DescribeSMBSettingsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeSMBSettings",
+    "x-amz-target": "StorageGateway_20130630.DescribeSMBSettings",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSMBSettingsInput(input, context));
@@ -939,7 +939,7 @@ export const serializeAws_json1_1DescribeSnapshotScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeSnapshotSchedule",
+    "x-amz-target": "StorageGateway_20130630.DescribeSnapshotSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSnapshotScheduleInput(input, context));
@@ -952,7 +952,7 @@ export const serializeAws_json1_1DescribeStorediSCSIVolumesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeStorediSCSIVolumes",
+    "x-amz-target": "StorageGateway_20130630.DescribeStorediSCSIVolumes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeStorediSCSIVolumesInput(input, context));
@@ -965,7 +965,7 @@ export const serializeAws_json1_1DescribeTapeArchivesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeTapeArchives",
+    "x-amz-target": "StorageGateway_20130630.DescribeTapeArchives",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTapeArchivesInput(input, context));
@@ -978,7 +978,7 @@ export const serializeAws_json1_1DescribeTapeRecoveryPointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeTapeRecoveryPoints",
+    "x-amz-target": "StorageGateway_20130630.DescribeTapeRecoveryPoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTapeRecoveryPointsInput(input, context));
@@ -991,7 +991,7 @@ export const serializeAws_json1_1DescribeTapesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeTapes",
+    "x-amz-target": "StorageGateway_20130630.DescribeTapes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTapesInput(input, context));
@@ -1004,7 +1004,7 @@ export const serializeAws_json1_1DescribeUploadBufferCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeUploadBuffer",
+    "x-amz-target": "StorageGateway_20130630.DescribeUploadBuffer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUploadBufferInput(input, context));
@@ -1017,7 +1017,7 @@ export const serializeAws_json1_1DescribeVTLDevicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeVTLDevices",
+    "x-amz-target": "StorageGateway_20130630.DescribeVTLDevices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeVTLDevicesInput(input, context));
@@ -1030,7 +1030,7 @@ export const serializeAws_json1_1DescribeWorkingStorageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DescribeWorkingStorage",
+    "x-amz-target": "StorageGateway_20130630.DescribeWorkingStorage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeWorkingStorageInput(input, context));
@@ -1043,7 +1043,7 @@ export const serializeAws_json1_1DetachVolumeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DetachVolume",
+    "x-amz-target": "StorageGateway_20130630.DetachVolume",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetachVolumeInput(input, context));
@@ -1056,7 +1056,7 @@ export const serializeAws_json1_1DisableGatewayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.DisableGateway",
+    "x-amz-target": "StorageGateway_20130630.DisableGateway",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisableGatewayInput(input, context));
@@ -1069,7 +1069,7 @@ export const serializeAws_json1_1JoinDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.JoinDomain",
+    "x-amz-target": "StorageGateway_20130630.JoinDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1JoinDomainInput(input, context));
@@ -1082,7 +1082,7 @@ export const serializeAws_json1_1ListAutomaticTapeCreationPoliciesCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ListAutomaticTapeCreationPolicies",
+    "x-amz-target": "StorageGateway_20130630.ListAutomaticTapeCreationPolicies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAutomaticTapeCreationPoliciesInput(input, context));
@@ -1095,7 +1095,7 @@ export const serializeAws_json1_1ListFileSharesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ListFileShares",
+    "x-amz-target": "StorageGateway_20130630.ListFileShares",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListFileSharesInput(input, context));
@@ -1108,7 +1108,7 @@ export const serializeAws_json1_1ListGatewaysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ListGateways",
+    "x-amz-target": "StorageGateway_20130630.ListGateways",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGatewaysInput(input, context));
@@ -1121,7 +1121,7 @@ export const serializeAws_json1_1ListLocalDisksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ListLocalDisks",
+    "x-amz-target": "StorageGateway_20130630.ListLocalDisks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLocalDisksInput(input, context));
@@ -1134,7 +1134,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ListTagsForResource",
+    "x-amz-target": "StorageGateway_20130630.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceInput(input, context));
@@ -1147,7 +1147,7 @@ export const serializeAws_json1_1ListTapePoolsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ListTapePools",
+    "x-amz-target": "StorageGateway_20130630.ListTapePools",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTapePoolsInput(input, context));
@@ -1160,7 +1160,7 @@ export const serializeAws_json1_1ListTapesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ListTapes",
+    "x-amz-target": "StorageGateway_20130630.ListTapes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTapesInput(input, context));
@@ -1173,7 +1173,7 @@ export const serializeAws_json1_1ListVolumeInitiatorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ListVolumeInitiators",
+    "x-amz-target": "StorageGateway_20130630.ListVolumeInitiators",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListVolumeInitiatorsInput(input, context));
@@ -1186,7 +1186,7 @@ export const serializeAws_json1_1ListVolumeRecoveryPointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ListVolumeRecoveryPoints",
+    "x-amz-target": "StorageGateway_20130630.ListVolumeRecoveryPoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListVolumeRecoveryPointsInput(input, context));
@@ -1199,7 +1199,7 @@ export const serializeAws_json1_1ListVolumesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ListVolumes",
+    "x-amz-target": "StorageGateway_20130630.ListVolumes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListVolumesInput(input, context));
@@ -1212,7 +1212,7 @@ export const serializeAws_json1_1NotifyWhenUploadedCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.NotifyWhenUploaded",
+    "x-amz-target": "StorageGateway_20130630.NotifyWhenUploaded",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1NotifyWhenUploadedInput(input, context));
@@ -1225,7 +1225,7 @@ export const serializeAws_json1_1RefreshCacheCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.RefreshCache",
+    "x-amz-target": "StorageGateway_20130630.RefreshCache",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RefreshCacheInput(input, context));
@@ -1238,7 +1238,7 @@ export const serializeAws_json1_1RemoveTagsFromResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.RemoveTagsFromResource",
+    "x-amz-target": "StorageGateway_20130630.RemoveTagsFromResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RemoveTagsFromResourceInput(input, context));
@@ -1251,7 +1251,7 @@ export const serializeAws_json1_1ResetCacheCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ResetCache",
+    "x-amz-target": "StorageGateway_20130630.ResetCache",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResetCacheInput(input, context));
@@ -1264,7 +1264,7 @@ export const serializeAws_json1_1RetrieveTapeArchiveCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.RetrieveTapeArchive",
+    "x-amz-target": "StorageGateway_20130630.RetrieveTapeArchive",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RetrieveTapeArchiveInput(input, context));
@@ -1277,7 +1277,7 @@ export const serializeAws_json1_1RetrieveTapeRecoveryPointCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.RetrieveTapeRecoveryPoint",
+    "x-amz-target": "StorageGateway_20130630.RetrieveTapeRecoveryPoint",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RetrieveTapeRecoveryPointInput(input, context));
@@ -1290,7 +1290,7 @@ export const serializeAws_json1_1SetLocalConsolePasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.SetLocalConsolePassword",
+    "x-amz-target": "StorageGateway_20130630.SetLocalConsolePassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetLocalConsolePasswordInput(input, context));
@@ -1303,7 +1303,7 @@ export const serializeAws_json1_1SetSMBGuestPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.SetSMBGuestPassword",
+    "x-amz-target": "StorageGateway_20130630.SetSMBGuestPassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SetSMBGuestPasswordInput(input, context));
@@ -1316,7 +1316,7 @@ export const serializeAws_json1_1ShutdownGatewayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.ShutdownGateway",
+    "x-amz-target": "StorageGateway_20130630.ShutdownGateway",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ShutdownGatewayInput(input, context));
@@ -1329,7 +1329,7 @@ export const serializeAws_json1_1StartAvailabilityMonitorTestCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.StartAvailabilityMonitorTest",
+    "x-amz-target": "StorageGateway_20130630.StartAvailabilityMonitorTest",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartAvailabilityMonitorTestInput(input, context));
@@ -1342,7 +1342,7 @@ export const serializeAws_json1_1StartGatewayCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.StartGateway",
+    "x-amz-target": "StorageGateway_20130630.StartGateway",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartGatewayInput(input, context));
@@ -1355,7 +1355,7 @@ export const serializeAws_json1_1UpdateAutomaticTapeCreationPolicyCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateAutomaticTapeCreationPolicy",
+    "x-amz-target": "StorageGateway_20130630.UpdateAutomaticTapeCreationPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateAutomaticTapeCreationPolicyInput(input, context));
@@ -1368,7 +1368,7 @@ export const serializeAws_json1_1UpdateBandwidthRateLimitCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateBandwidthRateLimit",
+    "x-amz-target": "StorageGateway_20130630.UpdateBandwidthRateLimit",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateBandwidthRateLimitInput(input, context));
@@ -1381,7 +1381,7 @@ export const serializeAws_json1_1UpdateBandwidthRateLimitScheduleCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateBandwidthRateLimitSchedule",
+    "x-amz-target": "StorageGateway_20130630.UpdateBandwidthRateLimitSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateBandwidthRateLimitScheduleInput(input, context));
@@ -1394,7 +1394,7 @@ export const serializeAws_json1_1UpdateChapCredentialsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateChapCredentials",
+    "x-amz-target": "StorageGateway_20130630.UpdateChapCredentials",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateChapCredentialsInput(input, context));
@@ -1407,7 +1407,7 @@ export const serializeAws_json1_1UpdateGatewayInformationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateGatewayInformation",
+    "x-amz-target": "StorageGateway_20130630.UpdateGatewayInformation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGatewayInformationInput(input, context));
@@ -1420,7 +1420,7 @@ export const serializeAws_json1_1UpdateGatewaySoftwareNowCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateGatewaySoftwareNow",
+    "x-amz-target": "StorageGateway_20130630.UpdateGatewaySoftwareNow",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGatewaySoftwareNowInput(input, context));
@@ -1433,7 +1433,7 @@ export const serializeAws_json1_1UpdateMaintenanceStartTimeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateMaintenanceStartTime",
+    "x-amz-target": "StorageGateway_20130630.UpdateMaintenanceStartTime",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMaintenanceStartTimeInput(input, context));
@@ -1446,7 +1446,7 @@ export const serializeAws_json1_1UpdateNFSFileShareCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateNFSFileShare",
+    "x-amz-target": "StorageGateway_20130630.UpdateNFSFileShare",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateNFSFileShareInput(input, context));
@@ -1459,7 +1459,7 @@ export const serializeAws_json1_1UpdateSMBFileShareCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateSMBFileShare",
+    "x-amz-target": "StorageGateway_20130630.UpdateSMBFileShare",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSMBFileShareInput(input, context));
@@ -1472,7 +1472,7 @@ export const serializeAws_json1_1UpdateSMBFileShareVisibilityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateSMBFileShareVisibility",
+    "x-amz-target": "StorageGateway_20130630.UpdateSMBFileShareVisibility",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSMBFileShareVisibilityInput(input, context));
@@ -1485,7 +1485,7 @@ export const serializeAws_json1_1UpdateSMBSecurityStrategyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateSMBSecurityStrategy",
+    "x-amz-target": "StorageGateway_20130630.UpdateSMBSecurityStrategy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSMBSecurityStrategyInput(input, context));
@@ -1498,7 +1498,7 @@ export const serializeAws_json1_1UpdateSnapshotScheduleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateSnapshotSchedule",
+    "x-amz-target": "StorageGateway_20130630.UpdateSnapshotSchedule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSnapshotScheduleInput(input, context));
@@ -1511,7 +1511,7 @@ export const serializeAws_json1_1UpdateVTLDeviceTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "StorageGateway_20130630.UpdateVTLDeviceType",
+    "x-amz-target": "StorageGateway_20130630.UpdateVTLDeviceType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateVTLDeviceTypeInput(input, context));

--- a/clients/client-support/protocols/Aws_json1_1.ts
+++ b/clients/client-support/protocols/Aws_json1_1.ts
@@ -110,7 +110,7 @@ export const serializeAws_json1_1AddAttachmentsToSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.AddAttachmentsToSet",
+    "x-amz-target": "AWSSupport_20130415.AddAttachmentsToSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddAttachmentsToSetRequest(input, context));
@@ -123,7 +123,7 @@ export const serializeAws_json1_1AddCommunicationToCaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.AddCommunicationToCase",
+    "x-amz-target": "AWSSupport_20130415.AddCommunicationToCase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AddCommunicationToCaseRequest(input, context));
@@ -136,7 +136,7 @@ export const serializeAws_json1_1CreateCaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.CreateCase",
+    "x-amz-target": "AWSSupport_20130415.CreateCase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateCaseRequest(input, context));
@@ -149,7 +149,7 @@ export const serializeAws_json1_1DescribeAttachmentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.DescribeAttachment",
+    "x-amz-target": "AWSSupport_20130415.DescribeAttachment",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAttachmentRequest(input, context));
@@ -162,7 +162,7 @@ export const serializeAws_json1_1DescribeCasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.DescribeCases",
+    "x-amz-target": "AWSSupport_20130415.DescribeCases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCasesRequest(input, context));
@@ -175,7 +175,7 @@ export const serializeAws_json1_1DescribeCommunicationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.DescribeCommunications",
+    "x-amz-target": "AWSSupport_20130415.DescribeCommunications",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeCommunicationsRequest(input, context));
@@ -188,7 +188,7 @@ export const serializeAws_json1_1DescribeServicesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.DescribeServices",
+    "x-amz-target": "AWSSupport_20130415.DescribeServices",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeServicesRequest(input, context));
@@ -201,7 +201,7 @@ export const serializeAws_json1_1DescribeSeverityLevelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.DescribeSeverityLevels",
+    "x-amz-target": "AWSSupport_20130415.DescribeSeverityLevels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSeverityLevelsRequest(input, context));
@@ -214,7 +214,7 @@ export const serializeAws_json1_1DescribeTrustedAdvisorCheckRefreshStatusesComma
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.DescribeTrustedAdvisorCheckRefreshStatuses",
+    "x-amz-target": "AWSSupport_20130415.DescribeTrustedAdvisorCheckRefreshStatuses",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTrustedAdvisorCheckRefreshStatusesRequest(input, context));
@@ -227,7 +227,7 @@ export const serializeAws_json1_1DescribeTrustedAdvisorCheckResultCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.DescribeTrustedAdvisorCheckResult",
+    "x-amz-target": "AWSSupport_20130415.DescribeTrustedAdvisorCheckResult",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTrustedAdvisorCheckResultRequest(input, context));
@@ -240,7 +240,7 @@ export const serializeAws_json1_1DescribeTrustedAdvisorChecksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.DescribeTrustedAdvisorChecks",
+    "x-amz-target": "AWSSupport_20130415.DescribeTrustedAdvisorChecks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTrustedAdvisorChecksRequest(input, context));
@@ -253,7 +253,7 @@ export const serializeAws_json1_1DescribeTrustedAdvisorCheckSummariesCommand = a
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.DescribeTrustedAdvisorCheckSummaries",
+    "x-amz-target": "AWSSupport_20130415.DescribeTrustedAdvisorCheckSummaries",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTrustedAdvisorCheckSummariesRequest(input, context));
@@ -266,7 +266,7 @@ export const serializeAws_json1_1RefreshTrustedAdvisorCheckCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.RefreshTrustedAdvisorCheck",
+    "x-amz-target": "AWSSupport_20130415.RefreshTrustedAdvisorCheck",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RefreshTrustedAdvisorCheckRequest(input, context));
@@ -279,7 +279,7 @@ export const serializeAws_json1_1ResolveCaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSSupport_20130415.ResolveCase",
+    "x-amz-target": "AWSSupport_20130415.ResolveCase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResolveCaseRequest(input, context));

--- a/clients/client-swf/protocols/Aws_json1_0.ts
+++ b/clients/client-swf/protocols/Aws_json1_0.ts
@@ -288,7 +288,7 @@ export const serializeAws_json1_0CountClosedWorkflowExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.CountClosedWorkflowExecutions",
+    "x-amz-target": "SimpleWorkflowService.CountClosedWorkflowExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CountClosedWorkflowExecutionsInput(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_0CountOpenWorkflowExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.CountOpenWorkflowExecutions",
+    "x-amz-target": "SimpleWorkflowService.CountOpenWorkflowExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CountOpenWorkflowExecutionsInput(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_0CountPendingActivityTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.CountPendingActivityTasks",
+    "x-amz-target": "SimpleWorkflowService.CountPendingActivityTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CountPendingActivityTasksInput(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_0CountPendingDecisionTasksCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.CountPendingDecisionTasks",
+    "x-amz-target": "SimpleWorkflowService.CountPendingDecisionTasks",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CountPendingDecisionTasksInput(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_0DeprecateActivityTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.DeprecateActivityType",
+    "x-amz-target": "SimpleWorkflowService.DeprecateActivityType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeprecateActivityTypeInput(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_0DeprecateDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.DeprecateDomain",
+    "x-amz-target": "SimpleWorkflowService.DeprecateDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeprecateDomainInput(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_0DeprecateWorkflowTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.DeprecateWorkflowType",
+    "x-amz-target": "SimpleWorkflowService.DeprecateWorkflowType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeprecateWorkflowTypeInput(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_0DescribeActivityTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.DescribeActivityType",
+    "x-amz-target": "SimpleWorkflowService.DescribeActivityType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeActivityTypeInput(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_0DescribeDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.DescribeDomain",
+    "x-amz-target": "SimpleWorkflowService.DescribeDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeDomainInput(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_0DescribeWorkflowExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.DescribeWorkflowExecution",
+    "x-amz-target": "SimpleWorkflowService.DescribeWorkflowExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeWorkflowExecutionInput(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_0DescribeWorkflowTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.DescribeWorkflowType",
+    "x-amz-target": "SimpleWorkflowService.DescribeWorkflowType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeWorkflowTypeInput(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_0GetWorkflowExecutionHistoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.GetWorkflowExecutionHistory",
+    "x-amz-target": "SimpleWorkflowService.GetWorkflowExecutionHistory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0GetWorkflowExecutionHistoryInput(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_0ListActivityTypesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.ListActivityTypes",
+    "x-amz-target": "SimpleWorkflowService.ListActivityTypes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListActivityTypesInput(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_0ListClosedWorkflowExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.ListClosedWorkflowExecutions",
+    "x-amz-target": "SimpleWorkflowService.ListClosedWorkflowExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListClosedWorkflowExecutionsInput(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_0ListDomainsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.ListDomains",
+    "x-amz-target": "SimpleWorkflowService.ListDomains",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListDomainsInput(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_0ListOpenWorkflowExecutionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.ListOpenWorkflowExecutions",
+    "x-amz-target": "SimpleWorkflowService.ListOpenWorkflowExecutions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListOpenWorkflowExecutionsInput(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_0ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.ListTagsForResource",
+    "x-amz-target": "SimpleWorkflowService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListTagsForResourceInput(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_0ListWorkflowTypesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.ListWorkflowTypes",
+    "x-amz-target": "SimpleWorkflowService.ListWorkflowTypes",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListWorkflowTypesInput(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_0PollForActivityTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.PollForActivityTask",
+    "x-amz-target": "SimpleWorkflowService.PollForActivityTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0PollForActivityTaskInput(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_0PollForDecisionTaskCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.PollForDecisionTask",
+    "x-amz-target": "SimpleWorkflowService.PollForDecisionTask",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0PollForDecisionTaskInput(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_0RecordActivityTaskHeartbeatCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.RecordActivityTaskHeartbeat",
+    "x-amz-target": "SimpleWorkflowService.RecordActivityTaskHeartbeat",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RecordActivityTaskHeartbeatInput(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_0RegisterActivityTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.RegisterActivityType",
+    "x-amz-target": "SimpleWorkflowService.RegisterActivityType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RegisterActivityTypeInput(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_0RegisterDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.RegisterDomain",
+    "x-amz-target": "SimpleWorkflowService.RegisterDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RegisterDomainInput(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_0RegisterWorkflowTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.RegisterWorkflowType",
+    "x-amz-target": "SimpleWorkflowService.RegisterWorkflowType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RegisterWorkflowTypeInput(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_0RequestCancelWorkflowExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.RequestCancelWorkflowExecution",
+    "x-amz-target": "SimpleWorkflowService.RequestCancelWorkflowExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RequestCancelWorkflowExecutionInput(input, context));
@@ -613,7 +613,7 @@ export const serializeAws_json1_0RespondActivityTaskCanceledCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.RespondActivityTaskCanceled",
+    "x-amz-target": "SimpleWorkflowService.RespondActivityTaskCanceled",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RespondActivityTaskCanceledInput(input, context));
@@ -626,7 +626,7 @@ export const serializeAws_json1_0RespondActivityTaskCompletedCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.RespondActivityTaskCompleted",
+    "x-amz-target": "SimpleWorkflowService.RespondActivityTaskCompleted",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RespondActivityTaskCompletedInput(input, context));
@@ -639,7 +639,7 @@ export const serializeAws_json1_0RespondActivityTaskFailedCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.RespondActivityTaskFailed",
+    "x-amz-target": "SimpleWorkflowService.RespondActivityTaskFailed",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RespondActivityTaskFailedInput(input, context));
@@ -652,7 +652,7 @@ export const serializeAws_json1_0RespondDecisionTaskCompletedCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.RespondDecisionTaskCompleted",
+    "x-amz-target": "SimpleWorkflowService.RespondDecisionTaskCompleted",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0RespondDecisionTaskCompletedInput(input, context));
@@ -665,7 +665,7 @@ export const serializeAws_json1_0SignalWorkflowExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.SignalWorkflowExecution",
+    "x-amz-target": "SimpleWorkflowService.SignalWorkflowExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0SignalWorkflowExecutionInput(input, context));
@@ -678,7 +678,7 @@ export const serializeAws_json1_0StartWorkflowExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.StartWorkflowExecution",
+    "x-amz-target": "SimpleWorkflowService.StartWorkflowExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0StartWorkflowExecutionInput(input, context));
@@ -691,7 +691,7 @@ export const serializeAws_json1_0TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.TagResource",
+    "x-amz-target": "SimpleWorkflowService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0TagResourceInput(input, context));
@@ -704,7 +704,7 @@ export const serializeAws_json1_0TerminateWorkflowExecutionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.TerminateWorkflowExecution",
+    "x-amz-target": "SimpleWorkflowService.TerminateWorkflowExecution",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0TerminateWorkflowExecutionInput(input, context));
@@ -717,7 +717,7 @@ export const serializeAws_json1_0UndeprecateActivityTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.UndeprecateActivityType",
+    "x-amz-target": "SimpleWorkflowService.UndeprecateActivityType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UndeprecateActivityTypeInput(input, context));
@@ -730,7 +730,7 @@ export const serializeAws_json1_0UndeprecateDomainCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.UndeprecateDomain",
+    "x-amz-target": "SimpleWorkflowService.UndeprecateDomain",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UndeprecateDomainInput(input, context));
@@ -743,7 +743,7 @@ export const serializeAws_json1_0UndeprecateWorkflowTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.UndeprecateWorkflowType",
+    "x-amz-target": "SimpleWorkflowService.UndeprecateWorkflowType",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UndeprecateWorkflowTypeInput(input, context));
@@ -756,7 +756,7 @@ export const serializeAws_json1_0UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "SimpleWorkflowService.UntagResource",
+    "x-amz-target": "SimpleWorkflowService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UntagResourceInput(input, context));

--- a/clients/client-textract/protocols/Aws_json1_1.ts
+++ b/clients/client-textract/protocols/Aws_json1_1.ts
@@ -78,7 +78,7 @@ export const serializeAws_json1_1AnalyzeDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Textract.AnalyzeDocument",
+    "x-amz-target": "Textract.AnalyzeDocument",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AnalyzeDocumentRequest(input, context));
@@ -91,7 +91,7 @@ export const serializeAws_json1_1DetectDocumentTextCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Textract.DetectDocumentText",
+    "x-amz-target": "Textract.DetectDocumentText",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DetectDocumentTextRequest(input, context));
@@ -104,7 +104,7 @@ export const serializeAws_json1_1GetDocumentAnalysisCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Textract.GetDocumentAnalysis",
+    "x-amz-target": "Textract.GetDocumentAnalysis",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDocumentAnalysisRequest(input, context));
@@ -117,7 +117,7 @@ export const serializeAws_json1_1GetDocumentTextDetectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Textract.GetDocumentTextDetection",
+    "x-amz-target": "Textract.GetDocumentTextDetection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetDocumentTextDetectionRequest(input, context));
@@ -130,7 +130,7 @@ export const serializeAws_json1_1StartDocumentAnalysisCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Textract.StartDocumentAnalysis",
+    "x-amz-target": "Textract.StartDocumentAnalysis",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartDocumentAnalysisRequest(input, context));
@@ -143,7 +143,7 @@ export const serializeAws_json1_1StartDocumentTextDetectionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Textract.StartDocumentTextDetection",
+    "x-amz-target": "Textract.StartDocumentTextDetection",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartDocumentTextDetectionRequest(input, context));

--- a/clients/client-timestream-query/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-query/protocols/Aws_json1_0.ts
@@ -40,7 +40,7 @@ export const serializeAws_json1_0CancelQueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.CancelQuery",
+    "x-amz-target": "Timestream_20181101.CancelQuery",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CancelQueryRequest(input, context));
@@ -53,7 +53,7 @@ export const serializeAws_json1_0DescribeEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.DescribeEndpoints",
+    "x-amz-target": "Timestream_20181101.DescribeEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeEndpointsRequest(input, context));
@@ -66,7 +66,7 @@ export const serializeAws_json1_0QueryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.Query",
+    "x-amz-target": "Timestream_20181101.Query",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0QueryRequest(input, context));

--- a/clients/client-timestream-write/protocols/Aws_json1_0.ts
+++ b/clients/client-timestream-write/protocols/Aws_json1_0.ts
@@ -78,7 +78,7 @@ export const serializeAws_json1_0CreateDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.CreateDatabase",
+    "x-amz-target": "Timestream_20181101.CreateDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateDatabaseRequest(input, context));
@@ -91,7 +91,7 @@ export const serializeAws_json1_0CreateTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.CreateTable",
+    "x-amz-target": "Timestream_20181101.CreateTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0CreateTableRequest(input, context));
@@ -104,7 +104,7 @@ export const serializeAws_json1_0DeleteDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.DeleteDatabase",
+    "x-amz-target": "Timestream_20181101.DeleteDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteDatabaseRequest(input, context));
@@ -117,7 +117,7 @@ export const serializeAws_json1_0DeleteTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.DeleteTable",
+    "x-amz-target": "Timestream_20181101.DeleteTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DeleteTableRequest(input, context));
@@ -130,7 +130,7 @@ export const serializeAws_json1_0DescribeDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.DescribeDatabase",
+    "x-amz-target": "Timestream_20181101.DescribeDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeDatabaseRequest(input, context));
@@ -143,7 +143,7 @@ export const serializeAws_json1_0DescribeEndpointsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.DescribeEndpoints",
+    "x-amz-target": "Timestream_20181101.DescribeEndpoints",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeEndpointsRequest(input, context));
@@ -156,7 +156,7 @@ export const serializeAws_json1_0DescribeTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.DescribeTable",
+    "x-amz-target": "Timestream_20181101.DescribeTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0DescribeTableRequest(input, context));
@@ -169,7 +169,7 @@ export const serializeAws_json1_0ListDatabasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.ListDatabases",
+    "x-amz-target": "Timestream_20181101.ListDatabases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListDatabasesRequest(input, context));
@@ -182,7 +182,7 @@ export const serializeAws_json1_0ListTablesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.ListTables",
+    "x-amz-target": "Timestream_20181101.ListTables",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListTablesRequest(input, context));
@@ -195,7 +195,7 @@ export const serializeAws_json1_0ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.ListTagsForResource",
+    "x-amz-target": "Timestream_20181101.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0ListTagsForResourceRequest(input, context));
@@ -208,7 +208,7 @@ export const serializeAws_json1_0TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.TagResource",
+    "x-amz-target": "Timestream_20181101.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0TagResourceRequest(input, context));
@@ -221,7 +221,7 @@ export const serializeAws_json1_0UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.UntagResource",
+    "x-amz-target": "Timestream_20181101.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UntagResourceRequest(input, context));
@@ -234,7 +234,7 @@ export const serializeAws_json1_0UpdateDatabaseCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.UpdateDatabase",
+    "x-amz-target": "Timestream_20181101.UpdateDatabase",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateDatabaseRequest(input, context));
@@ -247,7 +247,7 @@ export const serializeAws_json1_0UpdateTableCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.UpdateTable",
+    "x-amz-target": "Timestream_20181101.UpdateTable",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0UpdateTableRequest(input, context));
@@ -260,7 +260,7 @@ export const serializeAws_json1_0WriteRecordsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.0",
-    "X-Amz-Target": "Timestream_20181101.WriteRecords",
+    "x-amz-target": "Timestream_20181101.WriteRecords",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_0WriteRecordsRequest(input, context));

--- a/clients/client-transcribe/protocols/Aws_json1_1.ts
+++ b/clients/client-transcribe/protocols/Aws_json1_1.ts
@@ -176,7 +176,7 @@ export const serializeAws_json1_1CreateLanguageModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.CreateLanguageModel",
+    "x-amz-target": "Transcribe.CreateLanguageModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateLanguageModelRequest(input, context));
@@ -189,7 +189,7 @@ export const serializeAws_json1_1CreateMedicalVocabularyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.CreateMedicalVocabulary",
+    "x-amz-target": "Transcribe.CreateMedicalVocabulary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateMedicalVocabularyRequest(input, context));
@@ -202,7 +202,7 @@ export const serializeAws_json1_1CreateVocabularyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.CreateVocabulary",
+    "x-amz-target": "Transcribe.CreateVocabulary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateVocabularyRequest(input, context));
@@ -215,7 +215,7 @@ export const serializeAws_json1_1CreateVocabularyFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.CreateVocabularyFilter",
+    "x-amz-target": "Transcribe.CreateVocabularyFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateVocabularyFilterRequest(input, context));
@@ -228,7 +228,7 @@ export const serializeAws_json1_1DeleteLanguageModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.DeleteLanguageModel",
+    "x-amz-target": "Transcribe.DeleteLanguageModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLanguageModelRequest(input, context));
@@ -241,7 +241,7 @@ export const serializeAws_json1_1DeleteMedicalTranscriptionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.DeleteMedicalTranscriptionJob",
+    "x-amz-target": "Transcribe.DeleteMedicalTranscriptionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMedicalTranscriptionJobRequest(input, context));
@@ -254,7 +254,7 @@ export const serializeAws_json1_1DeleteMedicalVocabularyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.DeleteMedicalVocabulary",
+    "x-amz-target": "Transcribe.DeleteMedicalVocabulary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMedicalVocabularyRequest(input, context));
@@ -267,7 +267,7 @@ export const serializeAws_json1_1DeleteTranscriptionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.DeleteTranscriptionJob",
+    "x-amz-target": "Transcribe.DeleteTranscriptionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTranscriptionJobRequest(input, context));
@@ -280,7 +280,7 @@ export const serializeAws_json1_1DeleteVocabularyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.DeleteVocabulary",
+    "x-amz-target": "Transcribe.DeleteVocabulary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteVocabularyRequest(input, context));
@@ -293,7 +293,7 @@ export const serializeAws_json1_1DeleteVocabularyFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.DeleteVocabularyFilter",
+    "x-amz-target": "Transcribe.DeleteVocabularyFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteVocabularyFilterRequest(input, context));
@@ -306,7 +306,7 @@ export const serializeAws_json1_1DescribeLanguageModelCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.DescribeLanguageModel",
+    "x-amz-target": "Transcribe.DescribeLanguageModel",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeLanguageModelRequest(input, context));
@@ -319,7 +319,7 @@ export const serializeAws_json1_1GetMedicalTranscriptionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.GetMedicalTranscriptionJob",
+    "x-amz-target": "Transcribe.GetMedicalTranscriptionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMedicalTranscriptionJobRequest(input, context));
@@ -332,7 +332,7 @@ export const serializeAws_json1_1GetMedicalVocabularyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.GetMedicalVocabulary",
+    "x-amz-target": "Transcribe.GetMedicalVocabulary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMedicalVocabularyRequest(input, context));
@@ -345,7 +345,7 @@ export const serializeAws_json1_1GetTranscriptionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.GetTranscriptionJob",
+    "x-amz-target": "Transcribe.GetTranscriptionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTranscriptionJobRequest(input, context));
@@ -358,7 +358,7 @@ export const serializeAws_json1_1GetVocabularyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.GetVocabulary",
+    "x-amz-target": "Transcribe.GetVocabulary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetVocabularyRequest(input, context));
@@ -371,7 +371,7 @@ export const serializeAws_json1_1GetVocabularyFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.GetVocabularyFilter",
+    "x-amz-target": "Transcribe.GetVocabularyFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetVocabularyFilterRequest(input, context));
@@ -384,7 +384,7 @@ export const serializeAws_json1_1ListLanguageModelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.ListLanguageModels",
+    "x-amz-target": "Transcribe.ListLanguageModels",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLanguageModelsRequest(input, context));
@@ -397,7 +397,7 @@ export const serializeAws_json1_1ListMedicalTranscriptionJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.ListMedicalTranscriptionJobs",
+    "x-amz-target": "Transcribe.ListMedicalTranscriptionJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListMedicalTranscriptionJobsRequest(input, context));
@@ -410,7 +410,7 @@ export const serializeAws_json1_1ListMedicalVocabulariesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.ListMedicalVocabularies",
+    "x-amz-target": "Transcribe.ListMedicalVocabularies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListMedicalVocabulariesRequest(input, context));
@@ -423,7 +423,7 @@ export const serializeAws_json1_1ListTranscriptionJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.ListTranscriptionJobs",
+    "x-amz-target": "Transcribe.ListTranscriptionJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTranscriptionJobsRequest(input, context));
@@ -436,7 +436,7 @@ export const serializeAws_json1_1ListVocabulariesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.ListVocabularies",
+    "x-amz-target": "Transcribe.ListVocabularies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListVocabulariesRequest(input, context));
@@ -449,7 +449,7 @@ export const serializeAws_json1_1ListVocabularyFiltersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.ListVocabularyFilters",
+    "x-amz-target": "Transcribe.ListVocabularyFilters",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListVocabularyFiltersRequest(input, context));
@@ -462,7 +462,7 @@ export const serializeAws_json1_1StartMedicalTranscriptionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.StartMedicalTranscriptionJob",
+    "x-amz-target": "Transcribe.StartMedicalTranscriptionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartMedicalTranscriptionJobRequest(input, context));
@@ -475,7 +475,7 @@ export const serializeAws_json1_1StartTranscriptionJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.StartTranscriptionJob",
+    "x-amz-target": "Transcribe.StartTranscriptionJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartTranscriptionJobRequest(input, context));
@@ -488,7 +488,7 @@ export const serializeAws_json1_1UpdateMedicalVocabularyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.UpdateMedicalVocabulary",
+    "x-amz-target": "Transcribe.UpdateMedicalVocabulary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMedicalVocabularyRequest(input, context));
@@ -501,7 +501,7 @@ export const serializeAws_json1_1UpdateVocabularyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.UpdateVocabulary",
+    "x-amz-target": "Transcribe.UpdateVocabulary",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateVocabularyRequest(input, context));
@@ -514,7 +514,7 @@ export const serializeAws_json1_1UpdateVocabularyFilterCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "Transcribe.UpdateVocabularyFilter",
+    "x-amz-target": "Transcribe.UpdateVocabularyFilter",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateVocabularyFilterRequest(input, context));

--- a/clients/client-transfer/protocols/Aws_json1_1.ts
+++ b/clients/client-transfer/protocols/Aws_json1_1.ts
@@ -101,7 +101,7 @@ export const serializeAws_json1_1CreateServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.CreateServer",
+    "x-amz-target": "TransferService.CreateServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateServerRequest(input, context));
@@ -114,7 +114,7 @@ export const serializeAws_json1_1CreateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.CreateUser",
+    "x-amz-target": "TransferService.CreateUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserRequest(input, context));
@@ -127,7 +127,7 @@ export const serializeAws_json1_1DeleteServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.DeleteServer",
+    "x-amz-target": "TransferService.DeleteServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteServerRequest(input, context));
@@ -140,7 +140,7 @@ export const serializeAws_json1_1DeleteSshPublicKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.DeleteSshPublicKey",
+    "x-amz-target": "TransferService.DeleteSshPublicKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSshPublicKeyRequest(input, context));
@@ -153,7 +153,7 @@ export const serializeAws_json1_1DeleteUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.DeleteUser",
+    "x-amz-target": "TransferService.DeleteUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserRequest(input, context));
@@ -166,7 +166,7 @@ export const serializeAws_json1_1DescribeSecurityPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.DescribeSecurityPolicy",
+    "x-amz-target": "TransferService.DescribeSecurityPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeSecurityPolicyRequest(input, context));
@@ -179,7 +179,7 @@ export const serializeAws_json1_1DescribeServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.DescribeServer",
+    "x-amz-target": "TransferService.DescribeServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeServerRequest(input, context));
@@ -192,7 +192,7 @@ export const serializeAws_json1_1DescribeUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.DescribeUser",
+    "x-amz-target": "TransferService.DescribeUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserRequest(input, context));
@@ -205,7 +205,7 @@ export const serializeAws_json1_1ImportSshPublicKeyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.ImportSshPublicKey",
+    "x-amz-target": "TransferService.ImportSshPublicKey",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportSshPublicKeyRequest(input, context));
@@ -218,7 +218,7 @@ export const serializeAws_json1_1ListSecurityPoliciesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.ListSecurityPolicies",
+    "x-amz-target": "TransferService.ListSecurityPolicies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSecurityPoliciesRequest(input, context));
@@ -231,7 +231,7 @@ export const serializeAws_json1_1ListServersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.ListServers",
+    "x-amz-target": "TransferService.ListServers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListServersRequest(input, context));
@@ -244,7 +244,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.ListTagsForResource",
+    "x-amz-target": "TransferService.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -257,7 +257,7 @@ export const serializeAws_json1_1ListUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.ListUsers",
+    "x-amz-target": "TransferService.ListUsers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUsersRequest(input, context));
@@ -270,7 +270,7 @@ export const serializeAws_json1_1StartServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.StartServer",
+    "x-amz-target": "TransferService.StartServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartServerRequest(input, context));
@@ -283,7 +283,7 @@ export const serializeAws_json1_1StopServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.StopServer",
+    "x-amz-target": "TransferService.StopServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopServerRequest(input, context));
@@ -296,7 +296,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.TagResource",
+    "x-amz-target": "TransferService.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -309,7 +309,7 @@ export const serializeAws_json1_1TestIdentityProviderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.TestIdentityProvider",
+    "x-amz-target": "TransferService.TestIdentityProvider",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TestIdentityProviderRequest(input, context));
@@ -322,7 +322,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.UntagResource",
+    "x-amz-target": "TransferService.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -335,7 +335,7 @@ export const serializeAws_json1_1UpdateServerCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.UpdateServer",
+    "x-amz-target": "TransferService.UpdateServer",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateServerRequest(input, context));
@@ -348,7 +348,7 @@ export const serializeAws_json1_1UpdateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "TransferService.UpdateUser",
+    "x-amz-target": "TransferService.UpdateUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateUserRequest(input, context));

--- a/clients/client-translate/protocols/Aws_json1_1.ts
+++ b/clients/client-translate/protocols/Aws_json1_1.ts
@@ -97,7 +97,7 @@ export const serializeAws_json1_1CreateParallelDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.CreateParallelData",
+    "x-amz-target": "AWSShineFrontendService_20170701.CreateParallelData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateParallelDataRequest(input, context));
@@ -110,7 +110,7 @@ export const serializeAws_json1_1DeleteParallelDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.DeleteParallelData",
+    "x-amz-target": "AWSShineFrontendService_20170701.DeleteParallelData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteParallelDataRequest(input, context));
@@ -123,7 +123,7 @@ export const serializeAws_json1_1DeleteTerminologyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.DeleteTerminology",
+    "x-amz-target": "AWSShineFrontendService_20170701.DeleteTerminology",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTerminologyRequest(input, context));
@@ -136,7 +136,7 @@ export const serializeAws_json1_1DescribeTextTranslationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.DescribeTextTranslationJob",
+    "x-amz-target": "AWSShineFrontendService_20170701.DescribeTextTranslationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTextTranslationJobRequest(input, context));
@@ -149,7 +149,7 @@ export const serializeAws_json1_1GetParallelDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.GetParallelData",
+    "x-amz-target": "AWSShineFrontendService_20170701.GetParallelData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetParallelDataRequest(input, context));
@@ -162,7 +162,7 @@ export const serializeAws_json1_1GetTerminologyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.GetTerminology",
+    "x-amz-target": "AWSShineFrontendService_20170701.GetTerminology",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetTerminologyRequest(input, context));
@@ -175,7 +175,7 @@ export const serializeAws_json1_1ImportTerminologyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.ImportTerminology",
+    "x-amz-target": "AWSShineFrontendService_20170701.ImportTerminology",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportTerminologyRequest(input, context));
@@ -188,7 +188,7 @@ export const serializeAws_json1_1ListParallelDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.ListParallelData",
+    "x-amz-target": "AWSShineFrontendService_20170701.ListParallelData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListParallelDataRequest(input, context));
@@ -201,7 +201,7 @@ export const serializeAws_json1_1ListTerminologiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.ListTerminologies",
+    "x-amz-target": "AWSShineFrontendService_20170701.ListTerminologies",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTerminologiesRequest(input, context));
@@ -214,7 +214,7 @@ export const serializeAws_json1_1ListTextTranslationJobsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.ListTextTranslationJobs",
+    "x-amz-target": "AWSShineFrontendService_20170701.ListTextTranslationJobs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTextTranslationJobsRequest(input, context));
@@ -227,7 +227,7 @@ export const serializeAws_json1_1StartTextTranslationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.StartTextTranslationJob",
+    "x-amz-target": "AWSShineFrontendService_20170701.StartTextTranslationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartTextTranslationJobRequest(input, context));
@@ -240,7 +240,7 @@ export const serializeAws_json1_1StopTextTranslationJobCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.StopTextTranslationJob",
+    "x-amz-target": "AWSShineFrontendService_20170701.StopTextTranslationJob",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopTextTranslationJobRequest(input, context));
@@ -253,7 +253,7 @@ export const serializeAws_json1_1TranslateTextCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.TranslateText",
+    "x-amz-target": "AWSShineFrontendService_20170701.TranslateText",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TranslateTextRequest(input, context));
@@ -266,7 +266,7 @@ export const serializeAws_json1_1UpdateParallelDataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSShineFrontendService_20170701.UpdateParallelData",
+    "x-amz-target": "AWSShineFrontendService_20170701.UpdateParallelData",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateParallelDataRequest(input, context));

--- a/clients/client-waf-regional/protocols/Aws_json1_1.ts
+++ b/clients/client-waf-regional/protocols/Aws_json1_1.ts
@@ -439,7 +439,7 @@ export const serializeAws_json1_1AssociateWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.AssociateWebACL",
+    "x-amz-target": "AWSWAF_Regional_20161128.AssociateWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateWebACLRequest(input, context));
@@ -452,7 +452,7 @@ export const serializeAws_json1_1CreateByteMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateByteMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateByteMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateByteMatchSetRequest(input, context));
@@ -465,7 +465,7 @@ export const serializeAws_json1_1CreateGeoMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateGeoMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateGeoMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGeoMatchSetRequest(input, context));
@@ -478,7 +478,7 @@ export const serializeAws_json1_1CreateIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateIPSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateIPSetRequest(input, context));
@@ -491,7 +491,7 @@ export const serializeAws_json1_1CreateRateBasedRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateRateBasedRule",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateRateBasedRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRateBasedRuleRequest(input, context));
@@ -504,7 +504,7 @@ export const serializeAws_json1_1CreateRegexMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateRegexMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateRegexMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRegexMatchSetRequest(input, context));
@@ -517,7 +517,7 @@ export const serializeAws_json1_1CreateRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateRegexPatternSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRegexPatternSetRequest(input, context));
@@ -530,7 +530,7 @@ export const serializeAws_json1_1CreateRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateRule",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRuleRequest(input, context));
@@ -543,7 +543,7 @@ export const serializeAws_json1_1CreateRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateRuleGroup",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRuleGroupRequest(input, context));
@@ -556,7 +556,7 @@ export const serializeAws_json1_1CreateSizeConstraintSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateSizeConstraintSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateSizeConstraintSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSizeConstraintSetRequest(input, context));
@@ -569,7 +569,7 @@ export const serializeAws_json1_1CreateSqlInjectionMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateSqlInjectionMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateSqlInjectionMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSqlInjectionMatchSetRequest(input, context));
@@ -582,7 +582,7 @@ export const serializeAws_json1_1CreateWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateWebACL",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWebACLRequest(input, context));
@@ -595,7 +595,7 @@ export const serializeAws_json1_1CreateWebACLMigrationStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateWebACLMigrationStack",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateWebACLMigrationStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWebACLMigrationStackRequest(input, context));
@@ -608,7 +608,7 @@ export const serializeAws_json1_1CreateXssMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.CreateXssMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.CreateXssMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateXssMatchSetRequest(input, context));
@@ -621,7 +621,7 @@ export const serializeAws_json1_1DeleteByteMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteByteMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteByteMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteByteMatchSetRequest(input, context));
@@ -634,7 +634,7 @@ export const serializeAws_json1_1DeleteGeoMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteGeoMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteGeoMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteGeoMatchSetRequest(input, context));
@@ -647,7 +647,7 @@ export const serializeAws_json1_1DeleteIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteIPSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteIPSetRequest(input, context));
@@ -660,7 +660,7 @@ export const serializeAws_json1_1DeleteLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteLoggingConfiguration",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLoggingConfigurationRequest(input, context));
@@ -673,7 +673,7 @@ export const serializeAws_json1_1DeletePermissionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeletePermissionPolicy",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeletePermissionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePermissionPolicyRequest(input, context));
@@ -686,7 +686,7 @@ export const serializeAws_json1_1DeleteRateBasedRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteRateBasedRule",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteRateBasedRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRateBasedRuleRequest(input, context));
@@ -699,7 +699,7 @@ export const serializeAws_json1_1DeleteRegexMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteRegexMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteRegexMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRegexMatchSetRequest(input, context));
@@ -712,7 +712,7 @@ export const serializeAws_json1_1DeleteRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteRegexPatternSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRegexPatternSetRequest(input, context));
@@ -725,7 +725,7 @@ export const serializeAws_json1_1DeleteRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteRule",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRuleRequest(input, context));
@@ -738,7 +738,7 @@ export const serializeAws_json1_1DeleteRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteRuleGroup",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRuleGroupRequest(input, context));
@@ -751,7 +751,7 @@ export const serializeAws_json1_1DeleteSizeConstraintSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteSizeConstraintSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteSizeConstraintSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSizeConstraintSetRequest(input, context));
@@ -764,7 +764,7 @@ export const serializeAws_json1_1DeleteSqlInjectionMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteSqlInjectionMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteSqlInjectionMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSqlInjectionMatchSetRequest(input, context));
@@ -777,7 +777,7 @@ export const serializeAws_json1_1DeleteWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteWebACL",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWebACLRequest(input, context));
@@ -790,7 +790,7 @@ export const serializeAws_json1_1DeleteXssMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DeleteXssMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.DeleteXssMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteXssMatchSetRequest(input, context));
@@ -803,7 +803,7 @@ export const serializeAws_json1_1DisassociateWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.DisassociateWebACL",
+    "x-amz-target": "AWSWAF_Regional_20161128.DisassociateWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateWebACLRequest(input, context));
@@ -816,7 +816,7 @@ export const serializeAws_json1_1GetByteMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetByteMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetByteMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetByteMatchSetRequest(input, context));
@@ -829,7 +829,7 @@ export const serializeAws_json1_1GetChangeTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetChangeToken",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetChangeToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetChangeTokenRequest(input, context));
@@ -842,7 +842,7 @@ export const serializeAws_json1_1GetChangeTokenStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetChangeTokenStatus",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetChangeTokenStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetChangeTokenStatusRequest(input, context));
@@ -855,7 +855,7 @@ export const serializeAws_json1_1GetGeoMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetGeoMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetGeoMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetGeoMatchSetRequest(input, context));
@@ -868,7 +868,7 @@ export const serializeAws_json1_1GetIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetIPSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetIPSetRequest(input, context));
@@ -881,7 +881,7 @@ export const serializeAws_json1_1GetLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetLoggingConfiguration",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLoggingConfigurationRequest(input, context));
@@ -894,7 +894,7 @@ export const serializeAws_json1_1GetPermissionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetPermissionPolicy",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetPermissionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPermissionPolicyRequest(input, context));
@@ -907,7 +907,7 @@ export const serializeAws_json1_1GetRateBasedRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetRateBasedRule",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetRateBasedRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRateBasedRuleRequest(input, context));
@@ -920,7 +920,7 @@ export const serializeAws_json1_1GetRateBasedRuleManagedKeysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetRateBasedRuleManagedKeys",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetRateBasedRuleManagedKeys",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRateBasedRuleManagedKeysRequest(input, context));
@@ -933,7 +933,7 @@ export const serializeAws_json1_1GetRegexMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetRegexMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetRegexMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRegexMatchSetRequest(input, context));
@@ -946,7 +946,7 @@ export const serializeAws_json1_1GetRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetRegexPatternSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRegexPatternSetRequest(input, context));
@@ -959,7 +959,7 @@ export const serializeAws_json1_1GetRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetRule",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRuleRequest(input, context));
@@ -972,7 +972,7 @@ export const serializeAws_json1_1GetRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetRuleGroup",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRuleGroupRequest(input, context));
@@ -985,7 +985,7 @@ export const serializeAws_json1_1GetSampledRequestsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetSampledRequests",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetSampledRequests",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSampledRequestsRequest(input, context));
@@ -998,7 +998,7 @@ export const serializeAws_json1_1GetSizeConstraintSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetSizeConstraintSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetSizeConstraintSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSizeConstraintSetRequest(input, context));
@@ -1011,7 +1011,7 @@ export const serializeAws_json1_1GetSqlInjectionMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetSqlInjectionMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetSqlInjectionMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSqlInjectionMatchSetRequest(input, context));
@@ -1024,7 +1024,7 @@ export const serializeAws_json1_1GetWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetWebACL",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetWebACLRequest(input, context));
@@ -1037,7 +1037,7 @@ export const serializeAws_json1_1GetWebACLForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetWebACLForResource",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetWebACLForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetWebACLForResourceRequest(input, context));
@@ -1050,7 +1050,7 @@ export const serializeAws_json1_1GetXssMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.GetXssMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.GetXssMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetXssMatchSetRequest(input, context));
@@ -1063,7 +1063,7 @@ export const serializeAws_json1_1ListActivatedRulesInRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListActivatedRulesInRuleGroup",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListActivatedRulesInRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListActivatedRulesInRuleGroupRequest(input, context));
@@ -1076,7 +1076,7 @@ export const serializeAws_json1_1ListByteMatchSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListByteMatchSets",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListByteMatchSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListByteMatchSetsRequest(input, context));
@@ -1089,7 +1089,7 @@ export const serializeAws_json1_1ListGeoMatchSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListGeoMatchSets",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListGeoMatchSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGeoMatchSetsRequest(input, context));
@@ -1102,7 +1102,7 @@ export const serializeAws_json1_1ListIPSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListIPSets",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListIPSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListIPSetsRequest(input, context));
@@ -1115,7 +1115,7 @@ export const serializeAws_json1_1ListLoggingConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListLoggingConfigurations",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListLoggingConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLoggingConfigurationsRequest(input, context));
@@ -1128,7 +1128,7 @@ export const serializeAws_json1_1ListRateBasedRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListRateBasedRules",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListRateBasedRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRateBasedRulesRequest(input, context));
@@ -1141,7 +1141,7 @@ export const serializeAws_json1_1ListRegexMatchSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListRegexMatchSets",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListRegexMatchSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRegexMatchSetsRequest(input, context));
@@ -1154,7 +1154,7 @@ export const serializeAws_json1_1ListRegexPatternSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListRegexPatternSets",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListRegexPatternSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRegexPatternSetsRequest(input, context));
@@ -1167,7 +1167,7 @@ export const serializeAws_json1_1ListResourcesForWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListResourcesForWebACL",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListResourcesForWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourcesForWebACLRequest(input, context));
@@ -1180,7 +1180,7 @@ export const serializeAws_json1_1ListRuleGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListRuleGroups",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListRuleGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRuleGroupsRequest(input, context));
@@ -1193,7 +1193,7 @@ export const serializeAws_json1_1ListRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListRules",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRulesRequest(input, context));
@@ -1206,7 +1206,7 @@ export const serializeAws_json1_1ListSizeConstraintSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListSizeConstraintSets",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListSizeConstraintSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSizeConstraintSetsRequest(input, context));
@@ -1219,7 +1219,7 @@ export const serializeAws_json1_1ListSqlInjectionMatchSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListSqlInjectionMatchSets",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListSqlInjectionMatchSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSqlInjectionMatchSetsRequest(input, context));
@@ -1232,7 +1232,7 @@ export const serializeAws_json1_1ListSubscribedRuleGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListSubscribedRuleGroups",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListSubscribedRuleGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSubscribedRuleGroupsRequest(input, context));
@@ -1245,7 +1245,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListTagsForResource",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -1258,7 +1258,7 @@ export const serializeAws_json1_1ListWebACLsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListWebACLs",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListWebACLs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListWebACLsRequest(input, context));
@@ -1271,7 +1271,7 @@ export const serializeAws_json1_1ListXssMatchSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.ListXssMatchSets",
+    "x-amz-target": "AWSWAF_Regional_20161128.ListXssMatchSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListXssMatchSetsRequest(input, context));
@@ -1284,7 +1284,7 @@ export const serializeAws_json1_1PutLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.PutLoggingConfiguration",
+    "x-amz-target": "AWSWAF_Regional_20161128.PutLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutLoggingConfigurationRequest(input, context));
@@ -1297,7 +1297,7 @@ export const serializeAws_json1_1PutPermissionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.PutPermissionPolicy",
+    "x-amz-target": "AWSWAF_Regional_20161128.PutPermissionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutPermissionPolicyRequest(input, context));
@@ -1310,7 +1310,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.TagResource",
+    "x-amz-target": "AWSWAF_Regional_20161128.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -1323,7 +1323,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UntagResource",
+    "x-amz-target": "AWSWAF_Regional_20161128.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -1336,7 +1336,7 @@ export const serializeAws_json1_1UpdateByteMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateByteMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateByteMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateByteMatchSetRequest(input, context));
@@ -1349,7 +1349,7 @@ export const serializeAws_json1_1UpdateGeoMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateGeoMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateGeoMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGeoMatchSetRequest(input, context));
@@ -1362,7 +1362,7 @@ export const serializeAws_json1_1UpdateIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateIPSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateIPSetRequest(input, context));
@@ -1375,7 +1375,7 @@ export const serializeAws_json1_1UpdateRateBasedRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateRateBasedRule",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateRateBasedRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRateBasedRuleRequest(input, context));
@@ -1388,7 +1388,7 @@ export const serializeAws_json1_1UpdateRegexMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateRegexMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateRegexMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRegexMatchSetRequest(input, context));
@@ -1401,7 +1401,7 @@ export const serializeAws_json1_1UpdateRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateRegexPatternSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRegexPatternSetRequest(input, context));
@@ -1414,7 +1414,7 @@ export const serializeAws_json1_1UpdateRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateRule",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRuleRequest(input, context));
@@ -1427,7 +1427,7 @@ export const serializeAws_json1_1UpdateRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateRuleGroup",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRuleGroupRequest(input, context));
@@ -1440,7 +1440,7 @@ export const serializeAws_json1_1UpdateSizeConstraintSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateSizeConstraintSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateSizeConstraintSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSizeConstraintSetRequest(input, context));
@@ -1453,7 +1453,7 @@ export const serializeAws_json1_1UpdateSqlInjectionMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateSqlInjectionMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateSqlInjectionMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSqlInjectionMatchSetRequest(input, context));
@@ -1466,7 +1466,7 @@ export const serializeAws_json1_1UpdateWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateWebACL",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateWebACLRequest(input, context));
@@ -1479,7 +1479,7 @@ export const serializeAws_json1_1UpdateXssMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_Regional_20161128.UpdateXssMatchSet",
+    "x-amz-target": "AWSWAF_Regional_20161128.UpdateXssMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateXssMatchSetRequest(input, context));

--- a/clients/client-waf/protocols/Aws_json1_1.ts
+++ b/clients/client-waf/protocols/Aws_json1_1.ts
@@ -420,7 +420,7 @@ export const serializeAws_json1_1CreateByteMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateByteMatchSet",
+    "x-amz-target": "AWSWAF_20150824.CreateByteMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateByteMatchSetRequest(input, context));
@@ -433,7 +433,7 @@ export const serializeAws_json1_1CreateGeoMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateGeoMatchSet",
+    "x-amz-target": "AWSWAF_20150824.CreateGeoMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGeoMatchSetRequest(input, context));
@@ -446,7 +446,7 @@ export const serializeAws_json1_1CreateIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateIPSet",
+    "x-amz-target": "AWSWAF_20150824.CreateIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateIPSetRequest(input, context));
@@ -459,7 +459,7 @@ export const serializeAws_json1_1CreateRateBasedRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateRateBasedRule",
+    "x-amz-target": "AWSWAF_20150824.CreateRateBasedRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRateBasedRuleRequest(input, context));
@@ -472,7 +472,7 @@ export const serializeAws_json1_1CreateRegexMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateRegexMatchSet",
+    "x-amz-target": "AWSWAF_20150824.CreateRegexMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRegexMatchSetRequest(input, context));
@@ -485,7 +485,7 @@ export const serializeAws_json1_1CreateRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateRegexPatternSet",
+    "x-amz-target": "AWSWAF_20150824.CreateRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRegexPatternSetRequest(input, context));
@@ -498,7 +498,7 @@ export const serializeAws_json1_1CreateRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateRule",
+    "x-amz-target": "AWSWAF_20150824.CreateRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRuleRequest(input, context));
@@ -511,7 +511,7 @@ export const serializeAws_json1_1CreateRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateRuleGroup",
+    "x-amz-target": "AWSWAF_20150824.CreateRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRuleGroupRequest(input, context));
@@ -524,7 +524,7 @@ export const serializeAws_json1_1CreateSizeConstraintSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateSizeConstraintSet",
+    "x-amz-target": "AWSWAF_20150824.CreateSizeConstraintSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSizeConstraintSetRequest(input, context));
@@ -537,7 +537,7 @@ export const serializeAws_json1_1CreateSqlInjectionMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateSqlInjectionMatchSet",
+    "x-amz-target": "AWSWAF_20150824.CreateSqlInjectionMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateSqlInjectionMatchSetRequest(input, context));
@@ -550,7 +550,7 @@ export const serializeAws_json1_1CreateWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateWebACL",
+    "x-amz-target": "AWSWAF_20150824.CreateWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWebACLRequest(input, context));
@@ -563,7 +563,7 @@ export const serializeAws_json1_1CreateWebACLMigrationStackCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateWebACLMigrationStack",
+    "x-amz-target": "AWSWAF_20150824.CreateWebACLMigrationStack",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWebACLMigrationStackRequest(input, context));
@@ -576,7 +576,7 @@ export const serializeAws_json1_1CreateXssMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.CreateXssMatchSet",
+    "x-amz-target": "AWSWAF_20150824.CreateXssMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateXssMatchSetRequest(input, context));
@@ -589,7 +589,7 @@ export const serializeAws_json1_1DeleteByteMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteByteMatchSet",
+    "x-amz-target": "AWSWAF_20150824.DeleteByteMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteByteMatchSetRequest(input, context));
@@ -602,7 +602,7 @@ export const serializeAws_json1_1DeleteGeoMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteGeoMatchSet",
+    "x-amz-target": "AWSWAF_20150824.DeleteGeoMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteGeoMatchSetRequest(input, context));
@@ -615,7 +615,7 @@ export const serializeAws_json1_1DeleteIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteIPSet",
+    "x-amz-target": "AWSWAF_20150824.DeleteIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteIPSetRequest(input, context));
@@ -628,7 +628,7 @@ export const serializeAws_json1_1DeleteLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteLoggingConfiguration",
+    "x-amz-target": "AWSWAF_20150824.DeleteLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLoggingConfigurationRequest(input, context));
@@ -641,7 +641,7 @@ export const serializeAws_json1_1DeletePermissionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeletePermissionPolicy",
+    "x-amz-target": "AWSWAF_20150824.DeletePermissionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePermissionPolicyRequest(input, context));
@@ -654,7 +654,7 @@ export const serializeAws_json1_1DeleteRateBasedRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteRateBasedRule",
+    "x-amz-target": "AWSWAF_20150824.DeleteRateBasedRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRateBasedRuleRequest(input, context));
@@ -667,7 +667,7 @@ export const serializeAws_json1_1DeleteRegexMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteRegexMatchSet",
+    "x-amz-target": "AWSWAF_20150824.DeleteRegexMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRegexMatchSetRequest(input, context));
@@ -680,7 +680,7 @@ export const serializeAws_json1_1DeleteRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteRegexPatternSet",
+    "x-amz-target": "AWSWAF_20150824.DeleteRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRegexPatternSetRequest(input, context));
@@ -693,7 +693,7 @@ export const serializeAws_json1_1DeleteRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteRule",
+    "x-amz-target": "AWSWAF_20150824.DeleteRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRuleRequest(input, context));
@@ -706,7 +706,7 @@ export const serializeAws_json1_1DeleteRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteRuleGroup",
+    "x-amz-target": "AWSWAF_20150824.DeleteRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRuleGroupRequest(input, context));
@@ -719,7 +719,7 @@ export const serializeAws_json1_1DeleteSizeConstraintSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteSizeConstraintSet",
+    "x-amz-target": "AWSWAF_20150824.DeleteSizeConstraintSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSizeConstraintSetRequest(input, context));
@@ -732,7 +732,7 @@ export const serializeAws_json1_1DeleteSqlInjectionMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteSqlInjectionMatchSet",
+    "x-amz-target": "AWSWAF_20150824.DeleteSqlInjectionMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteSqlInjectionMatchSetRequest(input, context));
@@ -745,7 +745,7 @@ export const serializeAws_json1_1DeleteWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteWebACL",
+    "x-amz-target": "AWSWAF_20150824.DeleteWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWebACLRequest(input, context));
@@ -758,7 +758,7 @@ export const serializeAws_json1_1DeleteXssMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.DeleteXssMatchSet",
+    "x-amz-target": "AWSWAF_20150824.DeleteXssMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteXssMatchSetRequest(input, context));
@@ -771,7 +771,7 @@ export const serializeAws_json1_1GetByteMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetByteMatchSet",
+    "x-amz-target": "AWSWAF_20150824.GetByteMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetByteMatchSetRequest(input, context));
@@ -784,7 +784,7 @@ export const serializeAws_json1_1GetChangeTokenCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetChangeToken",
+    "x-amz-target": "AWSWAF_20150824.GetChangeToken",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetChangeTokenRequest(input, context));
@@ -797,7 +797,7 @@ export const serializeAws_json1_1GetChangeTokenStatusCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetChangeTokenStatus",
+    "x-amz-target": "AWSWAF_20150824.GetChangeTokenStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetChangeTokenStatusRequest(input, context));
@@ -810,7 +810,7 @@ export const serializeAws_json1_1GetGeoMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetGeoMatchSet",
+    "x-amz-target": "AWSWAF_20150824.GetGeoMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetGeoMatchSetRequest(input, context));
@@ -823,7 +823,7 @@ export const serializeAws_json1_1GetIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetIPSet",
+    "x-amz-target": "AWSWAF_20150824.GetIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetIPSetRequest(input, context));
@@ -836,7 +836,7 @@ export const serializeAws_json1_1GetLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetLoggingConfiguration",
+    "x-amz-target": "AWSWAF_20150824.GetLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLoggingConfigurationRequest(input, context));
@@ -849,7 +849,7 @@ export const serializeAws_json1_1GetPermissionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetPermissionPolicy",
+    "x-amz-target": "AWSWAF_20150824.GetPermissionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPermissionPolicyRequest(input, context));
@@ -862,7 +862,7 @@ export const serializeAws_json1_1GetRateBasedRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetRateBasedRule",
+    "x-amz-target": "AWSWAF_20150824.GetRateBasedRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRateBasedRuleRequest(input, context));
@@ -875,7 +875,7 @@ export const serializeAws_json1_1GetRateBasedRuleManagedKeysCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetRateBasedRuleManagedKeys",
+    "x-amz-target": "AWSWAF_20150824.GetRateBasedRuleManagedKeys",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRateBasedRuleManagedKeysRequest(input, context));
@@ -888,7 +888,7 @@ export const serializeAws_json1_1GetRegexMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetRegexMatchSet",
+    "x-amz-target": "AWSWAF_20150824.GetRegexMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRegexMatchSetRequest(input, context));
@@ -901,7 +901,7 @@ export const serializeAws_json1_1GetRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetRegexPatternSet",
+    "x-amz-target": "AWSWAF_20150824.GetRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRegexPatternSetRequest(input, context));
@@ -914,7 +914,7 @@ export const serializeAws_json1_1GetRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetRule",
+    "x-amz-target": "AWSWAF_20150824.GetRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRuleRequest(input, context));
@@ -927,7 +927,7 @@ export const serializeAws_json1_1GetRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetRuleGroup",
+    "x-amz-target": "AWSWAF_20150824.GetRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRuleGroupRequest(input, context));
@@ -940,7 +940,7 @@ export const serializeAws_json1_1GetSampledRequestsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetSampledRequests",
+    "x-amz-target": "AWSWAF_20150824.GetSampledRequests",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSampledRequestsRequest(input, context));
@@ -953,7 +953,7 @@ export const serializeAws_json1_1GetSizeConstraintSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetSizeConstraintSet",
+    "x-amz-target": "AWSWAF_20150824.GetSizeConstraintSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSizeConstraintSetRequest(input, context));
@@ -966,7 +966,7 @@ export const serializeAws_json1_1GetSqlInjectionMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetSqlInjectionMatchSet",
+    "x-amz-target": "AWSWAF_20150824.GetSqlInjectionMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSqlInjectionMatchSetRequest(input, context));
@@ -979,7 +979,7 @@ export const serializeAws_json1_1GetWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetWebACL",
+    "x-amz-target": "AWSWAF_20150824.GetWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetWebACLRequest(input, context));
@@ -992,7 +992,7 @@ export const serializeAws_json1_1GetXssMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.GetXssMatchSet",
+    "x-amz-target": "AWSWAF_20150824.GetXssMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetXssMatchSetRequest(input, context));
@@ -1005,7 +1005,7 @@ export const serializeAws_json1_1ListActivatedRulesInRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListActivatedRulesInRuleGroup",
+    "x-amz-target": "AWSWAF_20150824.ListActivatedRulesInRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListActivatedRulesInRuleGroupRequest(input, context));
@@ -1018,7 +1018,7 @@ export const serializeAws_json1_1ListByteMatchSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListByteMatchSets",
+    "x-amz-target": "AWSWAF_20150824.ListByteMatchSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListByteMatchSetsRequest(input, context));
@@ -1031,7 +1031,7 @@ export const serializeAws_json1_1ListGeoMatchSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListGeoMatchSets",
+    "x-amz-target": "AWSWAF_20150824.ListGeoMatchSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGeoMatchSetsRequest(input, context));
@@ -1044,7 +1044,7 @@ export const serializeAws_json1_1ListIPSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListIPSets",
+    "x-amz-target": "AWSWAF_20150824.ListIPSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListIPSetsRequest(input, context));
@@ -1057,7 +1057,7 @@ export const serializeAws_json1_1ListLoggingConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListLoggingConfigurations",
+    "x-amz-target": "AWSWAF_20150824.ListLoggingConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLoggingConfigurationsRequest(input, context));
@@ -1070,7 +1070,7 @@ export const serializeAws_json1_1ListRateBasedRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListRateBasedRules",
+    "x-amz-target": "AWSWAF_20150824.ListRateBasedRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRateBasedRulesRequest(input, context));
@@ -1083,7 +1083,7 @@ export const serializeAws_json1_1ListRegexMatchSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListRegexMatchSets",
+    "x-amz-target": "AWSWAF_20150824.ListRegexMatchSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRegexMatchSetsRequest(input, context));
@@ -1096,7 +1096,7 @@ export const serializeAws_json1_1ListRegexPatternSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListRegexPatternSets",
+    "x-amz-target": "AWSWAF_20150824.ListRegexPatternSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRegexPatternSetsRequest(input, context));
@@ -1109,7 +1109,7 @@ export const serializeAws_json1_1ListRuleGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListRuleGroups",
+    "x-amz-target": "AWSWAF_20150824.ListRuleGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRuleGroupsRequest(input, context));
@@ -1122,7 +1122,7 @@ export const serializeAws_json1_1ListRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListRules",
+    "x-amz-target": "AWSWAF_20150824.ListRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRulesRequest(input, context));
@@ -1135,7 +1135,7 @@ export const serializeAws_json1_1ListSizeConstraintSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListSizeConstraintSets",
+    "x-amz-target": "AWSWAF_20150824.ListSizeConstraintSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSizeConstraintSetsRequest(input, context));
@@ -1148,7 +1148,7 @@ export const serializeAws_json1_1ListSqlInjectionMatchSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListSqlInjectionMatchSets",
+    "x-amz-target": "AWSWAF_20150824.ListSqlInjectionMatchSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSqlInjectionMatchSetsRequest(input, context));
@@ -1161,7 +1161,7 @@ export const serializeAws_json1_1ListSubscribedRuleGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListSubscribedRuleGroups",
+    "x-amz-target": "AWSWAF_20150824.ListSubscribedRuleGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListSubscribedRuleGroupsRequest(input, context));
@@ -1174,7 +1174,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListTagsForResource",
+    "x-amz-target": "AWSWAF_20150824.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -1187,7 +1187,7 @@ export const serializeAws_json1_1ListWebACLsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListWebACLs",
+    "x-amz-target": "AWSWAF_20150824.ListWebACLs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListWebACLsRequest(input, context));
@@ -1200,7 +1200,7 @@ export const serializeAws_json1_1ListXssMatchSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.ListXssMatchSets",
+    "x-amz-target": "AWSWAF_20150824.ListXssMatchSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListXssMatchSetsRequest(input, context));
@@ -1213,7 +1213,7 @@ export const serializeAws_json1_1PutLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.PutLoggingConfiguration",
+    "x-amz-target": "AWSWAF_20150824.PutLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutLoggingConfigurationRequest(input, context));
@@ -1226,7 +1226,7 @@ export const serializeAws_json1_1PutPermissionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.PutPermissionPolicy",
+    "x-amz-target": "AWSWAF_20150824.PutPermissionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutPermissionPolicyRequest(input, context));
@@ -1239,7 +1239,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.TagResource",
+    "x-amz-target": "AWSWAF_20150824.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -1252,7 +1252,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UntagResource",
+    "x-amz-target": "AWSWAF_20150824.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -1265,7 +1265,7 @@ export const serializeAws_json1_1UpdateByteMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateByteMatchSet",
+    "x-amz-target": "AWSWAF_20150824.UpdateByteMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateByteMatchSetRequest(input, context));
@@ -1278,7 +1278,7 @@ export const serializeAws_json1_1UpdateGeoMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateGeoMatchSet",
+    "x-amz-target": "AWSWAF_20150824.UpdateGeoMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateGeoMatchSetRequest(input, context));
@@ -1291,7 +1291,7 @@ export const serializeAws_json1_1UpdateIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateIPSet",
+    "x-amz-target": "AWSWAF_20150824.UpdateIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateIPSetRequest(input, context));
@@ -1304,7 +1304,7 @@ export const serializeAws_json1_1UpdateRateBasedRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateRateBasedRule",
+    "x-amz-target": "AWSWAF_20150824.UpdateRateBasedRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRateBasedRuleRequest(input, context));
@@ -1317,7 +1317,7 @@ export const serializeAws_json1_1UpdateRegexMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateRegexMatchSet",
+    "x-amz-target": "AWSWAF_20150824.UpdateRegexMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRegexMatchSetRequest(input, context));
@@ -1330,7 +1330,7 @@ export const serializeAws_json1_1UpdateRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateRegexPatternSet",
+    "x-amz-target": "AWSWAF_20150824.UpdateRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRegexPatternSetRequest(input, context));
@@ -1343,7 +1343,7 @@ export const serializeAws_json1_1UpdateRuleCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateRule",
+    "x-amz-target": "AWSWAF_20150824.UpdateRule",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRuleRequest(input, context));
@@ -1356,7 +1356,7 @@ export const serializeAws_json1_1UpdateRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateRuleGroup",
+    "x-amz-target": "AWSWAF_20150824.UpdateRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRuleGroupRequest(input, context));
@@ -1369,7 +1369,7 @@ export const serializeAws_json1_1UpdateSizeConstraintSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateSizeConstraintSet",
+    "x-amz-target": "AWSWAF_20150824.UpdateSizeConstraintSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSizeConstraintSetRequest(input, context));
@@ -1382,7 +1382,7 @@ export const serializeAws_json1_1UpdateSqlInjectionMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateSqlInjectionMatchSet",
+    "x-amz-target": "AWSWAF_20150824.UpdateSqlInjectionMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateSqlInjectionMatchSetRequest(input, context));
@@ -1395,7 +1395,7 @@ export const serializeAws_json1_1UpdateWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateWebACL",
+    "x-amz-target": "AWSWAF_20150824.UpdateWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateWebACLRequest(input, context));
@@ -1408,7 +1408,7 @@ export const serializeAws_json1_1UpdateXssMatchSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20150824.UpdateXssMatchSet",
+    "x-amz-target": "AWSWAF_20150824.UpdateXssMatchSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateXssMatchSetRequest(input, context));

--- a/clients/client-wafv2/protocols/Aws_json1_1.ts
+++ b/clients/client-wafv2/protocols/Aws_json1_1.ts
@@ -262,7 +262,7 @@ export const serializeAws_json1_1AssociateWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.AssociateWebACL",
+    "x-amz-target": "AWSWAF_20190729.AssociateWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateWebACLRequest(input, context));
@@ -275,7 +275,7 @@ export const serializeAws_json1_1CheckCapacityCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.CheckCapacity",
+    "x-amz-target": "AWSWAF_20190729.CheckCapacity",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CheckCapacityRequest(input, context));
@@ -288,7 +288,7 @@ export const serializeAws_json1_1CreateIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.CreateIPSet",
+    "x-amz-target": "AWSWAF_20190729.CreateIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateIPSetRequest(input, context));
@@ -301,7 +301,7 @@ export const serializeAws_json1_1CreateRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.CreateRegexPatternSet",
+    "x-amz-target": "AWSWAF_20190729.CreateRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRegexPatternSetRequest(input, context));
@@ -314,7 +314,7 @@ export const serializeAws_json1_1CreateRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.CreateRuleGroup",
+    "x-amz-target": "AWSWAF_20190729.CreateRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateRuleGroupRequest(input, context));
@@ -327,7 +327,7 @@ export const serializeAws_json1_1CreateWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.CreateWebACL",
+    "x-amz-target": "AWSWAF_20190729.CreateWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWebACLRequest(input, context));
@@ -340,7 +340,7 @@ export const serializeAws_json1_1DeleteFirewallManagerRuleGroupsCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.DeleteFirewallManagerRuleGroups",
+    "x-amz-target": "AWSWAF_20190729.DeleteFirewallManagerRuleGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteFirewallManagerRuleGroupsRequest(input, context));
@@ -353,7 +353,7 @@ export const serializeAws_json1_1DeleteIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.DeleteIPSet",
+    "x-amz-target": "AWSWAF_20190729.DeleteIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteIPSetRequest(input, context));
@@ -366,7 +366,7 @@ export const serializeAws_json1_1DeleteLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.DeleteLoggingConfiguration",
+    "x-amz-target": "AWSWAF_20190729.DeleteLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteLoggingConfigurationRequest(input, context));
@@ -379,7 +379,7 @@ export const serializeAws_json1_1DeletePermissionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.DeletePermissionPolicy",
+    "x-amz-target": "AWSWAF_20190729.DeletePermissionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeletePermissionPolicyRequest(input, context));
@@ -392,7 +392,7 @@ export const serializeAws_json1_1DeleteRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.DeleteRegexPatternSet",
+    "x-amz-target": "AWSWAF_20190729.DeleteRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRegexPatternSetRequest(input, context));
@@ -405,7 +405,7 @@ export const serializeAws_json1_1DeleteRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.DeleteRuleGroup",
+    "x-amz-target": "AWSWAF_20190729.DeleteRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteRuleGroupRequest(input, context));
@@ -418,7 +418,7 @@ export const serializeAws_json1_1DeleteWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.DeleteWebACL",
+    "x-amz-target": "AWSWAF_20190729.DeleteWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWebACLRequest(input, context));
@@ -431,7 +431,7 @@ export const serializeAws_json1_1DescribeManagedRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.DescribeManagedRuleGroup",
+    "x-amz-target": "AWSWAF_20190729.DescribeManagedRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeManagedRuleGroupRequest(input, context));
@@ -444,7 +444,7 @@ export const serializeAws_json1_1DisassociateWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.DisassociateWebACL",
+    "x-amz-target": "AWSWAF_20190729.DisassociateWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateWebACLRequest(input, context));
@@ -457,7 +457,7 @@ export const serializeAws_json1_1GetIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.GetIPSet",
+    "x-amz-target": "AWSWAF_20190729.GetIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetIPSetRequest(input, context));
@@ -470,7 +470,7 @@ export const serializeAws_json1_1GetLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.GetLoggingConfiguration",
+    "x-amz-target": "AWSWAF_20190729.GetLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetLoggingConfigurationRequest(input, context));
@@ -483,7 +483,7 @@ export const serializeAws_json1_1GetPermissionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.GetPermissionPolicy",
+    "x-amz-target": "AWSWAF_20190729.GetPermissionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetPermissionPolicyRequest(input, context));
@@ -496,7 +496,7 @@ export const serializeAws_json1_1GetRateBasedStatementManagedKeysCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.GetRateBasedStatementManagedKeys",
+    "x-amz-target": "AWSWAF_20190729.GetRateBasedStatementManagedKeys",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRateBasedStatementManagedKeysRequest(input, context));
@@ -509,7 +509,7 @@ export const serializeAws_json1_1GetRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.GetRegexPatternSet",
+    "x-amz-target": "AWSWAF_20190729.GetRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRegexPatternSetRequest(input, context));
@@ -522,7 +522,7 @@ export const serializeAws_json1_1GetRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.GetRuleGroup",
+    "x-amz-target": "AWSWAF_20190729.GetRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetRuleGroupRequest(input, context));
@@ -535,7 +535,7 @@ export const serializeAws_json1_1GetSampledRequestsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.GetSampledRequests",
+    "x-amz-target": "AWSWAF_20190729.GetSampledRequests",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetSampledRequestsRequest(input, context));
@@ -548,7 +548,7 @@ export const serializeAws_json1_1GetWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.GetWebACL",
+    "x-amz-target": "AWSWAF_20190729.GetWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetWebACLRequest(input, context));
@@ -561,7 +561,7 @@ export const serializeAws_json1_1GetWebACLForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.GetWebACLForResource",
+    "x-amz-target": "AWSWAF_20190729.GetWebACLForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetWebACLForResourceRequest(input, context));
@@ -574,7 +574,7 @@ export const serializeAws_json1_1ListAvailableManagedRuleGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.ListAvailableManagedRuleGroups",
+    "x-amz-target": "AWSWAF_20190729.ListAvailableManagedRuleGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAvailableManagedRuleGroupsRequest(input, context));
@@ -587,7 +587,7 @@ export const serializeAws_json1_1ListIPSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.ListIPSets",
+    "x-amz-target": "AWSWAF_20190729.ListIPSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListIPSetsRequest(input, context));
@@ -600,7 +600,7 @@ export const serializeAws_json1_1ListLoggingConfigurationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.ListLoggingConfigurations",
+    "x-amz-target": "AWSWAF_20190729.ListLoggingConfigurations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListLoggingConfigurationsRequest(input, context));
@@ -613,7 +613,7 @@ export const serializeAws_json1_1ListRegexPatternSetsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.ListRegexPatternSets",
+    "x-amz-target": "AWSWAF_20190729.ListRegexPatternSets",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRegexPatternSetsRequest(input, context));
@@ -626,7 +626,7 @@ export const serializeAws_json1_1ListResourcesForWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.ListResourcesForWebACL",
+    "x-amz-target": "AWSWAF_20190729.ListResourcesForWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourcesForWebACLRequest(input, context));
@@ -639,7 +639,7 @@ export const serializeAws_json1_1ListRuleGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.ListRuleGroups",
+    "x-amz-target": "AWSWAF_20190729.ListRuleGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListRuleGroupsRequest(input, context));
@@ -652,7 +652,7 @@ export const serializeAws_json1_1ListTagsForResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.ListTagsForResource",
+    "x-amz-target": "AWSWAF_20190729.ListTagsForResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListTagsForResourceRequest(input, context));
@@ -665,7 +665,7 @@ export const serializeAws_json1_1ListWebACLsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.ListWebACLs",
+    "x-amz-target": "AWSWAF_20190729.ListWebACLs",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListWebACLsRequest(input, context));
@@ -678,7 +678,7 @@ export const serializeAws_json1_1PutLoggingConfigurationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.PutLoggingConfiguration",
+    "x-amz-target": "AWSWAF_20190729.PutLoggingConfiguration",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutLoggingConfigurationRequest(input, context));
@@ -691,7 +691,7 @@ export const serializeAws_json1_1PutPermissionPolicyCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.PutPermissionPolicy",
+    "x-amz-target": "AWSWAF_20190729.PutPermissionPolicy",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutPermissionPolicyRequest(input, context));
@@ -704,7 +704,7 @@ export const serializeAws_json1_1TagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.TagResource",
+    "x-amz-target": "AWSWAF_20190729.TagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TagResourceRequest(input, context));
@@ -717,7 +717,7 @@ export const serializeAws_json1_1UntagResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.UntagResource",
+    "x-amz-target": "AWSWAF_20190729.UntagResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UntagResourceRequest(input, context));
@@ -730,7 +730,7 @@ export const serializeAws_json1_1UpdateIPSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.UpdateIPSet",
+    "x-amz-target": "AWSWAF_20190729.UpdateIPSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateIPSetRequest(input, context));
@@ -743,7 +743,7 @@ export const serializeAws_json1_1UpdateRegexPatternSetCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.UpdateRegexPatternSet",
+    "x-amz-target": "AWSWAF_20190729.UpdateRegexPatternSet",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRegexPatternSetRequest(input, context));
@@ -756,7 +756,7 @@ export const serializeAws_json1_1UpdateRuleGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.UpdateRuleGroup",
+    "x-amz-target": "AWSWAF_20190729.UpdateRuleGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRuleGroupRequest(input, context));
@@ -769,7 +769,7 @@ export const serializeAws_json1_1UpdateWebACLCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "AWSWAF_20190729.UpdateWebACL",
+    "x-amz-target": "AWSWAF_20190729.UpdateWebACL",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateWebACLRequest(input, context));

--- a/clients/client-workdocs/protocols/Aws_restJson1.ts
+++ b/clients/client-workdocs/protocols/Aws_restJson1.ts
@@ -155,7 +155,7 @@ export const serializeAws_restJson1AbortDocumentVersionUploadCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions/{VersionId}";
   if (input.DocumentId !== undefined) {
@@ -194,7 +194,7 @@ export const serializeAws_restJson1ActivateUserCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/users/{UserId}/activation";
   if (input.UserId !== undefined) {
@@ -225,7 +225,7 @@ export const serializeAws_restJson1AddResourcePermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/resources/{ResourceId}/permissions";
   if (input.ResourceId !== undefined) {
@@ -264,7 +264,7 @@ export const serializeAws_restJson1CreateCommentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions/{VersionId}/comment";
   if (input.DocumentId !== undefined) {
@@ -312,7 +312,7 @@ export const serializeAws_restJson1CreateCustomMetadataCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/resources/{ResourceId}/customMetadata";
   if (input.ResourceId !== undefined) {
@@ -353,7 +353,7 @@ export const serializeAws_restJson1CreateFolderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/folders";
   let body: any;
@@ -380,7 +380,7 @@ export const serializeAws_restJson1CreateLabelsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/resources/{ResourceId}/labels";
   if (input.ResourceId !== undefined) {
@@ -451,7 +451,7 @@ export const serializeAws_restJson1CreateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/users";
   let body: any;
@@ -484,7 +484,7 @@ export const serializeAws_restJson1DeactivateUserCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/users/{UserId}/activation";
   if (input.UserId !== undefined) {
@@ -514,7 +514,7 @@ export const serializeAws_restJson1DeleteCommentCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions/{VersionId}/comment/{CommentId}";
   if (input.DocumentId !== undefined) {
@@ -562,7 +562,7 @@ export const serializeAws_restJson1DeleteCustomMetadataCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/resources/{ResourceId}/customMetadata";
   if (input.ResourceId !== undefined) {
@@ -598,7 +598,7 @@ export const serializeAws_restJson1DeleteDocumentCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}";
   if (input.DocumentId !== undefined) {
@@ -628,7 +628,7 @@ export const serializeAws_restJson1DeleteFolderCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/folders/{FolderId}";
   if (input.FolderId !== undefined) {
@@ -658,7 +658,7 @@ export const serializeAws_restJson1DeleteFolderContentsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/folders/{FolderId}/contents";
   if (input.FolderId !== undefined) {
@@ -688,7 +688,7 @@ export const serializeAws_restJson1DeleteLabelsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/resources/{ResourceId}/labels";
   if (input.ResourceId !== undefined) {
@@ -760,7 +760,7 @@ export const serializeAws_restJson1DeleteUserCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/users/{UserId}";
   if (input.UserId !== undefined) {
@@ -790,7 +790,7 @@ export const serializeAws_restJson1DescribeActivitiesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/activities";
   const query: any = {
@@ -825,7 +825,7 @@ export const serializeAws_restJson1DescribeCommentsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions/{VersionId}/comments";
   if (input.DocumentId !== undefined) {
@@ -869,7 +869,7 @@ export const serializeAws_restJson1DescribeDocumentVersionsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions";
   if (input.DocumentId !== undefined) {
@@ -906,7 +906,7 @@ export const serializeAws_restJson1DescribeFolderContentsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/folders/{FolderId}/contents";
   if (input.FolderId !== undefined) {
@@ -945,7 +945,7 @@ export const serializeAws_restJson1DescribeGroupsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/groups";
   const query: any = {
@@ -1006,7 +1006,7 @@ export const serializeAws_restJson1DescribeResourcePermissionsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/resources/{ResourceId}/permissions";
   if (input.ResourceId !== undefined) {
@@ -1042,7 +1042,7 @@ export const serializeAws_restJson1DescribeRootFoldersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/me/root";
   const query: any = {
@@ -1068,7 +1068,7 @@ export const serializeAws_restJson1DescribeUsersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/users";
   const query: any = {
@@ -1101,7 +1101,7 @@ export const serializeAws_restJson1GetCurrentUserCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/me";
   let body: any;
@@ -1122,7 +1122,7 @@ export const serializeAws_restJson1GetDocumentCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}";
   if (input.DocumentId !== undefined) {
@@ -1156,7 +1156,7 @@ export const serializeAws_restJson1GetDocumentPathCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}/path";
   if (input.DocumentId !== undefined) {
@@ -1192,7 +1192,7 @@ export const serializeAws_restJson1GetDocumentVersionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions/{VersionId}";
   if (input.DocumentId !== undefined) {
@@ -1236,7 +1236,7 @@ export const serializeAws_restJson1GetFolderCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/folders/{FolderId}";
   if (input.FolderId !== undefined) {
@@ -1270,7 +1270,7 @@ export const serializeAws_restJson1GetFolderPathCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/folders/{FolderId}/path";
   if (input.FolderId !== undefined) {
@@ -1306,7 +1306,7 @@ export const serializeAws_restJson1GetResourcesCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/resources";
   const query: any = {
@@ -1335,7 +1335,7 @@ export const serializeAws_restJson1InitiateDocumentVersionUploadCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents";
   let body: any;
@@ -1373,7 +1373,7 @@ export const serializeAws_restJson1RemoveAllResourcePermissionsCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/resources/{ResourceId}/permissions";
   if (input.ResourceId !== undefined) {
@@ -1403,7 +1403,7 @@ export const serializeAws_restJson1RemoveResourcePermissionCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/resources/{ResourceId}/permissions/{PrincipalId}";
   if (input.ResourceId !== undefined) {
@@ -1447,7 +1447,7 @@ export const serializeAws_restJson1UpdateDocumentCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}";
   if (input.DocumentId !== undefined) {
@@ -1484,7 +1484,7 @@ export const serializeAws_restJson1UpdateDocumentVersionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/documents/{DocumentId}/versions/{VersionId}";
   if (input.DocumentId !== undefined) {
@@ -1527,7 +1527,7 @@ export const serializeAws_restJson1UpdateFolderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/folders/{FolderId}";
   if (input.FolderId !== undefined) {
@@ -1564,7 +1564,7 @@ export const serializeAws_restJson1UpdateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.AuthenticationToken) && { Authentication: input.AuthenticationToken! }),
+    ...(isSerializableHeaderValue(input.AuthenticationToken) && { authentication: input.AuthenticationToken! }),
   };
   let resolvedPath = "/api/v1/users/{UserId}";
   if (input.UserId !== undefined) {

--- a/clients/client-workmail/protocols/Aws_json1_1.ts
+++ b/clients/client-workmail/protocols/Aws_json1_1.ts
@@ -173,7 +173,7 @@ export const serializeAws_json1_1AssociateDelegateToResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.AssociateDelegateToResource",
+    "x-amz-target": "WorkMailService.AssociateDelegateToResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateDelegateToResourceRequest(input, context));
@@ -186,7 +186,7 @@ export const serializeAws_json1_1AssociateMemberToGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.AssociateMemberToGroup",
+    "x-amz-target": "WorkMailService.AssociateMemberToGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateMemberToGroupRequest(input, context));
@@ -199,7 +199,7 @@ export const serializeAws_json1_1CreateAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.CreateAlias",
+    "x-amz-target": "WorkMailService.CreateAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateAliasRequest(input, context));
@@ -212,7 +212,7 @@ export const serializeAws_json1_1CreateGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.CreateGroup",
+    "x-amz-target": "WorkMailService.CreateGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateGroupRequest(input, context));
@@ -225,7 +225,7 @@ export const serializeAws_json1_1CreateResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.CreateResource",
+    "x-amz-target": "WorkMailService.CreateResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateResourceRequest(input, context));
@@ -238,7 +238,7 @@ export const serializeAws_json1_1CreateUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.CreateUser",
+    "x-amz-target": "WorkMailService.CreateUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateUserRequest(input, context));
@@ -251,7 +251,7 @@ export const serializeAws_json1_1DeleteAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DeleteAlias",
+    "x-amz-target": "WorkMailService.DeleteAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteAliasRequest(input, context));
@@ -264,7 +264,7 @@ export const serializeAws_json1_1DeleteGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DeleteGroup",
+    "x-amz-target": "WorkMailService.DeleteGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteGroupRequest(input, context));
@@ -277,7 +277,7 @@ export const serializeAws_json1_1DeleteMailboxPermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DeleteMailboxPermissions",
+    "x-amz-target": "WorkMailService.DeleteMailboxPermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteMailboxPermissionsRequest(input, context));
@@ -290,7 +290,7 @@ export const serializeAws_json1_1DeleteResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DeleteResource",
+    "x-amz-target": "WorkMailService.DeleteResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteResourceRequest(input, context));
@@ -303,7 +303,7 @@ export const serializeAws_json1_1DeleteUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DeleteUser",
+    "x-amz-target": "WorkMailService.DeleteUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteUserRequest(input, context));
@@ -316,7 +316,7 @@ export const serializeAws_json1_1DeregisterFromWorkMailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DeregisterFromWorkMail",
+    "x-amz-target": "WorkMailService.DeregisterFromWorkMail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterFromWorkMailRequest(input, context));
@@ -329,7 +329,7 @@ export const serializeAws_json1_1DescribeGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DescribeGroup",
+    "x-amz-target": "WorkMailService.DescribeGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeGroupRequest(input, context));
@@ -342,7 +342,7 @@ export const serializeAws_json1_1DescribeOrganizationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DescribeOrganization",
+    "x-amz-target": "WorkMailService.DescribeOrganization",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeOrganizationRequest(input, context));
@@ -355,7 +355,7 @@ export const serializeAws_json1_1DescribeResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DescribeResource",
+    "x-amz-target": "WorkMailService.DescribeResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeResourceRequest(input, context));
@@ -368,7 +368,7 @@ export const serializeAws_json1_1DescribeUserCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DescribeUser",
+    "x-amz-target": "WorkMailService.DescribeUser",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeUserRequest(input, context));
@@ -381,7 +381,7 @@ export const serializeAws_json1_1DisassociateDelegateFromResourceCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DisassociateDelegateFromResource",
+    "x-amz-target": "WorkMailService.DisassociateDelegateFromResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateDelegateFromResourceRequest(input, context));
@@ -394,7 +394,7 @@ export const serializeAws_json1_1DisassociateMemberFromGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.DisassociateMemberFromGroup",
+    "x-amz-target": "WorkMailService.DisassociateMemberFromGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateMemberFromGroupRequest(input, context));
@@ -407,7 +407,7 @@ export const serializeAws_json1_1GetMailboxDetailsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.GetMailboxDetails",
+    "x-amz-target": "WorkMailService.GetMailboxDetails",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1GetMailboxDetailsRequest(input, context));
@@ -420,7 +420,7 @@ export const serializeAws_json1_1ListAliasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.ListAliases",
+    "x-amz-target": "WorkMailService.ListAliases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAliasesRequest(input, context));
@@ -433,7 +433,7 @@ export const serializeAws_json1_1ListGroupMembersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.ListGroupMembers",
+    "x-amz-target": "WorkMailService.ListGroupMembers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGroupMembersRequest(input, context));
@@ -446,7 +446,7 @@ export const serializeAws_json1_1ListGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.ListGroups",
+    "x-amz-target": "WorkMailService.ListGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListGroupsRequest(input, context));
@@ -459,7 +459,7 @@ export const serializeAws_json1_1ListMailboxPermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.ListMailboxPermissions",
+    "x-amz-target": "WorkMailService.ListMailboxPermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListMailboxPermissionsRequest(input, context));
@@ -472,7 +472,7 @@ export const serializeAws_json1_1ListOrganizationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.ListOrganizations",
+    "x-amz-target": "WorkMailService.ListOrganizations",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListOrganizationsRequest(input, context));
@@ -485,7 +485,7 @@ export const serializeAws_json1_1ListResourceDelegatesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.ListResourceDelegates",
+    "x-amz-target": "WorkMailService.ListResourceDelegates",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourceDelegatesRequest(input, context));
@@ -498,7 +498,7 @@ export const serializeAws_json1_1ListResourcesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.ListResources",
+    "x-amz-target": "WorkMailService.ListResources",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListResourcesRequest(input, context));
@@ -511,7 +511,7 @@ export const serializeAws_json1_1ListUsersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.ListUsers",
+    "x-amz-target": "WorkMailService.ListUsers",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListUsersRequest(input, context));
@@ -524,7 +524,7 @@ export const serializeAws_json1_1PutMailboxPermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.PutMailboxPermissions",
+    "x-amz-target": "WorkMailService.PutMailboxPermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutMailboxPermissionsRequest(input, context));
@@ -537,7 +537,7 @@ export const serializeAws_json1_1RegisterToWorkMailCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.RegisterToWorkMail",
+    "x-amz-target": "WorkMailService.RegisterToWorkMail",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterToWorkMailRequest(input, context));
@@ -550,7 +550,7 @@ export const serializeAws_json1_1ResetPasswordCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.ResetPassword",
+    "x-amz-target": "WorkMailService.ResetPassword",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ResetPasswordRequest(input, context));
@@ -563,7 +563,7 @@ export const serializeAws_json1_1UpdateMailboxQuotaCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.UpdateMailboxQuota",
+    "x-amz-target": "WorkMailService.UpdateMailboxQuota",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateMailboxQuotaRequest(input, context));
@@ -576,7 +576,7 @@ export const serializeAws_json1_1UpdatePrimaryEmailAddressCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.UpdatePrimaryEmailAddress",
+    "x-amz-target": "WorkMailService.UpdatePrimaryEmailAddress",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdatePrimaryEmailAddressRequest(input, context));
@@ -589,7 +589,7 @@ export const serializeAws_json1_1UpdateResourceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkMailService.UpdateResource",
+    "x-amz-target": "WorkMailService.UpdateResource",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateResourceRequest(input, context));

--- a/clients/client-workspaces/protocols/Aws_json1_1.ts
+++ b/clients/client-workspaces/protocols/Aws_json1_1.ts
@@ -305,7 +305,7 @@ export const serializeAws_json1_1AssociateConnectionAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.AssociateConnectionAlias",
+    "x-amz-target": "WorkspacesService.AssociateConnectionAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateConnectionAliasRequest(input, context));
@@ -318,7 +318,7 @@ export const serializeAws_json1_1AssociateIpGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.AssociateIpGroups",
+    "x-amz-target": "WorkspacesService.AssociateIpGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AssociateIpGroupsRequest(input, context));
@@ -331,7 +331,7 @@ export const serializeAws_json1_1AuthorizeIpRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.AuthorizeIpRules",
+    "x-amz-target": "WorkspacesService.AuthorizeIpRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1AuthorizeIpRulesRequest(input, context));
@@ -344,7 +344,7 @@ export const serializeAws_json1_1CopyWorkspaceImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.CopyWorkspaceImage",
+    "x-amz-target": "WorkspacesService.CopyWorkspaceImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CopyWorkspaceImageRequest(input, context));
@@ -357,7 +357,7 @@ export const serializeAws_json1_1CreateConnectionAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.CreateConnectionAlias",
+    "x-amz-target": "WorkspacesService.CreateConnectionAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateConnectionAliasRequest(input, context));
@@ -370,7 +370,7 @@ export const serializeAws_json1_1CreateIpGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.CreateIpGroup",
+    "x-amz-target": "WorkspacesService.CreateIpGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateIpGroupRequest(input, context));
@@ -383,7 +383,7 @@ export const serializeAws_json1_1CreateTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.CreateTags",
+    "x-amz-target": "WorkspacesService.CreateTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateTagsRequest(input, context));
@@ -396,7 +396,7 @@ export const serializeAws_json1_1CreateWorkspacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.CreateWorkspaces",
+    "x-amz-target": "WorkspacesService.CreateWorkspaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1CreateWorkspacesRequest(input, context));
@@ -409,7 +409,7 @@ export const serializeAws_json1_1DeleteConnectionAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DeleteConnectionAlias",
+    "x-amz-target": "WorkspacesService.DeleteConnectionAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteConnectionAliasRequest(input, context));
@@ -422,7 +422,7 @@ export const serializeAws_json1_1DeleteIpGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DeleteIpGroup",
+    "x-amz-target": "WorkspacesService.DeleteIpGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteIpGroupRequest(input, context));
@@ -435,7 +435,7 @@ export const serializeAws_json1_1DeleteTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DeleteTags",
+    "x-amz-target": "WorkspacesService.DeleteTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteTagsRequest(input, context));
@@ -448,7 +448,7 @@ export const serializeAws_json1_1DeleteWorkspaceImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DeleteWorkspaceImage",
+    "x-amz-target": "WorkspacesService.DeleteWorkspaceImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeleteWorkspaceImageRequest(input, context));
@@ -461,7 +461,7 @@ export const serializeAws_json1_1DeregisterWorkspaceDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DeregisterWorkspaceDirectory",
+    "x-amz-target": "WorkspacesService.DeregisterWorkspaceDirectory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DeregisterWorkspaceDirectoryRequest(input, context));
@@ -474,7 +474,7 @@ export const serializeAws_json1_1DescribeAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeAccount",
+    "x-amz-target": "WorkspacesService.DescribeAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAccountRequest(input, context));
@@ -487,7 +487,7 @@ export const serializeAws_json1_1DescribeAccountModificationsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeAccountModifications",
+    "x-amz-target": "WorkspacesService.DescribeAccountModifications",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeAccountModificationsRequest(input, context));
@@ -500,7 +500,7 @@ export const serializeAws_json1_1DescribeClientPropertiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeClientProperties",
+    "x-amz-target": "WorkspacesService.DescribeClientProperties",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeClientPropertiesRequest(input, context));
@@ -513,7 +513,7 @@ export const serializeAws_json1_1DescribeConnectionAliasesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeConnectionAliases",
+    "x-amz-target": "WorkspacesService.DescribeConnectionAliases",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConnectionAliasesRequest(input, context));
@@ -526,7 +526,7 @@ export const serializeAws_json1_1DescribeConnectionAliasPermissionsCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeConnectionAliasPermissions",
+    "x-amz-target": "WorkspacesService.DescribeConnectionAliasPermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeConnectionAliasPermissionsRequest(input, context));
@@ -539,7 +539,7 @@ export const serializeAws_json1_1DescribeIpGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeIpGroups",
+    "x-amz-target": "WorkspacesService.DescribeIpGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeIpGroupsRequest(input, context));
@@ -552,7 +552,7 @@ export const serializeAws_json1_1DescribeTagsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeTags",
+    "x-amz-target": "WorkspacesService.DescribeTags",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeTagsRequest(input, context));
@@ -565,7 +565,7 @@ export const serializeAws_json1_1DescribeWorkspaceBundlesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeWorkspaceBundles",
+    "x-amz-target": "WorkspacesService.DescribeWorkspaceBundles",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeWorkspaceBundlesRequest(input, context));
@@ -578,7 +578,7 @@ export const serializeAws_json1_1DescribeWorkspaceDirectoriesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeWorkspaceDirectories",
+    "x-amz-target": "WorkspacesService.DescribeWorkspaceDirectories",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeWorkspaceDirectoriesRequest(input, context));
@@ -591,7 +591,7 @@ export const serializeAws_json1_1DescribeWorkspaceImagePermissionsCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeWorkspaceImagePermissions",
+    "x-amz-target": "WorkspacesService.DescribeWorkspaceImagePermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeWorkspaceImagePermissionsRequest(input, context));
@@ -604,7 +604,7 @@ export const serializeAws_json1_1DescribeWorkspaceImagesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeWorkspaceImages",
+    "x-amz-target": "WorkspacesService.DescribeWorkspaceImages",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeWorkspaceImagesRequest(input, context));
@@ -617,7 +617,7 @@ export const serializeAws_json1_1DescribeWorkspacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeWorkspaces",
+    "x-amz-target": "WorkspacesService.DescribeWorkspaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeWorkspacesRequest(input, context));
@@ -630,7 +630,7 @@ export const serializeAws_json1_1DescribeWorkspacesConnectionStatusCommand = asy
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeWorkspacesConnectionStatus",
+    "x-amz-target": "WorkspacesService.DescribeWorkspacesConnectionStatus",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeWorkspacesConnectionStatusRequest(input, context));
@@ -643,7 +643,7 @@ export const serializeAws_json1_1DescribeWorkspaceSnapshotsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DescribeWorkspaceSnapshots",
+    "x-amz-target": "WorkspacesService.DescribeWorkspaceSnapshots",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DescribeWorkspaceSnapshotsRequest(input, context));
@@ -656,7 +656,7 @@ export const serializeAws_json1_1DisassociateConnectionAliasCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DisassociateConnectionAlias",
+    "x-amz-target": "WorkspacesService.DisassociateConnectionAlias",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateConnectionAliasRequest(input, context));
@@ -669,7 +669,7 @@ export const serializeAws_json1_1DisassociateIpGroupsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.DisassociateIpGroups",
+    "x-amz-target": "WorkspacesService.DisassociateIpGroups",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1DisassociateIpGroupsRequest(input, context));
@@ -682,7 +682,7 @@ export const serializeAws_json1_1ImportWorkspaceImageCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.ImportWorkspaceImage",
+    "x-amz-target": "WorkspacesService.ImportWorkspaceImage",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ImportWorkspaceImageRequest(input, context));
@@ -695,7 +695,7 @@ export const serializeAws_json1_1ListAvailableManagementCidrRangesCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.ListAvailableManagementCidrRanges",
+    "x-amz-target": "WorkspacesService.ListAvailableManagementCidrRanges",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ListAvailableManagementCidrRangesRequest(input, context));
@@ -708,7 +708,7 @@ export const serializeAws_json1_1MigrateWorkspaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.MigrateWorkspace",
+    "x-amz-target": "WorkspacesService.MigrateWorkspace",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1MigrateWorkspaceRequest(input, context));
@@ -721,7 +721,7 @@ export const serializeAws_json1_1ModifyAccountCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.ModifyAccount",
+    "x-amz-target": "WorkspacesService.ModifyAccount",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyAccountRequest(input, context));
@@ -734,7 +734,7 @@ export const serializeAws_json1_1ModifyClientPropertiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.ModifyClientProperties",
+    "x-amz-target": "WorkspacesService.ModifyClientProperties",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyClientPropertiesRequest(input, context));
@@ -747,7 +747,7 @@ export const serializeAws_json1_1ModifySelfservicePermissionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.ModifySelfservicePermissions",
+    "x-amz-target": "WorkspacesService.ModifySelfservicePermissions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifySelfservicePermissionsRequest(input, context));
@@ -760,7 +760,7 @@ export const serializeAws_json1_1ModifyWorkspaceAccessPropertiesCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.ModifyWorkspaceAccessProperties",
+    "x-amz-target": "WorkspacesService.ModifyWorkspaceAccessProperties",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyWorkspaceAccessPropertiesRequest(input, context));
@@ -773,7 +773,7 @@ export const serializeAws_json1_1ModifyWorkspaceCreationPropertiesCommand = asyn
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.ModifyWorkspaceCreationProperties",
+    "x-amz-target": "WorkspacesService.ModifyWorkspaceCreationProperties",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyWorkspaceCreationPropertiesRequest(input, context));
@@ -786,7 +786,7 @@ export const serializeAws_json1_1ModifyWorkspacePropertiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.ModifyWorkspaceProperties",
+    "x-amz-target": "WorkspacesService.ModifyWorkspaceProperties",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyWorkspacePropertiesRequest(input, context));
@@ -799,7 +799,7 @@ export const serializeAws_json1_1ModifyWorkspaceStateCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.ModifyWorkspaceState",
+    "x-amz-target": "WorkspacesService.ModifyWorkspaceState",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1ModifyWorkspaceStateRequest(input, context));
@@ -812,7 +812,7 @@ export const serializeAws_json1_1RebootWorkspacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.RebootWorkspaces",
+    "x-amz-target": "WorkspacesService.RebootWorkspaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RebootWorkspacesRequest(input, context));
@@ -825,7 +825,7 @@ export const serializeAws_json1_1RebuildWorkspacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.RebuildWorkspaces",
+    "x-amz-target": "WorkspacesService.RebuildWorkspaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RebuildWorkspacesRequest(input, context));
@@ -838,7 +838,7 @@ export const serializeAws_json1_1RegisterWorkspaceDirectoryCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.RegisterWorkspaceDirectory",
+    "x-amz-target": "WorkspacesService.RegisterWorkspaceDirectory",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RegisterWorkspaceDirectoryRequest(input, context));
@@ -851,7 +851,7 @@ export const serializeAws_json1_1RestoreWorkspaceCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.RestoreWorkspace",
+    "x-amz-target": "WorkspacesService.RestoreWorkspace",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RestoreWorkspaceRequest(input, context));
@@ -864,7 +864,7 @@ export const serializeAws_json1_1RevokeIpRulesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.RevokeIpRules",
+    "x-amz-target": "WorkspacesService.RevokeIpRules",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1RevokeIpRulesRequest(input, context));
@@ -877,7 +877,7 @@ export const serializeAws_json1_1StartWorkspacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.StartWorkspaces",
+    "x-amz-target": "WorkspacesService.StartWorkspaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StartWorkspacesRequest(input, context));
@@ -890,7 +890,7 @@ export const serializeAws_json1_1StopWorkspacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.StopWorkspaces",
+    "x-amz-target": "WorkspacesService.StopWorkspaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1StopWorkspacesRequest(input, context));
@@ -903,7 +903,7 @@ export const serializeAws_json1_1TerminateWorkspacesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.TerminateWorkspaces",
+    "x-amz-target": "WorkspacesService.TerminateWorkspaces",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1TerminateWorkspacesRequest(input, context));
@@ -916,7 +916,7 @@ export const serializeAws_json1_1UpdateConnectionAliasPermissionCommand = async 
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.UpdateConnectionAliasPermission",
+    "x-amz-target": "WorkspacesService.UpdateConnectionAliasPermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateConnectionAliasPermissionRequest(input, context));
@@ -929,7 +929,7 @@ export const serializeAws_json1_1UpdateRulesOfIpGroupCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.UpdateRulesOfIpGroup",
+    "x-amz-target": "WorkspacesService.UpdateRulesOfIpGroup",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateRulesOfIpGroupRequest(input, context));
@@ -942,7 +942,7 @@ export const serializeAws_json1_1UpdateWorkspaceImagePermissionCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "WorkspacesService.UpdateWorkspaceImagePermission",
+    "x-amz-target": "WorkspacesService.UpdateWorkspaceImagePermission",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UpdateWorkspaceImagePermissionRequest(input, context));

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/JsonRpcProtocolGenerator.java
@@ -89,7 +89,7 @@ abstract class JsonRpcProtocolGenerator extends HttpRpcProtocolGenerator {
         // separated by a '.' character, for the target header.
         TypeScriptWriter writer = context.getWriter();
         String target = context.getService().getId().getName() + "." + operation.getId().getName();
-        writer.write("'X-Amz-Target': $S,", target);
+        writer.write("'x-amz-target': $S,", target);
     }
 
     @Override

--- a/protocol_tests/aws-json/protocols/Aws_json1_1.ts
+++ b/protocol_tests/aws-json/protocols/Aws_json1_1.ts
@@ -57,7 +57,7 @@ export const serializeAws_json1_1EmptyOperationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "JsonProtocol.EmptyOperation",
+    "x-amz-target": "JsonProtocol.EmptyOperation",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -68,7 +68,7 @@ export const serializeAws_json1_1GreetingWithErrorsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "JsonProtocol.GreetingWithErrors",
+    "x-amz-target": "JsonProtocol.GreetingWithErrors",
   };
   return buildHttpRpcRequest(context, headers, "/", undefined, undefined);
 };
@@ -79,7 +79,7 @@ export const serializeAws_json1_1JsonEnumsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "JsonProtocol.JsonEnums",
+    "x-amz-target": "JsonProtocol.JsonEnums",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1JsonEnumsInputOutput(input, context));
@@ -92,7 +92,7 @@ export const serializeAws_json1_1JsonUnionsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "JsonProtocol.JsonUnions",
+    "x-amz-target": "JsonProtocol.JsonUnions",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1UnionInputOutput(input, context));
@@ -105,7 +105,7 @@ export const serializeAws_json1_1KitchenSinkOperationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "JsonProtocol.KitchenSinkOperation",
+    "x-amz-target": "JsonProtocol.KitchenSinkOperation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1KitchenSink(input, context));
@@ -118,7 +118,7 @@ export const serializeAws_json1_1NullOperationCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "JsonProtocol.NullOperation",
+    "x-amz-target": "JsonProtocol.NullOperation",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1NullOperationInputOutput(input, context));
@@ -131,7 +131,7 @@ export const serializeAws_json1_1OperationWithOptionalInputOutputCommand = async
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "JsonProtocol.OperationWithOptionalInputOutput",
+    "x-amz-target": "JsonProtocol.OperationWithOptionalInputOutput",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1SimpleStruct(input, context));
@@ -144,7 +144,7 @@ export const serializeAws_json1_1PutAndGetInlineDocumentsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: __HeaderBag = {
     "content-type": "application/x-amz-json-1.1",
-    "X-Amz-Target": "JsonProtocol.PutAndGetInlineDocuments",
+    "x-amz-target": "JsonProtocol.PutAndGetInlineDocuments",
   };
   let body: any;
   body = JSON.stringify(serializeAws_json1_1PutAndGetInlineDocumentsInputOutput(input, context));

--- a/protocol_tests/aws-json/tests/functional/awsjson1_1.spec.ts
+++ b/protocol_tests/aws-json/tests/functional/awsjson1_1.spec.ts
@@ -187,8 +187,8 @@ it("includes_x_amz_target_and_content_type:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.EmptyOperation");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.EmptyOperation");
   }
 });
 
@@ -824,8 +824,8 @@ it("AwsJson11SerializeStringUnionValue:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.JsonUnions");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.JsonUnions");
 
     expect(r.body).toBeDefined();
     const bodyString = `{
@@ -867,8 +867,8 @@ it("AwsJson11SerializeBooleanUnionValue:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.JsonUnions");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.JsonUnions");
 
     expect(r.body).toBeDefined();
     const bodyString = `{
@@ -910,8 +910,8 @@ it("AwsJson11SerializeNumberUnionValue:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.JsonUnions");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.JsonUnions");
 
     expect(r.body).toBeDefined();
     const bodyString = `{
@@ -953,8 +953,8 @@ it("AwsJson11SerializeBlobUnionValue:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.JsonUnions");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.JsonUnions");
 
     expect(r.body).toBeDefined();
     const bodyString = `{
@@ -996,8 +996,8 @@ it("AwsJson11SerializeTimestampUnionValue:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.JsonUnions");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.JsonUnions");
 
     expect(r.body).toBeDefined();
     const bodyString = `{
@@ -1039,8 +1039,8 @@ it("AwsJson11SerializeEnumUnionValue:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.JsonUnions");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.JsonUnions");
 
     expect(r.body).toBeDefined();
     const bodyString = `{
@@ -1082,8 +1082,8 @@ it("AwsJson11SerializeListUnionValue:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.JsonUnions");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.JsonUnions");
 
     expect(r.body).toBeDefined();
     const bodyString = `{
@@ -1129,8 +1129,8 @@ it("AwsJson11SerializeMapUnionValue:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.JsonUnions");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.JsonUnions");
 
     expect(r.body).toBeDefined();
     const bodyString = `{
@@ -1177,8 +1177,8 @@ it("AwsJson11SerializeStructureUnionValue:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.JsonUnions");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.JsonUnions");
 
     expect(r.body).toBeDefined();
     const bodyString = `{
@@ -3887,8 +3887,8 @@ it("can_call_operation_with_no_input_or_output:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.OperationWithOptionalInputOutput");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.OperationWithOptionalInputOutput");
 
     expect(r.body).toBeDefined();
     const bodyString = `{}`;
@@ -3924,8 +3924,8 @@ it("can_call_operation_with_optional_input:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/x-amz-json-1.1");
-    expect(r.headers["X-Amz-Target"]).toBeDefined();
-    expect(r.headers["X-Amz-Target"]).toBe("JsonProtocol.OperationWithOptionalInputOutput");
+    expect(r.headers["x-amz-target"]).toBeDefined();
+    expect(r.headers["x-amz-target"]).toBe("JsonProtocol.OperationWithOptionalInputOutput");
 
     expect(r.body).toBeDefined();
     const bodyString = `{\"Value\":\"Hi\"}`;

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -371,10 +371,13 @@ export const serializeAws_restJson1HttpPrefixHeadersCommand = async (
   const headers: any = {
     ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
     ...(input.fooMap !== undefined &&
-      Object.keys(input.fooMap).reduce((acc: any, suffix: string) => {
-        acc["x-foo-" + suffix] = input.fooMap![suffix];
-        return acc;
-      }, {})),
+      Object.keys(input.fooMap).reduce(
+        (acc: any, suffix: string) => ({
+          ...acc,
+          [`x-foo-${suffix.toLowerCase()}`]: input.fooMap![suffix],
+        }),
+        {}
+      )),
   };
   let resolvedPath = "/HttpPrefixHeaders";
   let body: any;

--- a/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
+++ b/protocol_tests/aws-restjson/protocols/Aws_restJson1.ts
@@ -292,7 +292,7 @@ export const serializeAws_restJson1HttpPayloadTraitsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/octet-stream",
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
   };
   let resolvedPath = "/HttpPayloadTraits";
   let body: any;
@@ -317,7 +317,7 @@ export const serializeAws_restJson1HttpPayloadTraitsWithMediaTypeCommand = async
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "text/plain",
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
   };
   let resolvedPath = "/HttpPayloadTraitsWithMediaType";
   let body: any;
@@ -369,10 +369,10 @@ export const serializeAws_restJson1HttpPrefixHeadersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
     ...(input.fooMap !== undefined &&
       Object.keys(input.fooMap).reduce((acc: any, suffix: string) => {
-        acc["X-Foo-" + suffix] = input.fooMap![suffix];
+        acc["x-foo-" + suffix] = input.fooMap![suffix];
         return acc;
       }, {})),
   };
@@ -727,39 +727,39 @@ export const serializeAws_restJson1InputAndOutputWithHeadersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.headerString) && { "X-String": input.headerString! }),
-    ...(isSerializableHeaderValue(input.headerByte) && { "X-Byte": input.headerByte!.toString() }),
-    ...(isSerializableHeaderValue(input.headerShort) && { "X-Short": input.headerShort!.toString() }),
-    ...(isSerializableHeaderValue(input.headerInteger) && { "X-Integer": input.headerInteger!.toString() }),
-    ...(isSerializableHeaderValue(input.headerLong) && { "X-Long": input.headerLong!.toString() }),
+    ...(isSerializableHeaderValue(input.headerString) && { "x-string": input.headerString! }),
+    ...(isSerializableHeaderValue(input.headerByte) && { "x-byte": input.headerByte!.toString() }),
+    ...(isSerializableHeaderValue(input.headerShort) && { "x-short": input.headerShort!.toString() }),
+    ...(isSerializableHeaderValue(input.headerInteger) && { "x-integer": input.headerInteger!.toString() }),
+    ...(isSerializableHeaderValue(input.headerLong) && { "x-long": input.headerLong!.toString() }),
     ...(isSerializableHeaderValue(input.headerFloat) && {
-      "X-Float": input.headerFloat! % 1 == 0 ? input.headerFloat! + ".0" : input.headerFloat!.toString(),
+      "x-float": input.headerFloat! % 1 == 0 ? input.headerFloat! + ".0" : input.headerFloat!.toString(),
     }),
     ...(isSerializableHeaderValue(input.headerDouble) && {
-      "X-Double": input.headerDouble! % 1 == 0 ? input.headerDouble! + ".0" : input.headerDouble!.toString(),
+      "x-double": input.headerDouble! % 1 == 0 ? input.headerDouble! + ".0" : input.headerDouble!.toString(),
     }),
-    ...(isSerializableHeaderValue(input.headerTrueBool) && { "X-Boolean1": input.headerTrueBool!.toString() }),
-    ...(isSerializableHeaderValue(input.headerFalseBool) && { "X-Boolean2": input.headerFalseBool!.toString() }),
+    ...(isSerializableHeaderValue(input.headerTrueBool) && { "x-boolean1": input.headerTrueBool!.toString() }),
+    ...(isSerializableHeaderValue(input.headerFalseBool) && { "x-boolean2": input.headerFalseBool!.toString() }),
     ...(isSerializableHeaderValue(input.headerStringList) && {
-      "X-StringList": (input.headerStringList! || []).map((_entry) => _entry).join(", "),
+      "x-stringlist": (input.headerStringList! || []).map((_entry) => _entry).join(", "),
     }),
     ...(isSerializableHeaderValue(input.headerStringSet) && {
-      "X-StringSet": (Array.from(input.headerStringSet!.values()) || []).map((_entry) => _entry).join(", "),
+      "x-stringset": (Array.from(input.headerStringSet!.values()) || []).map((_entry) => _entry).join(", "),
     }),
     ...(isSerializableHeaderValue(input.headerIntegerList) && {
-      "X-IntegerList": (input.headerIntegerList! || []).map((_entry) => _entry.toString()).join(", "),
+      "x-integerlist": (input.headerIntegerList! || []).map((_entry) => _entry.toString()).join(", "),
     }),
     ...(isSerializableHeaderValue(input.headerBooleanList) && {
-      "X-BooleanList": (input.headerBooleanList! || []).map((_entry) => _entry.toString()).join(", "),
+      "x-booleanlist": (input.headerBooleanList! || []).map((_entry) => _entry.toString()).join(", "),
     }),
     ...(isSerializableHeaderValue(input.headerTimestampList) && {
-      "X-TimestampList": (input.headerTimestampList! || [])
+      "x-timestamplist": (input.headerTimestampList! || [])
         .map((_entry) => __dateToUtcString(_entry).toString())
         .join(", "),
     }),
-    ...(isSerializableHeaderValue(input.headerEnum) && { "X-Enum": input.headerEnum! }),
+    ...(isSerializableHeaderValue(input.headerEnum) && { "x-enum": input.headerEnum! }),
     ...(isSerializableHeaderValue(input.headerEnumList) && {
-      "X-EnumList": (input.headerEnumList! || []).map((_entry) => _entry).join(", "),
+      "x-enumlist": (input.headerEnumList! || []).map((_entry) => _entry).join(", "),
     }),
   };
   let resolvedPath = "/InputAndOutputWithHeaders";
@@ -996,7 +996,7 @@ export const serializeAws_restJson1MediaTypeHeaderCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     ...(isSerializableHeaderValue(input.json) && {
-      "X-Json": Buffer.from(__LazyJsonString.fromObject(input.json!)).toString("base64"),
+      "x-json": Buffer.from(__LazyJsonString.fromObject(input.json!)).toString("base64"),
     }),
   };
   let resolvedPath = "/MediaTypeHeader";
@@ -1058,9 +1058,9 @@ export const serializeAws_restJson1NullAndEmptyHeadersClientCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.a) && { "X-A": input.a! }),
-    ...(isSerializableHeaderValue(input.b) && { "X-B": input.b! }),
-    ...(isSerializableHeaderValue(input.c) && { "X-C": (input.c! || []).map((_entry) => _entry).join(", ") }),
+    ...(isSerializableHeaderValue(input.a) && { "x-a": input.a! }),
+    ...(isSerializableHeaderValue(input.b) && { "x-b": input.b! }),
+    ...(isSerializableHeaderValue(input.c) && { "x-c": (input.c! || []).map((_entry) => _entry).join(", ") }),
   };
   let resolvedPath = "/NullAndEmptyHeadersClient";
   let body: any;
@@ -1081,9 +1081,9 @@ export const serializeAws_restJson1NullAndEmptyHeadersServerCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.a) && { "X-A": input.a! }),
-    ...(isSerializableHeaderValue(input.b) && { "X-B": input.b! }),
-    ...(isSerializableHeaderValue(input.c) && { "X-C": (input.c! || []).map((_entry) => _entry).join(", ") }),
+    ...(isSerializableHeaderValue(input.a) && { "x-a": input.a! }),
+    ...(isSerializableHeaderValue(input.b) && { "x-b": input.b! }),
+    ...(isSerializableHeaderValue(input.c) && { "x-c": (input.c! || []).map((_entry) => _entry).join(", ") }),
   };
   let resolvedPath = "/NullAndEmptyHeadersServer";
   let body: any;
@@ -1179,7 +1179,7 @@ export const serializeAws_restJson1SimpleScalarPropertiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/json",
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
   };
   let resolvedPath = "/SimpleScalarProperties";
   let body: any;
@@ -1214,7 +1214,7 @@ export const serializeAws_restJson1StreamingTraitsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/octet-stream",
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
   };
   let resolvedPath = "/StreamingTraits";
   let body: any;
@@ -1239,7 +1239,7 @@ export const serializeAws_restJson1StreamingTraitsRequireLengthCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/octet-stream",
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
   };
   let resolvedPath = "/StreamingTraitsRequireLength";
   let body: any;
@@ -1264,7 +1264,7 @@ export const serializeAws_restJson1StreamingTraitsWithMediaTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "text/plain",
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
   };
   let resolvedPath = "/StreamingTraitsWithMediaType";
   let body: any;
@@ -1289,25 +1289,25 @@ export const serializeAws_restJson1TimestampFormatHeadersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     ...(isSerializableHeaderValue(input.memberEpochSeconds) && {
-      "X-memberEpochSeconds": Math.round(input.memberEpochSeconds!.getTime() / 1000).toString(),
+      "x-memberepochseconds": Math.round(input.memberEpochSeconds!.getTime() / 1000).toString(),
     }),
     ...(isSerializableHeaderValue(input.memberHttpDate) && {
-      "X-memberHttpDate": __dateToUtcString(input.memberHttpDate!).toString(),
+      "x-memberhttpdate": __dateToUtcString(input.memberHttpDate!).toString(),
     }),
     ...(isSerializableHeaderValue(input.memberDateTime) && {
-      "X-memberDateTime": (input.memberDateTime!.toISOString().split(".")[0] + "Z").toString(),
+      "x-memberdatetime": (input.memberDateTime!.toISOString().split(".")[0] + "Z").toString(),
     }),
     ...(isSerializableHeaderValue(input.defaultFormat) && {
-      "X-defaultFormat": __dateToUtcString(input.defaultFormat!).toString(),
+      "x-defaultformat": __dateToUtcString(input.defaultFormat!).toString(),
     }),
     ...(isSerializableHeaderValue(input.targetEpochSeconds) && {
-      "X-targetEpochSeconds": Math.round(input.targetEpochSeconds!.getTime() / 1000).toString(),
+      "x-targetepochseconds": Math.round(input.targetEpochSeconds!.getTime() / 1000).toString(),
     }),
     ...(isSerializableHeaderValue(input.targetHttpDate) && {
-      "X-targetHttpDate": __dateToUtcString(input.targetHttpDate!).toString(),
+      "x-targethttpdate": __dateToUtcString(input.targetHttpDate!).toString(),
     }),
     ...(isSerializableHeaderValue(input.targetDateTime) && {
-      "X-targetDateTime": (input.targetDateTime!.toISOString().split(".")[0] + "Z").toString(),
+      "x-targetdatetime": (input.targetDateTime!.toISOString().split(".")[0] + "Z").toString(),
     }),
   };
   let resolvedPath = "/TimestampFormatHeaders";

--- a/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
+++ b/protocol_tests/aws-restjson/tests/functional/restjson1.spec.ts
@@ -952,8 +952,8 @@ it("RestJsonHttpPayloadTraitsWithBlob:Request", async () => {
     expect(r.path).toBe("/HttpPayloadTraits");
     expect(r.headers["content-length"]).toBeDefined();
 
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
@@ -985,8 +985,8 @@ it("RestJsonHttpPayloadTraitsWithNoBlobBody:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/HttpPayloadTraits");
 
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeFalsy();
   }
@@ -1100,8 +1100,8 @@ it("RestJsonHttpPayloadTraitsWithMediaTypeWithBlob:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("text/plain");
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
@@ -1268,12 +1268,12 @@ it("RestJsonHttpPrefixHeadersArePresent:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/HttpPrefixHeaders");
 
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
-    expect(r.headers["X-Foo-Abc"]).toBeDefined();
-    expect(r.headers["X-Foo-Abc"]).toBe("Abc value");
-    expect(r.headers["X-Foo-Def"]).toBeDefined();
-    expect(r.headers["X-Foo-Def"]).toBe("Def value");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
+    expect(r.headers["x-foo-abc"]).toBeDefined();
+    expect(r.headers["x-foo-abc"]).toBe("Abc value");
+    expect(r.headers["x-foo-def"]).toBeDefined();
+    expect(r.headers["x-foo-def"]).toBe("Def value");
 
     expect(r.body).toBeFalsy();
   }
@@ -1306,8 +1306,8 @@ it("RestJsonHttpPrefixHeadersAreNotPresent:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/HttpPrefixHeaders");
 
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeFalsy();
   }
@@ -1787,12 +1787,12 @@ it("RestJsonInputAndOutputWithStringHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/InputAndOutputWithHeaders");
 
-    expect(r.headers["X-String"]).toBeDefined();
-    expect(r.headers["X-String"]).toBe("Hello");
-    expect(r.headers["X-StringList"]).toBeDefined();
-    expect(r.headers["X-StringList"]).toBe("a, b, c");
-    expect(r.headers["X-StringSet"]).toBeDefined();
-    expect(r.headers["X-StringSet"]).toBe("a, b, c");
+    expect(r.headers["x-string"]).toBeDefined();
+    expect(r.headers["x-string"]).toBe("Hello");
+    expect(r.headers["x-stringlist"]).toBeDefined();
+    expect(r.headers["x-stringlist"]).toBe("a, b, c");
+    expect(r.headers["x-stringset"]).toBeDefined();
+    expect(r.headers["x-stringset"]).toBe("a, b, c");
 
     expect(r.body).toBeFalsy();
   }
@@ -1835,20 +1835,20 @@ it("RestJsonInputAndOutputWithNumericHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/InputAndOutputWithHeaders");
 
-    expect(r.headers["X-Byte"]).toBeDefined();
-    expect(r.headers["X-Byte"]).toBe("1");
-    expect(r.headers["X-Double"]).toBeDefined();
-    expect(r.headers["X-Double"]).toBe("1.1");
-    expect(r.headers["X-Float"]).toBeDefined();
-    expect(r.headers["X-Float"]).toBe("1.1");
-    expect(r.headers["X-Integer"]).toBeDefined();
-    expect(r.headers["X-Integer"]).toBe("123");
-    expect(r.headers["X-IntegerList"]).toBeDefined();
-    expect(r.headers["X-IntegerList"]).toBe("1, 2, 3");
-    expect(r.headers["X-Long"]).toBeDefined();
-    expect(r.headers["X-Long"]).toBe("123");
-    expect(r.headers["X-Short"]).toBeDefined();
-    expect(r.headers["X-Short"]).toBe("123");
+    expect(r.headers["x-byte"]).toBeDefined();
+    expect(r.headers["x-byte"]).toBe("1");
+    expect(r.headers["x-double"]).toBeDefined();
+    expect(r.headers["x-double"]).toBe("1.1");
+    expect(r.headers["x-float"]).toBeDefined();
+    expect(r.headers["x-float"]).toBe("1.1");
+    expect(r.headers["x-integer"]).toBeDefined();
+    expect(r.headers["x-integer"]).toBe("123");
+    expect(r.headers["x-integerlist"]).toBeDefined();
+    expect(r.headers["x-integerlist"]).toBe("1, 2, 3");
+    expect(r.headers["x-long"]).toBeDefined();
+    expect(r.headers["x-long"]).toBe("123");
+    expect(r.headers["x-short"]).toBeDefined();
+    expect(r.headers["x-short"]).toBe("123");
 
     expect(r.body).toBeFalsy();
   }
@@ -1883,12 +1883,12 @@ it("RestJsonInputAndOutputWithBooleanHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/InputAndOutputWithHeaders");
 
-    expect(r.headers["X-Boolean1"]).toBeDefined();
-    expect(r.headers["X-Boolean1"]).toBe("true");
-    expect(r.headers["X-Boolean2"]).toBeDefined();
-    expect(r.headers["X-Boolean2"]).toBe("false");
-    expect(r.headers["X-BooleanList"]).toBeDefined();
-    expect(r.headers["X-BooleanList"]).toBe("true, false, true");
+    expect(r.headers["x-boolean1"]).toBeDefined();
+    expect(r.headers["x-boolean1"]).toBe("true");
+    expect(r.headers["x-boolean2"]).toBeDefined();
+    expect(r.headers["x-boolean2"]).toBe("false");
+    expect(r.headers["x-booleanlist"]).toBeDefined();
+    expect(r.headers["x-booleanlist"]).toBe("true, false, true");
 
     expect(r.body).toBeFalsy();
   }
@@ -1919,8 +1919,8 @@ it("RestJsonInputAndOutputWithTimestampHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/InputAndOutputWithHeaders");
 
-    expect(r.headers["X-TimestampList"]).toBeDefined();
-    expect(r.headers["X-TimestampList"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT");
+    expect(r.headers["x-timestamplist"]).toBeDefined();
+    expect(r.headers["x-timestamplist"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT");
 
     expect(r.body).toBeFalsy();
   }
@@ -1953,10 +1953,10 @@ it("RestJsonInputAndOutputWithEnumHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/InputAndOutputWithHeaders");
 
-    expect(r.headers["X-Enum"]).toBeDefined();
-    expect(r.headers["X-Enum"]).toBe("Foo");
-    expect(r.headers["X-EnumList"]).toBeDefined();
-    expect(r.headers["X-EnumList"]).toBe("Foo, Bar, Baz");
+    expect(r.headers["x-enum"]).toBeDefined();
+    expect(r.headers["x-enum"]).toBe("Foo");
+    expect(r.headers["x-enumlist"]).toBeDefined();
+    expect(r.headers["x-enumlist"]).toBe("Foo, Bar, Baz");
 
     expect(r.body).toBeFalsy();
   }
@@ -2017,8 +2017,8 @@ it("RestJsonInputAndOutputWithNumericHeaders:Response", async () => {
       200,
       {
         "x-float": "1.1",
-        "x-byte": "1",
         "x-long": "123",
+        "x-byte": "1",
         "x-integer": "123",
         "x-integerlist": "1, 2, 3",
         "x-double": "1.1",
@@ -4295,8 +4295,8 @@ it("MediaTypeHeaderInputBase64:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/MediaTypeHeader");
 
-    expect(r.headers["X-Json"]).toBeDefined();
-    expect(r.headers["X-Json"]).toBe("dHJ1ZQ==");
+    expect(r.headers["x-json"]).toBeDefined();
+    expect(r.headers["x-json"]).toBe("dHJ1ZQ==");
 
     expect(r.body).toBeFalsy();
   }
@@ -4463,9 +4463,9 @@ it("RestJsonNullAndEmptyHeaders:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/NullAndEmptyHeadersClient");
 
-    expect(r.headers["X-A"]).toBeUndefined();
-    expect(r.headers["X-B"]).toBeUndefined();
-    expect(r.headers["X-C"]).toBeUndefined();
+    expect(r.headers["x-a"]).toBeUndefined();
+    expect(r.headers["x-b"]).toBeUndefined();
+    expect(r.headers["x-c"]).toBeUndefined();
 
     expect(r.body).toBeFalsy();
   }
@@ -4741,8 +4741,8 @@ it("RestJsonSimpleScalarProperties:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/json");
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     const bodyString = `{
@@ -4921,8 +4921,8 @@ it("RestJsonStreamingTraitsWithBlob:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/octet-stream");
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
@@ -4954,8 +4954,8 @@ it("RestJsonStreamingTraitsWithNoBlobBody:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/StreamingTraits");
 
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeFalsy();
   }
@@ -5080,8 +5080,8 @@ it("RestJsonStreamingTraitsRequireLengthWithBlob:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/octet-stream");
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
@@ -5113,8 +5113,8 @@ it("RestJsonStreamingTraitsRequireLengthWithNoBlobBody:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/StreamingTraitsRequireLength");
 
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeFalsy();
   }
@@ -5238,8 +5238,8 @@ it("RestJsonStreamingTraitsWithMediaTypeWithBlob:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("text/plain");
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
@@ -5329,20 +5329,20 @@ it("RestJsonTimestampFormatHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/TimestampFormatHeaders");
 
-    expect(r.headers["X-defaultFormat"]).toBeDefined();
-    expect(r.headers["X-defaultFormat"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
-    expect(r.headers["X-memberDateTime"]).toBeDefined();
-    expect(r.headers["X-memberDateTime"]).toBe("2019-12-16T23:48:18Z");
-    expect(r.headers["X-memberEpochSeconds"]).toBeDefined();
-    expect(r.headers["X-memberEpochSeconds"]).toBe("1576540098");
-    expect(r.headers["X-memberHttpDate"]).toBeDefined();
-    expect(r.headers["X-memberHttpDate"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
-    expect(r.headers["X-targetDateTime"]).toBeDefined();
-    expect(r.headers["X-targetDateTime"]).toBe("2019-12-16T23:48:18Z");
-    expect(r.headers["X-targetEpochSeconds"]).toBeDefined();
-    expect(r.headers["X-targetEpochSeconds"]).toBe("1576540098");
-    expect(r.headers["X-targetHttpDate"]).toBeDefined();
-    expect(r.headers["X-targetHttpDate"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
+    expect(r.headers["x-defaultformat"]).toBeDefined();
+    expect(r.headers["x-defaultformat"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
+    expect(r.headers["x-memberdatetime"]).toBeDefined();
+    expect(r.headers["x-memberdatetime"]).toBe("2019-12-16T23:48:18Z");
+    expect(r.headers["x-memberepochseconds"]).toBeDefined();
+    expect(r.headers["x-memberepochseconds"]).toBe("1576540098");
+    expect(r.headers["x-memberhttpdate"]).toBeDefined();
+    expect(r.headers["x-memberhttpdate"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
+    expect(r.headers["x-targetdatetime"]).toBeDefined();
+    expect(r.headers["x-targetdatetime"]).toBe("2019-12-16T23:48:18Z");
+    expect(r.headers["x-targetepochseconds"]).toBeDefined();
+    expect(r.headers["x-targetepochseconds"]).toBe("1576540098");
+    expect(r.headers["x-targethttpdate"]).toBeDefined();
+    expect(r.headers["x-targethttpdate"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
 
     expect(r.body).toBeFalsy();
   }
@@ -5360,8 +5360,8 @@ it("RestJsonTimestampFormatHeaders:Response", async () => {
       {
         "x-targetepochseconds": "1576540098",
         "x-memberdatetime": "2019-12-16T23:48:18Z",
-        "x-defaultformat": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-memberepochseconds": "1576540098",
+        "x-defaultformat": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-targethttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-memberhttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-targetdatetime": "2019-12-16T23:48:18Z",

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -556,10 +556,13 @@ export const serializeAws_restXmlHttpPrefixHeadersCommand = async (
   const headers: any = {
     ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
     ...(input.fooMap !== undefined &&
-      Object.keys(input.fooMap).reduce((acc: any, suffix: string) => {
-        acc["x-foo-" + suffix] = input.fooMap![suffix];
-        return acc;
-      }, {})),
+      Object.keys(input.fooMap).reduce(
+        (acc: any, suffix: string) => ({
+          ...acc,
+          [`x-foo-${suffix.toLowerCase()}`]: input.fooMap![suffix],
+        }),
+        {}
+      )),
   };
   let resolvedPath = "/HttpPrefixHeaders";
   let body: any;

--- a/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
+++ b/protocol_tests/aws-restxml/protocols/Aws_restXml.ts
@@ -391,7 +391,7 @@ export const serializeAws_restXmlHttpPayloadTraitsCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/octet-stream",
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
   };
   let resolvedPath = "/HttpPayloadTraits";
   let body: any;
@@ -418,7 +418,7 @@ export const serializeAws_restXmlHttpPayloadTraitsWithMediaTypeCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "text/plain",
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
   };
   let resolvedPath = "/HttpPayloadTraitsWithMediaType";
   let body: any;
@@ -554,10 +554,10 @@ export const serializeAws_restXmlHttpPrefixHeadersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
     ...(input.fooMap !== undefined &&
       Object.keys(input.fooMap).reduce((acc: any, suffix: string) => {
-        acc["X-Foo-" + suffix] = input.fooMap![suffix];
+        acc["x-foo-" + suffix] = input.fooMap![suffix];
         return acc;
       }, {})),
   };
@@ -837,39 +837,39 @@ export const serializeAws_restXmlInputAndOutputWithHeadersCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.headerString) && { "X-String": input.headerString! }),
-    ...(isSerializableHeaderValue(input.headerByte) && { "X-Byte": input.headerByte!.toString() }),
-    ...(isSerializableHeaderValue(input.headerShort) && { "X-Short": input.headerShort!.toString() }),
-    ...(isSerializableHeaderValue(input.headerInteger) && { "X-Integer": input.headerInteger!.toString() }),
-    ...(isSerializableHeaderValue(input.headerLong) && { "X-Long": input.headerLong!.toString() }),
+    ...(isSerializableHeaderValue(input.headerString) && { "x-string": input.headerString! }),
+    ...(isSerializableHeaderValue(input.headerByte) && { "x-byte": input.headerByte!.toString() }),
+    ...(isSerializableHeaderValue(input.headerShort) && { "x-short": input.headerShort!.toString() }),
+    ...(isSerializableHeaderValue(input.headerInteger) && { "x-integer": input.headerInteger!.toString() }),
+    ...(isSerializableHeaderValue(input.headerLong) && { "x-long": input.headerLong!.toString() }),
     ...(isSerializableHeaderValue(input.headerFloat) && {
-      "X-Float": input.headerFloat! % 1 == 0 ? input.headerFloat! + ".0" : input.headerFloat!.toString(),
+      "x-float": input.headerFloat! % 1 == 0 ? input.headerFloat! + ".0" : input.headerFloat!.toString(),
     }),
     ...(isSerializableHeaderValue(input.headerDouble) && {
-      "X-Double": input.headerDouble! % 1 == 0 ? input.headerDouble! + ".0" : input.headerDouble!.toString(),
+      "x-double": input.headerDouble! % 1 == 0 ? input.headerDouble! + ".0" : input.headerDouble!.toString(),
     }),
-    ...(isSerializableHeaderValue(input.headerTrueBool) && { "X-Boolean1": input.headerTrueBool!.toString() }),
-    ...(isSerializableHeaderValue(input.headerFalseBool) && { "X-Boolean2": input.headerFalseBool!.toString() }),
+    ...(isSerializableHeaderValue(input.headerTrueBool) && { "x-boolean1": input.headerTrueBool!.toString() }),
+    ...(isSerializableHeaderValue(input.headerFalseBool) && { "x-boolean2": input.headerFalseBool!.toString() }),
     ...(isSerializableHeaderValue(input.headerStringList) && {
-      "X-StringList": (input.headerStringList! || []).map((_entry) => _entry).join(", "),
+      "x-stringlist": (input.headerStringList! || []).map((_entry) => _entry).join(", "),
     }),
     ...(isSerializableHeaderValue(input.headerStringSet) && {
-      "X-StringSet": (Array.from(input.headerStringSet!.values()) || []).map((_entry) => _entry).join(", "),
+      "x-stringset": (Array.from(input.headerStringSet!.values()) || []).map((_entry) => _entry).join(", "),
     }),
     ...(isSerializableHeaderValue(input.headerIntegerList) && {
-      "X-IntegerList": (input.headerIntegerList! || []).map((_entry) => _entry.toString()).join(", "),
+      "x-integerlist": (input.headerIntegerList! || []).map((_entry) => _entry.toString()).join(", "),
     }),
     ...(isSerializableHeaderValue(input.headerBooleanList) && {
-      "X-BooleanList": (input.headerBooleanList! || []).map((_entry) => _entry.toString()).join(", "),
+      "x-booleanlist": (input.headerBooleanList! || []).map((_entry) => _entry.toString()).join(", "),
     }),
     ...(isSerializableHeaderValue(input.headerTimestampList) && {
-      "X-TimestampList": (input.headerTimestampList! || [])
+      "x-timestamplist": (input.headerTimestampList! || [])
         .map((_entry) => __dateToUtcString(_entry).toString())
         .join(", "),
     }),
-    ...(isSerializableHeaderValue(input.headerEnum) && { "X-Enum": input.headerEnum! }),
+    ...(isSerializableHeaderValue(input.headerEnum) && { "x-enum": input.headerEnum! }),
     ...(isSerializableHeaderValue(input.headerEnumList) && {
-      "X-EnumList": (input.headerEnumList! || []).map((_entry) => _entry).join(", "),
+      "x-enumlist": (input.headerEnumList! || []).map((_entry) => _entry).join(", "),
     }),
   };
   let resolvedPath = "/InputAndOutputWithHeaders";
@@ -931,9 +931,9 @@ export const serializeAws_restXmlNullAndEmptyHeadersClientCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.a) && { "X-A": input.a! }),
-    ...(isSerializableHeaderValue(input.b) && { "X-B": input.b! }),
-    ...(isSerializableHeaderValue(input.c) && { "X-C": (input.c! || []).map((_entry) => _entry).join(", ") }),
+    ...(isSerializableHeaderValue(input.a) && { "x-a": input.a! }),
+    ...(isSerializableHeaderValue(input.b) && { "x-b": input.b! }),
+    ...(isSerializableHeaderValue(input.c) && { "x-c": (input.c! || []).map((_entry) => _entry).join(", ") }),
   };
   let resolvedPath = "/NullAndEmptyHeadersClient";
   let body: any;
@@ -954,9 +954,9 @@ export const serializeAws_restXmlNullAndEmptyHeadersServerCommand = async (
   context: __SerdeContext
 ): Promise<__HttpRequest> => {
   const headers: any = {
-    ...(isSerializableHeaderValue(input.a) && { "X-A": input.a! }),
-    ...(isSerializableHeaderValue(input.b) && { "X-B": input.b! }),
-    ...(isSerializableHeaderValue(input.c) && { "X-C": (input.c! || []).map((_entry) => _entry).join(", ") }),
+    ...(isSerializableHeaderValue(input.a) && { "x-a": input.a! }),
+    ...(isSerializableHeaderValue(input.b) && { "x-b": input.b! }),
+    ...(isSerializableHeaderValue(input.c) && { "x-c": (input.c! || []).map((_entry) => _entry).join(", ") }),
   };
   let resolvedPath = "/NullAndEmptyHeadersServer";
   let body: any;
@@ -1053,7 +1053,7 @@ export const serializeAws_restXmlSimpleScalarPropertiesCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     "content-type": "application/xml",
-    ...(isSerializableHeaderValue(input.foo) && { "X-Foo": input.foo! }),
+    ...(isSerializableHeaderValue(input.foo) && { "x-foo": input.foo! }),
   };
   let resolvedPath = "/SimpleScalarProperties";
   let body: any;
@@ -1122,25 +1122,25 @@ export const serializeAws_restXmlTimestampFormatHeadersCommand = async (
 ): Promise<__HttpRequest> => {
   const headers: any = {
     ...(isSerializableHeaderValue(input.memberEpochSeconds) && {
-      "X-memberEpochSeconds": Math.round(input.memberEpochSeconds!.getTime() / 1000).toString(),
+      "x-memberepochseconds": Math.round(input.memberEpochSeconds!.getTime() / 1000).toString(),
     }),
     ...(isSerializableHeaderValue(input.memberHttpDate) && {
-      "X-memberHttpDate": __dateToUtcString(input.memberHttpDate!).toString(),
+      "x-memberhttpdate": __dateToUtcString(input.memberHttpDate!).toString(),
     }),
     ...(isSerializableHeaderValue(input.memberDateTime) && {
-      "X-memberDateTime": (input.memberDateTime!.toISOString().split(".")[0] + "Z").toString(),
+      "x-memberdatetime": (input.memberDateTime!.toISOString().split(".")[0] + "Z").toString(),
     }),
     ...(isSerializableHeaderValue(input.defaultFormat) && {
-      "X-defaultFormat": __dateToUtcString(input.defaultFormat!).toString(),
+      "x-defaultformat": __dateToUtcString(input.defaultFormat!).toString(),
     }),
     ...(isSerializableHeaderValue(input.targetEpochSeconds) && {
-      "X-targetEpochSeconds": Math.round(input.targetEpochSeconds!.getTime() / 1000).toString(),
+      "x-targetepochseconds": Math.round(input.targetEpochSeconds!.getTime() / 1000).toString(),
     }),
     ...(isSerializableHeaderValue(input.targetHttpDate) && {
-      "X-targetHttpDate": __dateToUtcString(input.targetHttpDate!).toString(),
+      "x-targethttpdate": __dateToUtcString(input.targetHttpDate!).toString(),
     }),
     ...(isSerializableHeaderValue(input.targetDateTime) && {
-      "X-targetDateTime": (input.targetDateTime!.toISOString().split(".")[0] + "Z").toString(),
+      "x-targetdatetime": (input.targetDateTime!.toISOString().split(".")[0] + "Z").toString(),
     }),
   };
   let resolvedPath = "/TimestampFormatHeaders";

--- a/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
+++ b/protocol_tests/aws-restxml/tests/functional/restxml.spec.ts
@@ -851,8 +851,8 @@ it("HttpPayloadTraitsWithBlob:Request", async () => {
     expect(r.path).toBe("/HttpPayloadTraits");
     expect(r.headers["content-length"]).toBeDefined();
 
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
@@ -884,8 +884,8 @@ it("HttpPayloadTraitsWithNoBlobBody:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/HttpPayloadTraits");
 
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeFalsy();
   }
@@ -999,8 +999,8 @@ it("HttpPayloadTraitsWithMediaTypeWithBlob:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("text/plain");
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     expect(r.body).toMatchObject(Uint8Array.from("blobby blob blob", (c) => c.charCodeAt(0)));
@@ -1411,12 +1411,12 @@ it("HttpPrefixHeadersArePresent:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/HttpPrefixHeaders");
 
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
-    expect(r.headers["X-Foo-Abc"]).toBeDefined();
-    expect(r.headers["X-Foo-Abc"]).toBe("Abc value");
-    expect(r.headers["X-Foo-Def"]).toBeDefined();
-    expect(r.headers["X-Foo-Def"]).toBe("Def value");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
+    expect(r.headers["x-foo-abc"]).toBeDefined();
+    expect(r.headers["x-foo-abc"]).toBe("Abc value");
+    expect(r.headers["x-foo-def"]).toBeDefined();
+    expect(r.headers["x-foo-def"]).toBe("Def value");
 
     expect(r.body).toBeFalsy();
   }
@@ -1449,8 +1449,8 @@ it("HttpPrefixHeadersAreNotPresent:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/HttpPrefixHeaders");
 
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeFalsy();
   }
@@ -1764,12 +1764,12 @@ it("InputAndOutputWithStringHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/InputAndOutputWithHeaders");
 
-    expect(r.headers["X-String"]).toBeDefined();
-    expect(r.headers["X-String"]).toBe("Hello");
-    expect(r.headers["X-StringList"]).toBeDefined();
-    expect(r.headers["X-StringList"]).toBe("a, b, c");
-    expect(r.headers["X-StringSet"]).toBeDefined();
-    expect(r.headers["X-StringSet"]).toBe("a, b, c");
+    expect(r.headers["x-string"]).toBeDefined();
+    expect(r.headers["x-string"]).toBe("Hello");
+    expect(r.headers["x-stringlist"]).toBeDefined();
+    expect(r.headers["x-stringlist"]).toBe("a, b, c");
+    expect(r.headers["x-stringset"]).toBeDefined();
+    expect(r.headers["x-stringset"]).toBe("a, b, c");
 
     expect(r.body).toBeFalsy();
   }
@@ -1812,20 +1812,20 @@ it("InputAndOutputWithNumericHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/InputAndOutputWithHeaders");
 
-    expect(r.headers["X-Byte"]).toBeDefined();
-    expect(r.headers["X-Byte"]).toBe("1");
-    expect(r.headers["X-Double"]).toBeDefined();
-    expect(r.headers["X-Double"]).toBe("1.1");
-    expect(r.headers["X-Float"]).toBeDefined();
-    expect(r.headers["X-Float"]).toBe("1.1");
-    expect(r.headers["X-Integer"]).toBeDefined();
-    expect(r.headers["X-Integer"]).toBe("123");
-    expect(r.headers["X-IntegerList"]).toBeDefined();
-    expect(r.headers["X-IntegerList"]).toBe("1, 2, 3");
-    expect(r.headers["X-Long"]).toBeDefined();
-    expect(r.headers["X-Long"]).toBe("123");
-    expect(r.headers["X-Short"]).toBeDefined();
-    expect(r.headers["X-Short"]).toBe("123");
+    expect(r.headers["x-byte"]).toBeDefined();
+    expect(r.headers["x-byte"]).toBe("1");
+    expect(r.headers["x-double"]).toBeDefined();
+    expect(r.headers["x-double"]).toBe("1.1");
+    expect(r.headers["x-float"]).toBeDefined();
+    expect(r.headers["x-float"]).toBe("1.1");
+    expect(r.headers["x-integer"]).toBeDefined();
+    expect(r.headers["x-integer"]).toBe("123");
+    expect(r.headers["x-integerlist"]).toBeDefined();
+    expect(r.headers["x-integerlist"]).toBe("1, 2, 3");
+    expect(r.headers["x-long"]).toBeDefined();
+    expect(r.headers["x-long"]).toBe("123");
+    expect(r.headers["x-short"]).toBeDefined();
+    expect(r.headers["x-short"]).toBe("123");
 
     expect(r.body).toBeFalsy();
   }
@@ -1860,12 +1860,12 @@ it("InputAndOutputWithBooleanHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/InputAndOutputWithHeaders");
 
-    expect(r.headers["X-Boolean1"]).toBeDefined();
-    expect(r.headers["X-Boolean1"]).toBe("true");
-    expect(r.headers["X-Boolean2"]).toBeDefined();
-    expect(r.headers["X-Boolean2"]).toBe("false");
-    expect(r.headers["X-BooleanList"]).toBeDefined();
-    expect(r.headers["X-BooleanList"]).toBe("true, false, true");
+    expect(r.headers["x-boolean1"]).toBeDefined();
+    expect(r.headers["x-boolean1"]).toBe("true");
+    expect(r.headers["x-boolean2"]).toBeDefined();
+    expect(r.headers["x-boolean2"]).toBe("false");
+    expect(r.headers["x-booleanlist"]).toBeDefined();
+    expect(r.headers["x-booleanlist"]).toBe("true, false, true");
 
     expect(r.body).toBeFalsy();
   }
@@ -1896,8 +1896,8 @@ it("InputAndOutputWithTimestampHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/InputAndOutputWithHeaders");
 
-    expect(r.headers["X-TimestampList"]).toBeDefined();
-    expect(r.headers["X-TimestampList"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT");
+    expect(r.headers["x-timestamplist"]).toBeDefined();
+    expect(r.headers["x-timestamplist"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT, Mon, 16 Dec 2019 23:48:18 GMT");
 
     expect(r.body).toBeFalsy();
   }
@@ -1930,10 +1930,10 @@ it("InputAndOutputWithEnumHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/InputAndOutputWithHeaders");
 
-    expect(r.headers["X-Enum"]).toBeDefined();
-    expect(r.headers["X-Enum"]).toBe("Foo");
-    expect(r.headers["X-EnumList"]).toBeDefined();
-    expect(r.headers["X-EnumList"]).toBe("Foo, Bar, Baz");
+    expect(r.headers["x-enum"]).toBeDefined();
+    expect(r.headers["x-enum"]).toBe("Foo");
+    expect(r.headers["x-enumlist"]).toBeDefined();
+    expect(r.headers["x-enumlist"]).toBe("Foo, Bar, Baz");
 
     expect(r.body).toBeFalsy();
   }
@@ -1994,8 +1994,8 @@ it("InputAndOutputWithNumericHeaders:Response", async () => {
       200,
       {
         "x-float": "1.1",
-        "x-byte": "1",
         "x-long": "123",
+        "x-byte": "1",
         "x-integer": "123",
         "x-integerlist": "1, 2, 3",
         "x-double": "1.1",
@@ -2289,9 +2289,9 @@ it("NullAndEmptyHeaders:Request", async () => {
     expect(r.method).toBe("GET");
     expect(r.path).toBe("/NullAndEmptyHeadersClient");
 
-    expect(r.headers["X-A"]).toBeUndefined();
-    expect(r.headers["X-B"]).toBeUndefined();
-    expect(r.headers["X-C"]).toBeUndefined();
+    expect(r.headers["x-a"]).toBeUndefined();
+    expect(r.headers["x-b"]).toBeUndefined();
+    expect(r.headers["x-c"]).toBeUndefined();
 
     expect(r.body).toBeFalsy();
   }
@@ -2569,8 +2569,8 @@ it("SimpleScalarProperties:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/xml");
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     const bodyString = `<SimpleScalarPropertiesInputOutput>
@@ -2619,8 +2619,8 @@ it("SimpleScalarPropertiesWithEscapedCharacter:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/xml");
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     const bodyString = `<SimpleScalarPropertiesInputOutput>
@@ -2661,8 +2661,8 @@ it("SimpleScalarPropertiesWithWhiteSpace:Request", async () => {
 
     expect(r.headers["content-type"]).toBeDefined();
     expect(r.headers["content-type"]).toBe("application/xml");
-    expect(r.headers["X-Foo"]).toBeDefined();
-    expect(r.headers["X-Foo"]).toBe("Foo");
+    expect(r.headers["x-foo"]).toBeDefined();
+    expect(r.headers["x-foo"]).toBe("Foo");
 
     expect(r.body).toBeDefined();
     const bodyString = `<SimpleScalarPropertiesInputOutput>
@@ -2915,20 +2915,20 @@ it("TimestampFormatHeaders:Request", async () => {
     expect(r.method).toBe("POST");
     expect(r.path).toBe("/TimestampFormatHeaders");
 
-    expect(r.headers["X-defaultFormat"]).toBeDefined();
-    expect(r.headers["X-defaultFormat"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
-    expect(r.headers["X-memberDateTime"]).toBeDefined();
-    expect(r.headers["X-memberDateTime"]).toBe("2019-12-16T23:48:18Z");
-    expect(r.headers["X-memberEpochSeconds"]).toBeDefined();
-    expect(r.headers["X-memberEpochSeconds"]).toBe("1576540098");
-    expect(r.headers["X-memberHttpDate"]).toBeDefined();
-    expect(r.headers["X-memberHttpDate"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
-    expect(r.headers["X-targetDateTime"]).toBeDefined();
-    expect(r.headers["X-targetDateTime"]).toBe("2019-12-16T23:48:18Z");
-    expect(r.headers["X-targetEpochSeconds"]).toBeDefined();
-    expect(r.headers["X-targetEpochSeconds"]).toBe("1576540098");
-    expect(r.headers["X-targetHttpDate"]).toBeDefined();
-    expect(r.headers["X-targetHttpDate"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
+    expect(r.headers["x-defaultformat"]).toBeDefined();
+    expect(r.headers["x-defaultformat"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
+    expect(r.headers["x-memberdatetime"]).toBeDefined();
+    expect(r.headers["x-memberdatetime"]).toBe("2019-12-16T23:48:18Z");
+    expect(r.headers["x-memberepochseconds"]).toBeDefined();
+    expect(r.headers["x-memberepochseconds"]).toBe("1576540098");
+    expect(r.headers["x-memberhttpdate"]).toBeDefined();
+    expect(r.headers["x-memberhttpdate"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
+    expect(r.headers["x-targetdatetime"]).toBeDefined();
+    expect(r.headers["x-targetdatetime"]).toBe("2019-12-16T23:48:18Z");
+    expect(r.headers["x-targetepochseconds"]).toBeDefined();
+    expect(r.headers["x-targetepochseconds"]).toBe("1576540098");
+    expect(r.headers["x-targethttpdate"]).toBeDefined();
+    expect(r.headers["x-targethttpdate"]).toBe("Mon, 16 Dec 2019 23:48:18 GMT");
 
     expect(r.body).toBeFalsy();
   }
@@ -2946,8 +2946,8 @@ it("TimestampFormatHeaders:Response", async () => {
       {
         "x-targetepochseconds": "1576540098",
         "x-memberdatetime": "2019-12-16T23:48:18Z",
-        "x-defaultformat": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-memberepochseconds": "1576540098",
+        "x-defaultformat": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-targethttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-memberhttpdate": "Mon, 16 Dec 2019 23:48:18 GMT",
         "x-targetdatetime": "2019-12-16T23:48:18Z",


### PR DESCRIPTION
The HTTP request class doesn't have any implementations to insure
case-insensitivity of the http headers. So we need to be mindful
when populating these headers. Otherwise, the reqeust signature
will be messed up. This change will ensure the protocol-specific
default headers like content-type will be overriden by the serialized
header if exists.

For other headers added through middleware stack either by
customization or users, it wouldn't affect signing or sending as long
as the request doesn't contain same header names in different casing.
All the internal headers will be consistent. But users should be
careful when they are adding their own headers.

We don't add middleware to lowercase all headers to prevent
alternating the users' customizations.

Fixes: https://github.com/aws/aws-sdk-js-v3/issues/1800


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
