### PR TITLE
fix(clients): export explicit dependencies on @aws-sdk/types

### DIFF
--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-accessanalyzer/package.json
+++ b/clients/client-accessanalyzer/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-acm-pca/package.json
+++ b/clients/client-acm-pca/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-acm/package.json
+++ b/clients/client-acm/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-alexa-for-business/package.json
+++ b/clients/client-alexa-for-business/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-amplify/package.json
+++ b/clients/client-amplify/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-amplifybackend/package.json
+++ b/clients/client-amplifybackend/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-api-gateway/package.json
+++ b/clients/client-api-gateway/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-apigatewaymanagementapi/package.json
+++ b/clients/client-apigatewaymanagementapi/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-apigatewayv2/package.json
+++ b/clients/client-apigatewayv2/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-app-mesh/package.json
+++ b/clients/client-app-mesh/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-appconfig/package.json
+++ b/clients/client-appconfig/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-appflow/package.json
+++ b/clients/client-appflow/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-appintegrations/package.json
+++ b/clients/client-appintegrations/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-application-auto-scaling/package.json
+++ b/clients/client-application-auto-scaling/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-application-discovery-service/package.json
+++ b/clients/client-application-discovery-service/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-application-insights/package.json
+++ b/clients/client-application-insights/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-appstream/package.json
+++ b/clients/client-appstream/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-appsync/package.json
+++ b/clients/client-appsync/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-athena/package.json
+++ b/clients/client-athena/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-auditmanager/package.json
+++ b/clients/client-auditmanager/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-auto-scaling-plans/package.json
+++ b/clients/client-auto-scaling-plans/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-auto-scaling/package.json
+++ b/clients/client-auto-scaling/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-backup/package.json
+++ b/clients/client-backup/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-batch/package.json
+++ b/clients/client-batch/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-braket/package.json
+++ b/clients/client-braket/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-budgets/package.json
+++ b/clients/client-budgets/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-chime/package.json
+++ b/clients/client-chime/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloud9/package.json
+++ b/clients/client-cloud9/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-clouddirectory/package.json
+++ b/clients/client-clouddirectory/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloudformation/package.json
+++ b/clients/client-cloudformation/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloudfront/package.json
+++ b/clients/client-cloudfront/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloudhsm-v2/package.json
+++ b/clients/client-cloudhsm-v2/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloudhsm/package.json
+++ b/clients/client-cloudhsm/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloudsearch-domain/package.json
+++ b/clients/client-cloudsearch-domain/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloudsearch/package.json
+++ b/clients/client-cloudsearch/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloudtrail/package.json
+++ b/clients/client-cloudtrail/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloudwatch-events/package.json
+++ b/clients/client-cloudwatch-events/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloudwatch-logs/package.json
+++ b/clients/client-cloudwatch-logs/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cloudwatch/package.json
+++ b/clients/client-cloudwatch/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-codeartifact/package.json
+++ b/clients/client-codeartifact/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-codebuild/package.json
+++ b/clients/client-codebuild/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-codecommit/package.json
+++ b/clients/client-codecommit/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-codedeploy/package.json
+++ b/clients/client-codedeploy/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-codeguru-reviewer/package.json
+++ b/clients/client-codeguru-reviewer/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-codeguruprofiler/package.json
+++ b/clients/client-codeguruprofiler/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-codepipeline/package.json
+++ b/clients/client-codepipeline/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-codestar-connections/package.json
+++ b/clients/client-codestar-connections/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-codestar-notifications/package.json
+++ b/clients/client-codestar-notifications/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-codestar/package.json
+++ b/clients/client-codestar/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cognito-identity-provider/package.json
+++ b/clients/client-cognito-identity-provider/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -63,7 +63,6 @@
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
     "@aws-sdk/client-iam": "3.2.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",

--- a/clients/client-cognito-identity/package.json
+++ b/clients/client-cognito-identity/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cognito-sync/package.json
+++ b/clients/client-cognito-sync/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-comprehend/package.json
+++ b/clients/client-comprehend/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-comprehendmedical/package.json
+++ b/clients/client-comprehendmedical/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-compute-optimizer/package.json
+++ b/clients/client-compute-optimizer/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-config-service/package.json
+++ b/clients/client-config-service/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-connect-contact-lens/package.json
+++ b/clients/client-connect-contact-lens/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-connect/package.json
+++ b/clients/client-connect/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-connectparticipant/package.json
+++ b/clients/client-connectparticipant/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cost-and-usage-report-service/package.json
+++ b/clients/client-cost-and-usage-report-service/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-cost-explorer/package.json
+++ b/clients/client-cost-explorer/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-customer-profiles/package.json
+++ b/clients/client-customer-profiles/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-data-pipeline/package.json
+++ b/clients/client-data-pipeline/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-database-migration-service/package.json
+++ b/clients/client-database-migration-service/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-databrew/package.json
+++ b/clients/client-databrew/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-dataexchange/package.json
+++ b/clients/client-dataexchange/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-datasync/package.json
+++ b/clients/client-datasync/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-dax/package.json
+++ b/clients/client-dax/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-detective/package.json
+++ b/clients/client-detective/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-device-farm/package.json
+++ b/clients/client-device-farm/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-devops-guru/package.json
+++ b/clients/client-devops-guru/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-direct-connect/package.json
+++ b/clients/client-direct-connect/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-directory-service/package.json
+++ b/clients/client-directory-service/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-dlm/package.json
+++ b/clients/client-dlm/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-docdb/package.json
+++ b/clients/client-docdb/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-dynamodb-streams/package.json
+++ b/clients/client-dynamodb-streams/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-dynamodb/package.json
+++ b/clients/client-dynamodb/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-ebs/package.json
+++ b/clients/client-ebs/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ec2-instance-connect/package.json
+++ b/clients/client-ec2-instance-connect/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -64,7 +64,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-ec2/package.json
+++ b/clients/client-ec2/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ecr-public/package.json
+++ b/clients/client-ecr-public/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ecr/package.json
+++ b/clients/client-ecr/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ecs/package.json
+++ b/clients/client-ecs/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-efs/package.json
+++ b/clients/client-efs/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-eks/package.json
+++ b/clients/client-eks/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-elastic-beanstalk/package.json
+++ b/clients/client-elastic-beanstalk/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-elastic-inference/package.json
+++ b/clients/client-elastic-inference/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-elastic-load-balancing-v2/package.json
+++ b/clients/client-elastic-load-balancing-v2/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-elastic-load-balancing/package.json
+++ b/clients/client-elastic-load-balancing/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-elastic-transcoder/package.json
+++ b/clients/client-elastic-transcoder/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-elasticache/package.json
+++ b/clients/client-elasticache/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-elasticsearch-service/package.json
+++ b/clients/client-elasticsearch-service/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-emr-containers/package.json
+++ b/clients/client-emr-containers/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-emr/package.json
+++ b/clients/client-emr/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-eventbridge/package.json
+++ b/clients/client-eventbridge/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-firehose/package.json
+++ b/clients/client-firehose/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-fms/package.json
+++ b/clients/client-fms/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-forecast/package.json
+++ b/clients/client-forecast/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-forecastquery/package.json
+++ b/clients/client-forecastquery/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-frauddetector/package.json
+++ b/clients/client-frauddetector/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-fsx/package.json
+++ b/clients/client-fsx/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-gamelift/package.json
+++ b/clients/client-gamelift/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -48,6 +48,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-glacier/package.json
+++ b/clients/client-glacier/package.json
@@ -64,7 +64,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-global-accelerator/package.json
+++ b/clients/client-global-accelerator/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-glue/package.json
+++ b/clients/client-glue/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-greengrass/package.json
+++ b/clients/client-greengrass/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-groundstation/package.json
+++ b/clients/client-groundstation/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-guardduty/package.json
+++ b/clients/client-guardduty/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-health/package.json
+++ b/clients/client-health/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-healthlake/package.json
+++ b/clients/client-healthlake/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-honeycode/package.json
+++ b/clients/client-honeycode/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iam/package.json
+++ b/clients/client-iam/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-identitystore/package.json
+++ b/clients/client-identitystore/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-imagebuilder/package.json
+++ b/clients/client-imagebuilder/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-inspector/package.json
+++ b/clients/client-inspector/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iot-1click-devices-service/package.json
+++ b/clients/client-iot-1click-devices-service/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iot-1click-projects/package.json
+++ b/clients/client-iot-1click-projects/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iot-data-plane/package.json
+++ b/clients/client-iot-data-plane/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iot-events-data/package.json
+++ b/clients/client-iot-events-data/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iot-events/package.json
+++ b/clients/client-iot-events/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iot-jobs-data-plane/package.json
+++ b/clients/client-iot-jobs-data-plane/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-iot/package.json
+++ b/clients/client-iot/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iotanalytics/package.json
+++ b/clients/client-iotanalytics/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iotsecuretunneling/package.json
+++ b/clients/client-iotsecuretunneling/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iotsitewise/package.json
+++ b/clients/client-iotsitewise/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-iotthingsgraph/package.json
+++ b/clients/client-iotthingsgraph/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ivs/package.json
+++ b/clients/client-ivs/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-kafka/package.json
+++ b/clients/client-kafka/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-kendra/package.json
+++ b/clients/client-kendra/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-kinesis-analytics-v2/package.json
+++ b/clients/client-kinesis-analytics-v2/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-kinesis-analytics/package.json
+++ b/clients/client-kinesis-analytics/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-kinesis-video-archived-media/package.json
+++ b/clients/client-kinesis-video-archived-media/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-kinesis-video-media/package.json
+++ b/clients/client-kinesis-video-media/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-kinesis-video-signaling/package.json
+++ b/clients/client-kinesis-video-signaling/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-kinesis-video/package.json
+++ b/clients/client-kinesis-video/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -48,6 +48,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-kinesis/package.json
+++ b/clients/client-kinesis/package.json
@@ -64,7 +64,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-kms/package.json
+++ b/clients/client-kms/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-lakeformation/package.json
+++ b/clients/client-lakeformation/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-lambda/package.json
+++ b/clients/client-lambda/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-lex-model-building-service/package.json
+++ b/clients/client-lex-model-building-service/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-lex-runtime-service/package.json
+++ b/clients/client-lex-runtime-service/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-license-manager/package.json
+++ b/clients/client-license-manager/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-lightsail/package.json
+++ b/clients/client-lightsail/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-lookoutvision/package.json
+++ b/clients/client-lookoutvision/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-machine-learning/package.json
+++ b/clients/client-machine-learning/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-macie/package.json
+++ b/clients/client-macie/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-macie2/package.json
+++ b/clients/client-macie2/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-managedblockchain/package.json
+++ b/clients/client-managedblockchain/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-marketplace-catalog/package.json
+++ b/clients/client-marketplace-catalog/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-marketplace-commerce-analytics/package.json
+++ b/clients/client-marketplace-commerce-analytics/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-marketplace-entitlement-service/package.json
+++ b/clients/client-marketplace-entitlement-service/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-marketplace-metering/package.json
+++ b/clients/client-marketplace-metering/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-mediaconnect/package.json
+++ b/clients/client-mediaconnect/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-mediaconvert/package.json
+++ b/clients/client-mediaconvert/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-medialive/package.json
+++ b/clients/client-medialive/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-mediapackage-vod/package.json
+++ b/clients/client-mediapackage-vod/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-mediapackage/package.json
+++ b/clients/client-mediapackage/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-mediastore-data/package.json
+++ b/clients/client-mediastore-data/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-mediastore/package.json
+++ b/clients/client-mediastore/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-mediatailor/package.json
+++ b/clients/client-mediatailor/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-migration-hub/package.json
+++ b/clients/client-migration-hub/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-migrationhub-config/package.json
+++ b/clients/client-migrationhub-config/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-mobile/package.json
+++ b/clients/client-mobile/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-mq/package.json
+++ b/clients/client-mq/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-mturk/package.json
+++ b/clients/client-mturk/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-neptune/package.json
+++ b/clients/client-neptune/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-network-firewall/package.json
+++ b/clients/client-network-firewall/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-networkmanager/package.json
+++ b/clients/client-networkmanager/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-opsworks/package.json
+++ b/clients/client-opsworks/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-opsworkscm/package.json
+++ b/clients/client-opsworkscm/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-organizations/package.json
+++ b/clients/client-organizations/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-outposts/package.json
+++ b/clients/client-outposts/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-personalize-events/package.json
+++ b/clients/client-personalize-events/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-personalize-runtime/package.json
+++ b/clients/client-personalize-runtime/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-personalize/package.json
+++ b/clients/client-personalize/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-pi/package.json
+++ b/clients/client-pi/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-pinpoint-email/package.json
+++ b/clients/client-pinpoint-email/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-pinpoint-sms-voice/package.json
+++ b/clients/client-pinpoint-sms-voice/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-pinpoint/package.json
+++ b/clients/client-pinpoint/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-polly/package.json
+++ b/clients/client-polly/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-pricing/package.json
+++ b/clients/client-pricing/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-qldb-session/package.json
+++ b/clients/client-qldb-session/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-qldb/package.json
+++ b/clients/client-qldb/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-quicksight/package.json
+++ b/clients/client-quicksight/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ram/package.json
+++ b/clients/client-ram/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-rds-data/package.json
+++ b/clients/client-rds-data/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-rds/package.json
+++ b/clients/client-rds/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-redshift-data/package.json
+++ b/clients/client-redshift-data/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-redshift/package.json
+++ b/clients/client-redshift/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-rekognition/package.json
+++ b/clients/client-rekognition/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-resource-groups-tagging-api/package.json
+++ b/clients/client-resource-groups-tagging-api/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-resource-groups/package.json
+++ b/clients/client-resource-groups/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-robomaker/package.json
+++ b/clients/client-robomaker/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-route-53-domains/package.json
+++ b/clients/client-route-53-domains/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-route-53/package.json
+++ b/clients/client-route-53/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-route53resolver/package.json
+++ b/clients/client-route53resolver/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -65,7 +65,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",

--- a/clients/client-s3-control/package.json
+++ b/clients/client-s3-control/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -77,7 +77,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/chai": "^4.2.11",
     "@types/mocha": "^8.0.4",
     "@types/node": "^12.7.5",

--- a/clients/client-s3/package.json
+++ b/clients/client-s3/package.json
@@ -59,6 +59,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-s3outposts/package.json
+++ b/clients/client-s3outposts/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sagemaker-a2i-runtime/package.json
+++ b/clients/client-sagemaker-a2i-runtime/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sagemaker-edge/package.json
+++ b/clients/client-sagemaker-edge/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sagemaker-featurestore-runtime/package.json
+++ b/clients/client-sagemaker-featurestore-runtime/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sagemaker-runtime/package.json
+++ b/clients/client-sagemaker-runtime/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sagemaker/package.json
+++ b/clients/client-sagemaker/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-savingsplans/package.json
+++ b/clients/client-savingsplans/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-schemas/package.json
+++ b/clients/client-schemas/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-secrets-manager/package.json
+++ b/clients/client-secrets-manager/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-securityhub/package.json
+++ b/clients/client-securityhub/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-serverlessapplicationrepository/package.json
+++ b/clients/client-serverlessapplicationrepository/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-service-catalog-appregistry/package.json
+++ b/clients/client-service-catalog-appregistry/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-service-catalog/package.json
+++ b/clients/client-service-catalog/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-service-quotas/package.json
+++ b/clients/client-service-quotas/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-servicediscovery/package.json
+++ b/clients/client-servicediscovery/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ses/package.json
+++ b/clients/client-ses/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sesv2/package.json
+++ b/clients/client-sesv2/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sfn/package.json
+++ b/clients/client-sfn/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-shield/package.json
+++ b/clients/client-shield/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-signer/package.json
+++ b/clients/client-signer/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sms/package.json
+++ b/clients/client-sms/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-snowball/package.json
+++ b/clients/client-snowball/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sns/package.json
+++ b/clients/client-sns/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -63,7 +63,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sqs/package.json
+++ b/clients/client-sqs/package.json
@@ -47,6 +47,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-ssm/package.json
+++ b/clients/client-ssm/package.json
@@ -62,7 +62,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sso-admin/package.json
+++ b/clients/client-sso-admin/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sso-oidc/package.json
+++ b/clients/client-sso-oidc/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sso/package.json
+++ b/clients/client-sso/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-storage-gateway/package.json
+++ b/clients/client-storage-gateway/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-sts/package.json
+++ b/clients/client-sts/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-support/package.json
+++ b/clients/client-support/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-swf/package.json
+++ b/clients/client-swf/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-synthetics/package.json
+++ b/clients/client-synthetics/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-textract/package.json
+++ b/clients/client-textract/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-timestream-query/package.json
+++ b/clients/client-timestream-query/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-timestream-write/package.json
+++ b/clients/client-timestream-write/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -68,7 +68,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-transcribe-streaming/package.json
+++ b/clients/client-transcribe-streaming/package.json
@@ -53,6 +53,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-transcribe/package.json
+++ b/clients/client-transcribe/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-transfer/package.json
+++ b/clients/client-transfer/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -61,7 +61,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-translate/package.json
+++ b/clients/client-translate/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-waf-regional/package.json
+++ b/clients/client-waf-regional/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-waf/package.json
+++ b/clients/client-waf/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-wafv2/package.json
+++ b/clients/client-wafv2/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-workdocs/package.json
+++ b/clients/client-workdocs/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-worklink/package.json
+++ b/clients/client-worklink/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "@types/uuid": "^3.0.0",
     "jest": "^26.1.0",

--- a/clients/client-workmail/package.json
+++ b/clients/client-workmail/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-workmailmessageflow/package.json
+++ b/clients/client-workmailmessageflow/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-workspaces/package.json
+++ b/clients/client-workspaces/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/clients/client-xray/package.json
+++ b/clients/client-xray/package.json
@@ -60,7 +60,6 @@
   },
   "devDependencies": {
     "@aws-sdk/client-documentation-generator": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/node": "^12.7.5",
     "jest": "^26.1.0",
     "rimraf": "^3.0.0",

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -19,10 +19,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/chunked-blob-reader": "3.1.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/sha256-tree-hash": "3.1.0",
@@ -26,7 +27,6 @@
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0",
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-utf8-browser": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -18,6 +18,7 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/chunked-stream-reader-node": "3.1.0",
     "@aws-sdk/is-array-buffer": "3.1.0",
     "@aws-sdk/protocol-http": "3.2.0",
@@ -27,7 +28,6 @@
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0",
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-utf8-node": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "@aws-sdk/node-config-provider": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "tslib": "^1.8.0",
     "typescript": "~4.1.2"
   },
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/signature-v4": "3.2.0",
     "tslib": "^1.8.0"
   },

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -21,10 +21,10 @@
   "dependencies": {
     "@aws-sdk/client-cognito-identity": "3.2.0",
     "@aws-sdk/property-provider": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -23,10 +23,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/property-provider": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -23,10 +23,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/property-provider": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -24,10 +24,10 @@
   "dependencies": {
     "@aws-sdk/property-provider": "3.1.0",
     "@aws-sdk/shared-ini-file-loader": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -30,11 +30,11 @@
     "@aws-sdk/credential-provider-ini": "3.1.0",
     "@aws-sdk/credential-provider-process": "3.1.0",
     "@aws-sdk/property-provider": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/shared-ini-file-loader": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -25,10 +25,10 @@
     "@aws-sdk/credential-provider-ini": "3.1.0",
     "@aws-sdk/property-provider": "3.1.0",
     "@aws-sdk/shared-ini-file-loader": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/eventstream-marshaller": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-utf8-node": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -19,11 +19,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-crypto/crc32": "^1.0.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-hex-encoding": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-utf8-browser": "3.1.0",
     "@aws-sdk/util-utf8-node": "3.1.0",
     "@types/jest": "^26.0.4",

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -20,10 +20,10 @@
   "dependencies": {
     "@aws-sdk/eventstream-marshaller": "3.1.0",
     "@aws-sdk/eventstream-serde-universal": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -18,10 +18,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -20,10 +20,10 @@
   "dependencies": {
     "@aws-sdk/eventstream-marshaller": "3.1.0",
     "@aws-sdk/eventstream-serde-universal": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-utf8-node": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/eventstream-marshaller": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-utf8-node": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -21,12 +21,12 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/querystring-builder": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/abort-controller": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "typescript": "~4.1.2"
   },

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -20,11 +20,11 @@
   "dependencies": {
     "@aws-sdk/chunked-blob-reader": "3.1.0",
     "@aws-sdk/chunked-blob-reader-native": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0",
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-hex-encoding": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -18,7 +18,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "hash-test-vectors": "^1.3.2",
@@ -26,6 +25,7 @@
     "typescript": "~4.1.2"
   },
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-buffer-from": "3.1.0",
     "tslib": "^1.8.0"
   },

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -18,11 +18,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0",
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-hex-encoding": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -18,10 +18,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -18,7 +18,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",
     "@aws-sdk/util-base64-node": "3.1.0",
     "@aws-sdk/util-hex-encoding": "3.1.0",
@@ -29,6 +28,7 @@
     "typescript": "~4.1.2"
   },
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-utf8-browser": "3.1.0",
     "tslib": "^1.8.0"
   },

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -20,10 +20,10 @@
   "dependencies": {
     "@aws-sdk/is-array-buffer": "3.1.0",
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -19,13 +19,13 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-arn-parser": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/middleware-stack": "3.1.0",
     "@aws-sdk/node-config-provider": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -20,10 +20,10 @@
   "dependencies": {
     "@aws-sdk/middleware-header-default": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -18,10 +18,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -19,11 +19,11 @@
   "module": "./dist/es/index.js",
   "types": "./dist/cjs/index.d.ts",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/service-error-classification": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "react-native-get-random-values": "^1.4.0",
     "tslib": "^1.8.0",
     "uuid": "^3.0.0"
@@ -27,7 +28,6 @@
   "devDependencies": {
     "@aws-sdk/node-config-provider": "3.1.0",
     "@aws-sdk/smithy-client": "3.2.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -19,12 +19,12 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/signature-v4": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-format-url": "3.1.0",
     "@aws-sdk/util-uri-escape": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -20,12 +20,12 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/signature-v4": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-format-url": "3.1.0",
     "@aws-sdk/util-uri-escape": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -18,10 +18,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -20,12 +20,12 @@
   "dependencies": {
     "@aws-sdk/middleware-bucket-endpoint": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-arn-parser": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/middleware-stack": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -19,11 +19,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-arn-parser": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -18,11 +18,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-hex-encoding": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -22,13 +22,13 @@
     "@aws-sdk/middleware-signing": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/signature-v4": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-format-url": "3.1.0",
     "react-native-get-random-values": "^1.4.0",
     "tslib": "^1.8.0",
     "uuid": "^3.0.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "jest-websocket-mock": "^2.0.2",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -18,10 +18,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -18,7 +18,6 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
@@ -26,6 +25,7 @@
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/signature-v4": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "engines": {

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -18,10 +18,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -19,11 +19,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/middleware-stack": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -22,10 +22,10 @@
   "dependencies": {
     "@aws-sdk/property-provider": "3.1.0",
     "@aws-sdk/shared-ini-file-loader": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -23,10 +23,10 @@
     "@aws-sdk/abort-controller": "3.1.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/querystring-builder": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -21,6 +21,7 @@
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/signature-v4": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-create-request": "3.2.0",
     "@aws-sdk/util-format-url": "3.1.0",
     "tslib": "^1.8.0"
@@ -28,7 +29,6 @@
   "devDependencies": {
     "@aws-sdk/client-polly": "3.2.0",
     "@aws-sdk/hash-node": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -18,10 +18,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -19,10 +19,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -18,11 +18,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-uri-escape": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -18,10 +18,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -19,6 +19,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/signature-v4": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-format-url": "3.1.0",
     "@aws-sdk/util-hex-encoding": "3.1.0",
     "tslib": "^1.8.0"
@@ -27,7 +28,6 @@
     "@aws-sdk/client-s3": "3.2.0",
     "@aws-sdk/hash-node": "3.1.0",
     "@aws-sdk/protocol-http": "3.2.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -21,6 +21,7 @@
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/signature-v4": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-create-request": "3.2.0",
     "@aws-sdk/util-format-url": "3.1.0",
     "tslib": "^1.8.0"
@@ -28,7 +29,6 @@
   "devDependencies": {
     "@aws-sdk/client-s3": "3.2.0",
     "@aws-sdk/hash-node": "3.1.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^12.0.2",
     "jest": "^26.1.0",

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -18,11 +18,11 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0",
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-hex-encoding": "3.1.0",
     "@aws-sdk/util-utf8-node": "3.1.0",
     "@types/jest": "^26.0.4",

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -20,6 +20,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/is-array-buffer": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-hex-encoding": "3.1.0",
     "@aws-sdk/util-uri-escape": "3.1.0",
     "tslib": "^1.8.0"
@@ -27,7 +28,6 @@
   "devDependencies": {
     "@aws-crypto/sha256-js": "^1.0.0",
     "@aws-sdk/protocol-http": "3.2.0",
-    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/util-buffer-from": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/middleware-stack": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/url-parser-browser/package.json
+++ b/packages/url-parser-browser/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/querystring-parser": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/url-parser-node/package.json
+++ b/packages/url-parser-node/package.json
@@ -19,11 +19,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/querystring-parser": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0",
     "url": "^0.11.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -20,11 +20,11 @@
   "dependencies": {
     "@aws-sdk/middleware-stack": "3.1.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.3",
     "jest": "^26.1.0",

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -19,10 +19,10 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/querystring-builder": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -21,12 +21,12 @@
     "./index": "./index.native"
   },
   "dependencies": {
+    "@aws-sdk/types": "3.1.0",
     "bowser": "^2.11.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -19,11 +19,11 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@aws-sdk/node-config-provider": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
     "@aws-sdk/protocol-http": "3.2.0",
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "@types/node": "^10.0.0",
     "jest": "^26.1.0",

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -4,10 +4,10 @@
   "description": "Shared utilities for client waiters for the AWS SDK",
   "dependencies": {
     "@aws-sdk/abort-controller": "3.1.0",
+    "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"
   },
   "devDependencies": {
-    "@aws-sdk/types": "3.1.0",
     "@types/jest": "^26.0.4",
     "jest": "^26.1.0",
     "typescript": "~4.1.2"

--- a/protocol_tests/aws-ec2/package.json
+++ b/protocol_tests/aws-ec2/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/protocol_tests/aws-json/package.json
+++ b/protocol_tests/aws-json/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/protocol_tests/aws-query/package.json
+++ b/protocol_tests/aws-query/package.json
@@ -45,6 +45,7 @@
     "@aws-sdk/node-http-handler": "3.2.0",
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/protocol_tests/aws-restjson/package.json
+++ b/protocol_tests/aws-restjson/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/querystring-builder": "3.1.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",

--- a/protocol_tests/aws-restxml/package.json
+++ b/protocol_tests/aws-restxml/package.json
@@ -46,6 +46,7 @@
     "@aws-sdk/protocol-http": "3.2.0",
     "@aws-sdk/querystring-builder": "3.1.0",
     "@aws-sdk/smithy-client": "3.2.0",
+    "@aws-sdk/types": "3.1.0",
     "@aws-sdk/url-parser-browser": "3.1.0",
     "@aws-sdk/url-parser-node": "3.1.0",
     "@aws-sdk/util-base64-browser": "3.1.0",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-js-v3/issues/1842

Codegen: https://github.com/awslabs/smithy-typescript/pull/262

*Description of changes:*
Packages that depend on @aws-sdk/types should explicitly call out that dependency so that downstream consumers get type support out of the box and do not have to install their own version of @aws-sdk/types . This PR should do that for all packages that depend on @aws-sdk/types in AWS sdk v3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
