### PR TITLE
test(karma): fix karma dependency karma test

### DIFF
--- a/packages/fetch-http-handler/karma.conf.js
+++ b/packages/fetch-http-handler/karma.conf.js
@@ -22,7 +22,6 @@ module.exports = function (config) {
       },
     },
     karmaTypescriptConfig: {
-      tsconfig: "./tsconfig.json",
       bundlerOptions: {
         addNodeGlobals: false,
       },

--- a/packages/hash-blob-browser/karma.conf.js
+++ b/packages/hash-blob-browser/karma.conf.js
@@ -16,7 +16,6 @@ module.exports = function (config) {
       },
     },
     karmaTypescriptConfig: {
-      tsconfig: "./tsconfig.json",
       bundlerOptions: {
         addNodeGlobals: false,
       },


### PR DESCRIPTION
*Description of changes:*
These changes eliminate the warning when running these tests:
```console
13 01 2021 02:54:45.965:WARN [project.karma-typescript]: Tsconfig '/home/ec2-user/workspace/aws-sdk-js-v3/packages/fetch-http-handler/tsconfig.json' configured in karmaTypescriptConfig.tsconfig does not exist
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
