### PR TITLE
docs(credential-provider-imds): mention IMDSv1+IMDSv2 support

### DIFF
--- a/packages/credential-provider-imds/README.md
+++ b/packages/credential-provider-imds/README.md
@@ -17,8 +17,11 @@ for more information on using IAM roles with Amazon ECS.
 
 A `CredentialProvider` function created with `fromInstanceMetadata` will return
 a promise that will resolve with credentials for the IAM role associated with
-an EC2 instance. Please see [IAM Roles for Amazon EC2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
+an EC2 instance.
+Please see [IAM Roles for Amazon EC2](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html)
 for more information on using IAM roles with Amazon EC2.
+Both IMDSv1 (a request/response method) and IMDSv2 (a session-oriented method) are supported.
+Please see [Configure the instance metadata service](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) for more information.
 
 ## Supported configuration
 


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/pull/1358

*Description of changes:*
The support for Signed IMDS workflow was added in https://github.com/aws/aws-sdk-js-v3/pull/1358
This update explicitly calls out in README that both IMDSv1 and IMDSv2 are supported with a link to configuring instance metadata service documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
