### PR TITLE
chore(packages): use types as a declarationDir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ pids
 *.pid.lock
 lib-cov
 configuration
-coverage
 .nyc_output
 .grunt
 .lock-wscript
@@ -37,13 +36,9 @@ codegen/sdk-codegen/smithy-build.json
 */out/
 */*/out/
 
-protocol_tests/*/coverage
-protocol_tests/*/dist
-protocol_tests/*/types
-
-lib/*/coverage
-lib/*/dist
-lib/*/types
+coverage
+dist
+types
 
 /verdaccio/*
 !/verdaccio/config.yaml

--- a/lib/storage/package.json
+++ b/lib/storage/package.json
@@ -4,7 +4,7 @@
   "description": "Storage higher order operation",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "scripts": {
     "prepublishOnly": "yarn build:cjs && yarn build:es",
     "pretest": "yarn build:cjs",

--- a/lib/storage/tsconfig.cjs.json
+++ b/lib/storage/tsconfig.cjs.json
@@ -5,6 +5,7 @@
     "sourceMap": false,
     "declaration": true,
     "stripInternal": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "importHelpers": true,

--- a/lib/storage/tsconfig.es.json
+++ b/lib/storage/tsconfig.es.json
@@ -5,6 +5,7 @@
     "sourceMap": false,
     "declaration": true,
     "stripInternal": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "importHelpers": true,

--- a/packages/abort-controller/package.json
+++ b/packages/abort-controller/package.json
@@ -4,7 +4,7 @@
   "description": "A simple abort controller library",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "scripts": {
     "prepublishOnly": "yarn build:cjs && yarn build:es",
     "pretest": "yarn build:cjs",

--- a/packages/abort-controller/tsconfig.cjs.json
+++ b/packages/abort-controller/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/abort-controller/tsconfig.es.json
+++ b/packages/abort-controller/tsconfig.es.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
     "stripInternal": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/body-checksum-browser/package.json
+++ b/packages/body-checksum-browser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/body-checksum-browser/tsconfig.cjs.json
+++ b/packages/body-checksum-browser/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/body-checksum-browser/tsconfig.es.json
+++ b/packages/body-checksum-browser/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/body-checksum-node/package.json
+++ b/packages/body-checksum-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/body-checksum-node/tsconfig.cjs.json
+++ b/packages/body-checksum-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/body-checksum-node/tsconfig.es.json
+++ b/packages/body-checksum-node/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/chunked-blob-reader-native/package.json
+++ b/packages/chunked-blob-reader-native/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/chunked-blob-reader-native/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader-native/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/chunked-blob-reader-native/tsconfig.es.json
+++ b/packages/chunked-blob-reader-native/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/chunked-blob-reader/package.json
+++ b/packages/chunked-blob-reader/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/chunked-blob-reader/tsconfig.cjs.json
+++ b/packages/chunked-blob-reader/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/chunked-blob-reader/tsconfig.es.json
+++ b/packages/chunked-blob-reader/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/chunked-stream-reader-node/package.json
+++ b/packages/chunked-stream-reader-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/chunked-stream-reader-node/tsconfig.cjs.json
+++ b/packages/chunked-stream-reader-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/chunked-stream-reader-node/tsconfig.es.json
+++ b/packages/chunked-stream-reader-node/tsconfig.es.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/client-documentation-generator/package.json
+++ b/packages/client-documentation-generator/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/client-documentation-generator/tsconfig.cjs.json
+++ b/packages/client-documentation-generator/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "strict": false,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "experimentalDecorators": true,

--- a/packages/client-documentation-generator/tsconfig.es.json
+++ b/packages/client-documentation-generator/tsconfig.es.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "lib": ["es2015"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "experimentalDecorators": true,

--- a/packages/config-resolver/package.json
+++ b/packages/config-resolver/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/config-resolver/tsconfig.cjs.json
+++ b/packages/config-resolver/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/config-resolver/tsconfig.es.json
+++ b/packages/config-resolver/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/core-packages-documentation-generator/package.json
+++ b/packages/core-packages-documentation-generator/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/core-packages-documentation-generator/tsconfig.cjs.json
+++ b/packages/core-packages-documentation-generator/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "strict": false,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "experimentalDecorators": true,

--- a/packages/core-packages-documentation-generator/tsconfig.es.json
+++ b/packages/core-packages-documentation-generator/tsconfig.es.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "strict": false,
     "lib": ["es2015"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "experimentalDecorators": true,

--- a/packages/credential-provider-cognito-identity/package.json
+++ b/packages/credential-provider-cognito-identity/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "sideEffects": false,
   "author": {
     "name": "AWS SDK for JavaScript Team",

--- a/packages/credential-provider-cognito-identity/tsconfig.cjs.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "declarationDir": "./dist/cjs",

--- a/packages/credential-provider-cognito-identity/tsconfig.es.json
+++ b/packages/credential-provider-cognito-identity/tsconfig.es.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "declaration": false,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "declarationDir": null,

--- a/packages/credential-provider-env/package.json
+++ b/packages/credential-provider-env/package.json
@@ -32,7 +32,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/credential-provider-env/tsconfig.cjs.json
+++ b/packages/credential-provider-env/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-env/tsconfig.es.json
+++ b/packages/credential-provider-env/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/credential-provider-imds/package.json
+++ b/packages/credential-provider-imds/package.json
@@ -33,7 +33,7 @@
     "nock": "^13.0.2",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/credential-provider-imds/tsconfig.cjs.json
+++ b/packages/credential-provider-imds/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-imds/tsconfig.es.json
+++ b/packages/credential-provider-imds/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/credential-provider-ini/package.json
+++ b/packages/credential-provider-ini/package.json
@@ -33,7 +33,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/credential-provider-ini/tsconfig.cjs.json
+++ b/packages/credential-provider-ini/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-ini/tsconfig.es.json
+++ b/packages/credential-provider-ini/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/credential-provider-node/package.json
+++ b/packages/credential-provider-node/package.json
@@ -40,7 +40,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/credential-provider-node",
   "repository": {
     "type": "git",

--- a/packages/credential-provider-node/tsconfig.cjs.json
+++ b/packages/credential-provider-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-node/tsconfig.es.json
+++ b/packages/credential-provider-node/tsconfig.es.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/credential-provider-process/package.json
+++ b/packages/credential-provider-process/package.json
@@ -34,7 +34,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/credential-provider-process/tsconfig.cjs.json
+++ b/packages/credential-provider-process/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/credential-provider-process/tsconfig.es.json
+++ b/packages/credential-provider-process/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-handler-node/package.json
+++ b/packages/eventstream-handler-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-handler-node/tsconfig.cjs.json
+++ b/packages/eventstream-handler-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-handler-node/tsconfig.es.json
+++ b/packages/eventstream-handler-node/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-marshaller/package.json
+++ b/packages/eventstream-marshaller/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-marshaller/tsconfig.cjs.json
+++ b/packages/eventstream-marshaller/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-marshaller/tsconfig.es.json
+++ b/packages/eventstream-marshaller/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-serde-browser/package.json
+++ b/packages/eventstream-serde-browser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-serde-browser/tsconfig.cjs.json
+++ b/packages/eventstream-serde-browser/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-browser/tsconfig.es.json
+++ b/packages/eventstream-serde-browser/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable", "DOM"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-serde-config-resolver/package.json
+++ b/packages/eventstream-serde-config-resolver/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-config-resolver/tsconfig.es.json
+++ b/packages/eventstream-serde-config-resolver/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-serde-node/package.json
+++ b/packages/eventstream-serde-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-serde-node/tsconfig.cjs.json
+++ b/packages/eventstream-serde-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-node/tsconfig.es.json
+++ b/packages/eventstream-serde-node/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/eventstream-serde-universal/package.json
+++ b/packages/eventstream-serde-universal/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/eventstream-serde-universal/tsconfig.cjs.json
+++ b/packages/eventstream-serde-universal/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/eventstream-serde-universal/tsconfig.es.json
+++ b/packages/eventstream-serde-universal/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es2018.asynciterable"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/fetch-http-handler/package.json
+++ b/packages/fetch-http-handler/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "dependencies": {
     "@aws-sdk/protocol-http": "3.3.0",
     "@aws-sdk/querystring-builder": "3.3.0",

--- a/packages/fetch-http-handler/tsconfig.cjs.json
+++ b/packages/fetch-http-handler/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/fetch-http-handler/tsconfig.es.json
+++ b/packages/fetch-http-handler/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.iterable"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/hash-blob-browser/package.json
+++ b/packages/hash-blob-browser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/hash-blob-browser/tsconfig.cjs.json
+++ b/packages/hash-blob-browser/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/hash-blob-browser/tsconfig.es.json
+++ b/packages/hash-blob-browser/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/hash-node/package.json
+++ b/packages/hash-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/hash-node/tsconfig.cjs.json
+++ b/packages/hash-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/hash-node/tsconfig.es.json
+++ b/packages/hash-node/tsconfig.es.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/hash-stream-node/package.json
+++ b/packages/hash-stream-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/hash-stream-node/tsconfig.cjs.json
+++ b/packages/hash-stream-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/hash-stream-node/tsconfig.es.json
+++ b/packages/hash-stream-node/tsconfig.es.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/invalid-dependency/package.json
+++ b/packages/invalid-dependency/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/invalid-dependency/tsconfig.cjs.json
+++ b/packages/invalid-dependency/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/invalid-dependency/tsconfig.es.json
+++ b/packages/invalid-dependency/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/is-array-buffer/package.json
+++ b/packages/is-array-buffer/package.json
@@ -22,7 +22,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "dependencies": {
     "tslib": "^1.8.0"
   },

--- a/packages/is-array-buffer/tsconfig.cjs.json
+++ b/packages/is-array-buffer/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/is-array-buffer/tsconfig.es.json
+++ b/packages/is-array-buffer/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/karma-credential-loader/package.json
+++ b/packages/karma-credential-loader/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "declaration": false,
     "strict": false,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/karma-credential-loader/tsconfig.cjs.json
+++ b/packages/karma-credential-loader/tsconfig.cjs.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": false,
     "strict": false,
     "declarationDir": "./types",
     "rootDir": "./src",

--- a/packages/karma-credential-loader/tsconfig.es.json
+++ b/packages/karma-credential-loader/tsconfig.es.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "declaration": false,
     "strict": false,
     "lib": ["es2015"],
     "declarationDir": "./types",

--- a/packages/karma-credential-loader/tsconfig.es.json
+++ b/packages/karma-credential-loader/tsconfig.es.json
@@ -3,6 +3,7 @@
     "declaration": false,
     "strict": false,
     "lib": ["es2015"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/md5-js/package.json
+++ b/packages/md5-js/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/md5-js/tsconfig.cjs.json
+++ b/packages/md5-js/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/md5-js/tsconfig.es.json
+++ b/packages/md5-js/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-apply-body-checksum/package.json
+++ b/packages/middleware-apply-body-checksum/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-apply-body-checksum/tsconfig.cjs.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-apply-body-checksum/tsconfig.es.json
+++ b/packages/middleware-apply-body-checksum/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-bucket-endpoint/package.json
+++ b/packages/middleware-bucket-endpoint/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-bucket-endpoint/tsconfig.cjs.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-bucket-endpoint/tsconfig.es.json
+++ b/packages/middleware-bucket-endpoint/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-content-length/package.json
+++ b/packages/middleware-content-length/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-content-length/tsconfig.cjs.json
+++ b/packages/middleware-content-length/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-content-length/tsconfig.es.json
+++ b/packages/middleware-content-length/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-eventstream/package.json
+++ b/packages/middleware-eventstream/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-eventstream/tsconfig.cjs.json
+++ b/packages/middleware-eventstream/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-eventstream/tsconfig.es.json
+++ b/packages/middleware-eventstream/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-expect-continue/package.json
+++ b/packages/middleware-expect-continue/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-expect-continue/tsconfig.cjs.json
+++ b/packages/middleware-expect-continue/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-expect-continue/tsconfig.es.json
+++ b/packages/middleware-expect-continue/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-header-default/package.json
+++ b/packages/middleware-header-default/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-header-default/tsconfig.cjs.json
+++ b/packages/middleware-header-default/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-header-default/tsconfig.es.json
+++ b/packages/middleware-header-default/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-host-header/package.json
+++ b/packages/middleware-host-header/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-host-header/tsconfig.cjs.json
+++ b/packages/middleware-host-header/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-host-header/tsconfig.es.json
+++ b/packages/middleware-host-header/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-location-constraint/package.json
+++ b/packages/middleware-location-constraint/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-location-constraint/tsconfig.cjs.json
+++ b/packages/middleware-location-constraint/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-location-constraint/tsconfig.es.json
+++ b/packages/middleware-location-constraint/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-logger/package.json
+++ b/packages/middleware-logger/package.json
@@ -17,7 +17,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "dependencies": {
     "@aws-sdk/types": "3.1.0",
     "tslib": "^1.8.0"

--- a/packages/middleware-logger/tsconfig.cjs.json
+++ b/packages/middleware-logger/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-logger/tsconfig.es.json
+++ b/packages/middleware-logger/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-retry/package.json
+++ b/packages/middleware-retry/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-retry/tsconfig.cjs.json
+++ b/packages/middleware-retry/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "noUnusedLocals": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-retry/tsconfig.es.json
+++ b/packages/middleware-retry/tsconfig.es.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-api-gateway/package.json
+++ b/packages/middleware-sdk-api-gateway/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-api-gateway/tsconfig.es.json
+++ b/packages/middleware-sdk-api-gateway/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-ec2/package.json
+++ b/packages/middleware-sdk-ec2/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-ec2/tsconfig.cjs.json
+++ b/packages/middleware-sdk-ec2/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-ec2/tsconfig.es.json
+++ b/packages/middleware-sdk-ec2/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-glacier/package.json
+++ b/packages/middleware-sdk-glacier/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-glacier/tsconfig.cjs.json
+++ b/packages/middleware-sdk-glacier/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-glacier/tsconfig.es.json
+++ b/packages/middleware-sdk-glacier/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-machinelearning/package.json
+++ b/packages/middleware-sdk-machinelearning/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-machinelearning/tsconfig.es.json
+++ b/packages/middleware-sdk-machinelearning/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-rds/package.json
+++ b/packages/middleware-sdk-rds/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-rds/tsconfig.cjs.json
+++ b/packages/middleware-sdk-rds/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-rds/tsconfig.es.json
+++ b/packages/middleware-sdk-rds/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-route53/package.json
+++ b/packages/middleware-sdk-route53/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-route53/tsconfig.cjs.json
+++ b/packages/middleware-sdk-route53/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-route53/tsconfig.es.json
+++ b/packages/middleware-sdk-route53/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-s3-control/package.json
+++ b/packages/middleware-sdk-s3-control/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-s3-control/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-s3-control/tsconfig.es.json
+++ b/packages/middleware-sdk-s3-control/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-s3/package.json
+++ b/packages/middleware-sdk-s3/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-s3/tsconfig.cjs.json
+++ b/packages/middleware-sdk-s3/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-s3/tsconfig.es.json
+++ b/packages/middleware-sdk-s3/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-sqs/package.json
+++ b/packages/middleware-sdk-sqs/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-sdk-sqs/tsconfig.cjs.json
+++ b/packages/middleware-sdk-sqs/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-sqs/tsconfig.es.json
+++ b/packages/middleware-sdk-sqs/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-sdk-transcribe-streaming/package.json
+++ b/packages/middleware-sdk-transcribe-streaming/package.json
@@ -3,7 +3,7 @@
   "version": "3.3.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
+++ b/packages/middleware-sdk-transcribe-streaming/tsconfig.es.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "DOM"],
     "stripInternal": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": ".",

--- a/packages/middleware-serde/package.json
+++ b/packages/middleware-serde/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-serde/tsconfig.cjs.json
+++ b/packages/middleware-serde/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-serde/tsconfig.es.json
+++ b/packages/middleware-serde/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-signing/package.json
+++ b/packages/middleware-signing/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-signing/tsconfig.cjs.json
+++ b/packages/middleware-signing/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-signing/tsconfig.es.json
+++ b/packages/middleware-signing/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-ssec/package.json
+++ b/packages/middleware-ssec/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-ssec/tsconfig.cjs.json
+++ b/packages/middleware-ssec/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-ssec/tsconfig.es.json
+++ b/packages/middleware-ssec/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-stack/package.json
+++ b/packages/middleware-stack/package.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "dependencies": {
     "tslib": "^1.8.0"
   },

--- a/packages/middleware-stack/tsconfig.cjs.json
+++ b/packages/middleware-stack/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-stack/tsconfig.es.json
+++ b/packages/middleware-stack/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/middleware-user-agent/package.json
+++ b/packages/middleware-user-agent/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/middleware-user-agent/tsconfig.cjs.json
+++ b/packages/middleware-user-agent/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/middleware-user-agent/tsconfig.es.json
+++ b/packages/middleware-user-agent/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/node-config-provider/package.json
+++ b/packages/node-config-provider/package.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "dependencies": {
     "@aws-sdk/property-provider": "3.3.0",
     "@aws-sdk/shared-ini-file-loader": "3.1.0",

--- a/packages/node-config-provider/tsconfig.cjs.json
+++ b/packages/node-config-provider/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/node-config-provider/tsconfig.es.json
+++ b/packages/node-config-provider/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/node-http-handler/package.json
+++ b/packages/node-http-handler/package.json
@@ -18,7 +18,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "dependencies": {
     "@aws-sdk/abort-controller": "3.3.0",
     "@aws-sdk/protocol-http": "3.3.0",

--- a/packages/node-http-handler/tsconfig.cjs.json
+++ b/packages/node-http-handler/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/node-http-handler/tsconfig.es.json
+++ b/packages/node-http-handler/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.iterable"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/polly-request-presigner/package.json
+++ b/packages/polly-request-presigner/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/polly-request-presigner/tsconfig.cjs.json
+++ b/packages/polly-request-presigner/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/polly-request-presigner/tsconfig.es.json
+++ b/packages/polly-request-presigner/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/property-provider/package.json
+++ b/packages/property-provider/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/property-provider/tsconfig.cjs.json
+++ b/packages/property-provider/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/property-provider/tsconfig.es.json
+++ b/packages/property-provider/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/protocol-http/package.json
+++ b/packages/protocol-http/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "email": "",

--- a/packages/protocol-http/tsconfig.cjs.json
+++ b/packages/protocol-http/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/protocol-http/tsconfig.es.json
+++ b/packages/protocol-http/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/querystring-builder/package.json
+++ b/packages/querystring-builder/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/querystring-builder/tsconfig.cjs.json
+++ b/packages/querystring-builder/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/querystring-builder/tsconfig.es.json
+++ b/packages/querystring-builder/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/querystring-parser/package.json
+++ b/packages/querystring-parser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/querystring-parser/tsconfig.cjs.json
+++ b/packages/querystring-parser/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/querystring-parser/tsconfig.es.json
+++ b/packages/querystring-parser/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/s3-presigned-post/package.json
+++ b/packages/s3-presigned-post/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/s3-presigned-post/tsconfig.cjs.json
+++ b/packages/s3-presigned-post/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/s3-presigned-post/tsconfig.es.json
+++ b/packages/s3-presigned-post/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/s3-request-presigner/package.json
+++ b/packages/s3-request-presigner/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/s3-request-presigner/tsconfig.cjs.json
+++ b/packages/s3-request-presigner/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/s3-request-presigner/tsconfig.es.json
+++ b/packages/s3-request-presigner/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/service-error-classification/package.json
+++ b/packages/service-error-classification/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/service-error-classification/tsconfig.cjs.json
+++ b/packages/service-error-classification/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "noUnusedLocals": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/service-error-classification/tsconfig.es.json
+++ b/packages/service-error-classification/tsconfig.es.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "lib": ["es5", "es2015.collection", "es2015.iterable"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/sha256-tree-hash/package.json
+++ b/packages/sha256-tree-hash/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/sha256-tree-hash/tsconfig.cjs.json
+++ b/packages/sha256-tree-hash/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/sha256-tree-hash/tsconfig.es.json
+++ b/packages/sha256-tree-hash/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/shared-ini-file-loader/package.json
+++ b/packages/shared-ini-file-loader/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/shared-ini-file-loader/tsconfig.cjs.json
+++ b/packages/shared-ini-file-loader/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/shared-ini-file-loader/tsconfig.es.json
+++ b/packages/shared-ini-file-loader/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/signature-v4/package.json
+++ b/packages/signature-v4/package.json
@@ -4,7 +4,7 @@
   "description": "A standalone implementation of the AWS Signature V4 request signing algorithm",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "scripts": {
     "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:es": "tsc -p tsconfig.es.json",

--- a/packages/signature-v4/tsconfig.cjs.json
+++ b/packages/signature-v4/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "noUnusedLocals": true,

--- a/packages/signature-v4/tsconfig.es.json
+++ b/packages/signature-v4/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "stripInternal": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "noUnusedLocals": true,

--- a/packages/smithy-client/package.json
+++ b/packages/smithy-client/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/smithy-client/tsconfig.cjs.json
+++ b/packages/smithy-client/tsconfig.cjs.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "noUnusedLocals": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/smithy-client/tsconfig.es.json
+++ b/packages/smithy-client/tsconfig.es.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "noUnusedLocals": true,
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,7 +3,7 @@
   "version": "3.1.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "description": "Types for the AWS SDK",
   "devDependencies": {
     "typescript": "~4.1.2"

--- a/packages/types/tsconfig.cjs.json
+++ b/packages/types/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/types/tsconfig.es.json
+++ b/packages/types/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/url-parser-native/package.json
+++ b/packages/url-parser-native/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/url-parser-native/tsconfig.cjs.json
+++ b/packages/url-parser-native/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/url-parser-native/tsconfig.es.json
+++ b/packages/url-parser-native/tsconfig.es.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/url-parser/package.json
+++ b/packages/url-parser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/url-parser/tsconfig.cjs.json
+++ b/packages/url-parser/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/url-parser/tsconfig.es.json
+++ b/packages/url-parser/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-arn-parser/package.json
+++ b/packages/util-arn-parser/package.json
@@ -26,7 +26,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-arn-parser/tsconfig.cjs.json
+++ b/packages/util-arn-parser/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-arn-parser/tsconfig.es.json
+++ b/packages/util-arn-parser/tsconfig.es.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-base64-browser/package.json
+++ b/packages/util-base64-browser/package.json
@@ -26,7 +26,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-base64-browser",
   "repository": {
     "type": "git",

--- a/packages/util-base64-browser/tsconfig.cjs.json
+++ b/packages/util-base64-browser/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-base64-browser/tsconfig.es.json
+++ b/packages/util-base64-browser/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-base64-node/package.json
+++ b/packages/util-base64-node/package.json
@@ -27,7 +27,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-base64-node/tsconfig.cjs.json
+++ b/packages/util-base64-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-base64-node/tsconfig.es.json
+++ b/packages/util-base64-node/tsconfig.es.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-body-length-browser/package.json
+++ b/packages/util-body-length-browser/package.json
@@ -12,7 +12,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-body-length-browser/tsconfig.cjs.json
+++ b/packages/util-body-length-browser/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-body-length-browser/tsconfig.es.json
+++ b/packages/util-body-length-browser/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown", "dom"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-body-length-node/package.json
+++ b/packages/util-body-length-node/package.json
@@ -18,7 +18,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-body-length-node/tsconfig.cjs.json
+++ b/packages/util-body-length-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-body-length-node/tsconfig.es.json
+++ b/packages/util-body-length-node/tsconfig.es.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-buffer-from/package.json
+++ b/packages/util-buffer-from/package.json
@@ -26,7 +26,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-buffer-from/tsconfig.cjs.json
+++ b/packages/util-buffer-from/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-buffer-from/tsconfig.es.json
+++ b/packages/util-buffer-from/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-create-request/package.json
+++ b/packages/util-create-request/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-create-request/tsconfig.cjs.json
+++ b/packages/util-create-request/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-create-request/tsconfig.es.json
+++ b/packages/util-create-request/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-dynamodb/package.json
+++ b/packages/util-dynamodb/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-dynamodb/tsconfig.cjs.json
+++ b/packages/util-dynamodb/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-dynamodb/tsconfig.es.json
+++ b/packages/util-dynamodb/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-format-url/package.json
+++ b/packages/util-format-url/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-format-url/tsconfig.cjs.json
+++ b/packages/util-format-url/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-format-url/tsconfig.es.json
+++ b/packages/util-format-url/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-hex-encoding/package.json
+++ b/packages/util-hex-encoding/package.json
@@ -25,7 +25,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-hex-encoding/tsconfig.cjs.json
+++ b/packages/util-hex-encoding/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-hex-encoding/tsconfig.es.json
+++ b/packages/util-hex-encoding/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-locate-window/package.json
+++ b/packages/util-locate-window/package.json
@@ -25,7 +25,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-locate-window/tsconfig.cjs.json
+++ b/packages/util-locate-window/tsconfig.cjs.json
@@ -5,6 +5,7 @@
     "noImplicitAny": true,
     "noImplicitThis": true,
     "strictNullChecks": true,
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-locate-window/tsconfig.es.json
+++ b/packages/util-locate-window/tsconfig.es.json
@@ -6,6 +6,7 @@
     "noImplicitThis": true,
     "strictNullChecks": true,
     "lib": ["dom", "es5", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-uri-escape/package.json
+++ b/packages/util-uri-escape/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-uri-escape/tsconfig.cjs.json
+++ b/packages/util-uri-escape/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-uri-escape/tsconfig.es.json
+++ b/packages/util-uri-escape/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.promise", "es2015.collection", "es2015.iterable", "es2015.symbol.wellknown"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-user-agent-browser/package.json
+++ b/packages/util-user-agent-browser/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-user-agent-browser/tsconfig.cjs.json
+++ b/packages/util-user-agent-browser/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-user-agent-browser/tsconfig.es.json
+++ b/packages/util-user-agent-browser/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection", "dom"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-user-agent-node/package.json
+++ b/packages/util-user-agent-node/package.json
@@ -11,7 +11,7 @@
   },
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "author": {
     "name": "AWS SDK for JavaScript Team",
     "url": "https://aws.amazon.com/javascript/"

--- a/packages/util-user-agent-node/tsconfig.cjs.json
+++ b/packages/util-user-agent-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-user-agent-node/tsconfig.es.json
+++ b/packages/util-user-agent-node/tsconfig.es.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-utf8-browser/package.json
+++ b/packages/util-utf8-browser/package.json
@@ -25,7 +25,7 @@
     "jest": "^26.1.0",
     "typescript": "~4.1.2"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "homepage": "https://github.com/aws/aws-sdk-js-v3/tree/master/packages/util-utf8-browser",
   "repository": {
     "type": "git",

--- a/packages/util-utf8-browser/tsconfig.cjs.json
+++ b/packages/util-utf8-browser/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-utf8-browser/tsconfig.es.json
+++ b/packages/util-utf8-browser/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-utf8-node/package.json
+++ b/packages/util-utf8-node/package.json
@@ -30,7 +30,7 @@
   "jest": {
     "testEnvironment": "node"
   },
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-utf8-node/tsconfig.cjs.json
+++ b/packages/util-utf8-node/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-utf8-node/tsconfig.es.json
+++ b/packages/util-utf8-node/tsconfig.es.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/util-waiter/package.json
+++ b/packages/util-waiter/package.json
@@ -27,7 +27,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/util-waiter/tsconfig.cjs.json
+++ b/packages/util-waiter/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/util-waiter/tsconfig.es.json
+++ b/packages/util-waiter/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."

--- a/packages/xml-builder/package.json
+++ b/packages/xml-builder/package.json
@@ -25,7 +25,7 @@
   "license": "Apache-2.0",
   "main": "./dist/cjs/index.js",
   "module": "./dist/es/index.js",
-  "types": "./dist/cjs/index.d.ts",
+  "types": "./types/index.d.ts",
   "engines": {
     "node": ">= 10.0.0"
   },

--- a/packages/xml-builder/tsconfig.cjs.json
+++ b/packages/xml-builder/tsconfig.cjs.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/cjs",
     "baseUrl": "."

--- a/packages/xml-builder/tsconfig.es.json
+++ b/packages/xml-builder/tsconfig.es.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["es5", "es2015.collection"],
+    "declarationDir": "./types",
     "rootDir": "./src",
     "outDir": "./dist/es",
     "baseUrl": "."


### PR DESCRIPTION
*Issue #, if available:*
Refs: https://github.com/aws/aws-sdk-js-v3/issues/1919#issuecomment-764218895

*Description of changes:*
This issue was noticed while working on fix for https://github.com/aws/aws-sdk-js-v3/issues/1919

Using "./types" as a declarationDir in non-clients for the following reasons:
* The `"./types"` is used as a declarationDir already in clients.
* The types are independent of commonjs or esm modules.
* The legacy types can be generated as a postbuild step for types folder.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
