### PR TITLE
docs(credential-provider-imds): profile not supported in config options

### DIFF
--- a/packages/credential-provider-imds/README.md
+++ b/packages/credential-provider-imds/README.md
@@ -30,9 +30,3 @@ following options are supported:
   requests. If not specified, a default value of `1000` (one second) is used.
 - `maxRetries` - The maximum number of times any HTTP connections should be
   retried. If not specified, a default value of `0` will be used.
-
-Additionally, `fromInstanceMetadata` supports the following options:
-
-- `profile` - The configuration profile to use. If not specified, the provider
-  will use default profile name associated with the EC2 instance as reported by
-  the Instance Metadata Service.


### PR DESCRIPTION
*Issue #, if available:*
Refs https://github.com/aws/aws-sdk-js-v3/pull/103

*Description of changes:*
The configuration option `profile` was removed in https://github.com/aws/aws-sdk-js-v3/pull/103, but the README wasn't updated. This PR updates the README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
