### PR TITLE
fix(generate-clients): call mergeManifest when constructor.name is Object

### DIFF
--- a/scripts/generate-clients/copy-to-clients.js
+++ b/scripts/generate-clients/copy-to-clients.js
@@ -41,7 +41,7 @@ const getOverwritablePredicate = (packageName) => (pathName) => {
 const mergeManifest = (fromContent = {}, toContent = {}) => {
   const merged = {};
   for (const name of Object.keys(fromContent)) {
-    if (typeof fromContent[name] === "object") {
+    if (fromContent[name].constructor.name === "Object") {
       merged[name] = mergeManifest(fromContent[name], toContent[name]);
       if (name === "scripts" || name === "devDependencies") {
         // Allow target package.json(toContent) has its own special script or


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1919#issuecomment-764218895

*Description of changes:*
In https://github.com/aws/aws-sdk-js-v3/issues/1919, we decided to use [downlevel-dts](https://www.npmjs.com/package/downlevel-dts) to create type definition files which support TS 3.4 or later. The configuration for [typesVersions](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-1.html#version-selection-with-typesversions) contains an array which is replaced to an object by out copy-to-clients script as it returns true for typeof operation.

This PR changes the `typeof` check to `constructor.name` so that only objects are replaced in package.json

```console
$ node
Welcome to Node.js v14.15.4.
Type ".help" for more information.
> const arr = ["arr"];
undefined
> typeof arr
'object'
> arr.constructor.name
'Array'
> const obj = {"obj": "obj"};
undefined
> typeof obj
'object'
> obj.constructor.name
'Object'
> const str = "str";
undefined
> typeof str
'string'
> str.constructor.name
'String'
```

*Testing:*
Verified that generate-clients doesn't update any package.json because of this change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
