### PR TITLE
chore: remove exclude-created-before from lock config

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -18,8 +18,6 @@ jobs:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: 14
           pr-lock-inactive-days: 14
-          issue-exclude-created-before: '2020-10-01T00:00:00Z'
-          pr-exclude-created-before: '2020-10-01T00:00:00Z'
           issue-lock-comment: >
             This thread has been automatically locked since there has not been
             any recent activity after it was closed. Please open a 


### PR DESCRIPTION
*Issue #, if available:*
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/1881

*Description of changes:*
remove exclude-created-before from lock config.

The config was added to test GitHub Action lock-threads, and limit the number of notifications watchers will get.
The test is now complete. The exclude-created-before will now [default to ''](https://github.com/dessant/lock-threads#inputs), and closed threads from June-October will get locked over the weekend.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
