### PR TITLE
chore(clients): re-add retry headers for QLDB and Pinpoint SMS Voice

### DIFF
--- a/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
+++ b/clients/client-pinpoint-sms-voice/PinpointSMSVoiceClient.ts
@@ -44,13 +44,7 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import {
-  RetryInputConfig,
-  RetryResolvedConfig,
-  getOmitRetryHeadersPlugin,
-  getRetryPlugin,
-  resolveRetryConfig,
-} from "@aws-sdk/middleware-retry";
+import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -248,7 +242,6 @@ export class PinpointSMSVoiceClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
-    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   destroy(): void {

--- a/clients/client-qldb/QLDBClient.ts
+++ b/clients/client-qldb/QLDBClient.ts
@@ -58,13 +58,7 @@ import {
   resolveHostHeaderConfig,
 } from "@aws-sdk/middleware-host-header";
 import { getLoggerPlugin } from "@aws-sdk/middleware-logger";
-import {
-  RetryInputConfig,
-  RetryResolvedConfig,
-  getOmitRetryHeadersPlugin,
-  getRetryPlugin,
-  resolveRetryConfig,
-} from "@aws-sdk/middleware-retry";
+import { RetryInputConfig, RetryResolvedConfig, getRetryPlugin, resolveRetryConfig } from "@aws-sdk/middleware-retry";
 import {
   AwsAuthInputConfig,
   AwsAuthResolvedConfig,
@@ -284,7 +278,6 @@ export class QLDBClient extends __Client<
     this.middlewareStack.use(getHostHeaderPlugin(this.config));
     this.middlewareStack.use(getLoggerPlugin(this.config));
     this.middlewareStack.use(getUserAgentPlugin(this.config));
-    this.middlewareStack.use(getOmitRetryHeadersPlugin(this.config));
   }
 
   destroy(): void {

--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/AddOmitRetryHeadersDependency.java
@@ -32,9 +32,7 @@ public class AddOmitRetryHeadersDependency implements TypeScriptIntegration {
     private static final Set<String> SERVICE_IDS = SetUtils.of(
         "ConnectParticipant",
         "IoT Data Plane",
-        "IoT",
-        "Pinpoint SMS Voice",
-        "QLDB"
+        "IoT"
     );
 
     @Override


### PR DESCRIPTION
*Issue #, if available:*
Follow-up to https://github.com/aws/aws-sdk-js-v3/pull/1789

*Description of changes:*
Adding retry headers for services which now support them: QLDB and Pinpoint SMS Voice.

Verified that `access-control-allow-headers` includes `amz-sdk-invocation-id` and `amz-sdk-request` for QLDB and Pinpoint SMS voice.

<details>
<summary>QLDB</summary>

```console
$ curl --insecure -i -X OPTIONS https://qldb.us-east-1.amazonaws.com/ledgers/stringvalue/journal-kinesis-streams/stringvalue -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 Safari/537.36" -H "Origin: https://foo.example" -H "Access-Control-Request-Method: DELETE" -H "Access-Control-Request-Headers: user-agent,host,Authorization,amz-sdk-invocation-id,amz-sdk-request,x-amz-security-token" -H "host: qldb.us-east-1.amazonaws.com"


HTTP/2 200 
content-type: application/json
content-length: 0
date: Wed, 20 Jan 2021 02:04:48 GMT
x-amzn-requestid: 57eadc09-1cdd-4f06-8f30-3e3f6bf03054
access-control-allow-origin: *
access-control-allow-headers: Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-Content-Sha256,X-Amz-User-Agent,amz-sdk-invocation-id,amz-sdk-request
x-amz-apigw-id: ZbNmCGQkoAMFleQ=
access-control-allow-methods: DELETE,GET
x-amzn-trace-id: Root=1-60078fc0-13216629434b012875b05c31
x-cache: Miss from cloudfront
via: 1.1 7f5e0d3b9ea85d0d75063a66c0ebc841.cloudfront.net (CloudFront)
x-amz-cf-pop: HIO50-C1
x-amz-cf-id: 9Y0r3acAOy0mSIbvpmtUhK2WxX666Wz_0wlmW9ADX0cidow7QojgGg==
```

</details>

<details>
<summary>Pinpoint SMS Voice</summary>

```console
$ curl --insecure -i -X OPTIONS https://sms-voice.pinpoint.us-east-1.amazonaws.com/v1/sms-voice/configuration-sets -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 Safari/537.36" -H "Origin: https://foo.example" -H "Access-Control-Request-Method: POST" -H "Access-Control-Request-Headers: content-type,user-agent,content-length,host,Authorization,amz-sdk-invocation-id,amz-sdk-request,x-amz-security-token" -H "host: sms-voice.pinpoint.us-east-1.amazonaws.com"


HTTP/2 200 
content-type: application/json
content-length: 3
date: Wed, 20 Jan 2021 02:06:10 GMT
x-amzn-requestid: d4920a9c-3f6a-436e-8b32-54e4ef0b78e0
access-control-allow-origin: *
access-control-allow-headers: Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Content-Sha256,X-Amz-User-Agent,amz-sdk-invocation-id,amz-sdk-request
x-amz-apigw-id: ZbNy4F4uIAMFRVA=
access-control-allow-methods: GET,POST,PUT,DELETE,OPTIONS
x-cache: Miss from cloudfront
via: 1.1 bc24eca5e5d9f4acf2b3c88b0346cbb9.cloudfront.net (CloudFront)
x-amz-cf-pop: HIO50-C2
x-amz-cf-id: O4l9J-1yCzCYWIZD0R5xG1AaK2Sj_DxsUUH8eKJ0FBCf_SIL4sa6DQ==

{}
```

</details>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
